### PR TITLE
docs: gapfill CNWB OpenSpec (#11)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-11.md
+++ b/openspec/_ops/task_runs/ISSUE-11.md
@@ -1,0 +1,48 @@
+# ISSUE-11
+
+-
+- Issue: #11
+- Branch: task/11-cn-v1-workbench-openspec-gapfill
+- PR: <fill-after-created>
+
+## Plan
+
+- Gapfill `creonow-v1-workbench` 的 project/documents 规范与 P0 task cards，并修正不一致（constraints SSOT、`.creonow/skills`、测试路径统一）。
+- 运行格式化校验（Prettier），确保 openspec 文档可作为施工 SSOT。
+- 提交 PR（Closes #11）并启用 auto-merge；required checks 全绿后合并。
+
+## Runs
+
+### 2026-01-31 bootstrap
+
+- Command: `gh api -X PATCH repos/Leeky1017/CreoNow -f allow_auto_merge=true`
+- Key output: `{"allow_auto_merge":true}`
+
+- Command: `gh api -X PUT repos/Leeky1017/CreoNow/branches/main/protection --input -`
+- Key output: `required_status_checks.contexts=[check,openspec-log-guard,merge-gate]`
+
+- Command: `gh issue create -t \"[CN-V1] Workbench OpenSpec: gapfill project/documents + consistency\" -b \"...\"`
+- Key output: `https://github.com/Leeky1017/CreoNow/issues/11`
+
+- Command: `scripts/agent_worktree_setup.sh 11 cn-v1-workbench-openspec-gapfill`
+- Key output: `Worktree created: .worktrees/issue-11-cn-v1-workbench-openspec-gapfill`
+
+- Command: `rulebook task create issue-11-cn-v1-workbench-openspec-gapfill`
+- Key output: `✅ Task issue-11-cn-v1-workbench-openspec-gapfill created successfully`
+
+- Command: `rulebook task validate issue-11-cn-v1-workbench-openspec-gapfill`
+- Key output: `✅ Task issue-11-cn-v1-workbench-openspec-gapfill is valid`
+
+### 2026-01-31 validate + formatting
+
+- Command: `rulebook task validate issue-11-cn-v1-workbench-openspec-gapfill`
+- Key output: `✅ Task issue-11-cn-v1-workbench-openspec-gapfill is valid`
+
+- Command: `pnpm install`
+- Key output: `Done in 405ms`
+
+- Command: `pnpm exec prettier --write "openspec/specs/creonow-v1-workbench/**/*.md" "openspec/_ops/task_runs/ISSUE-11.md" "rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/**/*.md"`
+- Key output: `formatted updated markdown files`
+
+- Command: `pnpm exec prettier --check "openspec/specs/creonow-v1-workbench/**/*.md" "openspec/_ops/task_runs/ISSUE-11.md" "rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/**/*.md"`
+- Key output: `All matched files use Prettier code style!`

--- a/openspec/_ops/task_runs/ISSUE-11.md
+++ b/openspec/_ops/task_runs/ISSUE-11.md
@@ -3,7 +3,7 @@
 -
 - Issue: #11
 - Branch: task/11-cn-v1-workbench-openspec-gapfill
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/12
 
 ## Plan
 

--- a/openspec/specs/creonow-v1-workbench/design/04-context-engineering.md
+++ b/openspec/specs/creonow-v1-workbench/design/04-context-engineering.md
@@ -40,6 +40,8 @@ CN V1 的上下文层为 4 层（注入顺序固定）：
       *.md
       *.txt
       *.json
+    skills/
+      **/*  # project scope skills（见 design/06-skill-system.md）
     characters/
       *.md | *.json
     conversations/
@@ -50,8 +52,14 @@ CN V1 的上下文层为 4 层（注入顺序固定）：
 
 约束：
 
-- `.creonow/**` 仅用于规则/设定/对话/缓存（不得把用户文档 SSOT 放进这里）。
+- `.creonow/**` 仅用于“AI 辅助元数据”（rules/settings/skills/characters/conversations/cache 等），不得把用户文档 SSOT 放进这里。
 - 在 prompt/viewer/log 中引用文件路径时 MUST 使用 project-relative 路径（例如 `.creonow/settings/世界观.md`），禁止绝对路径。
+
+### 2.1.1 Constraints SSOT（MUST：写死，禁止双栈）
+
+- `.creonow/rules/constraints.json` MUST 作为 constraints 的 **SSOT**（project 作用域）。`constraints:get/set` 必须读写该文件（或等价的 project-relative 文件），不得再引入第二份 DB SSOT。
+- constraints 的内容属于 `rules` 层：变更必须可解释且可验收（会影响 `stablePrefixHash`，见 §3）。
+- 若文件不存在：`constraints:get` MUST 返回默认值（并可选地在 ensure 时落盘默认文件），但行为必须确定且可测。
 
 ### 2.2 IPC 通道（V1 必须）
 

--- a/openspec/specs/creonow-v1-workbench/design/11-project-and-documents.md
+++ b/openspec/specs/creonow-v1-workbench/design/11-project-and-documents.md
@@ -1,0 +1,126 @@
+# 11 - Project & Documents（project lifecycle / current project / filetree）
+
+> 上游 Requirements：`CNWB-REQ-005`、`CNWB-REQ-006`、`CNWB-REQ-020`、`CNWB-REQ-030`  
+> 目标：把 “project 与 documents 的最小闭环” 写成可实现、可验收、可 E2E 的规范，避免实现阶段在入口流/ID/落点上脑补与返工。
+
+---
+
+## 1. Project 模型（V1 写死）
+
+### 1.1 `projectId` 与 rootPath
+
+- `projectId` MUST 为稳定字符串（推荐：UUIDv4），用于关联 DB、FS 与 settings。
+- `rootPath` MUST 为 Windows 可用的真实路径，且支持空格/中文路径。
+
+### 1.2 Project Root 默认落点（V1 建议且推荐）
+
+为避免权限/可移植问题，V1 推荐由应用托管 project root（E2E 也更稳定）：
+
+```
+<CREONOW_USER_DATA_DIR>/
+  projects/
+    <projectId>/
+      .creonow/
+      (optional) documents/  # 若未来引入文件 SSOT，可预留；V1 默认 DB 为 SSOT
+```
+
+> 注：V1 文档 SSOT 建议为 DB（见 `design/02-document-model-ssot.md`），因此 project root 的主要职责是承载 `.creonow/**` 与未来扩展。
+
+---
+
+## 2. Project IPC（最小集合）
+
+### 2.1 通道（V1 MUST）
+
+- `project:create({ name?: string })` → `{ projectId, rootPath }`
+- `project:list({ includeDeleted?: boolean })` → `{ items: Array<{ projectId, name, rootPath, updatedAt }> }`
+- `project:getCurrent()` → `{ projectId, rootPath } | NOT_FOUND`
+- `project:setCurrent({ projectId })` → `{ projectId, rootPath } | NOT_FOUND`
+- `project:delete({ projectId })` → `{ deleted: true } | NOT_FOUND`
+
+约束：
+
+- `project:create` MUST 确保 `.creonow/` 目录结构存在（可调用 `context:creonow:ensure`）。
+- list 的排序必须确定（例如：`updatedAt desc, projectId asc`）。
+
+### 2.2 current project 持久化（MUST）
+
+- current project MUST 持久化（建议 settings key：`creonow.project.currentId`）。
+- app 重启后必须恢复 current project；若 project 不存在则必须返回 `NOT_FOUND` 并要求用户重新选择。
+
+---
+
+## 3. Documents（V1 最小闭环）
+
+### 3.1 DB SSOT 约束（与 `design/02` 对齐）
+
+- documents 内容 SSOT = `documents.content_json`（TipTap JSON）。
+- `documents.content_text/content_md` 为 derived 字段（用于 FTS/RAG/diff）。
+- 文档版本历史落在 `document_versions`（actor=`user|auto|ai`）。
+
+### 3.2 Documents IPC（V1 MUST）
+
+为避免与 “真实文件系统文件” 混淆，V1 建议显式区分 documents：
+
+- `file:document:create({ projectId, title?: string })` → `{ documentId }`
+- `file:document:list({ projectId })` → `{ items: Array<{ documentId, title, updatedAt }> }`
+- `file:document:read({ projectId, documentId })` → `{ content_json, content_text?, content_md?, content_hash, updated_at }`
+- `file:document:rename({ projectId, documentId, title })` → `{ updated: true }`
+- `file:document:delete({ projectId, documentId })` → `{ deleted: true }`
+- `file:document:setCurrent({ projectId, documentId })` → `{ documentId } | NOT_FOUND`
+- `file:document:getCurrent({ projectId })` → `{ documentId } | NOT_FOUND`
+
+约束：
+
+- 删除语义（V1 允许简化）必须写死：软删（tombstone）或硬删（二选一），但 list 默认不返回已删除。
+- `setCurrent/getCurrent` 的作用域必须是 project（不同 project 之间不得串）。
+
+---
+
+## 4. FileTree UI（Sidebar Files）
+
+对应设计稿：`12-sidebar-filetree.html`。
+
+### 4.1 最小交互（V1 MUST）
+
+- 列表：展示当前 project 的文档条目
+- 新建：创建文档并切换为 current
+- 切换：点击条目切换当前文档
+- 重命名：最小可用（inline 或 dialog 均可）
+- 删除：最小可用（可先无回收站，但必须可诊断）
+
+### 4.2 稳定选择器（MUST）
+
+- `sidebar-files`
+- `file-create`
+- `file-row-<documentId>`
+- `file-rename-<documentId>`（若有）
+- `file-delete-<documentId>`（若有）
+
+---
+
+## 5. Windows E2E 入口（必须可重复）
+
+### 5.1 建议的最小 E2E 场景
+
+- 启动 app（`CREONOW_E2E=1` + 独立 `CREONOW_USER_DATA_DIR`）
+- 创建 project（UI 或 IPC）
+- 创建 document → 在 filetree 可见
+- 输入内容 → autosave → 重启恢复（与 `P0-005` 对齐）
+- 新建第二篇 document → 切换 → 内容互不污染
+
+### 5.2 E2E 证据点（最低标准）
+
+- UI：断言 `sidebar-files`、`file-row-<id>` 可见
+- DB：断言 `projects/documents/document_versions/settings` 表存在且有记录
+- logs：至少记录 `project_created/project_set_current/document_created/document_set_current`
+
+---
+
+## Reference (WriteNow)
+
+参考路径（用于提炼语义与可测模式）：
+
+- `WriteNow/tests/e2e/app-launch.spec.ts`（稳定启动 + userDataDir 隔离的 E2E 形态）
+- `WriteNow/electron/ipc/files.cjs`（文件/文档 CRUD 的错误码与边界）
+- `WriteNow/src/types/ipc-generated.ts`（ipc channel 命名与请求/响应形态）

--- a/openspec/specs/creonow-v1-workbench/spec.md
+++ b/openspec/specs/creonow-v1-workbench/spec.md
@@ -91,6 +91,40 @@ CN V1 的打包、运行与 E2E 测试 MUST 以 Windows 为最高优先级；任
 - **WHEN** E2E 运行
   - **THEN** MUST 使用隔离的 `CREONOW_USER_DATA_DIR`，不得污染真实用户数据
 
+<a id="cnwb-req-005"></a>
+
+### CNWB-REQ-005: Project 生命周期（create/list/setCurrent/delete + rootPath）
+
+系统 MUST 提供 project 生命周期与 “current project” 的稳定语义，用于承载 `.creonow/`（rules/settings/skills/constraints）、documents/filetree 与 Windows E2E 的可重复入口。
+
+#### Scenarios
+
+- **WHEN** 用户创建项目（或 E2E 创建项目）
+  - **THEN** MUST 生成稳定 `projectId`，并返回 `rootPath`
+  - **AND** MUST 确保 `<projectRoot>/.creonow/` 存在（见 `design/04-context-engineering.md`）
+  - **AND** `rootPath` MUST 支持空格/中文路径（Windows 常见）
+- **WHEN** 用户切换当前项目
+  - **THEN** MUST 持久化 `currentProjectId`，并在 app 重启后恢复
+- **WHEN** 用户删除项目
+  - **THEN** MUST 从 `project:list` 消失，且对该 `projectId` 的后续访问 MUST 返回 `NOT_FOUND`（不得 silent fallback）
+
+<a id="cnwb-req-006"></a>
+
+### CNWB-REQ-006: Documents / FileTree（最小闭环：create/open/switch/rename/delete）
+
+系统 MUST 在单个 project 内提供 documents 的最小闭环，并在 UI 提供 Sidebar Files（`12-sidebar-filetree.html`）作为可发现入口；documents 的编辑与保存必须与 `CNWB-REQ-020/030`（SSOT/版本）一致。
+
+#### Scenarios
+
+- **WHEN** 用户创建文档
+  - **THEN** MUST 返回稳定 `documentId`，并在 filetree 列表中可见
+- **WHEN** 用户切换当前文档（点击 filetree 项）
+  - **THEN** editor MUST 切换到对应文档内容，且 `currentDocumentId` MUST 可重启恢复（project 作用域）
+- **WHEN** 用户重命名/删除文档
+  - **THEN** filetree 与后端 list MUST 立刻一致，且错误语义可判定（例如删除不存在文档 → `NOT_FOUND`）
+- **WHEN** E2E 运行
+  - **THEN** MUST 提供稳定 `data-testid`（例如 `sidebar-files`、`file-row-<documentId>`）以断言创建/切换/重命名/删除
+
 <a id="cnwb-req-010"></a>
 
 ### CNWB-REQ-010: 前端必须以 DESIGN_DECISIONS 为 SSOT（深色主题 P0）

--- a/openspec/specs/creonow-v1-workbench/task_cards/index.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/index.md
@@ -27,37 +27,47 @@
 4. `P0-004` SQLite bootstrap + migrations + logs（Windows 可观测）
    - Card: `task_cards/p0/P0-004-sqlite-bootstrap-migrations-logs.md`
    - Links: `CNWB-REQ-001`, `CNWB-REQ-120`, `design/10-windows-build-and-e2e.md`
-5. `P0-005` Editor SSOT + autosave + versioning（actor=user/auto）
+5. `P0-014` Project lifecycle + current project（入口与可重复 E2E）
+   - Card: `task_cards/p0/P0-014-project-lifecycle-and-current-project.md`
+   - Links: `CNWB-REQ-005`, `design/11-project-and-documents.md`
+6. `P0-005` Editor SSOT + autosave + versioning（actor=user/auto）
    - Card: `task_cards/p0/P0-005-editor-ssot-autosave-versioning.md`
    - Links: `CNWB-REQ-020/030`, `design/02-document-model-ssot.md`
-6. `P0-006` AI runtime + Fake AI server + stream/cancel/timeout
+7. `P0-015` Documents + FileTree minimal loop（create/switch/rename/delete）
+   - Card: `task_cards/p0/P0-015-documents-and-filetree-minimal.md`
+   - Links: `CNWB-REQ-006`, `design/11-project-and-documents.md`, `design/01-frontend-implementation.md`
+8. `P0-006` AI runtime + Fake AI server + stream/cancel/timeout
    - Card: `task_cards/p0/P0-006-ai-runtime-fake-provider-stream-cancel-timeout.md`
    - Links: `CNWB-REQ-050`, `design/09-ai-runtime-and-network.md`
-7. `P0-007` AI diff + apply（选区替换）+ actor=ai 版本
+9. `P0-007` AI diff + apply（选区替换）+ actor=ai 版本
    - Card: `task_cards/p0/P0-007-ai-diff-and-apply-selection-version-ai.md`
    - Links: `CNWB-REQ-030/050`, `design/02-document-model-ssot.md`
-8. `P0-008` Context engineering + viewer + redaction + watch `.creonow`
-   - Card: `task_cards/p0/P0-008-context-engineering-viewer-redaction-watch.md`
-   - Links: `CNWB-REQ-060`, `design/04-context-engineering.md`
-9. `P0-009` Memory：CRUD + settings + injection preview + preference learning
-   - Card: `task_cards/p0/P0-009-memory-crud-injection-preview-preference-learning.md`
-   - Links: `CNWB-REQ-070`, `design/05-memory-system.md`
-10. `P0-010` Skills：package loader + validator + list/toggle + UI 入口
+10. `P0-008` Context engineering + viewer + redaction + watch `.creonow`
+
+- Card: `task_cards/p0/P0-008-context-engineering-viewer-redaction-watch.md`
+- Links: `CNWB-REQ-060`, `design/04-context-engineering.md`
+
+11. `P0-009` Memory：CRUD + settings + injection preview + preference learning
+
+- Card: `task_cards/p0/P0-009-memory-crud-injection-preview-preference-learning.md`
+- Links: `CNWB-REQ-070`, `design/05-memory-system.md`
+
+12. `P0-010` Skills：package loader + validator + list/toggle + UI 入口
 
 - Card: `task_cards/p0/P0-010-skill-system-packages-validator-ui.md`
 - Links: `CNWB-REQ-080`, `design/06-skill-system.md`
 
-11. `P0-011` Knowledge Graph：CRUD + UI + context integration
+13. `P0-011` Knowledge Graph：CRUD + UI + context integration
 
 - Card: `task_cards/p0/P0-011-knowledge-graph-crud-ui-context.md`
 - Links: `CNWB-REQ-090`, `design/08-knowledge-graph.md`
 
-12. `P0-012` Search/Embedding/RAG：FTS + retrieve + fallback（Windows-first）
+14. `P0-012` Search/Embedding/RAG：FTS + retrieve + fallback（Windows-first）
 
 - Card: `task_cards/p0/P0-012-search-embedding-rag-minimal-fallback.md`
 - Links: `CNWB-REQ-100`, `design/07-search-embedding-rag.md`
 
-13. `P0-013` Constraints/Judge：最小可用 + Windows 可测降级
+15. `P0-013` Constraints/Judge：最小可用 + Windows 可测降级
 
 - Card: `task_cards/p0/P0-013-constraints-and-judge-minimal.md`
 - Links: `CNWB-REQ-110`, `spec.md`
@@ -86,8 +96,13 @@ flowchart TD
   P0001["P0-001 Windows CI/E2E/build"] --> P0002["P0-002 IPC contract/codegen"]
   P0002 --> P0003["P0-003 Renderer AppShell/Resizer/Prefs"]
   P0002 --> P0004["P0-004 SQLite bootstrap/migrations/logs"]
+  P0002 --> P0014["P0-014 Project lifecycle/current project"]
+  P0004 --> P0014
   P0003 --> P0005["P0-005 Editor SSOT/autosave/version"]
   P0004 --> P0005
+  P0014 --> P0005
+  P0005 --> P0015["P0-015 Documents/FileTree minimal loop"]
+  P0014 --> P0015
   P0005 --> P0006["P0-006 AI runtime + Fake AI + stream/cancel"]
   P0006 --> P0007["P0-007 Diff+Apply + actor=ai version"]
   P0004 --> P0008["P0-008 Context engine/viewer/redaction/watch"]
@@ -101,4 +116,5 @@ flowchart TD
   P0004 --> P0012["P0-012 Search/Embedding/RAG"]
   P0008 --> P0012
   P0004 --> P0013["P0-013 Constraints/Judge"]
+  P0014 --> P0013
 ```

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-003-renderer-design-tokens-appshell-resizer-preferences.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-003-renderer-design-tokens-appshell-resizer-preferences.md
@@ -28,7 +28,7 @@ Status: pending
 | Add    | `apps/desktop/renderer/src/components/layout/Resizer.tsx`              |
 | Add    | `apps/desktop/renderer/src/lib/preferences.ts`（PreferenceStore 实现） |
 | Add    | `apps/desktop/renderer/src/stores/layoutStore.ts`                      |
-| Add    | `apps/desktop/renderer/src/tests/e2e/layout-panels.spec.ts`            |
+| Add    | `apps/desktop/tests/e2e/layout-panels.spec.ts`                         |
 | Update | `apps/desktop/renderer/src/App.tsx`（使用 AppShell）                   |
 
 ## Acceptance Criteria

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md
@@ -12,6 +12,7 @@ Status: pending
 - Spec: `../spec.md#cnwb-req-030`
 - Design: `../design/02-document-model-ssot.md`
 - Design: `../design/01-frontend-implementation.md`（稳定选择器）
+- P0-014: `./P0-014-project-lifecycle-and-current-project.md`（projectId/rootPath/current project）
 - P0-002: `./P0-002-ipc-contract-ssot-and-codegen.md`
 - P0-003: `./P0-003-renderer-design-tokens-appshell-resizer-preferences.md`
 - P0-004: `./P0-004-sqlite-bootstrap-migrations-logs.md`
@@ -28,8 +29,8 @@ Status: pending
 | Add    | `apps/desktop/main/src/services/documents/documentService.ts`（SSOT 写入 + derived 生成 + 事务）           |
 | Add    | `apps/desktop/main/src/services/documents/derive.ts`（`content_text`/`content_md` 生成）                   |
 | Update | `apps/desktop/main/src/db/migrations/0001_init.sql`（补齐 documents/document_versions 列与索引）           |
-| Add    | `apps/desktop/renderer/src/tests/e2e/editor-autosave.spec.ts`                                              |
-| Add    | `apps/desktop/renderer/src/tests/unit/derive.test.ts`                                                      |
+| Add    | `apps/desktop/tests/e2e/editor-autosave.spec.ts`                                                           |
+| Add    | `apps/desktop/tests/unit/derive.test.ts`                                                                   |
 
 ## Acceptance Criteria
 

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-013-constraints-and-judge-minimal.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-013-constraints-and-judge-minimal.md
@@ -10,25 +10,29 @@ Status: pending
 
 - Spec: `../spec.md#cnwb-req-110`
 - Spec: `../spec.md#cnwb-req-040`（错误语义）
+- Design: `../design/04-context-engineering.md`（constraints SSOT：`.creonow/rules/constraints.json`）
+- P0-014: `./P0-014-project-lifecycle-and-current-project.md`（project root）
 - P0-004: `./P0-004-sqlite-bootstrap-migrations-logs.md`
 - P0-001: `./P0-001-windows-ci-windows-e2e-build-artifacts.md`
 
 ## Expected File Changes
 
-| 操作   | 文件路径                                                                                            |
-| ------ | --------------------------------------------------------------------------------------------------- |
-| Update | `apps/desktop/main/src/db/migrations/0001_init.sql`（constraints/judge 相关表）                     |
-| Add    | `apps/desktop/main/src/ipc/constraints.ts`（`constraints:get/set`）                                 |
-| Add    | `apps/desktop/main/src/ipc/judge.ts`（`judge:model:getState/ensure` + `judge:l2:prompt`）           |
-| Add    | `apps/desktop/main/src/services/judge/judgeService.ts`（状态机：not_ready/downloading/ready/error） |
-| Add    | `apps/desktop/renderer/src/features/settings/JudgeSection.tsx`（Settings UI 最小入口）              |
-| Add    | `apps/desktop/tests/e2e/judge.spec.ts`                                                              |
+| 操作   | 文件路径                                                                                                    |
+| ------ | ----------------------------------------------------------------------------------------------------------- |
+| Update | `apps/desktop/main/src/db/migrations/0001_init.sql`（judge 相关表；constraints 不作为 DB SSOT）             |
+| Add    | `apps/desktop/main/src/ipc/constraints.ts`（`constraints:get/set`；SSOT=`.creonow/rules/constraints.json`） |
+| Add    | `apps/desktop/main/src/ipc/judge.ts`（`judge:model:getState/ensure` + `judge:l2:prompt`）                   |
+| Add    | `apps/desktop/main/src/services/judge/judgeService.ts`（状态机：not_ready/downloading/ready/error）         |
+| Add    | `apps/desktop/renderer/src/features/settings/JudgeSection.tsx`（Settings UI 最小入口）                      |
+| Add    | `apps/desktop/tests/e2e/judge.spec.ts`                                                                      |
+| Add    | `apps/desktop/tests/integration/constraints-roundtrip.test.ts`                                              |
 
 ## Acceptance Criteria
 
 - [ ] Constraints：
-  - [ ] `constraints:get` 返回当前配置（含默认值）
-  - [ ] `constraints:set` 可更新并持久化
+  - [ ] SSOT：`.creonow/rules/constraints.json`（见 `design/04-context-engineering.md`）
+  - [ ] `constraints:get` 返回当前配置（含默认值；当文件缺失时行为必须确定）
+  - [ ] `constraints:set` 可更新并持久化到 SSOT 文件（不得写入第二份 DB SSOT）
   - [ ] 参数校验失败 → `INVALID_ARGUMENT`
 - [ ] Judge：
   - [ ] `judge:model:getState` 返回稳定状态枚举（至少：`not_ready/downloading/ready/error`）
@@ -41,12 +45,19 @@ Status: pending
 
 ## Tests
 
+- [ ] Integration：`constraints-roundtrip.test.ts`
+  - [ ] `constraints:get` 初始返回默认值（文件不存在时行为确定）
+  - [ ] `constraints:set` → 再次 `constraints:get`（roundtrip 一致）
+  - [ ] 非法 schema/参数 → `INVALID_ARGUMENT`
 - [ ] E2E（Windows）`judge.spec.ts`
   - [ ] 打开 Settings → 断言 judge 状态可见
   - [ ] 点击 ensure → 断言状态变化或出现可读错误（可测）
 
 ## Edge cases & Failure modes
 
+- `.creonow/rules/constraints.json` 不存在/损坏：
+  - `constraints:get` 必须返回默认值或 `INVALID_ARGUMENT`（二选一写死并可测）
+  - `constraints:set` 必须可恢复（覆盖写入）或返回可诊断错误
 - ensure 超时 → `TIMEOUT` 且状态回到可恢复态（不得卡死）
 - 用户取消 ensure → `CANCELED`
 - Windows 下载目录不可写 → `IO_ERROR`（可诊断）

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md
@@ -1,0 +1,66 @@
+# P0-014: Project lifecycle（create/list/setCurrent/getCurrent/delete + ensure `.creonow`）
+
+Status: pending
+
+## Goal
+
+补齐 V1 的“本地入口 + project 生命周期”闭环：projectId/rootPath 稳定、current project 可持久化可恢复，并在创建项目时确保 `<projectRoot>/.creonow/` 目录结构存在，支撑后续 documents/filetree、skills(project scope)、context watch 与 Windows E2E 的可重复入口。
+
+## Dependencies
+
+- Spec: `../spec.md#cnwb-req-005`
+- Spec: `../spec.md#cnwb-req-001`（Windows-first）
+- Design: `../design/11-project-and-documents.md`
+- Design: `../design/04-context-engineering.md`（`.creonow` 结构与 ensure）
+- P0-002: `./P0-002-ipc-contract-ssot-and-codegen.md`
+- P0-004: `./P0-004-sqlite-bootstrap-migrations-logs.md`（projects 表与 settings）
+- P0-001: `./P0-001-windows-ci-windows-e2e-build-artifacts.md`（E2E 门禁）
+
+## Expected File Changes
+
+| 操作   | 文件路径                                                                                                       |
+| ------ | -------------------------------------------------------------------------------------------------------------- |
+| Add    | `apps/desktop/main/src/ipc/project.ts`（`project:*` channels）                                                 |
+| Add    | `apps/desktop/main/src/services/projects/projectService.ts`（create/list/delete + current project）            |
+| Update | `apps/desktop/main/src/db/migrations/0001_init.sql`（确保 `projects` + `settings` 表字段满足本卡需求）         |
+| Add    | `apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx`（本地入口；`data-testid="welcome-screen"`）     |
+| Add    | `apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx`（`data-testid="create-project-dialog"`） |
+| Add    | `apps/desktop/renderer/src/stores/projectStore.ts`（project list/current project 状态）                        |
+| Add    | `apps/desktop/tests/e2e/project-lifecycle.spec.ts`                                                             |
+
+## Acceptance Criteria
+
+- [ ] `project:create`：
+  - [ ] 返回 `{ projectId, rootPath }`
+  - [ ] `rootPath` 支持空格/中文路径（Windows 常见）
+  - [ ] 创建完成后 `.creonow/` 目录结构已被 ensure（`context:creonow:ensure` 或等价）
+- [ ] `project:list`：
+  - [ ] 返回 deterministic 排序（写死排序规则并可测）
+- [ ] `project:setCurrent/getCurrent`：
+  - [ ] `setCurrent` 成功后 `getCurrent` 返回一致结果
+  - [ ] app 重启后 current project 仍可恢复（settings 持久化）
+- [ ] `project:delete`：
+  - [ ] 删除后 `project:list` 不再返回该项目
+  - [ ] 对已删除 `projectId` 的访问返回 `NOT_FOUND`（不得 silent fallback）
+- [ ] UI（最小可用）：
+  - [ ] 存在 `welcome-screen`，并能打开 `create-project-dialog` 完成创建
+
+## Tests
+
+- [ ] E2E（Windows）`project-lifecycle.spec.ts`
+  - [ ] 启动 → 创建 project → `project:getCurrent` 返回 projectId
+  - [ ] 断言 `.creonow/` 已存在（可通过 `context:creonow:status` 或等价可测路径）
+  - [ ] 重启 app → `project:getCurrent` 仍返回同 projectId
+
+## Edge cases & Failure modes
+
+- `CREONOW_USER_DATA_DIR` 含空格/中文（Windows 常见）→ 仍可 create/list/getCurrent
+- 删除当前项目 → 必须清空 current 并返回 `NOT_FOUND`（行为写死）
+- 创建项目时 FS 权限问题 → `IO_ERROR`，UI 提示“打开日志/重试”
+
+## Observability
+
+- `main.log` 关键行（结构化，至少包含）：
+  - `project_created`（projectId, rootPathRelative）
+  - `project_set_current`（projectId）
+  - `project_deleted`（projectId）

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-015-documents-and-filetree-minimal.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-015-documents-and-filetree-minimal.md
@@ -1,0 +1,68 @@
+# P0-015: Documents + FileTree（create/open/switch/rename/delete + currentDocument）
+
+Status: pending
+
+## Goal
+
+交付单 project 内 documents 的最小闭环，并把它落到 Sidebar Files（`12-sidebar-filetree.html`）：创建、切换、重命名、删除，以及 `currentDocumentId` 的 project 作用域持久化；同时为 Windows E2E 提供稳定的 `data-testid` 与可断言证据。
+
+## Dependencies
+
+- Spec: `../spec.md#cnwb-req-006`
+- Spec: `../spec.md#cnwb-req-020`（SSOT=TipTap JSON）
+- Spec: `../spec.md#cnwb-req-030`（versioning 关联）
+- Design: `../design/11-project-and-documents.md`
+- Design: `../design/01-frontend-implementation.md`（稳定选择器）
+- Design: `../design/02-document-model-ssot.md`（DB schema/derived/版本语义）
+- P0-014: `./P0-014-project-lifecycle-and-current-project.md`（projectId/rootPath/current project）
+- P0-005: `./P0-005-editor-ssot-autosave-versioning.md`（编辑器/保存/版本闭环）
+
+## Expected File Changes
+
+| 操作   | 文件路径                                                                                                 |
+| ------ | -------------------------------------------------------------------------------------------------------- |
+| Update | `apps/desktop/main/src/ipc/file.ts`（补齐 `file:document:*`：rename/delete/getCurrent/setCurrent 等）    |
+| Update | `apps/desktop/main/src/services/documents/documentService.ts`（list/rename/delete/currentDocument 语义） |
+| Update | `apps/desktop/main/src/db/migrations/0001_init.sql`（补齐 documents 字段/索引/（可选）tombstone）        |
+| Add    | `apps/desktop/renderer/src/features/files/FileTreePanel.tsx`（`data-testid=\"sidebar-files\"`）          |
+| Add    | `apps/desktop/renderer/src/stores/fileStore.ts`（documents list/currentDocumentId）                      |
+| Update | `apps/desktop/renderer/src/components/layout/Sidebar.tsx`（新增 Files tab 入口）                         |
+| Add    | `apps/desktop/tests/e2e/documents-filetree.spec.ts`                                                      |
+
+## Acceptance Criteria
+
+- [ ] Documents IPC（最小闭环）：
+  - [ ] `file:document:create/list/read/rename/delete` 可用且错误码稳定
+  - [ ] `file:document:setCurrent/getCurrent` 可用，且作用域为 project（不得串 project）
+- [ ] current document：
+  - [ ] 切换文档后 `currentDocumentId` 持久化，重启可恢复
+- [ ] FileTree UI：
+  - [ ] Sidebar 存在 Files 入口并可打开（`data-testid=\"sidebar-files\"`）
+  - [ ] 文档列表条目使用稳定选择器：`file-row-<documentId>`
+  - [ ] 新建文档入口存在：`file-create`
+  - [ ] 点击条目切换文档后，Editor 内容切换且不丢失（与 P0-005 的 autosave 对齐）
+
+## Tests
+
+- [ ] E2E（Windows）`documents-filetree.spec.ts`
+  - [ ] 创建 project → 创建 doc A → 输入内容并保存
+  - [ ] 创建 doc B → 切换到 B 输入不同内容
+  - [ ] 来回切换 A/B → 断言内容互不污染
+  - [ ] 重启 app → 断言 `currentDocumentId` 恢复且 filetree 列表可见
+
+## Edge cases & Failure modes
+
+- 删除当前文档：
+  - 必须写死语义（自动切到最近文档 / 清空 current），并在 E2E 断言
+- 重命名为空/超长：
+  - `INVALID_ARGUMENT` 且 message 可断言
+- 并发保存与切换：
+  - 必须定义行为（例如保存先完成或切换阻塞），不得 silent drop
+
+## Observability
+
+- `main.log` 记录：
+  - `document_created`（projectId, documentId）
+  - `document_renamed`（documentId）
+  - `document_deleted`（documentId）
+  - `document_set_current`（projectId, documentId）

--- a/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/.metadata.json
+++ b/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T02:12:15.210Z",
+  "updatedAt": "2026-01-31T02:12:15.210Z"
+}

--- a/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/proposal.md
+++ b/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: issue-11-cn-v1-workbench-openspec-gapfill
+
+## Why
+
+补齐 `creonow-v1-workbench` OpenSpec 的关键缺口，避免 P0 施工阶段被迫脑补/返工：当前缺少 project 生命周期与 documents/filetree 的稳定口径，并存在 `.creonow/skills` 与 constraints SSOT 等不一致，以及少量测试路径分裂问题。
+
+## What Changes
+
+- 在 `spec.md` 新增 `CNWB-REQ-005/006`（project lifecycle、documents/filetree minimal loop）。
+- 更新 `design/04-context-engineering.md`：补齐 `.creonow/skills/`，并写死 constraints SSOT。
+- 新增 `design/11-project-and-documents.md`：固化 project/documents 的 IPC、落点与 E2E 口径。
+- 新增 P0 task cards：`P0-014`、`P0-015`；修订 `P0-003/005/013` 与 `task_cards/index.md`（含依赖图）。
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-v1-workbench/spec.md`
+  - `openspec/specs/creonow-v1-workbench/design/04-context-engineering.md`
+  - `openspec/specs/creonow-v1-workbench/design/11-project-and-documents.md`
+  - `openspec/specs/creonow-v1-workbench/task_cards/**`
+- Affected code: None（本次仅补齐规范与任务卡）
+- Breaking change: NO（仅增强规范；不引入运行时 breaking change）
+- User benefit: P0 任务卡可直接施工，入口流/ID/落点/测试口径写死，减少返工与分歧

--- a/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,18 @@
+# Spec Delta: creonow-v1-workbench (ISSUE-11)
+
+本任务为 `openspec/specs/creonow-v1-workbench/` 的规范补齐（gapfill），用于把 P0 施工前置的“入口流/SSOT/测试口径”写死，避免实现阶段脑补与返工。
+
+## Changes
+
+- Add: `CNWB-REQ-005` Project lifecycle（create/list/setCurrent/getCurrent/delete + rootPath）
+- Add: `CNWB-REQ-006` Documents/FileTree minimal loop（create/open/switch/rename/delete + currentDocument）
+- Update: `design/04-context-engineering.md`
+  - `.creonow/` 结构补齐 `.creonow/skills/`
+  - constraints SSOT 写死为 `.creonow/rules/constraints.json`
+- Add: `design/11-project-and-documents.md`（project/documents IPC、落点、E2E 口径）
+- Add: `P0-014` / `P0-015` task cards，并修订 `P0-003/005/013` 与 `task_cards/index.md`
+
+## Acceptance
+
+- 新增/修订内容必须保持内部链接可用，且无悬空引用。
+- `openspec/_ops/task_runs/ISSUE-11.md` 存在并通过 `openspec-log-guard`。

--- a/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/tasks.md
+++ b/rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [ ] 1.1 更新 `spec.md`：新增 `CNWB-REQ-005/006`（project lifecycle、documents/filetree minimal loop）
+- [ ] 1.2 更新 `design/04-context-engineering.md`：补齐 `.creonow/skills/`，并写死 constraints SSOT
+- [ ] 1.3 新增 `design/11-project-and-documents.md`（project/documents IPC、落点、E2E 口径）
+- [ ] 1.4 新增 task cards：`P0-014`、`P0-015`
+- [ ] 1.5 修订 task cards：`P0-003/005/013`（统一测试落点、constraints SSOT 口径）
+- [ ] 1.6 更新 `task_cards/index.md`（补入新卡 + 更新依赖图）
+
+## 2. Testing
+
+- [ ] 2.1 `rulebook task validate issue-11-cn-v1-workbench-openspec-gapfill`
+- [ ] 2.2 `pnpm exec prettier --check` 覆盖本次修改范围（openspec + RUN_LOG + rulebook task）
+
+## 3. Documentation
+
+- [ ] 3.1 更新 `openspec/_ops/task_runs/ISSUE-11.md`（记录关键命令与输出）


### PR DESCRIPTION
Closes #11

## Summary
- Add `CNWB-REQ-005/006` (project lifecycle, documents/filetree minimal loop)
- Add `design/11-project-and-documents.md` and P0 task cards `P0-014/015`
- Align `.creonow/skills` and constraints SSOT; unify E2E path references

## Test plan
- `rulebook task validate issue-11-cn-v1-workbench-openspec-gapfill`
- `pnpm exec prettier --check "openspec/specs/creonow-v1-workbench/**/*.md" "openspec/_ops/task_runs/ISSUE-11.md" "rulebook/tasks/issue-11-cn-v1-workbench-openspec-gapfill/**/*.md"`

## Evidence
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-11.md`