### PR TITLE
[CNWB-P0] P0-014: Project lifecycle + current project (#25)

### DIFF
--- a/apps/desktop/main/src/ipc/contextCreonow.ts
+++ b/apps/desktop/main/src/ipc/contextCreonow.ts
@@ -1,0 +1,140 @@
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import {
+  ensureCreonowDirStructure,
+  getCreonowDirStatus,
+} from "../services/context/creonowDir";
+
+type ProjectRow = {
+  rootPath: string;
+};
+
+/**
+ * Register `context:creonow:*` IPC handlers (minimal subset for P0 entry).
+ *
+ * Why: `.creonow` is the stable, project-relative metadata root required by P0.
+ */
+export function registerCreonowContextIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "context:creonow:ensure",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<IpcResponse<{ rootPath: string; ensured: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      try {
+        const row = deps.db
+          .prepare<
+            [string],
+            ProjectRow
+          >("SELECT root_path as rootPath FROM projects WHERE project_id = ?")
+          .get(payload.projectId);
+        if (!row) {
+          return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Project not found" },
+          };
+        }
+
+        const ensured = ensureCreonowDirStructure(row.rootPath);
+        if (!ensured.ok) {
+          return { ok: false, error: ensured.error };
+        }
+
+        return { ok: true, data: { rootPath: row.rootPath, ensured: true } };
+      } catch (error) {
+        deps.logger.error("creonow_ensure_failed", {
+          code: "IO_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          ok: false,
+          error: { code: "IO_ERROR", message: "Failed to ensure .creonow" },
+        };
+      }
+    },
+  );
+
+  deps.ipcMain.handle(
+    "context:creonow:status",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<
+      IpcResponse<{ exists: boolean; watching: boolean; rootPath?: string }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      try {
+        const row = deps.db
+          .prepare<
+            [string],
+            ProjectRow
+          >("SELECT root_path as rootPath FROM projects WHERE project_id = ?")
+          .get(payload.projectId);
+        if (!row) {
+          return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Project not found" },
+          };
+        }
+
+        const status = getCreonowDirStatus(row.rootPath);
+        if (!status.ok) {
+          return { ok: false, error: status.error };
+        }
+
+        return {
+          ok: true,
+          data: {
+            exists: status.data.exists,
+            watching: false,
+            rootPath: row.rootPath,
+          },
+        };
+      } catch (error) {
+        deps.logger.error("creonow_status_failed", {
+          code: "IO_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          ok: false,
+          error: {
+            code: "IO_ERROR",
+            message: "Failed to read .creonow status",
+          },
+        };
+      }
+    },
+  );
+}

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -32,5 +32,46 @@ export const ipcContract = {
       request: s.object({}),
       response: s.object({ tableNames: s.array(s.string()) }),
     },
+    "project:create": {
+      request: s.object({ name: s.optional(s.string()) }),
+      response: s.object({ projectId: s.string(), rootPath: s.string() }),
+    },
+    "project:list": {
+      request: s.object({ includeDeleted: s.optional(s.boolean()) }),
+      response: s.object({
+        items: s.array(
+          s.object({
+            projectId: s.string(),
+            name: s.string(),
+            rootPath: s.string(),
+            updatedAt: s.number(),
+          }),
+        ),
+      }),
+    },
+    "project:getCurrent": {
+      request: s.object({}),
+      response: s.object({ projectId: s.string(), rootPath: s.string() }),
+    },
+    "project:setCurrent": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ projectId: s.string(), rootPath: s.string() }),
+    },
+    "project:delete": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ deleted: s.literal(true) }),
+    },
+    "context:creonow:ensure": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ rootPath: s.string(), ensured: s.literal(true) }),
+    },
+    "context:creonow:status": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({
+        exists: s.boolean(),
+        watching: s.boolean(),
+        rootPath: s.optional(s.string()),
+      }),
+    },
   },
 } as const;

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -1,0 +1,141 @@
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import { createProjectService } from "../services/projects/projectService";
+
+/**
+ * Register `project:*` IPC handlers.
+ *
+ * Why: project lifecycle is the stable V1 entry point for documents/context.
+ */
+export function registerProjectIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  userDataDir: string;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "project:create",
+    async (
+      _e,
+      payload: { name?: string },
+    ): Promise<IpcResponse<{ projectId: string; rootPath: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.create({ name: payload.name });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:list",
+    async (): Promise<
+      IpcResponse<{
+        items: Array<{
+          projectId: string;
+          name: string;
+          rootPath: string;
+          updatedAt: number;
+        }>;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.list();
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:getCurrent",
+    async (): Promise<IpcResponse<{ projectId: string; rootPath: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.getCurrent();
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:setCurrent",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<IpcResponse<{ projectId: string; rootPath: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.setCurrent({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:delete",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<IpcResponse<{ deleted: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.delete({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+}

--- a/apps/desktop/main/src/services/context/creonowDir.ts
+++ b/apps/desktop/main/src/services/context/creonowDir.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type {
+  IpcError,
+  IpcErrorCode,
+} from "../../../../../../packages/shared/types/ipc-generated";
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type ServiceResult<T> = Ok<T> | Err;
+
+/**
+ * Build a stable IPC error object.
+ *
+ * Why: `.creonow` operations must return deterministic error codes/messages for
+ * E2E and must not leak raw stacks across IPC.
+ */
+function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
+  return { ok: false, error: { code, message, details } };
+}
+
+export type CreonowDirStatus = {
+  exists: boolean;
+  creonowRootPath: string;
+};
+
+/**
+ * Compute the `.creonow` root path for a project root.
+ */
+export function getCreonowRootPath(projectRootPath: string): string {
+  return path.join(projectRootPath, ".creonow");
+}
+
+/**
+ * Ensure the `.creonow/` directory structure exists for a project.
+ *
+ * Why: downstream P0 features require a stable, project-relative metadata
+ * directory even when documents are stored in DB.
+ */
+export function ensureCreonowDirStructure(
+  projectRootPath: string,
+): ServiceResult<true> {
+  try {
+    const base = getCreonowRootPath(projectRootPath);
+    const dirs = [
+      base,
+      path.join(base, "rules"),
+      path.join(base, "settings"),
+      path.join(base, "skills"),
+      path.join(base, "characters"),
+      path.join(base, "conversations"),
+      path.join(base, "cache"),
+    ];
+    for (const d of dirs) {
+      fs.mkdirSync(d, { recursive: true });
+    }
+
+    const defaultFiles: Array<{ p: string; content: string }> = [
+      {
+        p: path.join(base, "rules", "style.md"),
+        content: "# Style\n\n",
+      },
+      {
+        p: path.join(base, "rules", "terminology.json"),
+        content: JSON.stringify({ terms: [] }, null, 2) + "\n",
+      },
+      {
+        p: path.join(base, "rules", "constraints.json"),
+        content: JSON.stringify({ version: 1, items: [] }, null, 2) + "\n",
+      },
+    ];
+    for (const f of defaultFiles) {
+      if (!fs.existsSync(f.p)) {
+        fs.writeFileSync(f.p, f.content, "utf8");
+      }
+    }
+
+    return { ok: true, data: true };
+  } catch (error) {
+    return ipcError(
+      "IO_ERROR",
+      "Failed to initialize .creonow directory",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+/**
+ * Read `.creonow` filesystem status for a project.
+ *
+ * Why: E2E must be able to assert `.creonow` existence deterministically.
+ */
+export function getCreonowDirStatus(
+  projectRootPath: string,
+): ServiceResult<CreonowDirStatus> {
+  const creonowRootPath = getCreonowRootPath(projectRootPath);
+  try {
+    const stat = fs.statSync(creonowRootPath);
+    return { ok: true, data: { exists: stat.isDirectory(), creonowRootPath } };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { ok: true, data: { exists: false, creonowRootPath } };
+    }
+    return ipcError(
+      "IO_ERROR",
+      "Failed to read .creonow status",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}

--- a/apps/desktop/main/src/services/projects/projectService.ts
+++ b/apps/desktop/main/src/services/projects/projectService.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import type Database from "better-sqlite3";
+
+import type {
+  IpcError,
+  IpcErrorCode,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../../logging/logger";
+import { redactUserDataPath } from "../../db/paths";
+import { ensureCreonowDirStructure } from "../context/creonowDir";
+
+export type ProjectInfo = {
+  projectId: string;
+  rootPath: string;
+};
+
+export type ProjectListItem = {
+  projectId: string;
+  name: string;
+  rootPath: string;
+  updatedAt: number;
+};
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type ServiceResult<T> = Ok<T> | Err;
+
+export type ProjectService = {
+  create: (args: { name?: string }) => ServiceResult<ProjectInfo>;
+  list: () => ServiceResult<{ items: ProjectListItem[] }>;
+  getCurrent: () => ServiceResult<ProjectInfo>;
+  setCurrent: (args: { projectId: string }) => ServiceResult<ProjectInfo>;
+  delete: (args: { projectId: string }) => ServiceResult<{ deleted: true }>;
+};
+
+const SETTINGS_SCOPE = "app" as const;
+const CURRENT_PROJECT_ID_KEY = "creonow.project.currentId" as const;
+
+function nowTs(): number {
+  return Date.now();
+}
+
+/**
+ * Build a stable IPC error object.
+ *
+ * Why: services must return deterministic error codes/messages for IPC tests.
+ */
+function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
+  return { ok: false, error: { code, message, details } };
+}
+
+/**
+ * Compute the app-managed project root path.
+ *
+ * Why: V1 prefers a userData-managed root for deterministic Windows E2E and
+ * to avoid permissions issues with arbitrary paths.
+ */
+function getProjectRootPath(userDataDir: string, projectId: string): string {
+  return path.join(userDataDir, "projects", projectId);
+}
+
+/**
+ * Read the current projectId from settings.
+ *
+ * Why: the current project must persist across restarts for a stable local entry.
+ */
+function readCurrentProjectId(db: Database.Database): ServiceResult<string> {
+  try {
+    const row = db
+      .prepare<
+        [string, string],
+        { value_json: string }
+      >("SELECT value_json FROM settings WHERE scope = ? AND key = ?")
+      .get(SETTINGS_SCOPE, CURRENT_PROJECT_ID_KEY);
+    if (!row) {
+      return ipcError("NOT_FOUND", "No current project");
+    }
+    const parsed: unknown = JSON.parse(row.value_json);
+    if (typeof parsed !== "string" || parsed.length === 0) {
+      return ipcError("DB_ERROR", "Invalid current project setting");
+    }
+    return { ok: true, data: parsed };
+  } catch (error) {
+    return ipcError(
+      "DB_ERROR",
+      "Failed to read current project setting",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+function writeCurrentProjectId(
+  db: Database.Database,
+  projectId: string,
+): ServiceResult<true> {
+  try {
+    const ts = nowTs();
+    db.prepare(
+      "INSERT INTO settings (scope, key, value_json, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(scope, key) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at",
+    ).run(
+      SETTINGS_SCOPE,
+      CURRENT_PROJECT_ID_KEY,
+      JSON.stringify(projectId),
+      ts,
+    );
+    return { ok: true, data: true };
+  } catch (error) {
+    return ipcError(
+      "DB_ERROR",
+      "Failed to persist current project",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+function clearCurrentProjectId(db: Database.Database): ServiceResult<true> {
+  try {
+    db.prepare("DELETE FROM settings WHERE scope = ? AND key = ?").run(
+      SETTINGS_SCOPE,
+      CURRENT_PROJECT_ID_KEY,
+    );
+    return { ok: true, data: true };
+  } catch (error) {
+    return ipcError(
+      "DB_ERROR",
+      "Failed to clear current project",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+function getProjectById(
+  db: Database.Database,
+  projectId: string,
+): ServiceResult<ProjectInfo & { name: string; updatedAt: number }> {
+  try {
+    const row = db
+      .prepare<
+        [string],
+        { projectId: string; name: string; rootPath: string; updatedAt: number }
+      >("SELECT project_id as projectId, name, root_path as rootPath, updated_at as updatedAt FROM projects WHERE project_id = ?")
+      .get(projectId);
+    if (!row) {
+      return ipcError("NOT_FOUND", "Project not found", { projectId });
+    }
+    return { ok: true, data: row };
+  } catch (error) {
+    return ipcError(
+      "DB_ERROR",
+      "Failed to load project",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+/**
+ * Create a project service backed by SQLite (SSOT).
+ */
+export function createProjectService(args: {
+  db: Database.Database;
+  userDataDir: string;
+  logger: Logger;
+}): ProjectService {
+  return {
+    create: ({ name }) => {
+      const projectId = randomUUID();
+      const rootPath = getProjectRootPath(args.userDataDir, projectId);
+
+      const ensured = ensureCreonowDirStructure(rootPath);
+      if (!ensured.ok) {
+        return ensured;
+      }
+
+      const ts = nowTs();
+      const safeName = name?.trim().length ? name.trim() : "Untitled";
+
+      try {
+        args.db
+          .prepare(
+            "INSERT INTO projects (project_id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+          )
+          .run(projectId, safeName, rootPath, ts, ts);
+
+        args.logger.info("project_created", {
+          project_id: projectId,
+          root_path: redactUserDataPath(args.userDataDir, rootPath),
+        });
+
+        return { ok: true, data: { projectId, rootPath } };
+      } catch (error) {
+        args.logger.error("project_create_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to create project");
+      }
+    },
+
+    list: () => {
+      try {
+        const rows = args.db
+          .prepare<
+            [],
+            ProjectListItem
+          >("SELECT project_id as projectId, name, root_path as rootPath, updated_at as updatedAt FROM projects ORDER BY updated_at DESC, project_id ASC")
+          .all();
+        return { ok: true, data: { items: rows } };
+      } catch (error) {
+        args.logger.error("project_list_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to list projects");
+      }
+    },
+
+    getCurrent: () => {
+      const currentId = readCurrentProjectId(args.db);
+      if (!currentId.ok) {
+        return currentId;
+      }
+
+      const project = getProjectById(args.db, currentId.data);
+      if (!project.ok) {
+        if (project.error.code === "NOT_FOUND") {
+          void clearCurrentProjectId(args.db);
+        }
+        return project;
+      }
+
+      return {
+        ok: true,
+        data: {
+          projectId: project.data.projectId,
+          rootPath: project.data.rootPath,
+        },
+      };
+    },
+
+    setCurrent: ({ projectId }) => {
+      if (projectId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "projectId is required");
+      }
+
+      const project = getProjectById(args.db, projectId);
+      if (!project.ok) {
+        return project;
+      }
+
+      const persisted = writeCurrentProjectId(args.db, projectId);
+      if (!persisted.ok) {
+        return persisted;
+      }
+
+      try {
+        args.db
+          .prepare("UPDATE projects SET updated_at = ? WHERE project_id = ?")
+          .run(nowTs(), projectId);
+      } catch (error) {
+        args.logger.error("project_touch_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      args.logger.info("project_set_current", { project_id: projectId });
+      return {
+        ok: true,
+        data: {
+          projectId: project.data.projectId,
+          rootPath: project.data.rootPath,
+        },
+      };
+    },
+
+    delete: ({ projectId }) => {
+      if (projectId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "projectId is required");
+      }
+
+      const project = getProjectById(args.db, projectId);
+      if (!project.ok) {
+        return project;
+      }
+
+      try {
+        args.db
+          .prepare("DELETE FROM projects WHERE project_id = ?")
+          .run(projectId);
+      } catch (error) {
+        args.logger.error("project_delete_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to delete project");
+      }
+
+      const currentId = readCurrentProjectId(args.db);
+      if (currentId.ok && currentId.data === projectId) {
+        void clearCurrentProjectId(args.db);
+      }
+
+      args.logger.info("project_deleted", { project_id: projectId });
+      return { ok: true, data: { deleted: true } };
+    },
+  };
+}

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 
 import { AppShell } from "./components/layout/AppShell";
+import { invoke } from "./lib/ipcClient";
 import { createPreferenceStore } from "./lib/preferences";
 import { createLayoutStore, LayoutStoreProvider } from "./stores/layoutStore";
+import {
+  createProjectStore,
+  ProjectStoreProvider,
+} from "./stores/projectStore";
 
 /**
  * App bootstraps renderer stores and mounts the Workbench shell.
@@ -13,9 +18,15 @@ export function App(): JSX.Element {
     return createLayoutStore(preferences);
   }, []);
 
+  const projectStore = React.useMemo(() => {
+    return createProjectStore({ invoke });
+  }, []);
+
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <AppShell />
-    </LayoutStoreProvider>
+    <ProjectStoreProvider store={projectStore}>
+      <LayoutStoreProvider store={layoutStore}>
+        <AppShell />
+      </LayoutStoreProvider>
+    </ProjectStoreProvider>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from "./Sidebar";
 import { StatusBar } from "./StatusBar";
 import { Resizer } from "./Resizer";
 import { CommandPalette } from "../../features/commandPalette/CommandPalette";
+import { WelcomeScreen } from "../../features/welcome/WelcomeScreen";
 
 /**
  * Clamp a value between min/max bounds.
@@ -174,7 +175,7 @@ export function AppShell(): JSX.Element {
               fontSize: 13,
             }}
           >
-            Editor (placeholder)
+            <WelcomeScreen />
           </main>
 
           {!panelCollapsed ? (

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+
+import { useProjectStore } from "../../stores/projectStore";
+
+/**
+ * Minimal create project dialog (P0).
+ *
+ * Why: provides a stable E2E entry point for creating and setting current
+ * project, without relying on native OS dialogs.
+ */
+export function CreateProjectDialog(props: {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}): JSX.Element | null {
+  const createAndSetCurrent = useProjectStore((s) => s.createAndSetCurrent);
+  const clearError = useProjectStore((s) => s.clearError);
+  const lastError = useProjectStore((s) => s.lastError);
+
+  const [name, setName] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!props.open) {
+      setName("");
+      setSubmitting(false);
+      clearError();
+    }
+  }, [clearError, props.open]);
+
+  if (!props.open) {
+    return null;
+  }
+
+  async function onSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    const res = await createAndSetCurrent({ name });
+    setSubmitting(false);
+    if (!res.ok) {
+      return;
+    }
+
+    props.onOpenChange(false);
+  }
+
+  return (
+    <div className="cn-overlay">
+      <div
+        data-testid="create-project-dialog"
+        role="dialog"
+        aria-modal="true"
+        style={{
+          width: 520,
+          borderRadius: "var(--radius-lg)",
+          background: "var(--color-bg-raised)",
+          border: "1px solid var(--color-border-default)",
+          padding: "var(--space-6)",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Create project</div>
+          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+            Creates a local project under your app profile.
+          </div>
+        </div>
+
+        <form onSubmit={onSubmit}>
+          <label
+            style={{
+              display: "block",
+              fontSize: 12,
+              color: "var(--color-fg-muted)",
+              marginBottom: "var(--space-2)",
+            }}
+          >
+            Name (optional)
+          </label>
+          <input
+            data-testid="create-project-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            placeholder="Untitled"
+            style={{
+              width: "100%",
+              height: 36,
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--color-border-default)",
+              background: "var(--color-bg-surface)",
+              color: "var(--color-fg-default)",
+              padding: "0 var(--space-3)",
+              outline: "none",
+              marginBottom: "var(--space-4)",
+            }}
+          />
+
+          {lastError ? (
+            <div
+              style={{
+                marginBottom: "var(--space-4)",
+                fontSize: 12,
+                color: "var(--color-fg-muted)",
+              }}
+            >
+              {lastError.code}: {lastError.message}
+            </div>
+          ) : null}
+
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+            <button
+              type="button"
+              onClick={() => props.onOpenChange(false)}
+              style={{
+                height: 32,
+                padding: "0 var(--space-3)",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--color-border-default)",
+                background: "transparent",
+                color: "var(--color-fg-default)",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              data-testid="create-project-submit"
+              type="submit"
+              disabled={submitting}
+              style={{
+                height: 32,
+                padding: "0 var(--space-3)",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--color-border-default)",
+                background: "var(--color-bg-selected)",
+                color: "var(--color-fg-default)",
+                cursor: submitting ? "not-allowed" : "pointer",
+                opacity: submitting ? 0.7 : 1,
+              }}
+            >
+              {submitting ? "Creating…" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx
+++ b/apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+
+import { CreateProjectDialog } from "../projects/CreateProjectDialog";
+import { useProjectStore } from "../../stores/projectStore";
+
+/**
+ * Welcome entry for a fresh profile.
+ *
+ * Why: provides a stable, testable P0 entry point (no current project yet).
+ */
+export function WelcomeScreen(): JSX.Element {
+  const current = useProjectStore((s) => s.current);
+  const bootstrapStatus = useProjectStore((s) => s.bootstrapStatus);
+  const bootstrap = useProjectStore((s) => s.bootstrap);
+
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (bootstrapStatus === "idle") {
+      void bootstrap();
+    }
+  }, [bootstrap, bootstrapStatus]);
+
+  if (current) {
+    return (
+      <div
+        style={{
+          width: "100%",
+          padding: "var(--space-6)",
+          color: "var(--color-fg-muted)",
+          fontSize: 13,
+        }}
+      >
+        Current project: {current.projectId}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-testid="welcome-screen"
+        style={{
+          width: "100%",
+          maxWidth: 640,
+          padding: "var(--space-6)",
+          borderRadius: "var(--radius-lg)",
+          border: "1px solid var(--color-border-default)",
+          background: "var(--color-bg-surface)",
+        }}
+      >
+        <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>
+          Welcome to CreoNow
+        </div>
+        <div style={{ fontSize: 13, color: "var(--color-fg-muted)" }}>
+          Create a local project to start.
+        </div>
+
+        <div style={{ marginTop: "var(--space-6)", display: "flex", gap: 8 }}>
+          <button
+            data-testid="welcome-create-project"
+            type="button"
+            onClick={() => setDialogOpen(true)}
+            style={{
+              height: 32,
+              padding: "0 var(--space-3)",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--color-border-default)",
+              background: "var(--color-bg-selected)",
+              color: "var(--color-fg-default)",
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Create project
+          </button>
+        </div>
+      </div>
+
+      <CreateProjectDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </>
+  );
+}

--- a/apps/desktop/renderer/src/stores/projectStore.tsx
+++ b/apps/desktop/renderer/src/stores/projectStore.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { create } from "zustand";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcRequest,
+  IpcResponse,
+  IpcResponseData,
+} from "../../../../../packages/shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;
+
+export type ProjectInfo = IpcResponseData<"project:getCurrent">;
+export type ProjectListItem = IpcResponseData<"project:list">["items"][number];
+
+export type ProjectState = {
+  current: ProjectInfo | null;
+  items: ProjectListItem[];
+  bootstrapStatus: "idle" | "loading" | "ready" | "error";
+  lastError: IpcError | null;
+};
+
+export type ProjectActions = {
+  bootstrap: () => Promise<void>;
+  createAndSetCurrent: (args: {
+    name?: string;
+  }) => Promise<IpcResponse<ProjectInfo>>;
+  clearError: () => void;
+};
+
+export type ProjectStore = ProjectState & ProjectActions;
+
+export type UseProjectStore = ReturnType<typeof createProjectStore>;
+
+const ProjectStoreContext = React.createContext<UseProjectStore | null>(null);
+
+/**
+ * Create a zustand store for project lifecycle state.
+ *
+ * Why: the renderer must be able to drive a minimal project entry flow and keep
+ * current project state in sync with IPC (typed invoke) for stable E2E.
+ */
+export function createProjectStore(deps: { invoke: IpcInvoke }) {
+  return create<ProjectStore>((set, get) => ({
+    current: null,
+    items: [],
+    bootstrapStatus: "idle",
+    lastError: null,
+
+    clearError: () => set({ lastError: null }),
+
+    bootstrap: async () => {
+      const state = get();
+      if (state.bootstrapStatus === "loading") {
+        return;
+      }
+
+      set({ bootstrapStatus: "loading", lastError: null });
+
+      const currentRes = await deps.invoke("project:getCurrent", {});
+      const current = currentRes.ok
+        ? currentRes.data
+        : currentRes.error.code === "NOT_FOUND"
+          ? null
+          : null;
+      if (!currentRes.ok && currentRes.error.code !== "NOT_FOUND") {
+        set({ bootstrapStatus: "error", lastError: currentRes.error });
+        return;
+      }
+
+      const listRes = await deps.invoke("project:list", {
+        includeDeleted: false,
+      });
+      if (!listRes.ok) {
+        set({ bootstrapStatus: "error", lastError: listRes.error, current });
+        return;
+      }
+
+      set({
+        bootstrapStatus: "ready",
+        current,
+        items: listRes.data.items,
+        lastError: null,
+      });
+    },
+
+    createAndSetCurrent: async ({ name }) => {
+      const created = await deps.invoke("project:create", { name });
+      if (!created.ok) {
+        set({ lastError: created.error });
+        return created;
+      }
+
+      const setRes = await deps.invoke("project:setCurrent", {
+        projectId: created.data.projectId,
+      });
+      if (!setRes.ok) {
+        set({ lastError: setRes.error });
+        return setRes;
+      }
+
+      set({ current: setRes.data, lastError: null });
+      void get().bootstrap();
+      return setRes;
+    },
+  }));
+}
+
+/**
+ * Provide a project store instance for the Workbench UI.
+ */
+export function ProjectStoreProvider(props: {
+  store: UseProjectStore;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <ProjectStoreContext.Provider value={props.store}>
+      {props.children}
+    </ProjectStoreContext.Provider>
+  );
+}
+
+/**
+ * Read values from the injected project store.
+ */
+export function useProjectStore<T>(selector: (state: ProjectStore) => T): T {
+  const store = React.useContext(ProjectStoreContext);
+  if (!store) {
+    throw new Error("ProjectStoreProvider is missing");
+  }
+  return store(selector);
+}

--- a/apps/desktop/tests/e2e/project-lifecycle.spec.ts
+++ b/apps/desktop/tests/e2e/project-lifecycle.spec.ts
@@ -1,0 +1,201 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+test("project lifecycle: create + ensure .creonow + restart restores current", async () => {
+  const userDataDir = await createIsolatedUserDataDir();
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const appRoot = path.resolve(__dirname, "../..");
+
+  async function launch() {
+    return await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+  }
+
+  const electronApp = await launch();
+  const page = await electronApp.firstWindow();
+  await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+  await expect(page.getByTestId("welcome-screen")).toBeVisible();
+
+  await page.getByTestId("welcome-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.getByTestId("create-project-name").fill("Demo Project");
+  await page.getByTestId("create-project-submit").click();
+
+  await page.waitForFunction(async () => {
+    if (!window.creonow) {
+      return false;
+    }
+    const res = await window.creonow.invoke("project:getCurrent", {});
+    return res.ok === true;
+  });
+
+  const current = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(current.ok).toBe(true);
+  if (!current.ok) {
+    throw new Error(`Expected ok current project, got: ${current.error.code}`);
+  }
+
+  const creonowDir = path.join(current.data.rootPath, ".creonow");
+  const creonowStat = await fs.stat(creonowDir);
+  expect(creonowStat.isDirectory()).toBe(true);
+
+  const projectId = current.data.projectId;
+
+  const status = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("context:creonow:status", {
+      projectId: projectIdParam,
+    });
+  }, projectId);
+  expect(status.ok).toBe(true);
+  if (!status.ok) {
+    throw new Error(`Expected ok .creonow status, got: ${status.error.code}`);
+  }
+  expect(status.data.exists).toBe(true);
+  expect(status.data.watching).toBe(false);
+  expect(status.data.rootPath).toBe(current.data.rootPath);
+
+  const list = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:list", {
+      includeDeleted: false,
+    });
+  });
+  expect(list.ok).toBe(true);
+  if (!list.ok) {
+    throw new Error(`Expected ok project:list, got: ${list.error.code}`);
+  }
+  expect(list.data.items.length).toBe(1);
+  expect(list.data.items[0]?.projectId).toBe(projectId);
+
+  await page.waitForTimeout(15);
+  const created2 = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:create", { name: "Second" });
+  });
+  expect(created2.ok).toBe(true);
+  if (!created2.ok) {
+    throw new Error(`Expected ok project:create, got: ${created2.error.code}`);
+  }
+
+  const list2 = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:list", {
+      includeDeleted: false,
+    });
+  });
+  expect(list2.ok).toBe(true);
+  if (!list2.ok) {
+    throw new Error(`Expected ok project:list, got: ${list2.error.code}`);
+  }
+  expect(list2.data.items.length).toBe(2);
+  for (let i = 0; i < list2.data.items.length - 1; i++) {
+    const a = list2.data.items[i];
+    const b = list2.data.items[i + 1];
+    if (!a || !b) {
+      throw new Error("Unexpected empty list item");
+    }
+    expect(a.updatedAt).toBeGreaterThanOrEqual(b.updatedAt);
+    if (a.updatedAt === b.updatedAt) {
+      expect(a.projectId.localeCompare(b.projectId)).toBeLessThanOrEqual(0);
+    }
+  }
+
+  await electronApp.close();
+
+  const electronApp2 = await launch();
+  const page2 = await electronApp2.firstWindow();
+  await page2.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page2.getByTestId("app-shell")).toBeVisible();
+
+  const current2 = await page2.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(current2.ok).toBe(true);
+  if (!current2.ok) {
+    throw new Error(`Expected ok current project, got: ${current2.error.code}`);
+  }
+  expect(current2.data.projectId).toBe(projectId);
+
+  const deleted = await page2.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:delete", {
+      projectId: projectIdParam,
+    });
+  }, projectId);
+  expect(deleted.ok).toBe(true);
+  if (!deleted.ok) {
+    throw new Error(`Expected ok project:delete, got: ${deleted.error.code}`);
+  }
+
+  const currentAfterDelete = await page2.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(currentAfterDelete.ok).toBe(false);
+  if (currentAfterDelete.ok) {
+    throw new Error("Expected NOT_FOUND current project after delete");
+  }
+  expect(currentAfterDelete.error.code).toBe("NOT_FOUND");
+
+  const setDeleted = await page2.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:setCurrent", {
+      projectId: projectIdParam,
+    });
+  }, projectId);
+  expect(setDeleted.ok).toBe(false);
+  if (setDeleted.ok) {
+    throw new Error("Expected NOT_FOUND setCurrent on deleted project");
+  }
+  expect(setDeleted.error.code).toBe("NOT_FOUND");
+
+  await electronApp2.close();
+});

--- a/openspec/_ops/task_runs/ISSUE-25.md
+++ b/openspec/_ops/task_runs/ISSUE-25.md
@@ -1,0 +1,37 @@
+# ISSUE-25
+
+- Issue: #25
+- Branch: task/25-p0-014-project-lifecycle-current-project
+- PR: <fill-after-created>
+
+## Plan
+
+- 实现 project IPC + ProjectService（create/list/setCurrent/getCurrent/delete）
+- 创建项目时 ensure `<projectRoot>/.creonow/` 目录结构并提供可测 status
+- Renderer 增加 welcome-screen + create-project-dialog，并补齐 Windows E2E
+
+## Runs
+
+### 2026-01-31 15:15 contract + e2e
+
+- Command: `pnpm -s contract:generate`
+- Key output: `(no output)`
+
+- Command: `pnpm -C apps/desktop test:e2e -- project-lifecycle.spec.ts`
+- Key output: `1 passed`
+
+### 2026-01-31 15:20 typecheck + lint
+
+- Command: `pnpm -C apps/desktop typecheck`
+- Key output: `exit 0`
+
+- Command: `pnpm -C apps/desktop lint`
+- Key output: `exit 0`
+
+### 2026-01-31 15:24 preflight formatting
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `PRE-FLIGHT FAILED: prettier --check`
+
+- Command: `pnpm exec prettier --write <files>`
+- Key output: `formatted files`

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -48,7 +48,17 @@ export type IpcErr = {
 
 export type IpcResponse<TData> = IpcOk<TData> | IpcErr;
 
-export const IPC_CHANNELS = ["app:ping", "db:debug:tableNames"] as const;
+export const IPC_CHANNELS = [
+  "app:ping",
+  "context:creonow:ensure",
+  "context:creonow:status",
+  "db:debug:tableNames",
+  "project:create",
+  "project:delete",
+  "project:getCurrent",
+  "project:list",
+  "project:setCurrent",
+] as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[number];
 
@@ -57,10 +67,75 @@ export type IpcChannelSpec = {
     request: Record<string, never>;
     response: Record<string, never>;
   };
+  "context:creonow:ensure": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      ensured: true;
+      rootPath: string;
+    };
+  };
+  "context:creonow:status": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      exists: boolean;
+      rootPath?: string;
+      watching: boolean;
+    };
+  };
   "db:debug:tableNames": {
     request: Record<string, never>;
     response: {
       tableNames: Array<string>;
+    };
+  };
+  "project:create": {
+    request: {
+      name?: string;
+    };
+    response: {
+      projectId: string;
+      rootPath: string;
+    };
+  };
+  "project:delete": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      deleted: true;
+    };
+  };
+  "project:getCurrent": {
+    request: Record<string, never>;
+    response: {
+      projectId: string;
+      rootPath: string;
+    };
+  };
+  "project:list": {
+    request: {
+      includeDeleted?: boolean;
+    };
+    response: {
+      items: Array<{
+        name: string;
+        projectId: string;
+        rootPath: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "project:setCurrent": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      projectId: string;
+      rootPath: string;
     };
   };
 };

--- a/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/.metadata.json
+++ b/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T06:37:35.328Z",
+  "updatedAt": "2026-01-31T06:37:35.328Z"
+}

--- a/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/proposal.md
+++ b/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: issue-25-p0-014-project-lifecycle-current-project
+
+## Why
+
+为 CN V1 Workbench 提供可重复的本地入口：project 生命周期（create/list/setCurrent/getCurrent/delete）+ current project 持久化恢复，并在创建 project 时确保 `<projectRoot>/.creonow/` 目录结构存在。该能力是后续 documents/filetree、context watch 与 Windows E2E 的共同依赖（`CNWB-REQ-005`）。
+
+## What Changes
+
+- Add: main `project:*` IPC channels + ProjectService（SQLite SSOT）。
+- Add: `.creonow` 目录 ensure/status（最小可测实现，供 E2E 断言）。
+- Add: renderer 最小入口 UI（welcome-screen + create-project-dialog），并通过 typed invoke 驱动 project 创建与 current project 恢复。
+- Add: Windows Playwright Electron E2E：project lifecycle + restart 恢复。
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md`
+  - `openspec/specs/creonow-v1-workbench/design/11-project-and-documents.md`
+  - `openspec/specs/creonow-v1-workbench/design/04-context-engineering.md`
+- Affected code:
+  - `apps/desktop/main/src/ipc/**`
+  - `apps/desktop/main/src/services/**`
+  - `apps/desktop/renderer/src/**`
+  - `apps/desktop/tests/e2e/project-lifecycle.spec.ts`
+- Breaking change: NO
+- User benefit: 用户可创建/切换/恢复当前 project；`.creonow` 元数据目录具备可验收落点；Windows E2E 入口稳定可重复。

--- a/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,14 @@
+# Spec Delta: creonow-v1-workbench (ISSUE-25)
+
+本任务实现 `P0-014`（Project lifecycle + current project），为 CN V1 Workbench 提供稳定的本地入口与可重复 E2E 基座。
+
+## Changes
+
+- Add: `project:*` IPC（create/list/setCurrent/getCurrent/delete）与 SQLite SSOT。
+- Add: `.creonow` 最小 ensure/status（创建目录结构，提供可测存在性）。
+- Add: renderer 最小入口（welcome-screen + create-project-dialog）。
+- Add: Windows Playwright Electron E2E：project create + ensure + restart restore。
+
+## Acceptance
+
+- 满足 `P0-014` task card 的 Acceptance Criteria 与 E2E 门禁。

--- a/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/tasks.md
+++ b/rulebook/tasks/issue-25-p0-014-project-lifecycle-current-project/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+- [x] 1.1 扩展 IPC contract + codegen（`project:*` + `context:creonow:*` 最小集）
+- [x] 1.2 实现 ProjectService（SQLite：create/list/delete + current project setting）
+- [x] 1.3 实现 `.creonow` ensure/status（FS 创建 + 可测存在性）
+- [x] 1.4 main 注册 IPC handlers（显式注入 db/logger/userData）
+- [x] 1.5 renderer：welcome-screen + create-project-dialog + projectStore
+- [x] 1.6 E2E：`project-lifecycle.spec.ts`（create + ensure + restart restore）
+
+## 2. Testing
+
+- [x] 2.1 本地：`pnpm -C apps/desktop test:e2e`（含 `project-lifecycle.spec.ts`）
+- [ ] 2.2 本地：`scripts/agent_pr_preflight.sh`
+
+## 3. Documentation
+
+- [x] 3.1 新增 `openspec/_ops/task_runs/ISSUE-25.md` 并持续追加 Runs（只追加不回写）
+- [x] 3.2 补齐 spec delta 并保持 `rulebook task validate` 通过


### PR DESCRIPTION
Closes #25

Implements project lifecycle IPC + SQLite SSOT (create/list/getCurrent/setCurrent/delete), ensures per-project .creonow/ metadata root, and adds a minimal renderer welcome/create-project entry.

Test plan:
- pnpm -C apps/desktop test:e2e -- project-lifecycle.spec.ts
- scripts/agent_pr_preflight.sh
