### PR TITLE
[CNWB-P0] P0-005: Editor SSOT + autosave + versioning (#27)

### DIFF
--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -10,6 +10,7 @@ import type { Logger } from "../logging/logger";
 import { getDbPaths, redactUserDataPath } from "./paths";
 
 import initSql from "./migrations/0001_init.sql?raw";
+import documentsSql from "./migrations/0002_documents_versioning.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -32,6 +33,7 @@ type Migration = {
 
 const MIGRATIONS: readonly Migration[] = [
   { version: 1, name: "0001_init", sql: initSql },
+  { version: 2, name: "0002_documents_versioning", sql: documentsSql },
 ];
 
 /**

--- a/apps/desktop/main/src/db/migrations/0002_documents_versioning.sql
+++ b/apps/desktop/main/src/db/migrations/0002_documents_versioning.sql
@@ -1,0 +1,23 @@
+-- Adds document/version fields required by P0-005.
+
+ALTER TABLE documents
+  ADD COLUMN content_hash TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE document_versions
+  ADD COLUMN reason TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE document_versions
+  ADD COLUMN content_hash TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE document_versions
+  ADD COLUMN diff_format TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE document_versions
+  ADD COLUMN diff_text TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_documents_project_updated
+  ON documents (project_id, updated_at DESC, document_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_document_versions_document_created
+  ON document_versions (document_id, created_at DESC, version_id ASC);
+

--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -7,7 +7,9 @@ import { BrowserWindow, app, ipcMain } from "electron";
 import type { IpcResponse } from "../../../../packages/shared/types/ipc-generated";
 import { initDb, type DbInitOk } from "./db/init";
 import { registerCreonowContextIpcHandlers } from "./ipc/contextCreonow";
+import { registerFileIpcHandlers } from "./ipc/file";
 import { registerProjectIpcHandlers } from "./ipc/project";
+import { registerVersionIpcHandlers } from "./ipc/version";
 import { createMainLogger, type Logger } from "./logging/logger";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -138,6 +140,18 @@ function registerIpcHandlers(deps: {
   });
 
   registerCreonowContextIpcHandlers({
+    ipcMain,
+    db: deps.db,
+    logger: deps.logger,
+  });
+
+  registerFileIpcHandlers({
+    ipcMain,
+    db: deps.db,
+    logger: deps.logger,
+  });
+
+  registerVersionIpcHandlers({
     ipcMain,
     db: deps.db,
     logger: deps.logger,

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -73,5 +73,73 @@ export const ipcContract = {
         rootPath: s.optional(s.string()),
       }),
     },
+    "file:document:create": {
+      request: s.object({
+        projectId: s.string(),
+        title: s.optional(s.string()),
+      }),
+      response: s.object({ documentId: s.string() }),
+    },
+    "file:document:list": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({
+        items: s.array(
+          s.object({
+            documentId: s.string(),
+            title: s.string(),
+            updatedAt: s.number(),
+          }),
+        ),
+      }),
+    },
+    "file:document:read": {
+      request: s.object({ projectId: s.string(), documentId: s.string() }),
+      response: s.object({
+        documentId: s.string(),
+        projectId: s.string(),
+        title: s.string(),
+        contentJson: s.string(),
+        contentText: s.string(),
+        contentMd: s.string(),
+        contentHash: s.string(),
+        updatedAt: s.number(),
+      }),
+    },
+    "file:document:write": {
+      request: s.object({
+        projectId: s.string(),
+        documentId: s.string(),
+        contentJson: s.string(),
+        actor: s.union(s.literal("user"), s.literal("auto")),
+        reason: s.union(s.literal("manual-save"), s.literal("autosave")),
+      }),
+      response: s.object({ updatedAt: s.number(), contentHash: s.string() }),
+    },
+    "file:document:delete": {
+      request: s.object({ projectId: s.string(), documentId: s.string() }),
+      response: s.object({ deleted: s.literal(true) }),
+    },
+    "version:list": {
+      request: s.object({ documentId: s.string() }),
+      response: s.object({
+        items: s.array(
+          s.object({
+            versionId: s.string(),
+            actor: s.union(
+              s.literal("user"),
+              s.literal("auto"),
+              s.literal("ai"),
+            ),
+            reason: s.string(),
+            contentHash: s.string(),
+            createdAt: s.number(),
+          }),
+        ),
+      }),
+    },
+    "version:restore": {
+      request: s.object({ documentId: s.string(), versionId: s.string() }),
+      response: s.object({ restored: s.literal(true) }),
+    },
   },
 } as const;

--- a/apps/desktop/main/src/ipc/file.ts
+++ b/apps/desktop/main/src/ipc/file.ts
@@ -1,0 +1,223 @@
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import { createDocumentService } from "../services/documents/documentService";
+
+type Actor = "user" | "auto";
+type SaveReason = "manual-save" | "autosave";
+
+/**
+ * Register `file:document:*` IPC handlers.
+ *
+ * Why: documents are DB SSOT in V1; renderer must persist TipTap JSON and read it
+ * back across restarts without leaking DB details across IPC.
+ */
+export function registerFileIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "file:document:create",
+    async (
+      _e,
+      payload: { projectId: string; title?: string },
+    ): Promise<IpcResponse<{ documentId: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.create({
+        projectId: payload.projectId,
+        title: payload.title,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:list",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<
+      IpcResponse<{
+        items: Array<{ documentId: string; title: string; updatedAt: number }>;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.list({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:read",
+    async (
+      _e,
+      payload: { projectId: string; documentId: string },
+    ): Promise<
+      IpcResponse<{
+        documentId: string;
+        projectId: string;
+        title: string;
+        contentJson: string;
+        contentText: string;
+        contentMd: string;
+        contentHash: string;
+        updatedAt: number;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.projectId.trim().length === 0 ||
+        payload.documentId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId/documentId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.read({
+        projectId: payload.projectId,
+        documentId: payload.documentId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:write",
+    async (
+      _e,
+      payload: {
+        projectId: string;
+        documentId: string;
+        contentJson: string;
+        actor: Actor;
+        reason: SaveReason;
+      },
+    ): Promise<IpcResponse<{ updatedAt: number; contentHash: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.projectId.trim().length === 0 ||
+        payload.documentId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId/documentId is required",
+          },
+        };
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(payload.contentJson);
+      } catch {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "contentJson must be valid JSON",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.write({
+        projectId: payload.projectId,
+        documentId: payload.documentId,
+        contentJson: parsed,
+        actor: payload.actor,
+        reason: payload.reason,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:delete",
+    async (
+      _e,
+      payload: { projectId: string; documentId: string },
+    ): Promise<IpcResponse<{ deleted: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.projectId.trim().length === 0 ||
+        payload.documentId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId/documentId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.delete({
+        projectId: payload.projectId,
+        documentId: payload.documentId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+}

--- a/apps/desktop/main/src/ipc/version.ts
+++ b/apps/desktop/main/src/ipc/version.ts
@@ -1,0 +1,93 @@
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import { createDocumentService } from "../services/documents/documentService";
+
+/**
+ * Register `version:*` IPC handlers (minimal subset for P0).
+ *
+ * Why: autosave evidence and restores must be observable and testable via IPC.
+ */
+export function registerVersionIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "version:list",
+    async (
+      _e,
+      payload: { documentId: string },
+    ): Promise<
+      IpcResponse<{
+        items: Array<{
+          versionId: string;
+          actor: "user" | "auto" | "ai";
+          reason: string;
+          contentHash: string;
+          createdAt: number;
+        }>;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.documentId.trim().length === 0) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "documentId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.listVersions({ documentId: payload.documentId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "version:restore",
+    async (
+      _e,
+      payload: { documentId: string; versionId: string },
+    ): Promise<IpcResponse<{ restored: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.documentId.trim().length === 0 ||
+        payload.versionId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "documentId/versionId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.restoreVersion({
+        documentId: payload.documentId,
+        versionId: payload.versionId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+}

--- a/apps/desktop/main/src/services/documents/derive.ts
+++ b/apps/desktop/main/src/services/documents/derive.ts
@@ -1,0 +1,87 @@
+import type { IpcError } from "../../../../../../packages/shared/types/ipc-generated";
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type DeriveResult<T> = Ok<T> | Err;
+
+export type DerivedContent = {
+  contentText: string;
+  contentMd: string;
+};
+
+type ProseMirrorNode = {
+  type: string;
+  text?: string;
+  content?: ProseMirrorNode[];
+};
+
+function ipcError(message: string, details?: unknown): Err {
+  return { ok: false, error: { code: "INVALID_ARGUMENT", message, details } };
+}
+
+function normalizeNewlines(s: string): string {
+  return s.replaceAll("\r\n", "\n");
+}
+
+function isProseMirrorNode(value: unknown): value is ProseMirrorNode {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof (value as { type?: unknown }).type === "string"
+  );
+}
+
+function isBlockNode(type: string): boolean {
+  return (
+    type === "paragraph" ||
+    type === "heading" ||
+    type === "blockquote" ||
+    type === "list_item"
+  );
+}
+
+function walkText(node: ProseMirrorNode, out: string[]): void {
+  if (node.type === "text") {
+    out.push(normalizeNewlines(node.text ?? ""));
+    return;
+  }
+
+  const children = node.content ?? [];
+  for (const child of children) {
+    if (!isProseMirrorNode(child)) {
+      continue;
+    }
+    walkText(child, out);
+  }
+
+  if (isBlockNode(node.type)) {
+    out.push("\n");
+  }
+}
+
+/**
+ * Derive `content_text` and `content_md` from a TipTap/ProseMirror JSON document.
+ *
+ * Why: V1 SSOT is `content_json`; derived fields must be deterministic and must
+ * never become a second truth source.
+ */
+export function deriveContent(args: {
+  contentJson: unknown;
+}): DeriveResult<DerivedContent> {
+  if (!isProseMirrorNode(args.contentJson)) {
+    return ipcError("Invalid TipTap JSON document");
+  }
+
+  const out: string[] = [];
+  walkText(args.contentJson, out);
+  const text = out.join("").replace(/\n+$/u, "");
+
+  return {
+    ok: true,
+    data: {
+      contentText: text,
+      contentMd: text,
+    },
+  };
+}

--- a/apps/desktop/main/src/services/documents/documentService.ts
+++ b/apps/desktop/main/src/services/documents/documentService.ts
@@ -1,0 +1,455 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type Database from "better-sqlite3";
+
+import type {
+  IpcError,
+  IpcErrorCode,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../../logging/logger";
+import { deriveContent } from "./derive";
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type ServiceResult<T> = Ok<T> | Err;
+
+export type DocumentListItem = {
+  documentId: string;
+  title: string;
+  updatedAt: number;
+};
+
+export type DocumentRead = {
+  documentId: string;
+  projectId: string;
+  title: string;
+  contentJson: string;
+  contentText: string;
+  contentMd: string;
+  contentHash: string;
+  updatedAt: number;
+};
+
+export type VersionListItem = {
+  versionId: string;
+  actor: "user" | "auto" | "ai";
+  reason: string;
+  contentHash: string;
+  createdAt: number;
+};
+
+export type DocumentService = {
+  create: (args: { projectId: string; title?: string }) => ServiceResult<{
+    documentId: string;
+  }>;
+  list: (args: { projectId: string }) => ServiceResult<{
+    items: DocumentListItem[];
+  }>;
+  read: (args: {
+    projectId: string;
+    documentId: string;
+  }) => ServiceResult<DocumentRead>;
+  write: (args: {
+    projectId: string;
+    documentId: string;
+    contentJson: unknown;
+    actor: "user" | "auto";
+    reason: "manual-save" | "autosave";
+  }) => ServiceResult<{
+    updatedAt: number;
+    contentHash: string;
+  }>;
+  delete: (args: {
+    projectId: string;
+    documentId: string;
+  }) => ServiceResult<{ deleted: true }>;
+
+  listVersions: (args: { documentId: string }) => ServiceResult<{
+    items: VersionListItem[];
+  }>;
+  restoreVersion: (args: {
+    documentId: string;
+    versionId: string;
+  }) => ServiceResult<{ restored: true }>;
+};
+
+const EMPTY_DOC = {
+  type: "doc",
+  content: [{ type: "paragraph" }],
+} as const;
+
+function nowTs(): number {
+  return Date.now();
+}
+
+/**
+ * Build a stable IPC error object.
+ *
+ * Why: services must return deterministic error codes/messages for IPC tests.
+ */
+function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
+  return { ok: false, error: { code, message, details } };
+}
+
+function hashJson(json: string): string {
+  return createHash("sha256").update(json, "utf8").digest("hex");
+}
+
+function serializeJson(value: unknown): ServiceResult<string> {
+  try {
+    return { ok: true, data: JSON.stringify(value) };
+  } catch (error) {
+    return ipcError(
+      "ENCODING_FAILED",
+      "Failed to encode document JSON",
+      error instanceof Error ? { message: error.message } : { error },
+    );
+  }
+}
+
+type DocumentRow = {
+  documentId: string;
+  projectId: string;
+  title: string;
+  contentJson: string;
+  contentText: string;
+  contentMd: string;
+  contentHash: string;
+  updatedAt: number;
+};
+
+type VersionRow = {
+  contentHash: string;
+};
+
+type VersionRestoreRow = {
+  projectId: string;
+  documentId: string;
+  contentJson: string;
+  contentText: string;
+  contentMd: string;
+  contentHash: string;
+};
+
+/**
+ * Create a document service backed by SQLite (SSOT).
+ */
+export function createDocumentService(args: {
+  db: Database.Database;
+  logger: Logger;
+}): DocumentService {
+  return {
+    create: ({ projectId, title }) => {
+      const safeTitle = title?.trim().length ? title.trim() : "Untitled";
+
+      const derived = deriveContent({ contentJson: EMPTY_DOC });
+      if (!derived.ok) {
+        return derived;
+      }
+      const encoded = serializeJson(EMPTY_DOC);
+      if (!encoded.ok) {
+        return encoded;
+      }
+      const contentHash = hashJson(encoded.data);
+
+      const documentId = randomUUID();
+      const ts = nowTs();
+
+      try {
+        args.db
+          .prepare(
+            "INSERT INTO documents (document_id, project_id, title, content_json, content_text, content_md, content_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            documentId,
+            projectId,
+            safeTitle,
+            encoded.data,
+            derived.data.contentText,
+            derived.data.contentMd,
+            contentHash,
+            ts,
+            ts,
+          );
+
+        args.logger.info("document_created", {
+          project_id: projectId,
+          document_id: documentId,
+        });
+
+        return { ok: true, data: { documentId } };
+      } catch (error) {
+        args.logger.error("document_create_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to create document");
+      }
+    },
+
+    list: ({ projectId }) => {
+      try {
+        const rows = args.db
+          .prepare<
+            [string],
+            DocumentListItem
+          >("SELECT document_id as documentId, title, updated_at as updatedAt FROM documents WHERE project_id = ? ORDER BY updated_at DESC, document_id ASC")
+          .all(projectId);
+        return { ok: true, data: { items: rows } };
+      } catch (error) {
+        args.logger.error("document_list_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to list documents");
+      }
+    },
+
+    read: ({ projectId, documentId }) => {
+      try {
+        const row = args.db
+          .prepare<
+            [string, string],
+            DocumentRow
+          >("SELECT document_id as documentId, project_id as projectId, title, content_json as contentJson, content_text as contentText, content_md as contentMd, content_hash as contentHash, updated_at as updatedAt FROM documents WHERE project_id = ? AND document_id = ?")
+          .get(projectId, documentId);
+        if (!row) {
+          return ipcError("NOT_FOUND", "Document not found");
+        }
+
+        return { ok: true, data: row };
+      } catch (error) {
+        args.logger.error("document_read_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to read document");
+      }
+    },
+
+    write: ({ projectId, documentId, contentJson, actor, reason }) => {
+      const derived = deriveContent({ contentJson });
+      if (!derived.ok) {
+        return derived;
+      }
+
+      const encoded = serializeJson(contentJson);
+      if (!encoded.ok) {
+        return encoded;
+      }
+      const contentHash = hashJson(encoded.data);
+      const ts = nowTs();
+
+      args.logger.info("doc_save_started", { document_id: documentId });
+
+      try {
+        args.db.transaction(() => {
+          const exists = args.db
+            .prepare<
+              [string, string],
+              { documentId: string }
+            >("SELECT document_id as documentId FROM documents WHERE project_id = ? AND document_id = ?")
+            .get(projectId, documentId);
+          if (!exists) {
+            throw new Error("NOT_FOUND");
+          }
+
+          args.db
+            .prepare(
+              "UPDATE documents SET content_json = ?, content_text = ?, content_md = ?, content_hash = ?, updated_at = ? WHERE project_id = ? AND document_id = ?",
+            )
+            .run(
+              encoded.data,
+              derived.data.contentText,
+              derived.data.contentMd,
+              contentHash,
+              ts,
+              projectId,
+              documentId,
+            );
+
+          const last = args.db
+            .prepare<
+              [string],
+              VersionRow
+            >("SELECT content_hash as contentHash FROM document_versions WHERE document_id = ? ORDER BY created_at DESC, version_id ASC LIMIT 1")
+            .get(documentId);
+          const lastHash = last?.contentHash ?? null;
+          const shouldInsertVersion =
+            actor === "user" ? true : lastHash !== contentHash;
+
+          if (shouldInsertVersion) {
+            const versionId = randomUUID();
+            args.db
+              .prepare(
+                "INSERT INTO document_versions (version_id, project_id, document_id, actor, reason, content_json, content_text, content_md, content_hash, diff_format, diff_text, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              )
+              .run(
+                versionId,
+                projectId,
+                documentId,
+                actor,
+                reason,
+                encoded.data,
+                derived.data.contentText,
+                derived.data.contentMd,
+                contentHash,
+                "",
+                "",
+                ts,
+              );
+
+            args.logger.info("version_created", {
+              version_id: versionId,
+              actor,
+              reason,
+              document_id: documentId,
+              content_hash: contentHash,
+            });
+          }
+        })();
+      } catch (error) {
+        const code =
+          error instanceof Error && error.message === "NOT_FOUND"
+            ? ("NOT_FOUND" as const)
+            : ("DB_ERROR" as const);
+        args.logger.error("doc_save_failed", {
+          code,
+          message: error instanceof Error ? error.message : String(error),
+          document_id: documentId,
+        });
+        return ipcError(
+          code,
+          code === "NOT_FOUND"
+            ? "Document not found"
+            : "Failed to save document",
+        );
+      }
+
+      args.logger.info("doc_save_succeeded", {
+        document_id: documentId,
+        content_hash: contentHash,
+      });
+      return { ok: true, data: { updatedAt: ts, contentHash } };
+    },
+
+    delete: ({ projectId, documentId }) => {
+      try {
+        const res = args.db
+          .prepare<
+            [string, string]
+          >("DELETE FROM documents WHERE project_id = ? AND document_id = ?")
+          .run(projectId, documentId);
+        if (res.changes === 0) {
+          return ipcError("NOT_FOUND", "Document not found");
+        }
+
+        args.logger.info("document_deleted", { document_id: documentId });
+        return { ok: true, data: { deleted: true } };
+      } catch (error) {
+        args.logger.error("document_delete_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to delete document");
+      }
+    },
+
+    listVersions: ({ documentId }) => {
+      try {
+        const rows = args.db
+          .prepare<
+            [string],
+            VersionListItem
+          >("SELECT version_id as versionId, actor, reason, content_hash as contentHash, created_at as createdAt FROM document_versions WHERE document_id = ? ORDER BY created_at DESC, version_id ASC")
+          .all(documentId);
+        return { ok: true, data: { items: rows } };
+      } catch (error) {
+        args.logger.error("version_list_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to list versions");
+      }
+    },
+
+    restoreVersion: ({ documentId, versionId }) => {
+      const ts = nowTs();
+
+      try {
+        args.db.transaction(() => {
+          const row = args.db
+            .prepare<
+              [string, string],
+              VersionRestoreRow
+            >("SELECT project_id as projectId, document_id as documentId, content_json as contentJson, content_text as contentText, content_md as contentMd, content_hash as contentHash FROM document_versions WHERE document_id = ? AND version_id = ?")
+            .get(documentId, versionId);
+          if (!row) {
+            throw new Error("NOT_FOUND");
+          }
+
+          const updated = args.db
+            .prepare<
+              [string, string, string, string, number, string]
+            >("UPDATE documents SET content_json = ?, content_text = ?, content_md = ?, content_hash = ?, updated_at = ? WHERE document_id = ?")
+            .run(
+              row.contentJson,
+              row.contentText,
+              row.contentMd,
+              row.contentHash,
+              ts,
+              row.documentId,
+            );
+          if (updated.changes === 0) {
+            throw new Error("NOT_FOUND");
+          }
+
+          const newVersionId = randomUUID();
+          args.db
+            .prepare(
+              "INSERT INTO document_versions (version_id, project_id, document_id, actor, reason, content_json, content_text, content_md, content_hash, diff_format, diff_text, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .run(
+              newVersionId,
+              row.projectId,
+              row.documentId,
+              "user",
+              "restore",
+              row.contentJson,
+              row.contentText,
+              row.contentMd,
+              row.contentHash,
+              "",
+              "",
+              ts,
+            );
+
+          args.logger.info("version_restored", {
+            document_id: row.documentId,
+            from_version_id: versionId,
+            new_version_id: newVersionId,
+          });
+        })();
+
+        return { ok: true, data: { restored: true } };
+      } catch (error) {
+        const code =
+          error instanceof Error && error.message === "NOT_FOUND"
+            ? ("NOT_FOUND" as const)
+            : ("DB_ERROR" as const);
+        args.logger.error("version_restore_failed", {
+          code,
+          message: error instanceof Error ? error.message : String(error),
+          document_id: documentId,
+          version_id: versionId,
+        });
+        return ipcError(
+          code,
+          code === "NOT_FOUND"
+            ? "Version not found"
+            : "Failed to restore version",
+        );
+      }
+    },
+  };
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,8 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
+    "@tiptap/react": "^2.26.0",
+    "@tiptap/starter-kit": "^2.26.0",
     "better-sqlite3": "^12.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { AppShell } from "./components/layout/AppShell";
 import { invoke } from "./lib/ipcClient";
 import { createPreferenceStore } from "./lib/preferences";
+import { createEditorStore, EditorStoreProvider } from "./stores/editorStore";
 import { createLayoutStore, LayoutStoreProvider } from "./stores/layoutStore";
 import {
   createProjectStore,
@@ -22,11 +23,17 @@ export function App(): JSX.Element {
     return createProjectStore({ invoke });
   }, []);
 
+  const editorStore = React.useMemo(() => {
+    return createEditorStore({ invoke });
+  }, []);
+
   return (
     <ProjectStoreProvider store={projectStore}>
-      <LayoutStoreProvider store={layoutStore}>
-        <AppShell />
-      </LayoutStoreProvider>
+      <EditorStoreProvider store={editorStore}>
+        <LayoutStoreProvider store={layoutStore}>
+          <AppShell />
+        </LayoutStoreProvider>
+      </EditorStoreProvider>
     </ProjectStoreProvider>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -7,7 +7,9 @@ import { Sidebar } from "./Sidebar";
 import { StatusBar } from "./StatusBar";
 import { Resizer } from "./Resizer";
 import { CommandPalette } from "../../features/commandPalette/CommandPalette";
+import { EditorPane } from "../../features/editor/EditorPane";
 import { WelcomeScreen } from "../../features/welcome/WelcomeScreen";
+import { useProjectStore } from "../../stores/projectStore";
 
 /**
  * Clamp a value between min/max bounds.
@@ -63,6 +65,7 @@ function computePanelMax(
  * + RightPanel) and wires resizing, persistence, and P0 keyboard shortcuts.
  */
 export function AppShell(): JSX.Element {
+  const currentProject = useProjectStore((s) => s.current);
   const sidebarWidth = useLayoutStore((s) => s.sidebarWidth);
   const panelWidth = useLayoutStore((s) => s.panelWidth);
   const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed);
@@ -169,13 +172,17 @@ export function AppShell(): JSX.Element {
               minWidth: LAYOUT_DEFAULTS.mainMinWidth,
               background: "var(--color-bg-base)",
               display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
+              alignItems: currentProject ? "stretch" : "center",
+              justifyContent: currentProject ? "stretch" : "center",
               color: "var(--color-fg-muted)",
               fontSize: 13,
             }}
           >
-            <WelcomeScreen />
+            {currentProject ? (
+              <EditorPane projectId={currentProject.projectId} />
+            ) : (
+              <WelcomeScreen />
+            )}
           </main>
 
           {!panelCollapsed ? (

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -1,10 +1,13 @@
 import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
+import { useEditorStore } from "../../stores/editorStore";
 
 /**
  * StatusBar is the fixed 28px bottom bar. P0 keeps it minimal but stable for
  * layout E2E selectors.
  */
 export function StatusBar(): JSX.Element {
+  const autosaveStatus = useEditorStore((s) => s.autosaveStatus);
+  const retryLastAutosave = useEditorStore((s) => s.retryLastAutosave);
   return (
     <div
       data-testid="layout-statusbar"
@@ -19,7 +22,21 @@ export function StatusBar(): JSX.Element {
         color: "var(--color-fg-muted)",
       }}
     >
-      Status: ready
+      <span
+        data-testid="editor-autosave-status"
+        data-status={autosaveStatus}
+        onClick={() => {
+          if (autosaveStatus === "error") {
+            void retryLastAutosave();
+          }
+        }}
+        style={{
+          cursor: autosaveStatus === "error" ? "pointer" : "default",
+          textDecoration: autosaveStatus === "error" ? "underline" : "none",
+        }}
+      >
+        {autosaveStatus}
+      </span>
     </div>
   );
 }

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+import { useEditorStore } from "../../stores/editorStore";
+import { useAutosave } from "./useAutosave";
+
+/**
+ * EditorPane mounts TipTap editor and wires autosave to the DB SSOT.
+ */
+export function EditorPane(props: { projectId: string }): JSX.Element {
+  const bootstrapForProject = useEditorStore((s) => s.bootstrapForProject);
+  const bootstrapStatus = useEditorStore((s) => s.bootstrapStatus);
+  const documentId = useEditorStore((s) => s.documentId);
+  const documentContentJson = useEditorStore((s) => s.documentContentJson);
+  const save = useEditorStore((s) => s.save);
+
+  const suppressAutosaveRef = React.useRef<boolean>(false);
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    autofocus: true,
+    editorProps: {
+      attributes: {
+        "data-testid": "tiptap-editor",
+        style:
+          "height:100%; outline:none; padding: 16px; color: var(--color-fg-default);",
+      },
+    },
+    content: { type: "doc", content: [{ type: "paragraph" }] },
+  });
+
+  React.useEffect(() => {
+    void bootstrapForProject(props.projectId);
+  }, [bootstrapForProject, props.projectId]);
+
+  React.useEffect(() => {
+    if (!editor || !documentContentJson) {
+      return;
+    }
+
+    try {
+      suppressAutosaveRef.current = true;
+      editor.commands.setContent(JSON.parse(documentContentJson));
+    } finally {
+      window.setTimeout(() => {
+        suppressAutosaveRef.current = false;
+      }, 0);
+    }
+  }, [documentContentJson, editor]);
+
+  useAutosave({
+    enabled: bootstrapStatus === "ready" && !!documentId,
+    projectId: props.projectId,
+    documentId: documentId ?? "",
+    editor,
+    suppressRef: suppressAutosaveRef,
+  });
+
+  React.useEffect(() => {
+    if (!editor || bootstrapStatus !== "ready" || !documentId) {
+      return;
+    }
+
+    const currentEditor = editor;
+    const currentDocumentId = documentId;
+
+    function onKeyDown(e: KeyboardEvent): void {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) {
+        return;
+      }
+
+      if (e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        const json = JSON.stringify(currentEditor.getJSON());
+        void save({
+          projectId: props.projectId,
+          documentId: currentDocumentId,
+          contentJson: json,
+          actor: "user",
+          reason: "manual-save",
+        });
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [bootstrapStatus, documentId, editor, props.projectId, save]);
+
+  if (bootstrapStatus !== "ready") {
+    return (
+      <div
+        style={{ padding: 16, color: "var(--color-fg-muted)", fontSize: 13 }}
+      >
+        Loading editor…
+      </div>
+    );
+  }
+
+  if (!documentId) {
+    return (
+      <div
+        style={{ padding: 16, color: "var(--color-fg-muted)", fontSize: 13 }}
+      >
+        No document selected.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ width: "100%", height: "100%", minWidth: 0 }}>
+      <EditorContent editor={editor} />
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/editor/useAutosave.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosave.ts
@@ -1,0 +1,74 @@
+import React from "react";
+import type { Editor } from "@tiptap/react";
+
+import { useEditorStore } from "../../stores/editorStore";
+
+/**
+ * Autosave hook for TipTap editor updates.
+ *
+ * Why: P0 requires a deterministic autosave state machine and retryability, and
+ * autosave must create `actor=auto` versions without spamming writes.
+ */
+export function useAutosave(args: {
+  enabled: boolean;
+  projectId: string;
+  documentId: string;
+  editor: Editor | null;
+  suppressRef: React.MutableRefObject<boolean>;
+}): void {
+  const save = useEditorStore((s) => s.save);
+  const setAutosaveStatus = useEditorStore((s) => s.setAutosaveStatus);
+
+  const timerRef = React.useRef<number | null>(null);
+  const lastQueuedJsonRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!args.enabled || !args.editor) {
+      return;
+    }
+
+    function onUpdate(): void {
+      if (args.suppressRef.current) {
+        return;
+      }
+
+      const json = args.editor ? JSON.stringify(args.editor.getJSON()) : "";
+      if (json.length === 0 || json === lastQueuedJsonRef.current) {
+        return;
+      }
+      lastQueuedJsonRef.current = json;
+
+      setAutosaveStatus("saving");
+
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => {
+        void save({
+          projectId: args.projectId,
+          documentId: args.documentId,
+          contentJson: json,
+          actor: "auto",
+          reason: "autosave",
+        });
+      }, 500);
+    }
+
+    args.editor.on("update", onUpdate);
+    return () => {
+      args.editor?.off("update", onUpdate);
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = null;
+    };
+  }, [
+    args.documentId,
+    args.editor,
+    args.enabled,
+    args.projectId,
+    args.suppressRef,
+    save,
+    setAutosaveStatus,
+  ]);
+}

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { create } from "zustand";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcRequest,
+} from "../../../../../packages/shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;
+
+export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
+
+export type EditorState = {
+  bootstrapStatus: "idle" | "loading" | "ready" | "error";
+  projectId: string | null;
+  documentId: string | null;
+  documentContentJson: string | null;
+  lastSavedOrQueuedJson: string | null;
+  autosaveStatus: AutosaveStatus;
+  autosaveError: IpcError | null;
+};
+
+export type EditorActions = {
+  bootstrapForProject: (projectId: string) => Promise<void>;
+  save: (args: {
+    projectId: string;
+    documentId: string;
+    contentJson: string;
+    actor: "user" | "auto";
+    reason: "manual-save" | "autosave";
+  }) => Promise<void>;
+  retryLastAutosave: () => Promise<void>;
+  setAutosaveStatus: (status: AutosaveStatus) => void;
+  clearAutosaveError: () => void;
+};
+
+export type EditorStore = EditorState & EditorActions;
+
+export type UseEditorStore = ReturnType<typeof createEditorStore>;
+
+const EditorStoreContext = React.createContext<UseEditorStore | null>(null);
+
+/**
+ * Create a zustand store for editor/document state.
+ *
+ * Why: editor state and autosave status must be shared between the editor pane
+ * and StatusBar, and must be driven through typed IPC.
+ */
+export function createEditorStore(deps: { invoke: IpcInvoke }) {
+  return create<EditorStore>((set, get) => ({
+    bootstrapStatus: "idle",
+    projectId: null,
+    documentId: null,
+    documentContentJson: null,
+    lastSavedOrQueuedJson: null,
+    autosaveStatus: "idle",
+    autosaveError: null,
+
+    setAutosaveStatus: (status) => set({ autosaveStatus: status }),
+    clearAutosaveError: () => set({ autosaveError: null }),
+
+    bootstrapForProject: async (projectId) => {
+      set({ bootstrapStatus: "loading" });
+
+      const listRes = await deps.invoke("file:document:list", { projectId });
+      if (!listRes.ok) {
+        set({ bootstrapStatus: "error" });
+        return;
+      }
+
+      let documentId = listRes.data.items[0]?.documentId ?? null;
+      if (!documentId) {
+        const created = await deps.invoke("file:document:create", {
+          projectId,
+        });
+        if (!created.ok) {
+          set({ bootstrapStatus: "error" });
+          return;
+        }
+        documentId = created.data.documentId;
+      }
+
+      const readRes = await deps.invoke("file:document:read", {
+        projectId,
+        documentId,
+      });
+      if (!readRes.ok) {
+        set({ bootstrapStatus: "error" });
+        return;
+      }
+
+      set({
+        bootstrapStatus: "ready",
+        projectId,
+        documentId,
+        documentContentJson: readRes.data.contentJson,
+      });
+    },
+
+    save: async ({ projectId, documentId, contentJson, actor, reason }) => {
+      set({ autosaveStatus: "saving", lastSavedOrQueuedJson: contentJson });
+
+      const res = await deps.invoke("file:document:write", {
+        projectId,
+        documentId,
+        contentJson,
+        actor,
+        reason,
+      });
+      if (!res.ok) {
+        set({ autosaveStatus: "error", autosaveError: res.error });
+        return;
+      }
+
+      set({
+        autosaveStatus: "saved",
+        autosaveError: null,
+      });
+    },
+
+    retryLastAutosave: async () => {
+      const state = get();
+      if (
+        !state.projectId ||
+        !state.documentId ||
+        !state.lastSavedOrQueuedJson ||
+        state.lastSavedOrQueuedJson.length === 0
+      ) {
+        return;
+      }
+
+      set({ autosaveError: null });
+      await state.save({
+        projectId: state.projectId,
+        documentId: state.documentId,
+        contentJson: state.lastSavedOrQueuedJson,
+        actor: "auto",
+        reason: "autosave",
+      });
+    },
+  }));
+}
+
+/**
+ * Provide an editor store instance for the Workbench UI.
+ */
+export function EditorStoreProvider(props: {
+  store: UseEditorStore;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <EditorStoreContext.Provider value={props.store}>
+      {props.children}
+    </EditorStoreContext.Provider>
+  );
+}
+
+/**
+ * Read values from the injected editor store.
+ */
+export function useEditorStore<T>(selector: (state: EditorStore) => T): T {
+  const store = React.useContext(EditorStoreContext);
+  if (!store) {
+    throw new Error("EditorStoreProvider is missing");
+  }
+  return store(selector);
+}

--- a/apps/desktop/tests/e2e/editor-autosave.spec.ts
+++ b/apps/desktop/tests/e2e/editor-autosave.spec.ts
@@ -1,0 +1,169 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+test("editor autosave: typing persists across restart (actor=auto)", async () => {
+  const userDataDir = await createIsolatedUserDataDir();
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const appRoot = path.resolve(__dirname, "../..");
+  const modKey = process.platform === "darwin" ? "Meta" : "Control";
+
+  async function launch() {
+    return await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+  }
+
+  const electronApp = await launch();
+  const page = await electronApp.firstWindow();
+  await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+
+  await expect(page.getByTestId("welcome-screen")).toBeVisible();
+  await page.getByTestId("welcome-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.getByTestId("create-project-name").fill("Demo Project");
+  await page.getByTestId("create-project-submit").click();
+
+  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+  await page.getByTestId("tiptap-editor").click();
+  await page.keyboard.type("Hello autosave");
+
+  await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+    "data-status",
+    "saved",
+  );
+
+  const project = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(project.ok).toBe(true);
+  if (!project.ok) {
+    throw new Error(`Expected ok current project, got: ${project.error.code}`);
+  }
+
+  const docs = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("file:document:list", {
+      projectId: projectIdParam,
+    });
+  }, project.data.projectId);
+  expect(docs.ok).toBe(true);
+  if (!docs.ok) {
+    throw new Error(`Expected ok document list, got: ${docs.error.code}`);
+  }
+  expect(docs.data.items.length).toBeGreaterThanOrEqual(1);
+  const documentId = docs.data.items[0]?.documentId;
+  if (!documentId) {
+    throw new Error("Missing documentId");
+  }
+
+  const docAfterFirstSave = await page.evaluate(
+    async ({ projectIdParam, documentIdParam }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("file:document:read", {
+        projectId: projectIdParam,
+        documentId: documentIdParam,
+      });
+    },
+    { projectIdParam: project.data.projectId, documentIdParam: documentId },
+  );
+  expect(docAfterFirstSave.ok).toBe(true);
+  if (!docAfterFirstSave.ok) {
+    throw new Error(
+      `Expected ok document read, got: ${docAfterFirstSave.error.code}`,
+    );
+  }
+  const hashV1 = docAfterFirstSave.data.contentHash;
+
+  await page.keyboard.press(`${modKey}+S`);
+
+  await page.keyboard.type(" changed");
+  await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+    "data-status",
+    "saved",
+  );
+
+  const versions = await page.evaluate(async (documentIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("version:list", {
+      documentId: documentIdParam,
+    });
+  }, documentId);
+  expect(versions.ok).toBe(true);
+  if (!versions.ok) {
+    throw new Error(`Expected ok version list, got: ${versions.error.code}`);
+  }
+  expect(versions.data.items.some((v) => v.actor === "auto")).toBe(true);
+  expect(versions.data.items.some((v) => v.actor === "user")).toBe(true);
+
+  const restoreTarget = versions.data.items.find(
+    (v) => v.contentHash === hashV1,
+  );
+  if (!restoreTarget) {
+    throw new Error("Missing restore target version");
+  }
+
+  const restored = await page.evaluate(
+    async ({ documentIdParam, versionIdParam }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("version:restore", {
+        documentId: documentIdParam,
+        versionId: versionIdParam,
+      });
+    },
+    { documentIdParam: documentId, versionIdParam: restoreTarget.versionId },
+  );
+  expect(restored.ok).toBe(true);
+  if (!restored.ok) {
+    throw new Error(`Expected ok restore, got: ${restored.error.code}`);
+  }
+
+  await electronApp.close();
+
+  const electronApp2 = await launch();
+  const page2 = await electronApp2.firstWindow();
+  await page2.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page2.getByTestId("app-shell")).toBeVisible();
+  await expect(page2.getByTestId("tiptap-editor")).toBeVisible();
+  await expect(page2.getByTestId("tiptap-editor")).toContainText(
+    "Hello autosave",
+  );
+  await expect(page2.getByTestId("tiptap-editor")).not.toContainText("changed");
+
+  await electronApp2.close();
+});

--- a/apps/desktop/tests/unit/derive.test.ts
+++ b/apps/desktop/tests/unit/derive.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+
+import { deriveContent } from "../../main/src/services/documents/derive";
+
+const sampleDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Hello" }],
+    },
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "World" }],
+    },
+  ],
+} as const;
+
+const first = deriveContent({ contentJson: sampleDoc });
+if (!first.ok) {
+  throw new Error(`Expected ok derive, got: ${first.error.code}`);
+}
+assert.equal(first.data.contentText, "Hello\nWorld");
+
+const second = deriveContent({ contentJson: sampleDoc });
+if (!second.ok) {
+  throw new Error(`Expected ok derive, got: ${second.error.code}`);
+}
+assert.equal(second.data.contentText, first.data.contentText);
+assert.equal(second.data.contentMd, first.data.contentMd);

--- a/openspec/_ops/task_runs/ISSUE-27.md
+++ b/openspec/_ops/task_runs/ISSUE-27.md
@@ -1,0 +1,33 @@
+# ISSUE-27
+
+- Issue: #27
+- Branch: task/27-p0-005-editor-ssot-autosave-versioning
+- PR: <fill-after-created>
+
+## Plan
+
+- 实现 editor SSOT（DB）+ autosave 状态机 + versioning（actor=user/auto）
+- 扩展 IPC contract（file/version）并确保 derived 生成 deterministic
+- Windows E2E：输入→autosave→重启恢复，并断言 version 证据
+
+## Runs
+
+### 2026-01-31 15:36 install deps
+
+- Command: `pnpm install --no-frozen-lockfile`
+- Key output: `Done`
+
+### 2026-01-31 15:45 unit tests
+
+- Command: `pnpm test:unit`
+- Key output: `exit 0`
+
+### 2026-01-31 15:49 desktop e2e
+
+- Command: `pnpm -C apps/desktop test:e2e -- editor-autosave.spec.ts`
+- Key output: `1 passed`
+
+### 2026-01-31 16:02 preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `prettier/typecheck/lint/contract:check/test:unit ✅`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "desktop:build:win": "pnpm -C apps/desktop build:win",
     "contract:generate": "tsx scripts/contract-generate.ts",
     "contract:check": "pnpm contract:generate && git diff --exit-code packages/shared/types/ipc-generated.ts",
-    "test:unit": "tsx apps/desktop/tests/unit/contract-generate.spec.ts",
+    "test:unit": "tsx apps/desktop/tests/unit/contract-generate.spec.ts && tsx apps/desktop/tests/unit/derive.test.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -53,11 +53,18 @@ export const IPC_CHANNELS = [
   "context:creonow:ensure",
   "context:creonow:status",
   "db:debug:tableNames",
+  "file:document:create",
+  "file:document:delete",
+  "file:document:list",
+  "file:document:read",
+  "file:document:write",
   "project:create",
   "project:delete",
   "project:getCurrent",
   "project:list",
   "project:setCurrent",
+  "version:list",
+  "version:restore",
 ] as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[number];
@@ -90,6 +97,65 @@ export type IpcChannelSpec = {
     request: Record<string, never>;
     response: {
       tableNames: Array<string>;
+    };
+  };
+  "file:document:create": {
+    request: {
+      projectId: string;
+      title?: string;
+    };
+    response: {
+      documentId: string;
+    };
+  };
+  "file:document:delete": {
+    request: {
+      documentId: string;
+      projectId: string;
+    };
+    response: {
+      deleted: true;
+    };
+  };
+  "file:document:list": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      items: Array<{
+        documentId: string;
+        title: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "file:document:read": {
+    request: {
+      documentId: string;
+      projectId: string;
+    };
+    response: {
+      contentHash: string;
+      contentJson: string;
+      contentMd: string;
+      contentText: string;
+      documentId: string;
+      projectId: string;
+      title: string;
+      updatedAt: number;
+    };
+  };
+  "file:document:write": {
+    request: {
+      actor: "user" | "auto";
+      contentJson: string;
+      documentId: string;
+      projectId: string;
+      reason: "manual-save" | "autosave";
+    };
+    response: {
+      contentHash: string;
+      updatedAt: number;
     };
   };
   "project:create": {
@@ -136,6 +202,29 @@ export type IpcChannelSpec = {
     response: {
       projectId: string;
       rootPath: string;
+    };
+  };
+  "version:list": {
+    request: {
+      documentId: string;
+    };
+    response: {
+      items: Array<{
+        actor: "user" | "auto" | "ai";
+        contentHash: string;
+        createdAt: number;
+        reason: string;
+        versionId: string;
+      }>;
+    };
+  };
+  "version:restore": {
+    request: {
+      documentId: string;
+      versionId: string;
+    };
+    response: {
+      restored: true;
     };
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,12 @@ importers:
 
   apps/desktop:
     dependencies:
+      "@tiptap/react":
+        specifier: ^2.26.0
+        version: 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)(react-dom@18.3.1)(react@18.3.1)
+      "@tiptap/starter-kit":
+        specifier: ^2.26.0
+        version: 2.27.2
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -1413,6 +1419,20 @@ packages:
       playwright: 1.58.1
     dev: true
 
+  /@popperjs/core@2.11.8:
+    resolution:
+      {
+        integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==,
+      }
+    dev: false
+
+  /@remirror/core-constants@3.0.0:
+    resolution:
+      {
+        integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==,
+      }
+    dev: false
+
   /@rolldown/pluginutils@1.0.0-beta.53:
     resolution:
       {
@@ -1713,6 +1733,341 @@ packages:
       defer-to-connect: 2.0.1
     dev: true
 
+  /@tiptap/core@2.27.2(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==,
+      }
+    peerDependencies:
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-blockquote@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-bold@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-bubble-menu@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+      tippy.js: 6.3.7
+    dev: false
+
+  /@tiptap/extension-bullet-list@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-code-block@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-code@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-document@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-dropcursor@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-floating-menu@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+      tippy.js: 6.3.7
+    dev: false
+
+  /@tiptap/extension-gapcursor@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-hard-break@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-heading@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-history@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-horizontal-rule@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2):
+    resolution:
+      {
+        integrity: sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
+  /@tiptap/extension-italic@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-list-item@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-ordered-list@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-paragraph@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-strike@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/extension-text@2.27.2(@tiptap/core@2.27.2):
+    resolution:
+      {
+        integrity: sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+    dev: false
+
+  /@tiptap/pm@2.27.2:
+    resolution:
+      {
+        integrity: sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==,
+      }
+    dependencies:
+      prosemirror-changeset: 2.3.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.0
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.3
+      prosemirror-menu: 1.2.5
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /@tiptap/react@2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution:
+      {
+        integrity: sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==,
+      }
+    peerDependencies:
+      "@tiptap/core": ^2.7.0
+      "@tiptap/pm": ^2.7.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/extension-bubble-menu": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-floating-menu": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/pm": 2.27.2
+      "@types/use-sync-external-store": 0.0.6
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    dev: false
+
+  /@tiptap/starter-kit@2.27.2:
+    resolution:
+      {
+        integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==,
+      }
+    dependencies:
+      "@tiptap/core": 2.27.2(@tiptap/pm@2.27.2)
+      "@tiptap/extension-blockquote": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-bold": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-bullet-list": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-code": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-code-block": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-document": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-dropcursor": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-gapcursor": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-hard-break": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-heading": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-history": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-horizontal-rule": 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)
+      "@tiptap/extension-italic": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-list-item": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-ordered-list": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-paragraph": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-strike": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-text": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/extension-text-style": 2.27.2(@tiptap/core@2.27.2)
+      "@tiptap/pm": 2.27.2
+    dev: false
+
   /@tootallnate/once@2.0.0:
     resolution:
       {
@@ -1824,6 +2179,30 @@ packages:
       "@types/node": 20.19.30
     dev: true
 
+  /@types/linkify-it@5.0.0:
+    resolution:
+      {
+        integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==,
+      }
+    dev: false
+
+  /@types/markdown-it@14.1.2:
+    resolution:
+      {
+        integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==,
+      }
+    dependencies:
+      "@types/linkify-it": 5.0.0
+      "@types/mdurl": 2.0.0
+    dev: false
+
+  /@types/mdurl@2.0.0:
+    resolution:
+      {
+        integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==,
+      }
+    dev: false
+
   /@types/ms@2.1.0:
     resolution:
       {
@@ -1895,6 +2274,13 @@ packages:
     dependencies:
       "@types/node": 20.19.30
     dev: true
+
+  /@types/use-sync-external-store@0.0.6:
+    resolution:
+      {
+        integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==,
+      }
+    dev: false
 
   /@types/verror@1.10.11:
     resolution:
@@ -2335,7 +2721,6 @@ packages:
       {
         integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
       }
-    dev: true
 
   /array-buffer-byte-length@1.0.2:
     resolution:
@@ -3021,6 +3406,13 @@ packages:
     dev: true
     optional: true
 
+  /crelt@1.0.6:
+    resolution:
+      {
+        integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==,
+      }
+    dev: false
+
   /cross-dirname@0.1.0:
     resolution:
       {
@@ -3495,6 +3887,14 @@ packages:
     dependencies:
       once: 1.4.0
 
+  /entities@4.5.0:
+    resolution:
+      {
+        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
+      }
+    engines: { node: ">=0.12" }
+    dev: false
+
   /env-paths@2.2.1:
     resolution:
       {
@@ -3756,7 +4156,6 @@ packages:
         integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
       }
     engines: { node: ">=10" }
-    dev: true
 
   /eslint-config-prettier@10.1.8(eslint@8.57.1):
     resolution:
@@ -3992,7 +4391,6 @@ packages:
       {
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
       }
-    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution:
@@ -5322,6 +5720,15 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /linkify-it@5.0.0:
+    resolution:
+      {
+        integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==,
+      }
+    dependencies:
+      uc.micro: 2.1.0
+    dev: false
+
   /locate-path@6.0.0:
     resolution:
       {
@@ -5481,6 +5888,21 @@ packages:
       - supports-color
     dev: true
 
+  /markdown-it@14.1.0:
+    resolution:
+      {
+        integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==,
+      }
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+    dev: false
+
   /matcher@3.0.0:
     resolution:
       {
@@ -5500,6 +5922,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
     dev: true
+
+  /mdurl@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==,
+      }
+    dev: false
 
   /mime-db@1.52.0:
     resolution:
@@ -6080,6 +6509,13 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
+  /orderedmap@2.1.1:
+    resolution:
+      {
+        integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==,
+      }
+    dev: false
+
   /own-keys@1.0.1:
     resolution:
       {
@@ -6383,6 +6819,203 @@ packages:
       react-is: 16.13.1
     dev: true
 
+  /prosemirror-changeset@2.3.1:
+    resolution:
+      {
+        integrity: sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==,
+      }
+    dependencies:
+      prosemirror-transform: 1.11.0
+    dev: false
+
+  /prosemirror-collab@1.3.1:
+    resolution:
+      {
+        integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==,
+      }
+    dependencies:
+      prosemirror-state: 1.4.4
+    dev: false
+
+  /prosemirror-commands@1.7.1:
+    resolution:
+      {
+        integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+    dev: false
+
+  /prosemirror-dropcursor@1.8.2:
+    resolution:
+      {
+        integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==,
+      }
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /prosemirror-gapcursor@1.4.0:
+    resolution:
+      {
+        integrity: sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==,
+      }
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /prosemirror-history@1.5.0:
+    resolution:
+      {
+        integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==,
+      }
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.5
+      rope-sequence: 1.3.4
+    dev: false
+
+  /prosemirror-inputrules@1.5.1:
+    resolution:
+      {
+        integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==,
+      }
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+    dev: false
+
+  /prosemirror-keymap@1.2.3:
+    resolution:
+      {
+        integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==,
+      }
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+    dev: false
+
+  /prosemirror-markdown@1.13.3:
+    resolution:
+      {
+        integrity: sha512-3E+Et6cdXIH0EgN2tGYQ+EBT7N4kMiZFsW+hzx+aPtOmADDHWCdd2uUQb7yklJrfUYUOjEEu22BiN6UFgPe4cQ==,
+      }
+    dependencies:
+      "@types/markdown-it": 14.1.2
+      markdown-it: 14.1.0
+      prosemirror-model: 1.25.4
+    dev: false
+
+  /prosemirror-menu@1.2.5:
+    resolution:
+      {
+        integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==,
+      }
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+    dev: false
+
+  /prosemirror-model@1.25.4:
+    resolution:
+      {
+        integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==,
+      }
+    dependencies:
+      orderedmap: 2.1.1
+    dev: false
+
+  /prosemirror-schema-basic@1.2.4:
+    resolution:
+      {
+        integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+    dev: false
+
+  /prosemirror-schema-list@1.5.1:
+    resolution:
+      {
+        integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+    dev: false
+
+  /prosemirror-state@1.4.4:
+    resolution:
+      {
+        integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /prosemirror-tables@1.8.5:
+    resolution:
+      {
+        integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==,
+      }
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5):
+    resolution:
+      {
+        integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==,
+      }
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+    dependencies:
+      "@remirror/core-constants": 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.5
+    dev: false
+
+  /prosemirror-transform@1.11.0:
+    resolution:
+      {
+        integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+    dev: false
+
+  /prosemirror-view@1.41.5:
+    resolution:
+      {
+        integrity: sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==,
+      }
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+    dev: false
+
   /pump@3.0.3:
     resolution:
       {
@@ -6391,6 +7024,14 @@ packages:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  /punycode.js@2.3.1:
+    resolution:
+      {
+        integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==,
+      }
+    engines: { node: ">=6" }
+    dev: false
 
   /punycode@2.3.1:
     resolution:
@@ -6685,6 +7326,13 @@ packages:
       "@rollup/rollup-win32-x64-msvc": 4.57.1
       fsevents: 2.3.3
     dev: true
+
+  /rope-sequence@1.3.4:
+    resolution:
+      {
+        integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==,
+      }
+    dev: false
 
   /run-parallel@1.2.0:
     resolution:
@@ -7386,6 +8034,15 @@ packages:
       picomatch: 4.0.3
     dev: true
 
+  /tippy.js@6.3.7:
+    resolution:
+      {
+        integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==,
+      }
+    dependencies:
+      "@popperjs/core": 2.11.8
+    dev: false
+
   /tmp-promise@3.0.3:
     resolution:
       {
@@ -7541,6 +8198,13 @@ packages:
     hasBin: true
     dev: true
 
+  /uc.micro@2.1.0:
+    resolution:
+      {
+        integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==,
+      }
+    dev: false
+
   /unbox-primitive@1.1.0:
     resolution:
       {
@@ -7647,6 +8311,17 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /use-sync-external-store@1.6.0(react@18.3.1):
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 18.3.1
+    dev: false
+
   /utf8-byte-length@1.0.5:
     resolution:
       {
@@ -7728,6 +8403,13 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
+
+  /w3c-keyname@2.2.8:
+    resolution:
+      {
+        integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
+      }
+    dev: false
 
   /wcwidth@1.0.1:
     resolution:

--- a/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/.metadata.json
+++ b/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T07:36:27.973Z",
+  "updatedAt": "2026-01-31T07:36:27.973Z"
+}

--- a/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/proposal.md
+++ b/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: issue-27-p0-005-editor-ssot-autosave-versioning
+
+## Why
+
+为 CN V1 Workbench 交付写作主链路“可靠保存”的最小闭环：TipTap editor 可编辑；文档 SSOT=TipTap JSON（DB）；autosave 状态可见且失败可恢复；版本历史最小可用（actor=user/auto）并可恢复；重启后内容不丢稿。该能力是后续 FileTree、AI diff/apply 与 RAG/FTS 的共同依赖（`CNWB-REQ-020/030`）。
+
+## What Changes
+
+- Add: renderer TipTap editor（`EditorPane`）+ editorStore + autosave 状态机（idle/saving/saved/error）。
+- Add: main `file:*` 与 `version:*` IPC（文档 CRUD + 版本 list/restore），并通过 IPC contract/codegen gate 强类型化。
+- Add: SQLite SSOT 写入（`documents`）+ derived 生成（`content_text/content_md`）+ 版本落盘（`document_versions`）的事务性实现。
+- Add: unit tests（derive deterministic）+ Windows Playwright Electron E2E（autosave + restart restore + version evidence）。
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md`
+  - `openspec/specs/creonow-v1-workbench/design/02-document-model-ssot.md`
+  - `openspec/specs/creonow-v1-workbench/design/11-project-and-documents.md`
+- Affected code:
+  - `apps/desktop/main/src/ipc/**`
+  - `apps/desktop/main/src/services/documents/**`
+  - `apps/desktop/main/src/db/migrations/**`
+  - `apps/desktop/renderer/src/features/editor/**`
+  - `apps/desktop/renderer/src/stores/**`
+  - `apps/desktop/tests/**`
+- Breaking change: NO
+- User benefit: 用户可在编辑器中输入并自动保存，状态可见；重启后内容可恢复；版本历史可查看并可回滚，降低丢稿风险。

--- a/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,14 @@
+# Spec Delta: creonow-v1-workbench (ISSUE-27)
+
+本任务实现 `P0-005`（Editor SSOT + autosave + versioning），完成写作主链路“可靠保存”的最小闭环。
+
+## Changes
+
+- Add: TipTap editor（renderer）与 autosave 状态机（idle/saving/saved/error）。
+- Add: 文档 SSOT（`documents.content_json`）写入 + derived 生成（`content_text/content_md`）与 deterministic 单元测试。
+- Add: `file:*` 与 `version:*` IPC（文档 CRUD + 版本 list/restore），并保持 IPC contract/codegen gate 全程强类型。
+- Add: Windows Playwright Electron E2E：输入→autosave→重启恢复 + 版本证据断言（actor=auto）。
+
+## Acceptance
+
+- 满足 `P0-005` task card 的 Acceptance Criteria，并通过 `windows-latest` E2E 门禁。

--- a/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/tasks.md
+++ b/rulebook/tasks/issue-27-p0-005-editor-ssot-autosave-versioning/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+- [x] 1.1 扩展 IPC contract + codegen（`file:*` + `version:*` 最小集）
+- [x] 1.2 SQLite schema/migrations：补齐 documents + document_versions 字段与索引
+- [x] 1.3 derive：`content_json -> content_text/content_md`（deterministic）+ unit tests
+- [x] 1.4 DocumentService：SSOT 写入 + derived 生成 + version 落盘（事务）
+- [x] 1.5 main IPC：document CRUD（create/read/write/list/delete）+ currentDocument（最小）+ version list/restore
+- [x] 1.6 renderer：EditorPane（TipTap）+ editorStore + autosave hook + StatusBar 状态
+- [x] 1.7 E2E：`editor-autosave.spec.ts`（输入→saved→重启恢复→version evidence）
+
+## 2. Testing
+
+- [x] 2.1 本地：`pnpm test:unit`（含 `derive.test.ts`）
+- [x] 2.2 本地：`pnpm -C apps/desktop test:e2e -- editor-autosave.spec.ts`
+- [x] 2.3 本地：`scripts/agent_pr_preflight.sh`
+
+## 3. Documentation
+
+- [x] 3.1 新增 `openspec/_ops/task_runs/ISSUE-27.md` 并持续追加 Runs（只追加不回写）
+- [x] 3.2 补齐 spec delta 并保持 `rulebook task validate` 通过


### PR DESCRIPTION
Closes #27

Implements TipTap editor + autosave state machine, persists documents as DB SSOT (content_json) with derived fields and version snapshots (actor=auto/user), and adds version list/restore IPC.

Test plan:
- pnpm test:unit
- pnpm -C apps/desktop test:e2e -- editor-autosave.spec.ts
- scripts/agent_pr_preflight.sh
