### PR TITLE
docs: close P0-005 + P0-014 task cards (#29)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-29.md
+++ b/openspec/_ops/task_runs/ISSUE-29.md
@@ -2,7 +2,7 @@
 
 - Issue: #29
 - Branch: task/29-docs-close-p0-005-p0-014
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/30
 
 ## Plan
 
@@ -40,3 +40,8 @@
 
 - Command: `scripts/agent_pr_preflight.sh`
 - Key output: `prettier/typecheck/lint/contract:check/test:unit ✅`
+
+### 2026-01-31 16:22 PR
+
+- Command: `gh pr create`
+- Key output: `PR #30`

--- a/openspec/_ops/task_runs/ISSUE-29.md
+++ b/openspec/_ops/task_runs/ISSUE-29.md
@@ -1,0 +1,42 @@
+# ISSUE-29
+
+- Issue: #29
+- Branch: task/29-docs-close-p0-005-p0-014
+- PR: <fill-after-created>
+
+## Plan
+
+- Close P0-005 + P0-014 task cards（Status/Acceptance/Tests/Completion）
+- Run preflight and record evidence
+
+## Runs
+
+### 2026-01-31 16:18 rulebook validate
+
+- Command: `rulebook task validate issue-29-docs-close-p0-005-p0-014`
+- Key output: `✅ Task issue-29-docs-close-p0-005-p0-014 is valid (warnings: No spec files found)`
+
+### 2026-01-31 16:19 preflight (failed)
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL: Command "prettier" not found`
+
+### 2026-01-31 16:20 install deps
+
+- Command: `pnpm install --frozen-lockfile`
+- Key output: `Done`
+
+### 2026-01-31 16:20 preflight (failed)
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `prettier --check failed (rulebook/tasks/issue-29-docs-close-p0-005-p0-014/.metadata.json, proposal.md)`
+
+### 2026-01-31 16:20 prettier --write
+
+- Command: `pnpm exec prettier --write <files>`
+- Key output: `formatted files`
+
+### 2026-01-31 16:21 preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `prettier/typecheck/lint/contract:check/test:unit ✅`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md
@@ -1,6 +1,6 @@
 # P0-005: Editor SSOT + autosave + versioning（actor=user/auto）
 
-Status: pending
+Status: done
 
 ## Goal
 
@@ -34,32 +34,32 @@ Status: pending
 
 ## Acceptance Criteria
 
-- [ ] TipTap editor 可用：
-  - [ ] 页面存在 `data-testid="tiptap-editor"`
-  - [ ] 可输入、可选区（为后续 AI apply 做准备）
-- [ ] 文档 SSOT：
-  - [ ] `content_json` 为唯一事实源（DB 中保存）
-  - [ ] 每次保存生成 `content_text/content_md`（derived），且不得反写覆盖 SSOT
-- [ ] autosave 状态可见：
-  - [ ] StatusBar 显示 `saving/saved/error`（文案可按设计稿，但必须稳定可测）
-  - [ ] 保存失败必须可恢复（至少提供重试）
-- [ ] 版本历史最小可用：
-  - [ ] autosave 产生 `actor=auto` 版本（去重：同 `content_hash` 不新增）
-  - [ ] 手动保存产生 `actor=user` 版本（策略写死并测试）
-  - [ ] `version:list` 可列出版本
-  - [ ] `version:restore` 可恢复到某个版本（最小：覆盖当前文档内容）
-- [ ] 重启恢复：
-  - [ ] 关闭 app → 再启动 → 当前文档内容保持（不丢稿）
+- [x] TipTap editor 可用：
+  - [x] 页面存在 `data-testid="tiptap-editor"`
+  - [x] 可输入、可选区（为后续 AI apply 做准备）
+- [x] 文档 SSOT：
+  - [x] `content_json` 为唯一事实源（DB 中保存）
+  - [x] 每次保存生成 `content_text/content_md`（derived），且不得反写覆盖 SSOT
+- [x] autosave 状态可见：
+  - [x] StatusBar 显示 `saving/saved/error`（文案可按设计稿，但必须稳定可测）
+  - [x] 保存失败必须可恢复（至少提供重试）
+- [x] 版本历史最小可用：
+  - [x] autosave 产生 `actor=auto` 版本（去重：同 `content_hash` 不新增）
+  - [x] 手动保存产生 `actor=user` 版本（策略写死并测试）
+  - [x] `version:list` 可列出版本
+  - [x] `version:restore` 可恢复到某个版本（最小：覆盖当前文档内容）
+- [x] 重启恢复：
+  - [x] 关闭 app → 再启动 → 当前文档内容保持（不丢稿）
 
 ## Tests
 
-- [ ] Unit：`derive.test.ts`
-  - [ ] 相同 `content_json` → `content_text` deterministic
+- [x] Unit：`derive.test.ts`
+  - [x] 相同 `content_json` → `content_text` deterministic
   - [ ] `content_md` 失败时降级策略可测（若实现）
-- [ ] E2E（Windows）`editor-autosave.spec.ts`
-  - [ ] 创建文档 → 输入 → 断言出现 `已保存`（或等价 saved 状态）
-  - [ ] 关闭 app → 再启动 → 断言内容仍存在
-  - [ ] 断言：`document_versions` 至少存在 1 条 `actor=auto` 记录
+- [x] E2E（Windows）`editor-autosave.spec.ts`
+  - [x] 创建文档 → 输入 → 断言出现 `已保存`（或等价 saved 状态）
+  - [x] 关闭 app → 再启动 → 断言内容仍存在
+  - [x] 断言：`document_versions` 至少存在 1 条 `actor=auto` 记录
 
 ## Edge cases & Failure modes
 
@@ -73,3 +73,9 @@ Status: pending
   - `doc_save_started` / `doc_save_succeeded`（含 documentId + content_hash）
   - `doc_save_failed`（含 error.code）
   - `version_created`（actor/reason）
+
+## Completion
+
+- Issue: #27
+- PR: #28
+- RUN_LOG: `openspec/_ops/task_runs/ISSUE-27.md`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md
@@ -1,6 +1,6 @@
 # P0-014: Project lifecycle（create/list/setCurrent/getCurrent/delete + ensure `.creonow`）
 
-Status: pending
+Status: done
 
 ## Goal
 
@@ -30,27 +30,27 @@ Status: pending
 
 ## Acceptance Criteria
 
-- [ ] `project:create`：
-  - [ ] 返回 `{ projectId, rootPath }`
-  - [ ] `rootPath` 支持空格/中文路径（Windows 常见）
-  - [ ] 创建完成后 `.creonow/` 目录结构已被 ensure（`context:creonow:ensure` 或等价）
-- [ ] `project:list`：
-  - [ ] 返回 deterministic 排序（写死排序规则并可测）
-- [ ] `project:setCurrent/getCurrent`：
-  - [ ] `setCurrent` 成功后 `getCurrent` 返回一致结果
-  - [ ] app 重启后 current project 仍可恢复（settings 持久化）
-- [ ] `project:delete`：
-  - [ ] 删除后 `project:list` 不再返回该项目
-  - [ ] 对已删除 `projectId` 的访问返回 `NOT_FOUND`（不得 silent fallback）
-- [ ] UI（最小可用）：
-  - [ ] 存在 `welcome-screen`，并能打开 `create-project-dialog` 完成创建
+- [x] `project:create`：
+  - [x] 返回 `{ projectId, rootPath }`
+  - [x] `rootPath` 支持空格/中文路径（Windows 常见）
+  - [x] 创建完成后 `.creonow/` 目录结构已被 ensure（`context:creonow:ensure` 或等价）
+- [x] `project:list`：
+  - [x] 返回 deterministic 排序（写死排序规则并可测）
+- [x] `project:setCurrent/getCurrent`：
+  - [x] `setCurrent` 成功后 `getCurrent` 返回一致结果
+  - [x] app 重启后 current project 仍可恢复（settings 持久化）
+- [x] `project:delete`：
+  - [x] 删除后 `project:list` 不再返回该项目
+  - [x] 对已删除 `projectId` 的访问返回 `NOT_FOUND`（不得 silent fallback）
+- [x] UI（最小可用）：
+  - [x] 存在 `welcome-screen`，并能打开 `create-project-dialog` 完成创建
 
 ## Tests
 
-- [ ] E2E（Windows）`project-lifecycle.spec.ts`
-  - [ ] 启动 → 创建 project → `project:getCurrent` 返回 projectId
-  - [ ] 断言 `.creonow/` 已存在（可通过 `context:creonow:status` 或等价可测路径）
-  - [ ] 重启 app → `project:getCurrent` 仍返回同 projectId
+- [x] E2E（Windows）`project-lifecycle.spec.ts`
+  - [x] 启动 → 创建 project → `project:getCurrent` 返回 projectId
+  - [x] 断言 `.creonow/` 已存在（可通过 `context:creonow:status` 或等价可测路径）
+  - [x] 重启 app → `project:getCurrent` 仍返回同 projectId
 
 ## Edge cases & Failure modes
 
@@ -64,3 +64,9 @@ Status: pending
   - `project_created`（projectId, rootPathRelative）
   - `project_set_current`（projectId）
   - `project_deleted`（projectId）
+
+## Completion
+
+- Issue: #25
+- PR: #26
+- RUN_LOG: `openspec/_ops/task_runs/ISSUE-25.md`

--- a/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/.metadata.json
+++ b/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T08:12:35.920Z",
+  "updatedAt": "2026-01-31T08:12:35.920Z"
+}

--- a/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/proposal.md
+++ b/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/proposal.md
@@ -1,0 +1,19 @@
+# Proposal: issue-29-docs-close-p0-005-p0-014
+
+## Why
+
+P0-014 / P0-005 的实现已合并，但对应 task card 仍为 `Status: pending` 且验收/测试项未勾选，导致进度与交付证据不可追踪、协作方容易误判任务状态。
+
+## What Changes
+
+- Update task cards：`P0-014`、`P0-005` 的 `Status/Acceptance/Tests` 与 `## Completion`（补齐 Issue/PR/RUN_LOG）。
+- Add RUN_LOG：新增 `openspec/_ops/task_runs/ISSUE-29.md` 并记录验证证据。
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-014-project-lifecycle-and-current-project.md`
+  - `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-005-editor-ssot-autosave-versioning.md`
+- Affected code: NONE (docs/rulebook only)
+- Breaking change: NO
+- User benefit: 进度、验收与证据可追踪；交付闭环更一致，减少协作摩擦。

--- a/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/tasks.md
+++ b/rulebook/tasks/issue-29-docs-close-p0-005-p0-014/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 更新 `P0-014` task card：Status/Acceptance/Tests/Completion
+- [x] 1.2 更新 `P0-005` task card：Status/Acceptance/Tests/Completion
+- [x] 1.3 新增并维护 `openspec/_ops/task_runs/ISSUE-29.md`（只追加不回写）
+
+## 2. Testing
+
+- [x] 2.1 `rulebook task validate issue-29-docs-close-p0-005-p0-014`
+- [x] 2.2 `scripts/agent_pr_preflight.sh`
+
+## 3. Documentation
+
+- [x] 3.1 在 `P0-014` / `P0-005` task cards 中补齐证据链接（Issue/PR/RUN_LOG）


### PR DESCRIPTION
Closes #29

## Summary
- Mark P0-014 and P0-005 task cards as done (acceptance/tests checked, completion links added)
- Add RUN_LOG for ISSUE-29 and create rulebook task

## Test plan
- `scripts/agent_pr_preflight.sh`

## Evidence
- `openspec/_ops/task_runs/ISSUE-29.md`