### PR TITLE
feat: documents filetree + current doc persistence (#31)

### DIFF
--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -180,6 +180,14 @@ export const ipcContract = {
         updatedAt: s.number(),
       }),
     },
+    "file:document:rename": {
+      request: s.object({
+        projectId: s.string(),
+        documentId: s.string(),
+        title: s.string(),
+      }),
+      response: s.object({ updated: s.literal(true) }),
+    },
     "file:document:write": {
       request: s.object({
         projectId: s.string(),
@@ -189,6 +197,14 @@ export const ipcContract = {
         reason: s.union(s.literal("manual-save"), s.literal("autosave")),
       }),
       response: s.object({ updatedAt: s.number(), contentHash: s.string() }),
+    },
+    "file:document:getCurrent": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ documentId: s.string() }),
+    },
+    "file:document:setCurrent": {
+      request: s.object({ projectId: s.string(), documentId: s.string() }),
+      response: s.object({ documentId: s.string() }),
     },
     "file:document:delete": {
       request: s.object({ projectId: s.string(), documentId: s.string() }),

--- a/apps/desktop/main/src/ipc/file.ts
+++ b/apps/desktop/main/src/ipc/file.ts
@@ -128,6 +128,43 @@ export function registerFileIpcHandlers(deps: {
   );
 
   deps.ipcMain.handle(
+    "file:document:rename",
+    async (
+      _e,
+      payload: { projectId: string; documentId: string; title: string },
+    ): Promise<IpcResponse<{ updated: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.projectId.trim().length === 0 ||
+        payload.documentId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId/documentId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.rename({
+        projectId: payload.projectId,
+        documentId: payload.documentId,
+        title: payload.title,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
     "file:document:write",
     async (
       _e,
@@ -178,6 +215,69 @@ export function registerFileIpcHandlers(deps: {
         contentJson: parsed,
         actor: payload.actor,
         reason: payload.reason,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:getCurrent",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<IpcResponse<{ documentId: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.getCurrent({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "file:document:setCurrent",
+    async (
+      _e,
+      payload: { projectId: string; documentId: string },
+    ): Promise<IpcResponse<{ documentId: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (
+        payload.projectId.trim().length === 0 ||
+        payload.documentId.trim().length === 0
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId/documentId is required",
+          },
+        };
+      }
+
+      const svc = createDocumentService({ db: deps.db, logger: deps.logger });
+      const res = svc.setCurrent({
+        projectId: payload.projectId,
+        documentId: payload.documentId,
       });
       return res.ok
         ? { ok: true, data: res.data }

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { invoke } from "./lib/ipcClient";
 import { createPreferenceStore } from "./lib/preferences";
 import { createAiStore, AiStoreProvider } from "./stores/aiStore";
 import { createEditorStore, EditorStoreProvider } from "./stores/editorStore";
+import { createFileStore, FileStoreProvider } from "./stores/fileStore";
 import { createLayoutStore, LayoutStoreProvider } from "./stores/layoutStore";
 import {
   createProjectStore,
@@ -32,13 +33,19 @@ export function App(): JSX.Element {
     return createAiStore({ invoke });
   }, []);
 
+  const fileStore = React.useMemo(() => {
+    return createFileStore({ invoke });
+  }, []);
+
   return (
     <AiStoreProvider store={aiStore}>
       <ProjectStoreProvider store={projectStore}>
         <EditorStoreProvider store={editorStore}>
-          <LayoutStoreProvider store={layoutStore}>
-            <AppShell />
-          </LayoutStoreProvider>
+          <FileStoreProvider store={fileStore}>
+            <LayoutStoreProvider store={layoutStore}>
+              <AppShell />
+            </LayoutStoreProvider>
+          </FileStoreProvider>
         </EditorStoreProvider>
       </ProjectStoreProvider>
     </AiStoreProvider>

--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -1,13 +1,23 @@
+import React from "react";
+
+import { FileTreePanel } from "../../features/files/FileTreePanel";
 import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
 
+type SidebarTab = "files";
+
 /**
- * Sidebar is the left panel container. P0 keeps it as a placeholder while
- * exposing stable selectors and correct resize constraints.
+ * Sidebar is the left panel container (Files/Outline/etc).
+ *
+ * Why: P0 wires the Files tab as the minimal documents entry point with stable
+ * selectors for Windows E2E.
  */
 export function Sidebar(props: {
   width: number;
   collapsed: boolean;
+  projectId: string | null;
 }): JSX.Element {
+  const [activeTab, setActiveTab] = React.useState<SidebarTab>("files");
+
   if (props.collapsed) {
     return (
       <aside
@@ -32,12 +42,49 @@ export function Sidebar(props: {
     >
       <div
         style={{
-          padding: 12,
-          fontSize: 12,
-          color: "var(--color-fg-muted)",
+          display: "flex",
+          gap: "var(--space-1)",
+          padding: "var(--space-2)",
+          borderBottom: "1px solid var(--color-separator)",
         }}
       >
-        Sidebar (placeholder)
+        <button
+          type="button"
+          onClick={() => setActiveTab("files")}
+          style={{
+            fontSize: 12,
+            padding: "var(--space-1) var(--space-2)",
+            borderRadius: "var(--radius-md)",
+            border:
+              activeTab === "files"
+                ? "1px solid var(--color-border-focus)"
+                : "1px solid var(--color-border-default)",
+            background:
+              activeTab === "files"
+                ? "var(--color-bg-selected)"
+                : "var(--color-bg-surface)",
+            color: "var(--color-fg-default)",
+            cursor: "pointer",
+          }}
+        >
+          Files
+        </button>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        {props.projectId && activeTab === "files" ? (
+          <FileTreePanel projectId={props.projectId} />
+        ) : (
+          <div
+            style={{
+              padding: "var(--space-3)",
+              fontSize: 12,
+              color: "var(--color-fg-muted)",
+            }}
+          >
+            Sidebar (no project)
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/apps/desktop/renderer/src/features/editor/useAutosave.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosave.ts
@@ -27,6 +27,8 @@ export function useAutosave(args: {
       return;
     }
 
+    lastQueuedJsonRef.current = null;
+
     function onUpdate(): void {
       if (args.suppressRef.current) {
         return;
@@ -59,8 +61,19 @@ export function useAutosave(args: {
       args.editor?.off("update", onUpdate);
       if (timerRef.current !== null) {
         window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+        const queued = lastQueuedJsonRef.current;
+        if (queued && queued.length > 0) {
+          void save({
+            projectId: args.projectId,
+            documentId: args.documentId,
+            contentJson: queued,
+            actor: "auto",
+            reason: "autosave",
+          });
+        }
       }
-      timerRef.current = null;
+      lastQueuedJsonRef.current = null;
     };
   }, [
     args.documentId,

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -1,0 +1,364 @@
+import React from "react";
+
+import { useEditorStore } from "../../stores/editorStore";
+import { useFileStore } from "../../stores/fileStore";
+
+type EditingState =
+  | { mode: "idle" }
+  | { mode: "rename"; documentId: string; title: string };
+
+/**
+ * FileTreePanel renders the project-scoped documents list (DB SSOT) and actions.
+ *
+ * Why: P0-015 requires a minimal documents loop with stable selectors for Windows E2E.
+ */
+export function FileTreePanel(props: { projectId: string }): JSX.Element {
+  const items = useFileStore((s) => s.items);
+  const currentDocumentId = useFileStore((s) => s.currentDocumentId);
+  const bootstrapStatus = useFileStore((s) => s.bootstrapStatus);
+  const lastError = useFileStore((s) => s.lastError);
+
+  const createAndSetCurrent = useFileStore((s) => s.createAndSetCurrent);
+  const rename = useFileStore((s) => s.rename);
+  const deleteDocument = useFileStore((s) => s.delete);
+  const setCurrent = useFileStore((s) => s.setCurrent);
+  const clearError = useFileStore((s) => s.clearError);
+
+  const openDocument = useEditorStore((s) => s.openDocument);
+  const openCurrentForProject = useEditorStore(
+    (s) => s.openCurrentDocumentForProject,
+  );
+
+  const [editing, setEditing] = React.useState<EditingState>({ mode: "idle" });
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  React.useEffect(() => {
+    if (editing.mode !== "rename") {
+      return;
+    }
+
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [editing.mode]);
+
+  async function onCreate(): Promise<void> {
+    const res = await createAndSetCurrent({ projectId: props.projectId });
+    if (!res.ok) {
+      return;
+    }
+    await openDocument({
+      projectId: props.projectId,
+      documentId: res.data.documentId,
+    });
+  }
+
+  async function onSelect(documentId: string): Promise<void> {
+    const setPromise = setCurrent({ projectId: props.projectId, documentId });
+    await openDocument({ projectId: props.projectId, documentId });
+    await setPromise;
+  }
+
+  async function onCommitRename(): Promise<void> {
+    if (editing.mode !== "rename") {
+      return;
+    }
+
+    const res = await rename({
+      projectId: props.projectId,
+      documentId: editing.documentId,
+      title: editing.title,
+    });
+    if (!res.ok) {
+      return;
+    }
+    setEditing({ mode: "idle" });
+  }
+
+  async function onDelete(documentId: string): Promise<void> {
+    const ok = window.confirm("Delete this document?");
+    if (!ok) {
+      return;
+    }
+
+    const res = await deleteDocument({ projectId: props.projectId, documentId });
+    if (!res.ok) {
+      return;
+    }
+
+    await openCurrentForProject(props.projectId);
+  }
+
+  return (
+    <div
+      data-testid="sidebar-files"
+      style={{ display: "flex", flexDirection: "column", minHeight: 0 }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "var(--space-3)",
+          borderBottom: "1px solid var(--color-separator)",
+        }}
+      >
+        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+          Files
+        </div>
+        <button
+          type="button"
+          data-testid="file-create"
+          onClick={() => void onCreate()}
+          style={{
+            fontSize: 12,
+            padding: "var(--space-2) var(--space-3)",
+            borderRadius: "var(--radius-md)",
+            border: "1px solid var(--color-border-default)",
+            background: "var(--color-bg-surface)",
+            color: "var(--color-fg-default)",
+            cursor: "pointer",
+          }}
+        >
+          New
+        </button>
+      </div>
+
+      {lastError ? (
+        <div
+          role="alert"
+          style={{
+            padding: "var(--space-3)",
+            fontSize: 12,
+            color: "var(--color-fg-default)",
+            borderBottom: "1px solid var(--color-separator)",
+          }}
+        >
+          <div style={{ marginBottom: "var(--space-2)" }}>
+            {lastError.code}: {lastError.message}
+          </div>
+          <button
+            type="button"
+            onClick={() => clearError()}
+            style={{
+              fontSize: 12,
+              padding: "var(--space-2) var(--space-3)",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--color-border-default)",
+              background: "var(--color-bg-surface)",
+              color: "var(--color-fg-default)",
+              cursor: "pointer",
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
+      <div style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
+        {bootstrapStatus !== "ready" ? (
+          <div
+            style={{
+              padding: "var(--space-3)",
+              fontSize: 12,
+              color: "var(--color-fg-muted)",
+            }}
+          >
+            Loading files…
+          </div>
+        ) : items.length === 0 ? (
+          <div
+            style={{
+              padding: "var(--space-3)",
+              fontSize: 12,
+              color: "var(--color-fg-muted)",
+            }}
+          >
+            No documents yet.
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-1)",
+            }}
+          >
+            {items.map((item) => {
+              const selected = item.documentId === currentDocumentId;
+              const isRenaming =
+                editing.mode === "rename" &&
+                editing.documentId === item.documentId;
+              return (
+                <div
+                  key={item.documentId}
+                  data-testid={`file-row-${item.documentId}`}
+                  aria-selected={selected}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--space-2)",
+                    padding: "var(--space-2) var(--space-3)",
+                    margin: `0 var(--space-2)`,
+                    borderRadius: "var(--radius-md)",
+                    border: `1px solid ${
+                      selected
+                        ? "var(--color-border-focus)"
+                        : "var(--color-border-default)"
+                    }`,
+                    background: selected
+                      ? "var(--color-bg-selected)"
+                      : "transparent",
+                    cursor: isRenaming ? "default" : "pointer",
+                  }}
+                  onClick={() => {
+                    if (isRenaming) {
+                      return;
+                    }
+                    void onSelect(item.documentId);
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    {isRenaming ? (
+                      <input
+                        ref={inputRef}
+                        data-testid={`file-rename-input-${item.documentId}`}
+                        value={editing.title}
+                        onChange={(e) =>
+                          setEditing({
+                            mode: "rename",
+                            documentId: item.documentId,
+                            title: e.target.value,
+                          })
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Escape") {
+                            setEditing({ mode: "idle" });
+                            return;
+                          }
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            void onCommitRename();
+                          }
+                        }}
+                        style={{
+                          width: "100%",
+                          fontSize: 12,
+                          padding: "var(--space-1) var(--space-2)",
+                          borderRadius: "var(--radius-sm)",
+                          border: "1px solid var(--color-border-default)",
+                          background: "var(--color-bg-base)",
+                          color: "var(--color-fg-default)",
+                        }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          fontSize: 12,
+                          color: "var(--color-fg-default)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.title}
+                      </div>
+                    )}
+                  </div>
+
+                  <div style={{ display: "flex", gap: "var(--space-1)" }}>
+                      {isRenaming ? (
+                        <>
+                          <button
+                            type="button"
+                            data-testid={`file-rename-confirm-${item.documentId}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              void onCommitRename();
+                            }}
+                            style={{
+                              fontSize: 12,
+                              padding: "var(--space-1) var(--space-2)",
+                              borderRadius: "var(--radius-md)",
+                              border: "1px solid var(--color-border-default)",
+                              background: "var(--color-bg-surface)",
+                              color: "var(--color-fg-default)",
+                              cursor: "pointer",
+                            }}
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditing({ mode: "idle" });
+                            }}
+                            style={{
+                              fontSize: 12,
+                              padding: "var(--space-1) var(--space-2)",
+                              borderRadius: "var(--radius-md)",
+                              border: "1px solid var(--color-border-default)",
+                              background: "var(--color-bg-surface)",
+                              color: "var(--color-fg-default)",
+                              cursor: "pointer",
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            data-testid={`file-rename-${item.documentId}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditing({
+                                mode: "rename",
+                                documentId: item.documentId,
+                                title: item.title,
+                              });
+                            }}
+                            style={{
+                              fontSize: 12,
+                              padding: "var(--space-1) var(--space-2)",
+                              borderRadius: "var(--radius-md)",
+                              border: "1px solid var(--color-border-default)",
+                              background: "var(--color-bg-surface)",
+                              color: "var(--color-fg-default)",
+                              cursor: "pointer",
+                            }}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            data-testid={`file-delete-${item.documentId}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              void onDelete(item.documentId);
+                            }}
+                            style={{
+                              fontSize: 12,
+                              padding: "var(--space-1) var(--space-2)",
+                              borderRadius: "var(--radius-md)",
+                              border: "1px solid var(--color-border-default)",
+                              background: "var(--color-bg-surface)",
+                              color: "var(--color-fg-default)",
+                              cursor: "pointer",
+                            }}
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/stores/fileStore.ts
+++ b/apps/desktop/renderer/src/stores/fileStore.ts
@@ -1,0 +1,286 @@
+import React from "react";
+import { create } from "zustand";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcRequest,
+  IpcResponse,
+  IpcResponseData,
+} from "../../../../../packages/shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;
+
+export type DocumentListItem = IpcResponseData<"file:document:list">["items"][number];
+
+export type FileState = {
+  projectId: string | null;
+  items: DocumentListItem[];
+  currentDocumentId: string | null;
+  bootstrapStatus: "idle" | "loading" | "ready" | "error";
+  lastError: IpcError | null;
+};
+
+export type FileActions = {
+  bootstrapForProject: (projectId: string) => Promise<void>;
+  refreshForProject: (projectId: string) => Promise<void>;
+  createAndSetCurrent: (args: {
+    projectId: string;
+    title?: string;
+  }) => Promise<IpcResponse<{ documentId: string }>>;
+  rename: (args: {
+    projectId: string;
+    documentId: string;
+    title: string;
+  }) => Promise<IpcResponse<{ updated: true }>>;
+  delete: (args: {
+    projectId: string;
+    documentId: string;
+  }) => Promise<IpcResponse<{ deleted: true }>>;
+  setCurrent: (args: {
+    projectId: string;
+    documentId: string;
+  }) => Promise<IpcResponse<{ documentId: string }>>;
+  clearError: () => void;
+};
+
+export type FileStore = FileState & FileActions;
+
+export type UseFileStore = ReturnType<typeof createFileStore>;
+
+const FileStoreContext = React.createContext<UseFileStore | null>(null);
+
+/**
+ * Create a zustand store for project-scoped documents list and current document.
+ *
+ * Why: the sidebar file tree must be driven through typed IPC with a stable,
+ * testable state machine, and `currentDocumentId` must persist per project.
+ */
+export function createFileStore(deps: { invoke: IpcInvoke }) {
+  async function loadDocuments(
+    projectId: string,
+  ): Promise<IpcInvokeResult<"file:document:list">> {
+    return await deps.invoke("file:document:list", { projectId });
+  }
+
+  async function loadCurrent(
+    projectId: string,
+  ): Promise<IpcInvokeResult<"file:document:getCurrent">> {
+    return await deps.invoke("file:document:getCurrent", { projectId });
+  }
+
+  async function persistCurrent(
+    projectId: string,
+    documentId: string,
+  ): Promise<IpcInvokeResult<"file:document:setCurrent">> {
+    return await deps.invoke("file:document:setCurrent", { projectId, documentId });
+  }
+
+  async function createDocument(
+    projectId: string,
+    title?: string,
+  ): Promise<IpcInvokeResult<"file:document:create">> {
+    return await deps.invoke("file:document:create", { projectId, title });
+  }
+
+  return create<FileStore>((set, get) => ({
+    projectId: null,
+    items: [],
+    currentDocumentId: null,
+    bootstrapStatus: "idle",
+    lastError: null,
+
+    clearError: () => set({ lastError: null }),
+
+    refreshForProject: async (projectId) => {
+      const listRes = await loadDocuments(projectId);
+      if (!listRes.ok) {
+        set({ lastError: listRes.error });
+        return;
+      }
+
+      const currentRes = await loadCurrent(projectId);
+      const currentDocumentId = currentRes.ok ? currentRes.data.documentId : null;
+
+      set({
+        projectId,
+        items: listRes.data.items,
+        currentDocumentId,
+      });
+    },
+
+    bootstrapForProject: async (projectId) => {
+      const state = get();
+      if (state.bootstrapStatus === "loading" && state.projectId === projectId) {
+        return;
+      }
+
+      set({
+        projectId,
+        bootstrapStatus: "loading",
+        lastError: null,
+        items: [],
+        currentDocumentId: null,
+      });
+
+      const listRes = await loadDocuments(projectId);
+      if (!listRes.ok) {
+        set({ bootstrapStatus: "error", lastError: listRes.error });
+        return;
+      }
+
+      const currentRes = await loadCurrent(projectId);
+      if (currentRes.ok) {
+        set({
+          bootstrapStatus: "ready",
+          items: listRes.data.items,
+          currentDocumentId: currentRes.data.documentId,
+          lastError: null,
+        });
+        return;
+      }
+      if (currentRes.error.code !== "NOT_FOUND") {
+        set({
+          bootstrapStatus: "error",
+          items: listRes.data.items,
+          lastError: currentRes.error,
+        });
+        return;
+      }
+
+      const firstExisting = listRes.data.items[0]?.documentId ?? null;
+      if (firstExisting) {
+        const setRes = await persistCurrent(projectId, firstExisting);
+        if (!setRes.ok) {
+          set({
+            bootstrapStatus: "error",
+            items: listRes.data.items,
+            lastError: setRes.error,
+          });
+          return;
+        }
+        set({
+          bootstrapStatus: "ready",
+          items: listRes.data.items,
+          currentDocumentId: setRes.data.documentId,
+          lastError: null,
+        });
+        return;
+      }
+
+      const created = await createDocument(projectId);
+      if (!created.ok) {
+        set({ bootstrapStatus: "error", lastError: created.error });
+        return;
+      }
+
+      const setRes = await persistCurrent(projectId, created.data.documentId);
+      if (!setRes.ok) {
+        set({ bootstrapStatus: "error", lastError: setRes.error });
+        return;
+      }
+
+      const listRes2 = await loadDocuments(projectId);
+      if (!listRes2.ok) {
+        set({ bootstrapStatus: "error", lastError: listRes2.error });
+        return;
+      }
+
+      set({
+        bootstrapStatus: "ready",
+        items: listRes2.data.items,
+        currentDocumentId: setRes.data.documentId,
+        lastError: null,
+      });
+    },
+
+    createAndSetCurrent: async ({ projectId, title }) => {
+      const created = await createDocument(projectId, title);
+      if (!created.ok) {
+        set({ lastError: created.error });
+        return created;
+      }
+
+      const setRes = await persistCurrent(projectId, created.data.documentId);
+      if (!setRes.ok) {
+        set({ lastError: setRes.error });
+        return setRes;
+      }
+
+      await get().refreshForProject(projectId);
+      return setRes;
+    },
+
+    rename: async ({ projectId, documentId, title }) => {
+      const res = await deps.invoke("file:document:rename", {
+        projectId,
+        documentId,
+        title,
+      });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      await get().refreshForProject(projectId);
+      return res;
+    },
+
+    delete: async ({ projectId, documentId }) => {
+      const res = await deps.invoke("file:document:delete", {
+        projectId,
+        documentId,
+      });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      await get().refreshForProject(projectId);
+      return res;
+    },
+
+    setCurrent: async ({ projectId, documentId }) => {
+      const prev = get().currentDocumentId;
+      set({ currentDocumentId: documentId });
+
+      const res = await persistCurrent(projectId, documentId);
+      if (!res.ok) {
+        set({ currentDocumentId: prev, lastError: res.error });
+        return res;
+      }
+
+      set({ currentDocumentId: res.data.documentId });
+      return res;
+    },
+  }));
+}
+
+/**
+ * Provide a file store instance for the Workbench UI.
+ */
+export function FileStoreProvider(props: {
+  store: UseFileStore;
+  children: React.ReactNode;
+}): JSX.Element {
+  return React.createElement(
+    FileStoreContext.Provider,
+    { value: props.store },
+    props.children,
+  );
+}
+
+/**
+ * Read values from the injected file store.
+ */
+export function useFileStore<T>(selector: (state: FileStore) => T): T {
+  const store = React.useContext(FileStoreContext);
+  if (!store) {
+    throw new Error("FileStoreProvider is missing");
+  }
+  return store(selector);
+}

--- a/apps/desktop/tests/e2e/documents-filetree.spec.ts
+++ b/apps/desktop/tests/e2e/documents-filetree.spec.ts
@@ -1,0 +1,269 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+/**
+ * Parse the documentId from a `file-row-<documentId>` test id.
+ *
+ * Why: E2E must be resilient to UUID-based document ids.
+ */
+function parseDocumentId(testId: string): string {
+  const prefix = "file-row-";
+  if (!testId.startsWith(prefix)) {
+    throw new Error(`Unexpected file row test id: ${testId}`);
+  }
+  const id = testId.slice(prefix.length);
+  if (id.length === 0) {
+    throw new Error("Missing document id");
+  }
+  return id;
+}
+
+test("documents filetree: create/switch/rename/delete + current restore", async () => {
+  const userDataDir = await createIsolatedUserDataDir();
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const appRoot = path.resolve(__dirname, "../..");
+
+  async function launch() {
+    return await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+  }
+
+  const electronApp = await launch();
+  const page = await electronApp.firstWindow();
+  await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+
+  await expect(page.getByTestId("welcome-screen")).toBeVisible();
+  await page.getByTestId("welcome-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.getByTestId("create-project-name").fill("Demo Project");
+  await page.getByTestId("create-project-submit").click();
+
+  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+  await expect(page.getByTestId("sidebar-files")).toBeVisible();
+
+  const firstRow = page.locator('[data-testid^="file-row-"]').first();
+  await expect(firstRow).toBeVisible();
+  const firstRowIdAttr = await firstRow.getAttribute("data-testid");
+  if (!firstRowIdAttr) {
+    throw new Error("Missing data-testid on file row");
+  }
+  const docAId = parseDocumentId(firstRowIdAttr);
+
+  await firstRow.locator(`[data-testid="file-rename-${docAId}"]`).click();
+  await page.getByTestId(`file-rename-input-${docAId}`).fill("Doc A");
+  await page.getByTestId(`file-rename-confirm-${docAId}`).click();
+  await expect(page.getByTestId(`file-row-${docAId}`)).toContainText("Doc A");
+
+  const project = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(project.ok).toBe(true);
+  if (!project.ok) {
+    throw new Error(`Expected ok current project, got: ${project.error.code}`);
+  }
+
+  const invalidRenameEmpty = await page.evaluate(
+    async ({ projectIdParam, documentIdParam }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("file:document:rename", {
+        projectId: projectIdParam,
+        documentId: documentIdParam,
+        title: "",
+      });
+    },
+    { projectIdParam: project.data.projectId, documentIdParam: docAId },
+  );
+  expect(invalidRenameEmpty.ok).toBe(false);
+  if (invalidRenameEmpty.ok) {
+    throw new Error("Expected INVALID_ARGUMENT on empty title rename");
+  }
+  expect(invalidRenameEmpty.error.code).toBe("INVALID_ARGUMENT");
+
+  const invalidRenameLong = await page.evaluate(
+    async ({ projectIdParam, documentIdParam }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("file:document:rename", {
+        projectId: projectIdParam,
+        documentId: documentIdParam,
+        title: "a".repeat(201),
+      });
+    },
+    { projectIdParam: project.data.projectId, documentIdParam: docAId },
+  );
+  expect(invalidRenameLong.ok).toBe(false);
+  if (invalidRenameLong.ok) {
+    throw new Error("Expected INVALID_ARGUMENT on long title rename");
+  }
+  expect(invalidRenameLong.error.code).toBe("INVALID_ARGUMENT");
+
+  await page.getByTestId("tiptap-editor").click();
+  await page.keyboard.type("Alpha content");
+  await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+    "data-status",
+    "saved",
+  );
+
+  await page.getByTestId("file-create").click();
+
+  const selectedRow = page.locator(
+    '[data-testid^="file-row-"][aria-selected="true"]',
+  );
+  await expect(selectedRow).toBeVisible();
+  const selectedIdAttr = await selectedRow.getAttribute("data-testid");
+  if (!selectedIdAttr) {
+    throw new Error("Missing data-testid on selected file row");
+  }
+  const docBId = parseDocumentId(selectedIdAttr);
+  expect(docBId).not.toBe(docAId);
+
+  await expect(page.getByTestId("editor-pane")).toHaveAttribute(
+    "data-document-id",
+    docBId,
+  );
+
+  await page.getByTestId(`file-rename-${docBId}`).click();
+  await page.getByTestId(`file-rename-input-${docBId}`).fill("Doc B");
+  await page.getByTestId(`file-rename-confirm-${docBId}`).click();
+
+  await page.getByTestId("tiptap-editor").click();
+  await page.keyboard.type("Beta content");
+  await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+    "data-status",
+    "saved",
+  );
+
+  await page
+    .getByTestId(`file-row-${docAId}`)
+    .click({ position: { x: 5, y: 5 } });
+  await expect(page.getByTestId(`file-row-${docAId}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page.getByTestId("editor-pane")).toHaveAttribute(
+    "data-document-id",
+    docAId,
+  );
+  await expect(page.getByTestId("tiptap-editor")).toContainText("Alpha content");
+  await expect(page.getByTestId("tiptap-editor")).not.toContainText(
+    "Beta content",
+  );
+
+  await page
+    .getByTestId(`file-row-${docBId}`)
+    .click({ position: { x: 5, y: 5 } });
+  await expect(page.getByTestId(`file-row-${docBId}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page.getByTestId("editor-pane")).toHaveAttribute(
+    "data-document-id",
+    docBId,
+  );
+  await expect(page.getByTestId("tiptap-editor")).toContainText("Beta content");
+  await expect(page.getByTestId("tiptap-editor")).not.toContainText(
+    "Alpha content",
+  );
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId(`file-delete-${docBId}`).click();
+
+  await expect(page.getByTestId(`file-row-${docBId}`)).toHaveCount(0);
+  await expect(page.getByTestId("editor-pane")).toHaveAttribute(
+    "data-document-id",
+    docAId,
+  );
+  await expect(page.getByTestId("tiptap-editor")).toContainText("Alpha content");
+
+  const currentDoc = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("file:document:getCurrent", {
+      projectId: projectIdParam,
+    });
+  }, project.data.projectId);
+  expect(currentDoc.ok).toBe(true);
+  if (!currentDoc.ok) {
+    throw new Error(`Expected ok current document, got: ${currentDoc.error.code}`);
+  }
+  expect(currentDoc.data.documentId).toBe(docAId);
+
+  await electronApp.close();
+
+  const electronApp2 = await launch();
+  const page2 = await electronApp2.firstWindow();
+  await page2.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page2.getByTestId("app-shell")).toBeVisible();
+  await expect(page2.getByTestId("sidebar-files")).toBeVisible();
+  await expect(page2.getByTestId("tiptap-editor")).toBeVisible();
+
+  const project2 = await page2.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(project2.ok).toBe(true);
+  if (!project2.ok) {
+    throw new Error(`Expected ok current project, got: ${project2.error.code}`);
+  }
+  expect(project2.data.projectId).toBe(project.data.projectId);
+
+  const currentDoc2 = await page2.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("file:document:getCurrent", {
+      projectId: projectIdParam,
+    });
+  }, project.data.projectId);
+  expect(currentDoc2.ok).toBe(true);
+  if (!currentDoc2.ok) {
+    throw new Error(`Expected ok current document, got: ${currentDoc2.error.code}`);
+  }
+  expect(currentDoc2.data.documentId).toBe(docAId);
+
+  await expect(page2.getByTestId(`file-row-${docAId}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page2.getByTestId("editor-pane")).toHaveAttribute(
+    "data-document-id",
+    docAId,
+  );
+  await expect(page2.getByTestId("tiptap-editor")).toContainText("Alpha content");
+
+  await electronApp2.close();
+});

--- a/openspec/_ops/task_runs/ISSUE-31.md
+++ b/openspec/_ops/task_runs/ISSUE-31.md
@@ -1,0 +1,40 @@
+# ISSUE-31
+
+- Issue: #31
+- Branch: task/31-p0-015-documents-filetree
+- PR: <fill-after-created>
+
+## Plan
+
+- 补齐 Documents IPC + DocumentService：rename/delete/currentDocument 语义（project 作用域）
+- Renderer 增加 Sidebar Files + fileStore（稳定 `data-testid`）
+- 增加 Windows E2E：documents create/switch/rename/delete + 重启恢复 currentDocument
+
+## Runs
+
+### 2026-01-31 18:18 bootstrap
+
+- Command: `gh issue create -t "[CN-V1] P0-015: Documents + FileTree minimal" -b "<...>"`
+- Key output: `https://github.com/Leeky1017/CreoNow/issues/31`
+
+- Command: `scripts/agent_worktree_setup.sh 31 p0-015-documents-filetree`
+- Key output: `Worktree created: .worktrees/issue-31-p0-015-documents-filetree`
+
+### 2026-01-31 18:27 deps + contract
+
+- Command: `pnpm install`
+- Key output: `Done in 1.4s`
+
+- Command: `pnpm -s contract:generate`
+- Key output: `(no output)`
+
+### 2026-01-31 18:29 checks
+
+- Command: `pnpm -C apps/desktop typecheck`
+- Key output: `exit 0`
+
+- Command: `pnpm -C apps/desktop lint`
+- Key output: `exit 0`
+
+- Command: `pnpm test:unit`
+- Key output: `exit 0`

--- a/openspec/_ops/task_runs/ISSUE-31.md
+++ b/openspec/_ops/task_runs/ISSUE-31.md
@@ -46,3 +46,20 @@
 
 - Command: `gh pr create --draft --title "feat: documents rename + current doc IPC (#31)" --body "Closes #31 ..."`
 - Key output: `https://github.com/Leeky1017/CreoNow/pull/34`
+
+### 2026-01-31 17:53 filetree + e2e
+
+- Command: `pnpm -C apps/desktop typecheck`
+- Key output: `exit 0`
+
+- Command: `pnpm -C apps/desktop lint`
+- Key output: `exit 0`
+
+- Command: `pnpm test:unit`
+- Key output: `exit 0`
+
+- Command: `pnpm -C apps/desktop test:e2e -- documents-filetree.spec.ts`
+- Key output: `1 passed`
+
+- Command: `pnpm -C apps/desktop test:e2e -- app-launch.spec.ts project-lifecycle.spec.ts editor-autosave.spec.ts`
+- Key output: `3 passed`

--- a/openspec/_ops/task_runs/ISSUE-31.md
+++ b/openspec/_ops/task_runs/ISSUE-31.md
@@ -2,7 +2,7 @@
 
 - Issue: #31
 - Branch: task/31-p0-015-documents-filetree
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/34
 
 ## Plan
 
@@ -38,3 +38,11 @@
 
 - Command: `pnpm test:unit`
 - Key output: `exit 0`
+
+### 2026-01-31 18:31 pr
+
+- Command: `git push -u origin HEAD`
+- Key output: `new branch: task/31-p0-015-documents-filetree`
+
+- Command: `gh pr create --draft --title "feat: documents rename + current doc IPC (#31)" --body "Closes #31 ..."`
+- Key output: `https://github.com/Leeky1017/CreoNow/pull/34`

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -60,8 +60,11 @@ export const IPC_CHANNELS = [
   "db:debug:tableNames",
   "file:document:create",
   "file:document:delete",
+  "file:document:getCurrent",
   "file:document:list",
   "file:document:read",
+  "file:document:rename",
+  "file:document:setCurrent",
   "file:document:write",
   "judge:model:ensure",
   "judge:model:getState",
@@ -183,6 +186,14 @@ export type IpcChannelSpec = {
       deleted: true;
     };
   };
+  "file:document:getCurrent": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      documentId: string;
+    };
+  };
   "file:document:list": {
     request: {
       projectId: string;
@@ -209,6 +220,25 @@ export type IpcChannelSpec = {
       projectId: string;
       title: string;
       updatedAt: number;
+    };
+  };
+  "file:document:rename": {
+    request: {
+      documentId: string;
+      projectId: string;
+      title: string;
+    };
+    response: {
+      updated: true;
+    };
+  };
+  "file:document:setCurrent": {
+    request: {
+      documentId: string;
+      projectId: string;
+    };
+    response: {
+      documentId: string;
     };
   };
   "file:document:write": {

--- a/rulebook/tasks/issue-31-p0-015-documents-filetree/.metadata.json
+++ b/rulebook/tasks/issue-31-p0-015-documents-filetree/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T08:52:29.492Z",
+  "updatedAt": "2026-01-31T08:52:29.492Z"
+}

--- a/rulebook/tasks/issue-31-p0-015-documents-filetree/proposal.md
+++ b/rulebook/tasks/issue-31-p0-015-documents-filetree/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: issue-31-p0-015-documents-filetree
+
+## Why
+P0 Workbench 需要在单 project 内交付 documents 的最小闭环（create/open/switch/rename/delete + currentDocumentId 持久化），并提供 Windows E2E 可断言的稳定选择器与可观测证据。
+
+## What Changes
+- Main：补齐 `file:document:*` IPC（rename/getCurrent/setCurrent 等）与 DocumentService 对应语义（project 作用域、删除当前文档的确定性行为）。
+- DB：按 SSOT 约束补齐 documents 相关字段/索引（若缺失）以支撑稳定 list/read/write。
+- Renderer：新增 Sidebar Files 面板 + Zustand store，驱动文档列表与 currentDocument 切换。
+- Tests：新增 Playwright Electron E2E 覆盖 create/switch/rename/delete + 重启恢复。
+
+## Impact
+- Affected specs:
+  - openspec/specs/creonow-v1-workbench/spec.md#cnwb-req-006
+  - openspec/specs/creonow-v1-workbench/spec.md#cnwb-req-020
+  - openspec/specs/creonow-v1-workbench/spec.md#cnwb-req-030
+- Affected code:
+  - apps/desktop/main/src/ipc/file.ts
+  - apps/desktop/main/src/services/documents/documentService.ts
+  - apps/desktop/main/src/db/migrations/*
+  - apps/desktop/renderer/src/features/files/*
+  - apps/desktop/renderer/src/stores/*
+  - apps/desktop/tests/e2e/documents-filetree.spec.ts
+- Breaking change: NO
+- User benefit: 用户可在项目内创建/管理多文档并可靠切换；重启后恢复上次编辑文档，避免“进来就是空白/丢失上下文”。

--- a/rulebook/tasks/issue-31-p0-015-documents-filetree/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-31-p0-015-documents-filetree/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,51 @@
+# Spec Delta: P0-015 Documents + FileTree minimal
+
+## Scope
+
+This task implements the minimal “documents within a single project” loop:
+
+- Create / list / read / write (existing)
+- Rename / delete
+- `currentDocumentId` persisted per project and restored on restart
+- Stable `data-testid` hooks for Windows Playwright E2E
+
+## IPC Contract (additions)
+
+Channels:
+
+- `file:document:rename({ projectId, documentId, title }) -> { updated: true }`
+- `file:document:setCurrent({ projectId, documentId }) -> { documentId }`
+- `file:document:getCurrent({ projectId }) -> { documentId }`
+
+Error codes (deterministic):
+
+- `INVALID_ARGUMENT`: missing/blank ids; invalid title (empty or too long)
+- `NOT_FOUND`: document not found under the given project; no current document
+- `DB_ERROR`: database operation failed
+
+## Persistence semantics
+
+- `currentDocumentId` MUST be scoped to the project (no cross-project leakage).
+- Storage MUST use the existing `settings` table:
+  - `scope = "project:<projectId>"`
+  - `key = "creonow.document.currentId"`
+  - `value_json = JSON.stringify(documentId)`
+
+## Delete semantics (V1 deterministic)
+
+When deleting the current document:
+
+- If there exists another document under the same project, the app MUST select
+  the most recently updated remaining document as the new current document.
+- If no documents remain, the app MUST clear the current document setting and
+  `getCurrent` MUST return `NOT_FOUND`.
+
+## Observability
+
+Main process MUST log:
+
+- `document_created` (projectId, documentId)
+- `document_renamed` (documentId)
+- `document_deleted` (documentId)
+- `document_set_current` (projectId, documentId)
+

--- a/rulebook/tasks/issue-31-p0-015-documents-filetree/tasks.md
+++ b/rulebook/tasks/issue-31-p0-015-documents-filetree/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+- [ ] 1.1 补齐 `file:document:*` IPC：rename/getCurrent/setCurrent（错误码稳定）
+- [ ] 1.2 DocumentService：rename/currentDocument（project 作用域，删除当前文档语义写死）
+- [ ] 1.3 DB migrations：documents 字段/索引对齐 SSOT 设计（必要时新增 migration）
+- [ ] 1.4 Renderer：Sidebar Files + `fileStore`（稳定 `data-testid`）
+
+## 2. Testing
+- [ ] 2.1 E2E：documents create/switch/rename/delete（含边界：空 title、超长 title、删除当前文档）
+- [ ] 2.2 E2E：重启恢复 currentDocumentId，且内容互不污染（对齐 P0-005 autosave）
+
+## 3. Documentation
+- [ ] 3.1 更新 task card Completion（PR + RUN_LOG）
+- [ ] 3.2 归档 rulebook task（merge 后）


### PR DESCRIPTION
Closes #31

Implements P0-015 Documents + FileTree minimal:
- IPC: file:document:rename/getCurrent/setCurrent (plus existing create/list/read/write/delete)
- Main: currentDocumentId persisted per project; deleting current doc switches to most recently updated remaining doc
- Renderer: Sidebar Files tab + FileTreePanel + fileStore with stable data-testid selectors
- E2E: documents-filetree.spec.ts (create/switch/rename/delete + restart restore)

Test Plan:
- pnpm -C apps/desktop typecheck
- pnpm -C apps/desktop lint
- pnpm test:unit
- pnpm -C apps/desktop test:e2e -- documents-filetree.spec.ts
- pnpm -C apps/desktop test:e2e -- app-launch.spec.ts project-lifecycle.spec.ts editor-autosave.spec.ts

Run log:
- openspec/_ops/task_runs/ISSUE-31.md
