### PR TITLE
P0-013: Constraints + Judge minimal (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Unit tests
         run: pnpm test:unit
 
+      - name: Integration tests
+        run: pnpm test:integration
+
   windows-e2e:
     runs-on: windows-latest
     steps:

--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -11,6 +11,7 @@ import { getDbPaths, redactUserDataPath } from "./paths";
 
 import initSql from "./migrations/0001_init.sql?raw";
 import documentsSql from "./migrations/0002_documents_versioning.sql?raw";
+import judgeSql from "./migrations/0003_judge.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -34,6 +35,7 @@ type Migration = {
 const MIGRATIONS: readonly Migration[] = [
   { version: 1, name: "0001_init", sql: initSql },
   { version: 2, name: "0002_documents_versioning", sql: documentsSql },
+  { version: 3, name: "0003_judge", sql: judgeSql },
 ];
 
 /**

--- a/apps/desktop/main/src/db/migrations/0001_init.sql
+++ b/apps/desktop/main/src/db/migrations/0001_init.sql
@@ -72,3 +72,11 @@ CREATE TABLE IF NOT EXISTS kg_relations (
   FOREIGN KEY(to_entity_id) REFERENCES kg_entities(entity_id) ON DELETE CASCADE
 );
 
+-- P0-013: Judge model metadata (minimal baseline).
+CREATE TABLE IF NOT EXISTS judge_models (
+  model_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  error_code TEXT,
+  error_message TEXT,
+  updated_at INTEGER NOT NULL
+);

--- a/apps/desktop/main/src/db/migrations/0003_judge.sql
+++ b/apps/desktop/main/src/db/migrations/0003_judge.sql
@@ -1,0 +1,9 @@
+-- Adds judge model metadata tables required by P0-013.
+
+CREATE TABLE IF NOT EXISTS judge_models (
+  model_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  error_code TEXT,
+  error_message TEXT,
+  updated_at INTEGER NOT NULL
+);

--- a/apps/desktop/main/src/ipc/constraints.ts
+++ b/apps/desktop/main/src/ipc/constraints.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+
+import type {
+  IpcError,
+  IpcResponse,
+} from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import { ensureCreonowDirStructure } from "../services/context/creonowDir";
+
+type ConstraintsConfig = {
+  version: 1;
+  items: string[];
+};
+
+type ProjectRow = {
+  rootPath: string;
+};
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+type ServiceResult<T> = Ok<T> | Err;
+
+/**
+ * Return a new default constraints config.
+ *
+ * Why: callers must never share/mutate a singleton default across IPC requests.
+ */
+function getDefaultConstraints(): ConstraintsConfig {
+  return { version: 1, items: [] };
+}
+
+/**
+ * Narrow unknown to a record.
+ */
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null;
+}
+
+/**
+ * Validate the constraints JSON shape.
+ *
+ * Why: constraints are part of prompt rules; invalid state must be rejected with
+ * a stable `INVALID_ARGUMENT` error for E2E and recovery.
+ */
+function isConstraintsConfig(x: unknown): x is ConstraintsConfig {
+  if (!isRecord(x)) {
+    return false;
+  }
+  if (x.version !== 1) {
+    return false;
+  }
+  if (!Array.isArray(x.items)) {
+    return false;
+  }
+  return x.items.every((v) => typeof v === "string");
+}
+
+/**
+ * Build a stable IPC error object.
+ *
+ * Why: filesystem errors must not leak raw stacks across IPC.
+ */
+function ipcError(code: IpcError["code"], message: string): Err {
+  return { ok: false, error: { code, message } };
+}
+
+/**
+ * Compute the constraints SSOT absolute path.
+ */
+function getConstraintsPath(projectRootPath: string): string {
+  return path.join(projectRootPath, ".creonow", "rules", "constraints.json");
+}
+
+/**
+ * Read and validate constraints from disk.
+ */
+async function readConstraintsFile(
+  constraintsPath: string,
+): Promise<ServiceResult<ConstraintsConfig>> {
+  try {
+    const raw = await fs.readFile(constraintsPath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isConstraintsConfig(parsed)) {
+      return ipcError(
+        "INVALID_ARGUMENT",
+        "constraints.json has invalid schema",
+      );
+    }
+    return { ok: true, data: parsed };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { ok: true, data: getDefaultConstraints() };
+    }
+    if (error instanceof Error && error.name === "SyntaxError") {
+      return ipcError("INVALID_ARGUMENT", "constraints.json is not valid JSON");
+    }
+    return ipcError("IO_ERROR", "Failed to read constraints");
+  }
+}
+
+/**
+ * Write constraints SSOT to disk (overwriting any previous content).
+ */
+async function writeConstraintsFile(args: {
+  constraintsPath: string;
+  constraints: ConstraintsConfig;
+}): Promise<ServiceResult<true>> {
+  try {
+    const json = JSON.stringify(args.constraints, null, 2) + "\n";
+    await fs.writeFile(args.constraintsPath, json, "utf8");
+    return { ok: true, data: true };
+  } catch {
+    return ipcError("IO_ERROR", "Failed to write constraints");
+  }
+}
+
+/**
+ * Register `constraints:*` IPC handlers.
+ *
+ * Why: constraints are project-scoped rules with SSOT at
+ * `.creonow/rules/constraints.json` (no DB dual-write).
+ */
+export function registerConstraintsIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "constraints:get",
+    async (
+      _e,
+      payload: { projectId: string },
+    ): Promise<IpcResponse<{ constraints: ConstraintsConfig }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+
+      try {
+        const row = deps.db
+          .prepare<
+            [string],
+            ProjectRow
+          >("SELECT root_path as rootPath FROM projects WHERE project_id = ?")
+          .get(payload.projectId);
+        if (!row) {
+          return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Project not found" },
+          };
+        }
+
+        const constraintsPath = getConstraintsPath(row.rootPath);
+        const res = await readConstraintsFile(constraintsPath);
+        if (!res.ok) {
+          deps.logger.error("constraints_read_failed", {
+            projectId: payload.projectId,
+            code: res.error.code,
+          });
+          return { ok: false, error: res.error };
+        }
+
+        return { ok: true, data: { constraints: res.data } };
+      } catch (error) {
+        deps.logger.error("constraints_get_failed", {
+          code: "IO_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          ok: false,
+          error: { code: "IO_ERROR", message: "Failed to get constraints" },
+        };
+      }
+    },
+  );
+
+  deps.ipcMain.handle(
+    "constraints:set",
+    async (
+      _e,
+      payload: { projectId: string; constraints: ConstraintsConfig },
+    ): Promise<IpcResponse<{ constraints: ConstraintsConfig }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      if (payload.projectId.trim().length === 0) {
+        return {
+          ok: false,
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+        };
+      }
+      if (!isConstraintsConfig(payload.constraints)) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "constraints must match schema",
+          },
+        };
+      }
+
+      try {
+        const row = deps.db
+          .prepare<
+            [string],
+            ProjectRow
+          >("SELECT root_path as rootPath FROM projects WHERE project_id = ?")
+          .get(payload.projectId);
+        if (!row) {
+          return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Project not found" },
+          };
+        }
+
+        const ensured = ensureCreonowDirStructure(row.rootPath);
+        if (!ensured.ok) {
+          deps.logger.error("constraints_ensure_creonow_failed", {
+            projectId: payload.projectId,
+            code: ensured.error.code,
+          });
+          return { ok: false, error: ensured.error };
+        }
+
+        const constraintsPath = getConstraintsPath(row.rootPath);
+        const wrote = await writeConstraintsFile({
+          constraintsPath,
+          constraints: payload.constraints,
+        });
+        if (!wrote.ok) {
+          deps.logger.error("constraints_write_failed", {
+            projectId: payload.projectId,
+            code: wrote.error.code,
+          });
+          return { ok: false, error: wrote.error };
+        }
+
+        deps.logger.info("constraints_updated", {
+          projectId: payload.projectId,
+          items_count: payload.constraints.items.length,
+        });
+        return { ok: true, data: { constraints: payload.constraints } };
+      } catch (error) {
+        deps.logger.error("constraints_set_failed", {
+          code: "IO_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          ok: false,
+          error: { code: "IO_ERROR", message: "Failed to set constraints" },
+        };
+      }
+    },
+  );
+}

--- a/apps/desktop/main/src/ipc/judge.ts
+++ b/apps/desktop/main/src/ipc/judge.ts
@@ -1,0 +1,48 @@
+import type { IpcMain } from "electron";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type {
+  JudgeModelState,
+  JudgeService,
+} from "../services/judge/judgeService";
+
+/**
+ * Register `judge:*` IPC handlers.
+ *
+ * Why: renderer must be able to observe model readiness and trigger ensure
+ * deterministically for Windows E2E.
+ */
+export function registerJudgeIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  judgeService: JudgeService;
+}): void {
+  deps.ipcMain.handle(
+    "judge:model:getState",
+    async (): Promise<IpcResponse<{ state: JudgeModelState }>> => {
+      return { ok: true, data: { state: deps.judgeService.getState() } };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "judge:model:ensure",
+    async (
+      _e,
+      payload: { timeoutMs?: number } | undefined,
+    ): Promise<IpcResponse<{ state: JudgeModelState }>> => {
+      const timeoutMs = payload?.timeoutMs;
+      if (timeoutMs !== undefined && typeof timeoutMs !== "number") {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "timeoutMs must be number",
+          },
+        };
+      }
+      const res = await deps.judgeService.ensure({ timeoutMs });
+      return res.ok
+        ? { ok: true, data: { state: res.data } }
+        : { ok: false, error: res.error };
+    },
+  );
+}

--- a/apps/desktop/main/src/services/judge/judgeService.ts
+++ b/apps/desktop/main/src/services/judge/judgeService.ts
@@ -1,0 +1,186 @@
+import type {
+  IpcError,
+  IpcErrorCode,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../../logging/logger";
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type ServiceResult<T> = Ok<T> | Err;
+
+export type JudgeModelStatus = "not_ready" | "downloading" | "ready" | "error";
+
+export type JudgeModelState =
+  | { status: "not_ready" }
+  | { status: "downloading" }
+  | { status: "ready" }
+  | { status: "error"; error: { code: IpcErrorCode; message: string } };
+
+export type JudgeService = {
+  getState: () => JudgeModelState;
+  ensure: (args?: {
+    timeoutMs?: number;
+  }) => Promise<ServiceResult<JudgeModelState>>;
+};
+
+/**
+ * Create a stable IPC error object.
+ *
+ * Why: judge failures must return deterministic error codes/messages for E2E.
+ */
+function ipcError(code: IpcErrorCode, message: string): Err {
+  return { ok: false, error: { code, message } };
+}
+
+/**
+ * Sleep for a given duration.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Run an async operation with a timeout.
+ */
+async function withTimeout<T>(
+  op: () => Promise<T>,
+  timeoutMs: number,
+): Promise<ServiceResult<T>> {
+  let timeoutHandle: NodeJS.Timeout | null = null;
+  try {
+    const res = await Promise.race([
+      op(),
+      new Promise<never>((_resolve, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error("timeout")),
+          timeoutMs,
+        );
+      }),
+    ]);
+    return { ok: true, data: res };
+  } catch (error) {
+    if (error instanceof Error && error.message === "timeout") {
+      return ipcError("TIMEOUT", "Judge model ensure timed out");
+    }
+    return ipcError(
+      "INTERNAL",
+      error instanceof Error ? error.message : "Judge ensure failed",
+    );
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+/**
+ * Create the JudgeService state machine.
+ *
+ * Why: judge model availability must be observable and Windows E2E-testable even
+ * before a real model download/load pipeline is implemented.
+ */
+export function createJudgeService(deps: {
+  logger: Logger;
+  isE2E: boolean;
+  defaultTimeoutMs?: number;
+}): JudgeService {
+  let state: JudgeModelState = { status: "not_ready" };
+  let inflight: Promise<ServiceResult<JudgeModelState>> | null = null;
+
+  /**
+   * Emit a stable state log record.
+   *
+   * Why: Windows E2E must be able to assert judge state/ensure evidence via
+   * `main.log` without relying on UI timing.
+   */
+  function logState(next: JudgeModelState): void {
+    deps.logger.info("judge_state", {
+      status: next.status,
+      errorCode: next.status === "error" ? next.error.code : undefined,
+    });
+  }
+
+  /**
+   * Update the in-memory state machine.
+   *
+   * Why: keeping state transitions centralized ensures we never silently skip
+   * observability logs for judge readiness.
+   */
+  function setState(next: JudgeModelState): void {
+    state = next;
+    logState(next);
+  }
+
+  /**
+   * Ensure the judge model is available (real or degraded for E2E).
+   */
+  async function runEnsure(timeoutMs: number): Promise<ServiceResult<true>> {
+    if (!deps.isE2E) {
+      return ipcError(
+        "MODEL_NOT_READY",
+        "Judge model ensure is not implemented (non-E2E build)",
+      );
+    }
+
+    return await withTimeout(async () => {
+      await sleep(25);
+      return true as const;
+    }, timeoutMs);
+  }
+
+  return {
+    getState: () => state,
+    ensure: async (args) => {
+      if (state.status === "ready") {
+        return { ok: true, data: state };
+      }
+
+      if (inflight) {
+        return await inflight;
+      }
+
+      const timeoutMs = Math.max(
+        0,
+        args?.timeoutMs ?? deps.defaultTimeoutMs ?? 15_000,
+      );
+
+      deps.logger.info("judge_ensure_started", {
+        timeoutMs,
+        isE2E: deps.isE2E,
+      });
+      setState({ status: "downloading" });
+
+      inflight = (async () => {
+        const ensured = await runEnsure(timeoutMs);
+        inflight = null;
+
+        if (!ensured.ok) {
+          deps.logger.error("judge_ensure_failed", {
+            code: ensured.error.code,
+          });
+          setState({
+            status: "error",
+            error: { code: ensured.error.code, message: ensured.error.message },
+          });
+          return { ok: false, error: ensured.error };
+        }
+
+        deps.logger.info("judge_ensure_succeeded", {});
+        setState({ status: "ready" });
+        return { ok: true, data: state };
+      })();
+
+      const result = await inflight;
+      if (!result.ok && state.status === "downloading") {
+        // Why: never leave state stuck in downloading on failure paths.
+        setState({
+          status: "error",
+          error: { code: result.error.code, message: result.error.message },
+        });
+      }
+      return result;
+    },
+  };
+}

--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -1,4 +1,5 @@
 import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
+import { SettingsPanel } from "../../features/settings/SettingsPanel";
 
 /**
  * RightPanel is the right-side panel container (AI/Info). P0 wires visibility
@@ -27,11 +28,7 @@ export function RightPanel(props: {
         flexDirection: "column",
       }}
     >
-      <div
-        style={{ padding: 12, fontSize: 12, color: "var(--color-fg-muted)" }}
-      >
-        Right panel (placeholder)
-      </div>
+      <SettingsPanel />
     </aside>
   );
 }

--- a/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+
+import type { IpcChannelSpec } from "../../../../../../packages/shared/types/ipc-generated";
+import { invoke } from "../../lib/ipcClient";
+
+type JudgeModelState =
+  IpcChannelSpec["judge:model:getState"]["response"]["state"];
+
+/**
+ * Render judge state into a stable, human-readable label.
+ */
+function formatState(state: JudgeModelState): string {
+  if (state.status === "error") {
+    return `error (${state.error.code})`;
+  }
+  return state.status;
+}
+
+/**
+ * JudgeSection is the Settings surface for model readiness.
+ *
+ * Why: P0 requires a stable, E2E-testable status + ensure entry without silent failure.
+ */
+export function JudgeSection(): JSX.Element {
+  const [state, setState] = React.useState<JudgeModelState | null>(null);
+  const [errorText, setErrorText] = React.useState<string | null>(null);
+  const [ensureBusy, setEnsureBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    let canceled = false;
+    void (async () => {
+      const res = await invoke("judge:model:getState", {});
+      if (canceled) {
+        return;
+      }
+      if (res.ok) {
+        setState(res.data.state);
+        setErrorText(null);
+        return;
+      }
+      setErrorText(`${res.error.code}: ${res.error.message}`);
+    })();
+    return () => {
+      canceled = true;
+    };
+  }, []);
+
+  async function ensure(): Promise<void> {
+    if (ensureBusy) {
+      return;
+    }
+    setEnsureBusy(true);
+    setErrorText(null);
+    setState({ status: "downloading" });
+
+    try {
+      const res = await invoke("judge:model:ensure", {});
+      if (res.ok) {
+        setState(res.data.state);
+        return;
+      }
+      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setState({
+        status: "error",
+        error: { code: res.error.code, message: res.error.message },
+      });
+    } finally {
+      setEnsureBusy(false);
+    }
+  }
+
+  return (
+    <section
+      data-testid="settings-judge-section"
+      style={{
+        padding: 12,
+        borderRadius: "var(--radius-lg)",
+        border: "1px solid var(--color-border-default)",
+        background: "var(--color-bg-raised)",
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>
+        Judge model
+      </div>
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--color-fg-muted)",
+          marginBottom: 10,
+        }}
+      >
+        Status:{" "}
+        <span
+          data-testid="judge-status"
+          style={{ color: "var(--color-fg-default)" }}
+        >
+          {state ? formatState(state) : "loading"}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <button
+          data-testid="judge-ensure"
+          type="button"
+          onClick={() => void ensure()}
+          disabled={ensureBusy}
+          style={{
+            height: 32,
+            padding: "0 var(--space-3)",
+            borderRadius: "var(--radius-md)",
+            border: "1px solid var(--color-border-default)",
+            background: "var(--color-bg-selected)",
+            color: "var(--color-fg-default)",
+            cursor: ensureBusy ? "not-allowed" : "pointer",
+            fontSize: 13,
+            opacity: ensureBusy ? 0.7 : 1,
+          }}
+        >
+          Ensure
+        </button>
+
+        {errorText ? (
+          <div
+            data-testid="judge-error"
+            style={{ fontSize: 12, color: "var(--color-fg-muted)" }}
+          >
+            {errorText}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/renderer/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/renderer/src/features/settings/SettingsPanel.tsx
@@ -1,0 +1,23 @@
+import { JudgeSection } from "./JudgeSection";
+
+/**
+ * SettingsPanel is the minimal Settings surface rendered in the right panel.
+ *
+ * Why: P0 requires an always-available, E2E-testable entry point for judge state.
+ */
+export function SettingsPanel(): JSX.Element {
+  return (
+    <div
+      data-testid="settings-panel"
+      style={{
+        padding: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 800 }}>Settings</div>
+      <JudgeSection />
+    </div>
+  );
+}

--- a/apps/desktop/tests/integration/constraints-roundtrip.test.ts
+++ b/apps/desktop/tests/integration/constraints-roundtrip.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { IpcResponse } from "../../../../packages/shared/types/ipc-generated";
+import { registerConstraintsIpcHandlers } from "../../main/src/ipc/constraints";
+import type { Logger } from "../../main/src/logging/logger";
+
+import type Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+type FakeIpcMain = {
+  handle: (channel: string, handler: Handler) => void;
+};
+
+type ConstraintsConfig = { version: 1; items: string[] };
+
+/**
+ * Create a unique temp directory for integration tests.
+ *
+ * Why: isolation prevents tests from depending on local developer state.
+ */
+async function createTempDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow Integration 世界 ");
+  return await fs.mkdtemp(base);
+}
+
+/**
+ * Create a no-op logger.
+ *
+ * Why: IPC handlers require an explicit logger dependency.
+ */
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+/**
+ * Create a minimal DB stub that supports `projects` lookups.
+ */
+function createDbStub(args: {
+  projectId: string;
+  rootPath: string;
+}): Database.Database {
+  const row = { rootPath: args.rootPath };
+  const prepare = () => {
+    return {
+      get: (projectId: string) => {
+        return projectId === args.projectId ? row : undefined;
+      },
+    };
+  };
+  return { prepare } as unknown as Database.Database;
+}
+
+/**
+ * Create a minimal `ipcMain.handle` harness for integration tests.
+ */
+function createIpcHarness(): {
+  ipcMain: FakeIpcMain;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain: FakeIpcMain = {
+    handle: (channel, handler) => {
+      handlers.set(channel, handler);
+    },
+  };
+  return { ipcMain, handlers };
+}
+
+const projectId = `proj_${randomUUID()}`;
+const projectRoot = await createTempDir();
+const db = createDbStub({ projectId, rootPath: projectRoot });
+const logger = createLogger();
+const { ipcMain, handlers } = createIpcHarness();
+
+registerConstraintsIpcHandlers({
+  ipcMain: ipcMain as unknown as IpcMain,
+  db,
+  logger,
+});
+
+const getHandler = handlers.get("constraints:get");
+assert.ok(getHandler, "Missing handler constraints:get");
+const setHandler = handlers.get("constraints:set");
+assert.ok(setHandler, "Missing handler constraints:set");
+
+const first = (await getHandler({}, { projectId })) as IpcResponse<{
+  constraints: ConstraintsConfig;
+}>;
+assert.equal(first.ok, true);
+if (first.ok) {
+  assert.deepEqual(first.data.constraints, { version: 1, items: [] });
+}
+
+const desired: ConstraintsConfig = { version: 1, items: ["no spoilers"] };
+const setRes = (await setHandler(
+  {},
+  { projectId, constraints: desired },
+)) as IpcResponse<{
+  constraints: ConstraintsConfig;
+}>;
+assert.equal(setRes.ok, true);
+
+const second = (await getHandler({}, { projectId })) as IpcResponse<{
+  constraints: ConstraintsConfig;
+}>;
+assert.equal(second.ok, true);
+if (second.ok) {
+  assert.deepEqual(second.data.constraints, desired);
+}
+
+const invalid = (await setHandler(
+  {},
+  {
+    projectId,
+    constraints: { version: 2, items: [] },
+  },
+)) as IpcResponse<unknown>;
+assert.equal(invalid.ok, false);
+if (!invalid.ok) {
+  assert.equal(invalid.error.code, "INVALID_ARGUMENT");
+}
+
+const constraintsPath = path.join(
+  projectRoot,
+  ".creonow",
+  "rules",
+  "constraints.json",
+);
+await fs.writeFile(constraintsPath, "{", "utf8");
+
+const corrupted = (await getHandler({}, { projectId })) as IpcResponse<unknown>;
+assert.equal(corrupted.ok, false);
+if (!corrupted.ok) {
+  assert.equal(corrupted.error.code, "INVALID_ARGUMENT");
+}
+
+await fs.rm(projectRoot, { recursive: true, force: true });

--- a/openspec/_ops/task_runs/ISSUE-32.md
+++ b/openspec/_ops/task_runs/ISSUE-32.md
@@ -49,3 +49,8 @@
 
 - Command: `pnpm -C apps/desktop test:e2e -- judge.spec.ts db-bootstrap.spec.ts`
 - Key output: `2 passed`
+
+### 2026-01-31 17:33 preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: `exit 0`

--- a/openspec/_ops/task_runs/ISSUE-32.md
+++ b/openspec/_ops/task_runs/ISSUE-32.md
@@ -1,0 +1,51 @@
+# ISSUE-32
+
+- Issue: #32
+- Branch: task/32-p0-013-constraints-judge
+- PR: <fill-after-created>
+
+## Plan
+
+- 实现 constraints IPC：SSOT `.creonow/rules/constraints.json`（get/set + 校验 + 可观测日志）
+- 实现 judge 状态机 + IPC：`judge:model:getState/ensure`（Windows E2E 可测降级；稳定错误码）
+- renderer Settings 增加 `JudgeSection`，并补齐 Integration + Windows E2E
+
+## Runs
+
+### 2026-01-31 17:01 setup + contract + typecheck
+
+- Command: `rulebook task validate issue-32-p0-013-constraints-judge`
+- Key output: `✅ Task issue-32-p0-013-constraints-judge is valid`
+
+- Command: `pnpm install --frozen-lockfile || pnpm install`
+- Key output: `Done in 1.4s`
+
+- Command: `pnpm -s contract:generate`
+- Key output: `(no output)`
+
+- Command: `pnpm typecheck`
+- Key output: `exit 0`
+
+### 2026-01-31 17:02 unit tests
+
+- Command: `pnpm test:unit`
+- Key output: `exit 0`
+
+### 2026-01-31 17:22 db migration update (typecheck)
+
+- Command: `pnpm typecheck`
+- Key output: `exit 0`
+
+### 2026-01-31 17:32 verify (lint + tests)
+
+- Command: `pnpm lint`
+- Key output: `exit 0`
+
+- Command: `pnpm test:unit`
+- Key output: `exit 0`
+
+- Command: `pnpm test:integration`
+- Key output: `exit 0`
+
+- Command: `pnpm -C apps/desktop test:e2e -- judge.spec.ts db-bootstrap.spec.ts`
+- Key output: `2 passed`

--- a/openspec/_ops/task_runs/ISSUE-32.md
+++ b/openspec/_ops/task_runs/ISSUE-32.md
@@ -2,7 +2,7 @@
 
 - Issue: #32
 - Branch: task/32-p0-013-constraints-judge
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/35
 
 ## Plan
 
@@ -54,3 +54,11 @@
 
 - Command: `scripts/agent_pr_preflight.sh`
 - Key output: `exit 0`
+
+### 2026-01-31 17:35 PR
+
+- Command: `git push -u origin HEAD`
+- Key output: `pushed task/32-p0-013-constraints-judge`
+
+- Command: `gh pr create ...`
+- Key output: `https://github.com/Leeky1017/CreoNow/pull/35`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "contract:generate": "tsx scripts/contract-generate.ts",
     "contract:check": "pnpm contract:generate && git diff --exit-code packages/shared/types/ipc-generated.ts",
     "test:unit": "tsx apps/desktop/tests/unit/contract-generate.spec.ts && tsx apps/desktop/tests/unit/derive.test.ts",
+    "test:integration": "tsx apps/desktop/tests/integration/constraints-roundtrip.test.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -50,6 +50,8 @@ export type IpcResponse<TData> = IpcOk<TData> | IpcErr;
 
 export const IPC_CHANNELS = [
   "app:ping",
+  "constraints:get",
+  "constraints:set",
   "context:creonow:ensure",
   "context:creonow:status",
   "db:debug:tableNames",
@@ -58,6 +60,8 @@ export const IPC_CHANNELS = [
   "file:document:list",
   "file:document:read",
   "file:document:write",
+  "judge:model:ensure",
+  "judge:model:getState",
   "project:create",
   "project:delete",
   "project:getCurrent",
@@ -73,6 +77,32 @@ export type IpcChannelSpec = {
   "app:ping": {
     request: Record<string, never>;
     response: Record<string, never>;
+  };
+  "constraints:get": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      constraints: {
+        items: Array<string>;
+        version: 1;
+      };
+    };
+  };
+  "constraints:set": {
+    request: {
+      constraints: {
+        items: Array<string>;
+        version: 1;
+      };
+      projectId: string;
+    };
+    response: {
+      constraints: {
+        items: Array<string>;
+        version: 1;
+      };
+    };
   };
   "context:creonow:ensure": {
     request: {
@@ -156,6 +186,82 @@ export type IpcChannelSpec = {
     response: {
       contentHash: string;
       updatedAt: number;
+    };
+  };
+  "judge:model:ensure": {
+    request: {
+      timeoutMs?: number;
+    };
+    response: {
+      state:
+        | {
+            status: "not_ready";
+          }
+        | {
+            status: "downloading";
+          }
+        | {
+            status: "ready";
+          }
+        | {
+            error: {
+              code:
+                | "INVALID_ARGUMENT"
+                | "NOT_FOUND"
+                | "ALREADY_EXISTS"
+                | "CONFLICT"
+                | "PERMISSION_DENIED"
+                | "UNSUPPORTED"
+                | "IO_ERROR"
+                | "DB_ERROR"
+                | "MODEL_NOT_READY"
+                | "ENCODING_FAILED"
+                | "RATE_LIMITED"
+                | "TIMEOUT"
+                | "CANCELED"
+                | "UPSTREAM_ERROR"
+                | "INTERNAL";
+              message: string;
+            };
+            status: "error";
+          };
+    };
+  };
+  "judge:model:getState": {
+    request: Record<string, never>;
+    response: {
+      state:
+        | {
+            status: "not_ready";
+          }
+        | {
+            status: "downloading";
+          }
+        | {
+            status: "ready";
+          }
+        | {
+            error: {
+              code:
+                | "INVALID_ARGUMENT"
+                | "NOT_FOUND"
+                | "ALREADY_EXISTS"
+                | "CONFLICT"
+                | "PERMISSION_DENIED"
+                | "UNSUPPORTED"
+                | "IO_ERROR"
+                | "DB_ERROR"
+                | "MODEL_NOT_READY"
+                | "ENCODING_FAILED"
+                | "RATE_LIMITED"
+                | "TIMEOUT"
+                | "CANCELED"
+                | "UPSTREAM_ERROR"
+                | "INTERNAL";
+              message: string;
+            };
+            status: "error";
+          };
     };
   };
   "project:create": {

--- a/rulebook/tasks/issue-32-p0-013-constraints-judge/.metadata.json
+++ b/rulebook/tasks/issue-32-p0-013-constraints-judge/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T08:48:19.047Z",
+  "updatedAt": "2026-01-31T08:48:19.047Z"
+}

--- a/rulebook/tasks/issue-32-p0-013-constraints-judge/proposal.md
+++ b/rulebook/tasks/issue-32-p0-013-constraints-judge/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: issue-32-p0-013-constraints-judge
+
+## Why
+
+为 CN V1 Workbench 提供最小可用的写作约束（constraints）与质量门禁（judge）基础能力：约束配置可读写且以 `.creonow/rules/constraints.json` 为唯一 SSOT；judge 模型的状态可见且可触发 ensure，并在 Windows CI 上可测（允许可观测的降级路径，禁止 silent failure）。
+
+## What Changes
+
+- Add: `constraints:get/set` IPC handlers（SSOT=`.creonow/rules/constraints.json`；缺失返回默认值；参数校验失败→`INVALID_ARGUMENT`）。
+- Add: `judge:model:getState/ensure` IPC handlers（返回稳定状态枚举；ensure 可触发状态变化或返回可读错误码）。
+- Add: `JudgeService`（状态机：`not_ready/downloading/ready/error`；可观测日志）。
+- Add: renderer Settings 最小入口中的 `JudgeSection`（展示状态 + ensure 操作）。
+- Add: tests：
+  - Integration：constraints roundtrip + invalid args。
+  - Windows E2E：Settings 可见 judge 状态；ensure 可触发变化或可读错误。
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-013-constraints-and-judge-minimal.md`
+  - `openspec/specs/creonow-v1-workbench/design/04-context-engineering.md`
+- Affected code:
+  - `apps/desktop/main/src/ipc/**`
+  - `apps/desktop/main/src/services/**`
+  - `apps/desktop/renderer/src/**`
+  - `apps/desktop/tests/**`
+- Breaking change: NO
+- User benefit: 用户可配置写作约束并触发/观察 judge 模型准备状态，为后续质量门禁与一致性检查提供可验收的 P0 基座。

--- a/rulebook/tasks/issue-32-p0-013-constraints-judge/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-32-p0-013-constraints-judge/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,13 @@
+# Spec Delta: creonow-v1-workbench (ISSUE-32)
+
+本任务实现 `P0-013`（Constraints / Judge 最小可用 + Windows 可测降级），为 CN V1 Workbench 引入可验收的规则约束 SSOT 与 judge 模型状态基座。
+
+## Changes
+
+- Add: `constraints:get/set` IPC（SSOT=`.creonow/rules/constraints.json`；缺失返回默认值；参数校验失败→`INVALID_ARGUMENT`）。
+- Add: `judge:model:getState/ensure` IPC（稳定状态枚举：`not_ready/downloading/ready/error`；Windows E2E 可测且可观测的降级路径）。
+- Add: Settings UI 最小入口中的 judge 状态展示与 ensure 操作。
+
+## Acceptance
+
+- 满足 `P0-013` task card 的 Acceptance Criteria（含 Integration + Windows E2E）。

--- a/rulebook/tasks/issue-32-p0-013-constraints-judge/tasks.md
+++ b/rulebook/tasks/issue-32-p0-013-constraints-judge/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [ ] 1.1 扩展 IPC contract + codegen（`constraints:*` / `judge:*`）
+- [ ] 1.2 main：constraints IPC（SSOT `.creonow/rules/constraints.json`）
+- [ ] 1.3 main：JudgeService + judge IPC（state machine + ensure）
+- [ ] 1.4 DB：judge 相关表 + migration（不引入 constraints DB SSOT）
+- [ ] 1.5 renderer：Settings UI 最小入口 + `JudgeSection`
+
+## 2. Testing
+
+- [ ] 2.1 Integration：constraints roundtrip + invalid args
+- [ ] 2.2 Windows E2E：Settings 展示 judge 状态 + ensure 可测
+
+## 3. Documentation
+
+- [ ] 3.1 新增 `openspec/_ops/task_runs/ISSUE-32.md` 并持续追加 Runs（只追加不回写）
+- [ ] 3.2 补齐 spec delta，并保持 `rulebook_task_validate` 通过


### PR DESCRIPTION
Closes #32

## Summary
- Add constraints SSOT IPC (`constraints:get/set`) backed by `.creonow/rules/constraints.json`
- Add judge model IPC (`judge:model:getState/ensure`) + JudgeService state machine (E2E-degraded ensure)
- Add Settings panel `JudgeSection` and tests (integration + E2E)

## Test plan
- `scripts/agent_pr_preflight.sh`
- `pnpm test:integration`
- `pnpm -C apps/desktop test:e2e -- judge.spec.ts db-bootstrap.spec.ts`

## Evidence
- `openspec/_ops/task_runs/ISSUE-32.md`