### PR TITLE
Fix: modal overlay z-index (Windows E2E) (#47)

### DIFF
--- a/apps/desktop/renderer/src/styles/globals.css
+++ b/apps/desktop/renderer/src/styles/globals.css
@@ -54,6 +54,7 @@ body {
 .cn-overlay {
   position: fixed;
   inset: 0;
+  z-index: 1000;
   background: var(--color-scrim);
   display: flex;
   align-items: center;

--- a/openspec/_ops/task_runs/ISSUE-47.md
+++ b/openspec/_ops/task_runs/ISSUE-47.md
@@ -2,7 +2,7 @@
 
 - Issue: #47
 - Branch: task/47-windows-e2e-overlay-zindex
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/48
 
 ## Plan
 
@@ -52,3 +52,21 @@
 - Command: `scripts/agent_pr_preflight.sh`
 - Key output: exit 0
 - Evidence: prettier/typecheck/lint/contract/unit gates satisfied
+
+### 2026-01-31 21:02 push
+
+- Command: `git push -u origin HEAD`
+- Key output: pushed `task/47-windows-e2e-overlay-zindex`
+- Evidence: branch `task/47-windows-e2e-overlay-zindex`
+
+### 2026-01-31 21:02 pr
+
+- Command: `gh pr create ...`
+- Key output: `https://github.com/Leeky1017/CreoNow/pull/48`
+- Evidence: PR #48
+
+### 2026-01-31 21:02 auto-merge
+
+- Command: `gh pr merge 48 --auto --squash`
+- Key output: auto-merge enabled
+- Evidence: PR #48

--- a/openspec/_ops/task_runs/ISSUE-47.md
+++ b/openspec/_ops/task_runs/ISSUE-47.md
@@ -1,0 +1,54 @@
+# ISSUE-47
+
+- Issue: #47
+- Branch: task/47-windows-e2e-overlay-zindex
+- PR: <fill-after-created>
+
+## Plan
+
+- Make overlays stack above panels (z-index).
+- Verify preflight + Windows E2E in CI.
+
+## Runs
+
+### 2026-01-31 20:54 issue
+
+- Command: `gh issue create -t "[CN-V1] Fix: modal overlay above panels (Windows E2E)" ...`
+- Key output: `https://github.com/Leeky1017/CreoNow/issues/47`
+- Evidence: issue #47
+
+### 2026-01-31 20:55 worktree
+
+- Command: `scripts/agent_worktree_setup.sh 47 windows-e2e-overlay-zindex`
+- Key output: `Worktree created: .worktrees/issue-47-windows-e2e-overlay-zindex`
+- Evidence: branch `task/47-windows-e2e-overlay-zindex`
+
+### 2026-01-31 20:55 rulebook
+
+- Command: `rulebook task create issue-47-windows-e2e-overlay-zindex`
+- Key output: `✅ Task issue-47-windows-e2e-overlay-zindex created successfully`
+- Evidence: `rulebook/tasks/issue-47-windows-e2e-overlay-zindex/`
+
+### 2026-01-31 20:56 rulebook validate
+
+- Command: `rulebook task validate issue-47-windows-e2e-overlay-zindex`
+- Key output: `✅ Task issue-47-windows-e2e-overlay-zindex is valid`
+- Evidence: `rulebook/tasks/issue-47-windows-e2e-overlay-zindex/specs/creonow-v1-workbench/spec.md`
+
+### 2026-01-31 20:57 deps
+
+- Command: `pnpm install`
+- Key output: `Packages: +687`
+- Evidence: `node_modules/` present
+
+### 2026-01-31 20:58 overlay z-index
+
+- Command: edit `apps/desktop/renderer/src/styles/globals.css`
+- Key output: `.cn-overlay` adds `z-index: 1000` to keep overlays above panels
+- Evidence: `apps/desktop/renderer/src/styles/globals.css`
+
+### 2026-01-31 20:59 preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: exit 0
+- Evidence: prettier/typecheck/lint/contract/unit gates satisfied

--- a/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/.metadata.json
+++ b/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-01-31T12:57:39.032Z",
+  "updatedAt": "2026-01-31T12:57:39.032Z"
+}

--- a/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/proposal.md
+++ b/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/proposal.md
@@ -1,0 +1,19 @@
+# Proposal: issue-47-windows-e2e-overlay-zindex
+
+## Why
+
+Windows CI E2E cannot click the Create Project dialog submit button because the
+right panel intercepts pointer events. This blocks multiple flows and masks real
+regressions.
+
+## What Changes
+
+Add an explicit `z-index` to `.cn-overlay` so modal overlays (CreateProjectDialog
+and CommandPalette) always stack above side panels.
+
+## Impact
+
+- Affected specs: creonow-v1-workbench
+- Affected code: `apps/desktop/renderer/src/styles/globals.css`
+- Breaking change: NO
+- User benefit: dialogs are clickable; Windows E2E is stable

--- a/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,18 @@
+# Spec Delta: creonow-v1-workbench (ISSUE-47)
+
+## Scope
+
+Fix modal overlay stacking so `.cn-overlay` surfaces always sit above side panels,
+unblocking Windows Playwright E2E for project creation.
+
+## Additions / Clarifications
+
+- `.cn-overlay` MUST have an explicit high z-index so dialogs are not covered by
+  side panels (e.g. `layout-panel` / `ai-panel`) and clicks are not intercepted.
+
+## Scenarios
+
+- WHEN CreateProjectDialog is open THEN clicking `create-project-submit` works
+  even with the right panel visible.
+- WHEN CommandPalette is open THEN it captures clicks/input regardless of panel
+  visibility.

--- a/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/tasks.md
+++ b/rulebook/tasks/issue-47-windows-e2e-overlay-zindex/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [ ] 1.1 Add z-index to `.cn-overlay`
+- [ ] 1.2 Update RUN_LOG with evidence
+
+## 2. Testing
+
+- [ ] 2.1 Run preflight (format/typecheck/lint/contract/unit)
+- [ ] 2.2 Verify `windows-e2e` passes in CI
+
+## 3. Documentation
+
+- [ ] 3.1 N/A (no user-facing docs)
+- [ ] 3.2 N/A (no changelog in repo)


### PR DESCRIPTION
Closes #47

Fixes Windows Playwright E2E clicks being intercepted by the right panel by giving `.cn-overlay` an explicit high z-index.

Test plan
- `scripts/agent_pr_preflight.sh`
- CI: verify `windows-e2e` passes
