### PR TITLE
P0-011: Knowledge Graph (CRUD + UI + context) (#51)

### DIFF
--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -13,6 +13,7 @@ import initSql from "./migrations/0001_init.sql?raw";
 import documentsSql from "./migrations/0002_documents_versioning.sql?raw";
 import judgeSql from "./migrations/0003_judge.sql?raw";
 import skillsSql from "./migrations/0004_skills.sql?raw";
+import knowledgeGraphSql from "./migrations/0005_knowledge_graph.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -38,6 +39,7 @@ const MIGRATIONS: readonly Migration[] = [
   { version: 2, name: "0002_documents_versioning", sql: documentsSql },
   { version: 3, name: "0003_judge", sql: judgeSql },
   { version: 4, name: "0004_skills", sql: skillsSql },
+  { version: 5, name: "0005_knowledge_graph", sql: knowledgeGraphSql },
 ];
 
 /**

--- a/apps/desktop/main/src/db/migrations/0001_init.sql
+++ b/apps/desktop/main/src/db/migrations/0001_init.sql
@@ -87,22 +87,42 @@ CREATE INDEX IF NOT EXISTS idx_skill_feedback_evidence_action
 
 CREATE TABLE IF NOT EXISTS kg_entities (
   entity_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
   name TEXT NOT NULL,
-  entity_type TEXT NOT NULL,
-  data_json TEXT NOT NULL,
-  updated_at INTEGER NOT NULL
+  entity_type TEXT,
+  description TEXT,
+  metadata_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(project_id) REFERENCES projects(project_id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_kg_entities_project_updated
+  ON kg_entities(project_id, updated_at DESC, entity_id ASC);
 
 CREATE TABLE IF NOT EXISTS kg_relations (
   relation_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
   from_entity_id TEXT NOT NULL,
   to_entity_id TEXT NOT NULL,
   relation_type TEXT NOT NULL,
-  data_json TEXT NOT NULL,
+  metadata_json TEXT NOT NULL,
+  evidence_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  FOREIGN KEY(project_id) REFERENCES projects(project_id) ON DELETE CASCADE,
   FOREIGN KEY(from_entity_id) REFERENCES kg_entities(entity_id) ON DELETE CASCADE,
   FOREIGN KEY(to_entity_id) REFERENCES kg_entities(entity_id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_updated
+  ON kg_relations(project_id, updated_at DESC, relation_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_from
+  ON kg_relations(project_id, from_entity_id, relation_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_to
+  ON kg_relations(project_id, to_entity_id, relation_id ASC);
 
 -- P0-013: Judge model metadata (minimal baseline).
 CREATE TABLE IF NOT EXISTS judge_models (

--- a/apps/desktop/main/src/db/migrations/0005_knowledge_graph.sql
+++ b/apps/desktop/main/src/db/migrations/0005_knowledge_graph.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS kg_relations;
+DROP TABLE IF EXISTS kg_entities;
+
+CREATE TABLE IF NOT EXISTS kg_entities (
+  entity_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  entity_type TEXT,
+  description TEXT,
+  metadata_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_entities_project_updated
+  ON kg_entities(project_id, updated_at DESC, entity_id ASC);
+
+CREATE TABLE IF NOT EXISTS kg_relations (
+  relation_id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  from_entity_id TEXT NOT NULL,
+  to_entity_id TEXT NOT NULL,
+  relation_type TEXT NOT NULL,
+  metadata_json TEXT NOT NULL,
+  evidence_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(project_id) REFERENCES projects(project_id) ON DELETE CASCADE,
+  FOREIGN KEY(from_entity_id) REFERENCES kg_entities(entity_id) ON DELETE CASCADE,
+  FOREIGN KEY(to_entity_id) REFERENCES kg_entities(entity_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_updated
+  ON kg_relations(project_id, updated_at DESC, relation_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_from
+  ON kg_relations(project_id, from_entity_id, relation_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_project_to
+  ON kg_relations(project_id, to_entity_id, relation_id ASC);
+

--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -11,6 +11,7 @@ import { registerContextIpcHandlers } from "./ipc/context";
 import { registerConstraintsIpcHandlers } from "./ipc/constraints";
 import { registerFileIpcHandlers } from "./ipc/file";
 import { registerJudgeIpcHandlers } from "./ipc/judge";
+import { registerKnowledgeGraphIpcHandlers } from "./ipc/knowledgeGraph";
 import { registerMemoryIpcHandlers } from "./ipc/memory";
 import { registerProjectIpcHandlers } from "./ipc/project";
 import { registerSkillIpcHandlers } from "./ipc/skills";
@@ -220,6 +221,12 @@ function registerIpcHandlers(deps: {
   });
 
   registerMemoryIpcHandlers({
+    ipcMain,
+    db: deps.db,
+    logger: deps.logger,
+  });
+
+  registerKnowledgeGraphIpcHandlers({
     ipcMain,
     db: deps.db,
     logger: deps.logger,

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -95,6 +95,29 @@ const MEMORY_INJECTION_ITEM_SCHEMA = s.object({
   reason: MEMORY_INJECTION_REASON_SCHEMA,
 });
 
+const KG_ENTITY_SCHEMA = s.object({
+  entityId: s.string(),
+  projectId: s.string(),
+  name: s.string(),
+  entityType: s.optional(s.string()),
+  description: s.optional(s.string()),
+  metadataJson: s.string(),
+  createdAt: s.number(),
+  updatedAt: s.number(),
+});
+
+const KG_RELATION_SCHEMA = s.object({
+  relationId: s.string(),
+  projectId: s.string(),
+  fromEntityId: s.string(),
+  toEntityId: s.string(),
+  relationType: s.string(),
+  metadataJson: s.string(),
+  evidenceJson: s.string(),
+  createdAt: s.number(),
+  updatedAt: s.number(),
+});
+
 export const ipcContract = {
   version: 1,
   errorCodes: IPC_ERROR_CODES,
@@ -247,6 +270,78 @@ export const ipcContract = {
           }),
         ),
       }),
+    },
+    "kg:graph:get": {
+      request: s.object({
+        projectId: s.string(),
+        purpose: s.optional(s.union(s.literal("ui"), s.literal("context"))),
+      }),
+      response: s.object({
+        entities: s.array(KG_ENTITY_SCHEMA),
+        relations: s.array(KG_RELATION_SCHEMA),
+      }),
+    },
+    "kg:entity:create": {
+      request: s.object({
+        projectId: s.string(),
+        name: s.string(),
+        entityType: s.optional(s.string()),
+        description: s.optional(s.string()),
+        metadataJson: s.optional(s.string()),
+      }),
+      response: KG_ENTITY_SCHEMA,
+    },
+    "kg:entity:list": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ items: s.array(KG_ENTITY_SCHEMA) }),
+    },
+    "kg:entity:update": {
+      request: s.object({
+        entityId: s.string(),
+        patch: s.object({
+          name: s.optional(s.string()),
+          entityType: s.optional(s.string()),
+          description: s.optional(s.string()),
+          metadataJson: s.optional(s.string()),
+        }),
+      }),
+      response: KG_ENTITY_SCHEMA,
+    },
+    "kg:entity:delete": {
+      request: s.object({ entityId: s.string() }),
+      response: s.object({ deleted: s.literal(true) }),
+    },
+    "kg:relation:create": {
+      request: s.object({
+        projectId: s.string(),
+        fromEntityId: s.string(),
+        toEntityId: s.string(),
+        relationType: s.string(),
+        metadataJson: s.optional(s.string()),
+        evidenceJson: s.optional(s.string()),
+      }),
+      response: KG_RELATION_SCHEMA,
+    },
+    "kg:relation:list": {
+      request: s.object({ projectId: s.string() }),
+      response: s.object({ items: s.array(KG_RELATION_SCHEMA) }),
+    },
+    "kg:relation:update": {
+      request: s.object({
+        relationId: s.string(),
+        patch: s.object({
+          fromEntityId: s.optional(s.string()),
+          toEntityId: s.optional(s.string()),
+          relationType: s.optional(s.string()),
+          metadataJson: s.optional(s.string()),
+          evidenceJson: s.optional(s.string()),
+        }),
+      }),
+      response: KG_RELATION_SCHEMA,
+    },
+    "kg:relation:delete": {
+      request: s.object({ relationId: s.string() }),
+      response: s.object({ deleted: s.literal(true) }),
     },
     "skill:list": {
       request: s.object({ includeDisabled: s.optional(s.boolean()) }),

--- a/apps/desktop/main/src/ipc/knowledgeGraph.ts
+++ b/apps/desktop/main/src/ipc/knowledgeGraph.ts
@@ -81,7 +81,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.graphGet(payload);
       if (payload.purpose === "context" && res.ok) {
         deps.logger.info("kg_injected", {
@@ -98,14 +101,20 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
 
   deps.ipcMain.handle(
     "kg:entity:create",
-    async (_e, payload: EntityCreatePayload): Promise<IpcResponse<KgEntity>> => {
+    async (
+      _e,
+      payload: EntityCreatePayload,
+    ): Promise<IpcResponse<KgEntity>> => {
       if (!deps.db) {
         return {
           ok: false,
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.entityCreate(payload);
       return res.ok
         ? { ok: true, data: res.data }
@@ -125,7 +134,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.entityList(payload);
       return res.ok
         ? { ok: true, data: res.data }
@@ -135,14 +147,20 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
 
   deps.ipcMain.handle(
     "kg:entity:update",
-    async (_e, payload: EntityUpdatePayload): Promise<IpcResponse<KgEntity>> => {
+    async (
+      _e,
+      payload: EntityUpdatePayload,
+    ): Promise<IpcResponse<KgEntity>> => {
       if (!deps.db) {
         return {
           ok: false,
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.entityUpdate({
         entityId: payload.entityId,
         patch: payload.patch,
@@ -165,7 +183,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.entityDelete(payload);
       return res.ok
         ? { ok: true, data: res.data }
@@ -185,7 +206,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.relationCreate(payload);
       return res.ok
         ? { ok: true, data: res.data }
@@ -205,7 +229,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.relationList(payload);
       return res.ok
         ? { ok: true, data: res.data }
@@ -225,7 +252,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.relationUpdate({
         relationId: payload.relationId,
         patch: payload.patch,
@@ -248,7 +278,10 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const svc = createKnowledgeGraphService({
+        db: deps.db,
+        logger: deps.logger,
+      });
       const res = svc.relationDelete(payload);
       return res.ok
         ? { ok: true, data: res.data }

--- a/apps/desktop/main/src/ipc/knowledgeGraph.ts
+++ b/apps/desktop/main/src/ipc/knowledgeGraph.ts
@@ -1,0 +1,258 @@
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+import {
+  createKnowledgeGraphService,
+  type KgEntity,
+  type KgGraph,
+  type KgRelation,
+} from "../services/kg/kgService";
+
+type GraphGetPayload = {
+  projectId: string;
+  purpose?: "ui" | "context";
+};
+
+type EntityCreatePayload = {
+  projectId: string;
+  name: string;
+  entityType?: string;
+  description?: string;
+  metadataJson?: string;
+};
+
+type EntityListPayload = { projectId: string };
+
+type EntityUpdatePayload = {
+  entityId: string;
+  patch: Partial<
+    Pick<KgEntity, "name" | "entityType" | "description" | "metadataJson">
+  >;
+};
+
+type EntityDeletePayload = { entityId: string };
+
+type RelationCreatePayload = {
+  projectId: string;
+  fromEntityId: string;
+  toEntityId: string;
+  relationType: string;
+  metadataJson?: string;
+  evidenceJson?: string;
+};
+
+type RelationListPayload = { projectId: string };
+
+type RelationUpdatePayload = {
+  relationId: string;
+  patch: Partial<
+    Pick<
+      KgRelation,
+      | "fromEntityId"
+      | "toEntityId"
+      | "relationType"
+      | "metadataJson"
+      | "evidenceJson"
+    >
+  >;
+};
+
+type RelationDeletePayload = { relationId: string };
+
+/**
+ * Register `kg:*` IPC handlers (Knowledge Graph).
+ *
+ * Why: KG is persisted in SQLite but controlled via renderer UI and context
+ * assembly; IPC provides the stable contract boundary.
+ */
+export function registerKnowledgeGraphIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+}): void {
+  deps.ipcMain.handle(
+    "kg:graph:get",
+    async (_e, payload: GraphGetPayload): Promise<IpcResponse<KgGraph>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.graphGet(payload);
+      if (payload.purpose === "context" && res.ok) {
+        deps.logger.info("kg_injected", {
+          project_id: payload.projectId.trim(),
+          entity_count: res.data.entities.length,
+          relation_count: res.data.relations.length,
+        });
+      }
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:entity:create",
+    async (_e, payload: EntityCreatePayload): Promise<IpcResponse<KgEntity>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.entityCreate(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:entity:list",
+    async (
+      _e,
+      payload: EntityListPayload,
+    ): Promise<IpcResponse<{ items: KgEntity[] }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.entityList(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:entity:update",
+    async (_e, payload: EntityUpdatePayload): Promise<IpcResponse<KgEntity>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.entityUpdate({
+        entityId: payload.entityId,
+        patch: payload.patch,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:entity:delete",
+    async (
+      _e,
+      payload: EntityDeletePayload,
+    ): Promise<IpcResponse<{ deleted: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.entityDelete(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:relation:create",
+    async (
+      _e,
+      payload: RelationCreatePayload,
+    ): Promise<IpcResponse<KgRelation>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.relationCreate(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:relation:list",
+    async (
+      _e,
+      payload: RelationListPayload,
+    ): Promise<IpcResponse<{ items: KgRelation[] }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.relationList(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:relation:update",
+    async (
+      _e,
+      payload: RelationUpdatePayload,
+    ): Promise<IpcResponse<KgRelation>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.relationUpdate({
+        relationId: payload.relationId,
+        patch: payload.patch,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "kg:relation:delete",
+    async (
+      _e,
+      payload: RelationDeletePayload,
+    ): Promise<IpcResponse<{ deleted: true }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createKnowledgeGraphService({ db: deps.db, logger: deps.logger });
+      const res = svc.relationDelete(payload);
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+}

--- a/apps/desktop/main/src/services/kg/kgService.ts
+++ b/apps/desktop/main/src/services/kg/kgService.ts
@@ -1,0 +1,949 @@
+import { randomUUID } from "node:crypto";
+
+import type Database from "better-sqlite3";
+
+import type {
+  IpcError,
+  IpcErrorCode,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import type { Logger } from "../../logging/logger";
+
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: IpcError };
+export type ServiceResult<T> = Ok<T> | Err;
+
+export type KgEntity = {
+  entityId: string;
+  projectId: string;
+  name: string;
+  entityType?: string;
+  description?: string;
+  metadataJson: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type KgRelation = {
+  relationId: string;
+  projectId: string;
+  fromEntityId: string;
+  toEntityId: string;
+  relationType: string;
+  metadataJson: string;
+  evidenceJson: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type KgGraph = {
+  entities: KgEntity[];
+  relations: KgRelation[];
+};
+
+export type KnowledgeGraphService = {
+  graphGet: (args: { projectId: string }) => ServiceResult<KgGraph>;
+
+  entityCreate: (args: {
+    projectId: string;
+    name: string;
+    entityType?: string;
+    description?: string;
+    metadataJson?: string;
+  }) => ServiceResult<KgEntity>;
+  entityList: (args: { projectId: string }) => ServiceResult<{ items: KgEntity[] }>;
+  entityUpdate: (args: {
+    entityId: string;
+    patch: {
+      name?: string;
+      entityType?: string;
+      description?: string;
+      metadataJson?: string;
+    };
+  }) => ServiceResult<KgEntity>;
+  entityDelete: (args: { entityId: string }) => ServiceResult<{ deleted: true }>;
+
+  relationCreate: (args: {
+    projectId: string;
+    fromEntityId: string;
+    toEntityId: string;
+    relationType: string;
+    metadataJson?: string;
+    evidenceJson?: string;
+  }) => ServiceResult<KgRelation>;
+  relationList: (args: {
+    projectId: string;
+  }) => ServiceResult<{ items: KgRelation[] }>;
+  relationUpdate: (args: {
+    relationId: string;
+    patch: {
+      fromEntityId?: string;
+      toEntityId?: string;
+      relationType?: string;
+      metadataJson?: string;
+      evidenceJson?: string;
+    };
+  }) => ServiceResult<KgRelation>;
+  relationDelete: (args: {
+    relationId: string;
+  }) => ServiceResult<{ deleted: true }>;
+};
+
+const MAX_METADATA_JSON_BYTES = 32 * 1024;
+const MAX_NAME_CHARS = 256;
+const MAX_ENTITY_TYPE_CHARS = 64;
+const MAX_DESCRIPTION_CHARS = 4096;
+const MAX_RELATION_TYPE_CHARS = 64;
+
+/**
+ * Build a stable IPC error object.
+ *
+ * Why: services must return deterministic error codes/messages for IPC tests.
+ */
+function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
+  return { ok: false, error: { code, message, details } };
+}
+
+/**
+ * Normalize optional strings to a trimmed value.
+ *
+ * Why: we must not persist whitespace-only values that later confuse both UI
+ * rendering and deterministic context injection.
+ */
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+/**
+ * Normalize optional strings to a nullable value.
+ *
+ * Why: the IPC surface uses optional strings for patches, but the DB stores
+ * "unset" as NULL to avoid mixing empty strings with real data.
+ */
+function normalizeNullableText(value: string | undefined): string | null {
+  const normalized = normalizeOptionalText(value);
+  return normalized ?? null;
+}
+
+/**
+ * Validate a `projectId` string early.
+ *
+ * Why: DB foreign keys would turn bad inputs into `DB_ERROR`, but the contract
+ * requires stable `INVALID_ARGUMENT` semantics.
+ */
+function validateProjectId(projectId: string): Err | null {
+  if (projectId.trim().length === 0) {
+    return ipcError("INVALID_ARGUMENT", "projectId is required");
+  }
+  return null;
+}
+
+/**
+ * Validate metadata JSON constraints before touching the DB.
+ *
+ * Why: the spec requires a deterministic `INVALID_ARGUMENT` on oversize payloads,
+ * rather than a DB constraint error or silent truncation.
+ */
+function validateMetadataJson(
+  fieldName: string,
+  value: string,
+  maxBytes: number,
+): Err | null {
+  if (value.trim().length === 0) {
+    return ipcError("INVALID_ARGUMENT", `${fieldName} is required`);
+  }
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes > maxBytes) {
+    return ipcError(
+      "INVALID_ARGUMENT",
+      `${fieldName} exceeds ${maxBytes} bytes`,
+      { maxBytes, sizeBytes: bytes },
+    );
+  }
+  try {
+    JSON.parse(value);
+  } catch (error) {
+    return ipcError("INVALID_ARGUMENT", `${fieldName} must be valid JSON`, {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return null;
+}
+
+/**
+ * Validate evidence JSON constraints before touching the DB.
+ *
+ * Why: evidence must remain structured and debuggable for context injection,
+ * without relying on implicit parsing failures downstream.
+ */
+function validateEvidenceJson(fieldName: string, value: string): Err | null {
+  const metaRes = validateMetadataJson(fieldName, value, MAX_METADATA_JSON_BYTES);
+  if (metaRes) {
+    return metaRes;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) {
+      return ipcError("INVALID_ARGUMENT", `${fieldName} must be a JSON array`);
+    }
+  } catch {
+    return ipcError("INVALID_ARGUMENT", `${fieldName} must be valid JSON`);
+  }
+  return null;
+}
+
+type ProjectExistsRow = { projectId: string };
+
+/**
+ * Check that a project exists before writing project-scoped data.
+ *
+ * Why: we must return `NOT_FOUND` instead of surfacing DB foreign key failures
+ * across the IPC boundary.
+ */
+function ensureProjectExists(
+  db: Database.Database,
+  projectId: string,
+): Err | null {
+  const row = db
+    .prepare<
+      [string],
+      ProjectExistsRow
+    >("SELECT project_id as projectId FROM projects WHERE project_id = ?")
+    .get(projectId);
+  if (!row) {
+    return ipcError("NOT_FOUND", "Project not found");
+  }
+  return null;
+}
+
+type EntityRow = {
+  entityId: string;
+  projectId: string;
+  name: string;
+  entityType: string | null;
+  description: string | null;
+  metadataJson: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+/**
+ * Load an entity row by id.
+ *
+ * Why: IPC update/delete flows require deterministic "exists" checks and a
+ * single source of truth for DB field mapping.
+ */
+function selectEntityById(
+  db: Database.Database,
+  entityId: string,
+): EntityRow | undefined {
+  return db
+    .prepare<
+      [string],
+      EntityRow
+    >("SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE entity_id = ?")
+    .get(entityId);
+}
+
+/**
+ * Convert a DB row into the IPC-safe entity shape.
+ *
+ * Why: normalize nullable DB columns to `undefined` to keep payloads compact and
+ * stable for the renderer and context injection formatting.
+ */
+function rowToEntity(row: EntityRow): KgEntity {
+  return {
+    entityId: row.entityId,
+    projectId: row.projectId,
+    name: row.name,
+    entityType: row.entityType ?? undefined,
+    description: row.description ?? undefined,
+    metadataJson: row.metadataJson,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+type RelationRow = {
+  relationId: string;
+  projectId: string;
+  fromEntityId: string;
+  toEntityId: string;
+  relationType: string;
+  metadataJson: string;
+  evidenceJson: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+/**
+ * Load a relation row by id.
+ *
+ * Why: update/delete need stable NOT_FOUND detection without duplicating SQL.
+ */
+function selectRelationById(
+  db: Database.Database,
+  relationId: string,
+): RelationRow | undefined {
+  return db
+    .prepare<
+      [string],
+      RelationRow
+    >("SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE relation_id = ?")
+    .get(relationId);
+}
+
+/**
+ * Convert a DB row into the IPC-safe relation shape.
+ *
+ * Why: keep mapping logic centralized so schema changes don't silently drift.
+ */
+function rowToRelation(row: RelationRow): KgRelation {
+  return {
+    relationId: row.relationId,
+    projectId: row.projectId,
+    fromEntityId: row.fromEntityId,
+    toEntityId: row.toEntityId,
+    relationType: row.relationType,
+    metadataJson: row.metadataJson,
+    evidenceJson: row.evidenceJson,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+type EntityExistsRow = { entityId: string };
+
+/**
+ * Ensure an entity exists for a given project.
+ *
+ * Why: relationship endpoints require deterministic `NOT_FOUND` semantics for
+ * foreign keys, instead of surfacing DB constraint errors.
+ */
+function ensureEntityExistsInProject(
+  db: Database.Database,
+  args: { projectId: string; entityId: string; fieldName: string },
+): Err | null {
+  const row = db
+    .prepare<
+      [string, string],
+      EntityExistsRow
+    >(
+      "SELECT entity_id as entityId FROM kg_entities WHERE project_id = ? AND entity_id = ?",
+    )
+    .get(args.projectId, args.entityId);
+  if (!row) {
+    return ipcError("NOT_FOUND", `${args.fieldName} not found`);
+  }
+  return null;
+}
+
+/**
+ * Create a KnowledgeGraphService backed by SQLite (SSOT).
+ */
+export function createKnowledgeGraphService(args: {
+  db: Database.Database;
+  logger: Logger;
+}): KnowledgeGraphService {
+  return {
+    graphGet: ({ projectId }) => {
+      const invalidProjectId = validateProjectId(projectId);
+      if (invalidProjectId) {
+        return invalidProjectId;
+      }
+
+      try {
+        const projectExists = ensureProjectExists(args.db, projectId.trim());
+        if (projectExists) {
+          return projectExists;
+        }
+
+        const entities = args.db
+          .prepare<[string], EntityRow>(
+            "SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC",
+          )
+          .all(projectId.trim())
+          .map(rowToEntity);
+
+        const relations = args.db
+          .prepare<[string], RelationRow>(
+            "SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC",
+          )
+          .all(projectId.trim())
+          .map(rowToRelation);
+
+        return { ok: true, data: { entities, relations } };
+      } catch (error) {
+        args.logger.error("kg_graph_get_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to load knowledge graph");
+      }
+    },
+
+    entityCreate: ({
+      projectId,
+      name,
+      entityType,
+      description,
+      metadataJson,
+    }) => {
+      const invalidProjectId = validateProjectId(projectId);
+      if (invalidProjectId) {
+        return invalidProjectId;
+      }
+
+      const normalizedName = name.trim();
+      if (normalizedName.length === 0) {
+        return ipcError("INVALID_ARGUMENT", "name is required");
+      }
+      if (normalizedName.length > MAX_NAME_CHARS) {
+        return ipcError("INVALID_ARGUMENT", `name exceeds ${MAX_NAME_CHARS} chars`);
+      }
+
+      const normalizedType = normalizeOptionalText(entityType);
+      if (normalizedType && normalizedType.length > MAX_ENTITY_TYPE_CHARS) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `entityType exceeds ${MAX_ENTITY_TYPE_CHARS} chars`,
+        );
+      }
+
+      const normalizedDescription = normalizeOptionalText(description);
+      if (
+        normalizedDescription &&
+        normalizedDescription.length > MAX_DESCRIPTION_CHARS
+      ) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `description exceeds ${MAX_DESCRIPTION_CHARS} chars`,
+        );
+      }
+
+      const normalizedMetadataJson = normalizeOptionalText(metadataJson) ?? "{}";
+      const metadataValid = validateMetadataJson(
+        "metadataJson",
+        normalizedMetadataJson,
+        MAX_METADATA_JSON_BYTES,
+      );
+      if (metadataValid) {
+        return metadataValid;
+      }
+
+      const entityId = randomUUID();
+      const ts = Date.now();
+
+      try {
+        const projectExists = ensureProjectExists(args.db, projectId.trim());
+        if (projectExists) {
+          return projectExists;
+        }
+
+        args.db
+          .prepare(
+            "INSERT INTO kg_entities (entity_id, project_id, name, entity_type, description, metadata_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            entityId,
+            projectId.trim(),
+            normalizedName,
+            normalizedType ?? null,
+            normalizedDescription ?? null,
+            normalizedMetadataJson,
+            ts,
+            ts,
+          );
+
+        args.logger.info("kg_entity_created", {
+          entity_id: entityId,
+          project_id: projectId.trim(),
+          name_len: normalizedName.length,
+          metadata_bytes: Buffer.byteLength(normalizedMetadataJson, "utf8"),
+        });
+      } catch (error) {
+        args.logger.error("kg_entity_create_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to create entity");
+      }
+
+      const row = selectEntityById(args.db, entityId);
+      if (!row) {
+        return ipcError("DB_ERROR", "Failed to load created entity");
+      }
+      return { ok: true, data: rowToEntity(row) };
+    },
+
+    entityList: ({ projectId }) => {
+      const invalidProjectId = validateProjectId(projectId);
+      if (invalidProjectId) {
+        return invalidProjectId;
+      }
+
+      try {
+        const projectExists = ensureProjectExists(args.db, projectId.trim());
+        if (projectExists) {
+          return projectExists;
+        }
+
+        const rows = args.db
+          .prepare<[string], EntityRow>(
+            "SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC",
+          )
+          .all(projectId.trim());
+        return { ok: true, data: { items: rows.map(rowToEntity) } };
+      } catch (error) {
+        args.logger.error("kg_entity_list_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to list entities");
+      }
+    },
+
+    entityUpdate: ({ entityId, patch }) => {
+      if (entityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "entityId is required");
+      }
+      const patchKeys = Object.keys(patch) as Array<keyof typeof patch>;
+      if (patchKeys.length === 0) {
+        return ipcError("INVALID_ARGUMENT", "patch is required");
+      }
+
+      const normalizedName =
+        typeof patch.name === "string" ? patch.name.trim() : undefined;
+      if (typeof normalizedName === "string") {
+        if (normalizedName.length === 0) {
+          return ipcError("INVALID_ARGUMENT", "name is required");
+        }
+        if (normalizedName.length > MAX_NAME_CHARS) {
+          return ipcError(
+            "INVALID_ARGUMENT",
+            `name exceeds ${MAX_NAME_CHARS} chars`,
+          );
+        }
+      }
+
+      const normalizedType = normalizeNullableText(patch.entityType);
+      if (
+        typeof patch.entityType === "string" &&
+        normalizedType &&
+        normalizedType.length > MAX_ENTITY_TYPE_CHARS
+      ) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `entityType exceeds ${MAX_ENTITY_TYPE_CHARS} chars`,
+        );
+      }
+
+      const normalizedDescription = normalizeNullableText(patch.description);
+      if (
+        typeof patch.description === "string" &&
+        normalizedDescription &&
+        normalizedDescription.length > MAX_DESCRIPTION_CHARS
+      ) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `description exceeds ${MAX_DESCRIPTION_CHARS} chars`,
+        );
+      }
+
+      const normalizedMetadataJson =
+        typeof patch.metadataJson === "string"
+          ? patch.metadataJson.trim()
+          : undefined;
+      if (typeof normalizedMetadataJson === "string") {
+        const metadataValid = validateMetadataJson(
+          "metadataJson",
+          normalizedMetadataJson,
+          MAX_METADATA_JSON_BYTES,
+        );
+        if (metadataValid) {
+          return metadataValid;
+        }
+      }
+
+      const ts = Date.now();
+
+      try {
+        const existing = selectEntityById(args.db, entityId.trim());
+        if (!existing) {
+          return ipcError("NOT_FOUND", "Entity not found");
+        }
+
+        args.db
+          .prepare(
+            "UPDATE kg_entities SET name = ?, entity_type = ?, description = ?, metadata_json = ?, updated_at = ? WHERE entity_id = ?",
+          )
+          .run(
+            normalizedName ?? existing.name,
+            typeof patch.entityType === "string"
+              ? normalizedType
+              : existing.entityType,
+            typeof patch.description === "string"
+              ? normalizedDescription
+              : existing.description,
+            normalizedMetadataJson ?? existing.metadataJson,
+            ts,
+            entityId.trim(),
+          );
+
+        args.logger.info("kg_entity_updated", {
+          entity_id: entityId.trim(),
+          project_id: existing.projectId,
+        });
+      } catch (error) {
+        args.logger.error("kg_entity_update_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to update entity");
+      }
+
+      const row = selectEntityById(args.db, entityId.trim());
+      if (!row) {
+        return ipcError("DB_ERROR", "Failed to load updated entity");
+      }
+      return { ok: true, data: rowToEntity(row) };
+    },
+
+    entityDelete: ({ entityId }) => {
+      if (entityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "entityId is required");
+      }
+
+      try {
+        const existing = selectEntityById(args.db, entityId.trim());
+        if (!existing) {
+          return ipcError("NOT_FOUND", "Entity not found");
+        }
+
+        let relationsDeleted = 0;
+        args.db.transaction(() => {
+          const res = args.db
+            .prepare(
+              "DELETE FROM kg_relations WHERE project_id = ? AND (from_entity_id = ? OR to_entity_id = ?)",
+            )
+            .run(existing.projectId, entityId.trim(), entityId.trim());
+          relationsDeleted = res.changes;
+
+          args.db
+            .prepare("DELETE FROM kg_entities WHERE entity_id = ?")
+            .run(entityId.trim());
+        })();
+
+        args.logger.info("kg_entity_deleted", {
+          entity_id: entityId.trim(),
+          project_id: existing.projectId,
+          relations_deleted: relationsDeleted,
+        });
+
+        return { ok: true, data: { deleted: true } };
+      } catch (error) {
+        args.logger.error("kg_entity_delete_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to delete entity");
+      }
+    },
+
+    relationCreate: ({
+      projectId,
+      fromEntityId,
+      toEntityId,
+      relationType,
+      metadataJson,
+      evidenceJson,
+    }) => {
+      const invalidProjectId = validateProjectId(projectId);
+      if (invalidProjectId) {
+        return invalidProjectId;
+      }
+
+      if (fromEntityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "fromEntityId is required");
+      }
+      if (toEntityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "toEntityId is required");
+      }
+
+      const normalizedRelationType = relationType.trim();
+      if (normalizedRelationType.length === 0) {
+        return ipcError("INVALID_ARGUMENT", "relationType is required");
+      }
+      if (normalizedRelationType.length > MAX_RELATION_TYPE_CHARS) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `relationType exceeds ${MAX_RELATION_TYPE_CHARS} chars`,
+        );
+      }
+
+      const normalizedMetadataJson = normalizeOptionalText(metadataJson) ?? "{}";
+      const metadataValid = validateMetadataJson(
+        "metadataJson",
+        normalizedMetadataJson,
+        MAX_METADATA_JSON_BYTES,
+      );
+      if (metadataValid) {
+        return metadataValid;
+      }
+
+      const normalizedEvidenceJson = normalizeOptionalText(evidenceJson) ?? "[]";
+      const evidenceValid = validateEvidenceJson(
+        "evidenceJson",
+        normalizedEvidenceJson,
+      );
+      if (evidenceValid) {
+        return evidenceValid;
+      }
+
+      const relationId = randomUUID();
+      const ts = Date.now();
+
+      try {
+        const projectExists = ensureProjectExists(args.db, projectId.trim());
+        if (projectExists) {
+          return projectExists;
+        }
+        const fromExists = ensureEntityExistsInProject(args.db, {
+          projectId: projectId.trim(),
+          entityId: fromEntityId.trim(),
+          fieldName: "fromEntityId",
+        });
+        if (fromExists) {
+          return fromExists;
+        }
+        const toExists = ensureEntityExistsInProject(args.db, {
+          projectId: projectId.trim(),
+          entityId: toEntityId.trim(),
+          fieldName: "toEntityId",
+        });
+        if (toExists) {
+          return toExists;
+        }
+
+        args.db
+          .prepare(
+            "INSERT INTO kg_relations (relation_id, project_id, from_entity_id, to_entity_id, relation_type, metadata_json, evidence_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            relationId,
+            projectId.trim(),
+            fromEntityId.trim(),
+            toEntityId.trim(),
+            normalizedRelationType,
+            normalizedMetadataJson,
+            normalizedEvidenceJson,
+            ts,
+            ts,
+          );
+
+        args.logger.info("kg_relation_created", {
+          relation_id: relationId,
+          project_id: projectId.trim(),
+          metadata_bytes: Buffer.byteLength(normalizedMetadataJson, "utf8"),
+        });
+      } catch (error) {
+        args.logger.error("kg_relation_create_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to create relation");
+      }
+
+      const row = selectRelationById(args.db, relationId);
+      if (!row) {
+        return ipcError("DB_ERROR", "Failed to load created relation");
+      }
+      return { ok: true, data: rowToRelation(row) };
+    },
+
+    relationList: ({ projectId }) => {
+      const invalidProjectId = validateProjectId(projectId);
+      if (invalidProjectId) {
+        return invalidProjectId;
+      }
+
+      try {
+        const projectExists = ensureProjectExists(args.db, projectId.trim());
+        if (projectExists) {
+          return projectExists;
+        }
+
+        const rows = args.db
+          .prepare<[string], RelationRow>(
+            "SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC",
+          )
+          .all(projectId.trim());
+        return { ok: true, data: { items: rows.map(rowToRelation) } };
+      } catch (error) {
+        args.logger.error("kg_relation_list_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to list relations");
+      }
+    },
+
+    relationUpdate: ({ relationId, patch }) => {
+      if (relationId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "relationId is required");
+      }
+      const patchKeys = Object.keys(patch) as Array<keyof typeof patch>;
+      if (patchKeys.length === 0) {
+        return ipcError("INVALID_ARGUMENT", "patch is required");
+      }
+
+      const normalizedRelationType =
+        typeof patch.relationType === "string" ? patch.relationType.trim() : null;
+      if (typeof patch.relationType === "string") {
+        if (!normalizedRelationType || normalizedRelationType.length === 0) {
+          return ipcError("INVALID_ARGUMENT", "relationType is required");
+        }
+        if (normalizedRelationType.length > MAX_RELATION_TYPE_CHARS) {
+          return ipcError(
+            "INVALID_ARGUMENT",
+            `relationType exceeds ${MAX_RELATION_TYPE_CHARS} chars`,
+          );
+        }
+      }
+
+      const normalizedMetadataJson =
+        typeof patch.metadataJson === "string"
+          ? patch.metadataJson.trim()
+          : undefined;
+      if (typeof normalizedMetadataJson === "string") {
+        const metadataValid = validateMetadataJson(
+          "metadataJson",
+          normalizedMetadataJson,
+          MAX_METADATA_JSON_BYTES,
+        );
+        if (metadataValid) {
+          return metadataValid;
+        }
+      }
+
+      const normalizedEvidenceJson =
+        typeof patch.evidenceJson === "string"
+          ? patch.evidenceJson.trim()
+          : undefined;
+      if (typeof normalizedEvidenceJson === "string") {
+        const evidenceValid = validateEvidenceJson(
+          "evidenceJson",
+          normalizedEvidenceJson,
+        );
+        if (evidenceValid) {
+          return evidenceValid;
+        }
+      }
+
+      if (typeof patch.fromEntityId === "string" && patch.fromEntityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "fromEntityId is required");
+      }
+      if (typeof patch.toEntityId === "string" && patch.toEntityId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "toEntityId is required");
+      }
+
+      const ts = Date.now();
+
+      try {
+        const existing = selectRelationById(args.db, relationId.trim());
+        if (!existing) {
+          return ipcError("NOT_FOUND", "Relation not found");
+        }
+
+        const nextFromEntityId =
+          typeof patch.fromEntityId === "string"
+            ? patch.fromEntityId.trim()
+            : existing.fromEntityId;
+        const nextToEntityId =
+          typeof patch.toEntityId === "string"
+            ? patch.toEntityId.trim()
+            : existing.toEntityId;
+
+        const fromExists = ensureEntityExistsInProject(args.db, {
+          projectId: existing.projectId,
+          entityId: nextFromEntityId,
+          fieldName: "fromEntityId",
+        });
+        if (fromExists) {
+          return fromExists;
+        }
+        const toExists = ensureEntityExistsInProject(args.db, {
+          projectId: existing.projectId,
+          entityId: nextToEntityId,
+          fieldName: "toEntityId",
+        });
+        if (toExists) {
+          return toExists;
+        }
+
+        args.db
+          .prepare(
+            "UPDATE kg_relations SET from_entity_id = ?, to_entity_id = ?, relation_type = ?, metadata_json = ?, evidence_json = ?, updated_at = ? WHERE relation_id = ?",
+          )
+          .run(
+            nextFromEntityId,
+            nextToEntityId,
+            normalizedRelationType ?? existing.relationType,
+            normalizedMetadataJson ?? existing.metadataJson,
+            normalizedEvidenceJson ?? existing.evidenceJson,
+            ts,
+            relationId.trim(),
+          );
+
+        args.logger.info("kg_relation_updated", {
+          relation_id: relationId.trim(),
+          project_id: existing.projectId,
+        });
+      } catch (error) {
+        args.logger.error("kg_relation_update_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to update relation");
+      }
+
+      const row = selectRelationById(args.db, relationId.trim());
+      if (!row) {
+        return ipcError("DB_ERROR", "Failed to load updated relation");
+      }
+      return { ok: true, data: rowToRelation(row) };
+    },
+
+    relationDelete: ({ relationId }) => {
+      if (relationId.trim().length === 0) {
+        return ipcError("INVALID_ARGUMENT", "relationId is required");
+      }
+
+      try {
+        const existing = selectRelationById(args.db, relationId.trim());
+        if (!existing) {
+          return ipcError("NOT_FOUND", "Relation not found");
+        }
+
+        args.db
+          .prepare("DELETE FROM kg_relations WHERE relation_id = ?")
+          .run(relationId.trim());
+
+        args.logger.info("kg_relation_deleted", {
+          relation_id: relationId.trim(),
+          project_id: existing.projectId,
+        });
+        return { ok: true, data: { deleted: true } };
+      } catch (error) {
+        args.logger.error("kg_relation_delete_failed", {
+          code: "DB_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return ipcError("DB_ERROR", "Failed to delete relation");
+      }
+    },
+  };
+}

--- a/apps/desktop/main/src/services/kg/kgService.ts
+++ b/apps/desktop/main/src/services/kg/kgService.ts
@@ -50,7 +50,9 @@ export type KnowledgeGraphService = {
     description?: string;
     metadataJson?: string;
   }) => ServiceResult<KgEntity>;
-  entityList: (args: { projectId: string }) => ServiceResult<{ items: KgEntity[] }>;
+  entityList: (args: {
+    projectId: string;
+  }) => ServiceResult<{ items: KgEntity[] }>;
   entityUpdate: (args: {
     entityId: string;
     patch: {
@@ -60,7 +62,9 @@ export type KnowledgeGraphService = {
       metadataJson?: string;
     };
   }) => ServiceResult<KgEntity>;
-  entityDelete: (args: { entityId: string }) => ServiceResult<{ deleted: true }>;
+  entityDelete: (args: {
+    entityId: string;
+  }) => ServiceResult<{ deleted: true }>;
 
   relationCreate: (args: {
     projectId: string;
@@ -180,7 +184,11 @@ function validateMetadataJson(
  * without relying on implicit parsing failures downstream.
  */
 function validateEvidenceJson(fieldName: string, value: string): Err | null {
-  const metaRes = validateMetadataJson(fieldName, value, MAX_METADATA_JSON_BYTES);
+  const metaRes = validateMetadataJson(
+    fieldName,
+    value,
+    MAX_METADATA_JSON_BYTES,
+  );
   if (metaRes) {
     return metaRes;
   }
@@ -331,9 +339,7 @@ function ensureEntityExistsInProject(
     .prepare<
       [string, string],
       EntityExistsRow
-    >(
-      "SELECT entity_id as entityId FROM kg_entities WHERE project_id = ? AND entity_id = ?",
-    )
+    >("SELECT entity_id as entityId FROM kg_entities WHERE project_id = ? AND entity_id = ?")
     .get(args.projectId, args.entityId);
   if (!row) {
     return ipcError("NOT_FOUND", `${args.fieldName} not found`);
@@ -362,16 +368,18 @@ export function createKnowledgeGraphService(args: {
         }
 
         const entities = args.db
-          .prepare<[string], EntityRow>(
-            "SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC",
-          )
+          .prepare<
+            [string],
+            EntityRow
+          >("SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC")
           .all(projectId.trim())
           .map(rowToEntity);
 
         const relations = args.db
-          .prepare<[string], RelationRow>(
-            "SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC",
-          )
+          .prepare<
+            [string],
+            RelationRow
+          >("SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC")
           .all(projectId.trim())
           .map(rowToRelation);
 
@@ -402,7 +410,10 @@ export function createKnowledgeGraphService(args: {
         return ipcError("INVALID_ARGUMENT", "name is required");
       }
       if (normalizedName.length > MAX_NAME_CHARS) {
-        return ipcError("INVALID_ARGUMENT", `name exceeds ${MAX_NAME_CHARS} chars`);
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `name exceeds ${MAX_NAME_CHARS} chars`,
+        );
       }
 
       const normalizedType = normalizeOptionalText(entityType);
@@ -424,7 +435,8 @@ export function createKnowledgeGraphService(args: {
         );
       }
 
-      const normalizedMetadataJson = normalizeOptionalText(metadataJson) ?? "{}";
+      const normalizedMetadataJson =
+        normalizeOptionalText(metadataJson) ?? "{}";
       const metadataValid = validateMetadataJson(
         "metadataJson",
         normalizedMetadataJson,
@@ -492,9 +504,10 @@ export function createKnowledgeGraphService(args: {
         }
 
         const rows = args.db
-          .prepare<[string], EntityRow>(
-            "SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC",
-          )
+          .prepare<
+            [string],
+            EntityRow
+          >("SELECT entity_id as entityId, project_id as projectId, name, entity_type as entityType, description, metadata_json as metadataJson, created_at as createdAt, updated_at as updatedAt FROM kg_entities WHERE project_id = ? ORDER BY updated_at DESC, entity_id ASC")
           .all(projectId.trim());
         return { ok: true, data: { items: rows.map(rowToEntity) } };
       } catch (error) {
@@ -684,7 +697,8 @@ export function createKnowledgeGraphService(args: {
         );
       }
 
-      const normalizedMetadataJson = normalizeOptionalText(metadataJson) ?? "{}";
+      const normalizedMetadataJson =
+        normalizeOptionalText(metadataJson) ?? "{}";
       const metadataValid = validateMetadataJson(
         "metadataJson",
         normalizedMetadataJson,
@@ -694,7 +708,8 @@ export function createKnowledgeGraphService(args: {
         return metadataValid;
       }
 
-      const normalizedEvidenceJson = normalizeOptionalText(evidenceJson) ?? "[]";
+      const normalizedEvidenceJson =
+        normalizeOptionalText(evidenceJson) ?? "[]";
       const evidenceValid = validateEvidenceJson(
         "evidenceJson",
         normalizedEvidenceJson,
@@ -777,9 +792,10 @@ export function createKnowledgeGraphService(args: {
         }
 
         const rows = args.db
-          .prepare<[string], RelationRow>(
-            "SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC",
-          )
+          .prepare<
+            [string],
+            RelationRow
+          >("SELECT relation_id as relationId, project_id as projectId, from_entity_id as fromEntityId, to_entity_id as toEntityId, relation_type as relationType, metadata_json as metadataJson, evidence_json as evidenceJson, created_at as createdAt, updated_at as updatedAt FROM kg_relations WHERE project_id = ? ORDER BY updated_at DESC, relation_id ASC")
           .all(projectId.trim());
         return { ok: true, data: { items: rows.map(rowToRelation) } };
       } catch (error) {
@@ -801,7 +817,9 @@ export function createKnowledgeGraphService(args: {
       }
 
       const normalizedRelationType =
-        typeof patch.relationType === "string" ? patch.relationType.trim() : null;
+        typeof patch.relationType === "string"
+          ? patch.relationType.trim()
+          : null;
       if (typeof patch.relationType === "string") {
         if (!normalizedRelationType || normalizedRelationType.length === 0) {
           return ipcError("INVALID_ARGUMENT", "relationType is required");
@@ -843,10 +861,16 @@ export function createKnowledgeGraphService(args: {
         }
       }
 
-      if (typeof patch.fromEntityId === "string" && patch.fromEntityId.trim().length === 0) {
+      if (
+        typeof patch.fromEntityId === "string" &&
+        patch.fromEntityId.trim().length === 0
+      ) {
         return ipcError("INVALID_ARGUMENT", "fromEntityId is required");
       }
-      if (typeof patch.toEntityId === "string" && patch.toEntityId.trim().length === 0) {
+      if (
+        typeof patch.toEntityId === "string" &&
+        patch.toEntityId.trim().length === 0
+      ) {
         return ipcError("INVALID_ARGUMENT", "toEntityId is required");
       }
 

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "./stores/contextStore";
 import { createEditorStore, EditorStoreProvider } from "./stores/editorStore";
 import { createFileStore, FileStoreProvider } from "./stores/fileStore";
+import { createKgStore, KgStoreProvider } from "./stores/kgStore";
 import { createLayoutStore, LayoutStoreProvider } from "./stores/layoutStore";
 import { createMemoryStore, MemoryStoreProvider } from "./stores/memoryStore";
 import {
@@ -46,6 +47,10 @@ export function App(): JSX.Element {
     return createFileStore({ invoke });
   }, []);
 
+  const kgStore = React.useMemo(() => {
+    return createKgStore({ invoke });
+  }, []);
+
   const memoryStore = React.useMemo(() => {
     return createMemoryStore({ invoke });
   }, []);
@@ -56,11 +61,13 @@ export function App(): JSX.Element {
         <ContextStoreProvider store={contextStore}>
           <EditorStoreProvider store={editorStore}>
             <FileStoreProvider store={fileStore}>
-              <MemoryStoreProvider store={memoryStore}>
-              <LayoutStoreProvider store={layoutStore}>
-                <AppShell />
-              </LayoutStoreProvider>
-              </MemoryStoreProvider>
+              <KgStoreProvider store={kgStore}>
+                <MemoryStoreProvider store={memoryStore}>
+                  <LayoutStoreProvider store={layoutStore}>
+                    <AppShell />
+                  </LayoutStoreProvider>
+                </MemoryStoreProvider>
+              </KgStoreProvider>
             </FileStoreProvider>
           </EditorStoreProvider>
         </ContextStoreProvider>

--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
 import { FileTreePanel } from "../../features/files/FileTreePanel";
+import { KnowledgeGraphPanel } from "../../features/kg/KnowledgeGraphPanel";
 import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
 
-type SidebarTab = "files";
+type SidebarTab = "files" | "kg";
 
 /**
  * Sidebar is the left panel container (Files/Outline/etc).
@@ -69,11 +70,36 @@ export function Sidebar(props: {
         >
           Files
         </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("kg")}
+          style={{
+            fontSize: 12,
+            padding: "var(--space-1) var(--space-2)",
+            borderRadius: "var(--radius-md)",
+            border:
+              activeTab === "kg"
+                ? "1px solid var(--color-border-focus)"
+                : "1px solid var(--color-border-default)",
+            background:
+              activeTab === "kg"
+                ? "var(--color-bg-selected)"
+                : "var(--color-bg-surface)",
+            color: "var(--color-fg-default)",
+            cursor: "pointer",
+          }}
+        >
+          KG
+        </button>
       </div>
 
       <div style={{ flex: 1, minHeight: 0 }}>
-        {props.projectId && activeTab === "files" ? (
-          <FileTreePanel projectId={props.projectId} />
+        {props.projectId ? (
+          activeTab === "files" ? (
+            <FileTreePanel projectId={props.projectId} />
+          ) : (
+            <KnowledgeGraphPanel projectId={props.projectId} />
+          )
         ) : (
           <div
             style={{

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -136,6 +136,7 @@ export function AiPanel(): JSX.Element {
 
     const assembled = await refreshContext({
       projectId: currentProject?.projectId ?? projectId ?? null,
+      skillId: selectedSkillId ?? null,
       immediateInput: input,
     });
 
@@ -205,6 +206,7 @@ export function AiPanel(): JSX.Element {
             onClick={() =>
               void toggleViewer({
                 projectId: currentProject?.projectId ?? projectId ?? null,
+                skillId: selectedSkillId ?? null,
                 immediateInput: input,
               })
             }
@@ -475,4 +477,3 @@ export function AiPanel(): JSX.Element {
     </section>
   );
 }
-

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -23,9 +23,7 @@ function entityLabel(args: { name: string; entityType?: string }): string {
  * Why: P0 requires KG discoverability (sidebar entry), CRUD, and predictable
  * data for context injection.
  */
-export function KnowledgeGraphPanel(props: {
-  projectId: string;
-}): JSX.Element {
+export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   const bootstrapStatus = useKgStore((s) => s.bootstrapStatus);
   const entities = useKgStore((s) => s.entities);
   const relations = useKgStore((s) => s.relations);
@@ -383,10 +381,18 @@ export function KnowledgeGraphPanel(props: {
                     ) : (
                       <>
                         <div style={{ fontSize: 12 }}>
-                          {entityLabel({ name: e.name, entityType: e.entityType })}
+                          {entityLabel({
+                            name: e.name,
+                            entityType: e.entityType,
+                          })}
                         </div>
                         {e.description ? (
-                          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+                          <div
+                            style={{
+                              fontSize: 12,
+                              color: "var(--color-fg-muted)",
+                            }}
+                          >
                             {e.description}
                           </div>
                         ) : null}
@@ -590,7 +596,8 @@ export function KnowledgeGraphPanel(props: {
               >
                 {relations.map((r) => {
                   const isEditing =
-                    editing.mode === "relation" && editing.relationId === r.relationId;
+                    editing.mode === "relation" &&
+                    editing.relationId === r.relationId;
                   return (
                     <div
                       key={r.relationId}
@@ -690,7 +697,9 @@ export function KnowledgeGraphPanel(props: {
                             <button
                               type="button"
                               onClick={() =>
-                                void relationDelete({ relationId: r.relationId })
+                                void relationDelete({
+                                  relationId: r.relationId,
+                                })
                               }
                               style={{
                                 border: "1px solid var(--color-border-default)",

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -1,0 +1,720 @@
+import React from "react";
+
+import { useKgStore } from "../../stores/kgStore";
+
+type EditingState =
+  | { mode: "idle" }
+  | {
+      mode: "entity";
+      entityId: string;
+      name: string;
+      entityType: string;
+      description: string;
+    }
+  | { mode: "relation"; relationId: string; relationType: string };
+
+function entityLabel(args: { name: string; entityType?: string }): string {
+  return args.entityType ? `${args.name} (${args.entityType})` : args.name;
+}
+
+/**
+ * KnowledgeGraphPanel renders the minimal KG CRUD surface.
+ *
+ * Why: P0 requires KG discoverability (sidebar entry), CRUD, and predictable
+ * data for context injection.
+ */
+export function KnowledgeGraphPanel(props: {
+  projectId: string;
+}): JSX.Element {
+  const bootstrapStatus = useKgStore((s) => s.bootstrapStatus);
+  const entities = useKgStore((s) => s.entities);
+  const relations = useKgStore((s) => s.relations);
+  const lastError = useKgStore((s) => s.lastError);
+
+  const bootstrapForProject = useKgStore((s) => s.bootstrapForProject);
+  const clearError = useKgStore((s) => s.clearError);
+
+  const entityCreate = useKgStore((s) => s.entityCreate);
+  const entityUpdate = useKgStore((s) => s.entityUpdate);
+  const entityDelete = useKgStore((s) => s.entityDelete);
+
+  const relationCreate = useKgStore((s) => s.relationCreate);
+  const relationUpdate = useKgStore((s) => s.relationUpdate);
+  const relationDelete = useKgStore((s) => s.relationDelete);
+
+  const [editing, setEditing] = React.useState<EditingState>({ mode: "idle" });
+
+  const [createName, setCreateName] = React.useState("");
+  const [createType, setCreateType] = React.useState("");
+  const [createDescription, setCreateDescription] = React.useState("");
+
+  const [relFromId, setRelFromId] = React.useState("");
+  const [relToId, setRelToId] = React.useState("");
+  const [relType, setRelType] = React.useState("");
+
+  const isReady = bootstrapStatus === "ready";
+
+  React.useEffect(() => {
+    void bootstrapForProject(props.projectId);
+  }, [bootstrapForProject, props.projectId]);
+
+  React.useEffect(() => {
+    if (entities.length === 0) {
+      setRelFromId("");
+      setRelToId("");
+      return;
+    }
+    if (!entities.some((e) => e.entityId === relFromId)) {
+      setRelFromId(entities[0]!.entityId);
+    }
+    if (!entities.some((e) => e.entityId === relToId)) {
+      const fallback = entities[1]?.entityId ?? entities[0]!.entityId;
+      setRelToId(fallback);
+    }
+  }, [entities, relFromId, relToId]);
+
+  async function onCreateEntity(): Promise<void> {
+    const res = await entityCreate({
+      name: createName,
+      entityType: createType,
+      description: createDescription,
+    });
+    if (!res.ok) {
+      return;
+    }
+    setCreateName("");
+    setCreateType("");
+    setCreateDescription("");
+  }
+
+  async function onDeleteEntity(entityId: string): Promise<void> {
+    const ok = window.confirm("Delete this entity? Relations will be removed.");
+    if (!ok) {
+      return;
+    }
+    await entityDelete({ entityId });
+    if (editing.mode === "entity" && editing.entityId === entityId) {
+      setEditing({ mode: "idle" });
+    }
+  }
+
+  async function onSaveEdit(): Promise<void> {
+    if (editing.mode === "entity") {
+      const res = await entityUpdate({
+        entityId: editing.entityId,
+        patch: {
+          name: editing.name,
+          entityType: editing.entityType,
+          description: editing.description,
+        },
+      });
+      if (!res.ok) {
+        return;
+      }
+      setEditing({ mode: "idle" });
+      return;
+    }
+
+    if (editing.mode === "relation") {
+      const res = await relationUpdate({
+        relationId: editing.relationId,
+        patch: { relationType: editing.relationType },
+      });
+      if (!res.ok) {
+        return;
+      }
+      setEditing({ mode: "idle" });
+      return;
+    }
+  }
+
+  async function onCreateRelation(): Promise<void> {
+    if (entities.length === 0) {
+      return;
+    }
+    const res = await relationCreate({
+      fromEntityId: relFromId,
+      toEntityId: relToId,
+      relationType: relType,
+    });
+    if (!res.ok) {
+      return;
+    }
+    setRelType("");
+  }
+
+  function getEntityName(entityId: string): string {
+    const e = entities.find((x) => x.entityId === entityId);
+    return e ? e.name : entityId;
+  }
+
+  return (
+    <section
+      data-testid="sidebar-kg"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "var(--space-3)",
+          borderBottom: "1px solid var(--color-separator)",
+        }}
+      >
+        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+          Knowledge Graph
+        </div>
+        <div style={{ fontSize: 11, color: "var(--color-fg-muted)" }}>
+          {bootstrapStatus}
+        </div>
+      </div>
+
+      {lastError ? (
+        <div
+          role="alert"
+          style={{
+            padding: "var(--space-3)",
+            fontSize: 12,
+            color: "var(--color-fg-default)",
+            borderBottom: "1px solid var(--color-separator)",
+          }}
+        >
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <div
+              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+              data-testid="kg-error-code"
+            >
+              {lastError.code}
+            </div>
+            <button
+              type="button"
+              onClick={clearError}
+              style={{
+                marginLeft: "auto",
+                border: "1px solid var(--color-border-default)",
+                borderRadius: 6,
+                padding: "2px 8px",
+                background: "var(--color-bg-surface)",
+                color: "var(--color-fg-default)",
+                cursor: "pointer",
+                fontSize: 12,
+              }}
+            >
+              Dismiss
+            </button>
+          </div>
+          <div style={{ marginTop: 6 }}>{lastError.message}</div>
+        </div>
+      ) : null}
+
+      <div style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
+        <div style={{ padding: "var(--space-3)" }}>
+          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+            Entities
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-2)",
+              marginTop: "var(--space-2)",
+              paddingBottom: "var(--space-3)",
+              borderBottom: "1px solid var(--color-separator)",
+            }}
+          >
+            <input
+              data-testid="kg-entity-name"
+              placeholder="Name"
+              value={createName}
+              onChange={(e) => setCreateName(e.target.value)}
+              style={{
+                border: "1px solid var(--color-border-default)",
+                borderRadius: "var(--radius-md)",
+                padding: "var(--space-2) var(--space-3)",
+                background: "var(--color-bg-surface)",
+                color: "var(--color-fg-default)",
+                fontSize: 12,
+              }}
+            />
+            <input
+              placeholder="Type (optional)"
+              value={createType}
+              onChange={(e) => setCreateType(e.target.value)}
+              style={{
+                border: "1px solid var(--color-border-default)",
+                borderRadius: "var(--radius-md)",
+                padding: "var(--space-2) var(--space-3)",
+                background: "var(--color-bg-surface)",
+                color: "var(--color-fg-default)",
+                fontSize: 12,
+              }}
+            />
+            <input
+              placeholder="Description (optional)"
+              value={createDescription}
+              onChange={(e) => setCreateDescription(e.target.value)}
+              style={{
+                border: "1px solid var(--color-border-default)",
+                borderRadius: "var(--radius-md)",
+                padding: "var(--space-2) var(--space-3)",
+                background: "var(--color-bg-surface)",
+                color: "var(--color-fg-default)",
+                fontSize: 12,
+              }}
+            />
+            <button
+              type="button"
+              data-testid="kg-entity-create"
+              onClick={() => void onCreateEntity()}
+              disabled={!isReady}
+              style={{
+                alignSelf: "flex-start",
+                fontSize: 12,
+                padding: "var(--space-2) var(--space-3)",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--color-border-default)",
+                background: "var(--color-bg-surface)",
+                color: "var(--color-fg-default)",
+                cursor: !isReady ? "not-allowed" : "pointer",
+                opacity: !isReady ? 0.6 : 1,
+              }}
+            >
+              Create entity
+            </button>
+          </div>
+
+          {entities.length === 0 ? (
+            <div
+              style={{
+                marginTop: "var(--space-3)",
+                fontSize: 12,
+                color: "var(--color-fg-muted)",
+              }}
+            >
+              No entities yet.
+            </div>
+          ) : (
+            <div
+              style={{
+                marginTop: "var(--space-3)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--space-2)",
+              }}
+            >
+              {entities.map((e) => {
+                const isEditing =
+                  editing.mode === "entity" && editing.entityId === e.entityId;
+                return (
+                  <div
+                    key={e.entityId}
+                    data-testid={`kg-entity-row-${e.entityId}`}
+                    style={{
+                      border: "1px solid var(--color-separator)",
+                      borderRadius: 8,
+                      padding: 10,
+                      background: "var(--color-bg-base)",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 8,
+                    }}
+                  >
+                    {isEditing ? (
+                      <>
+                        <input
+                          value={editing.name}
+                          onChange={(evt) =>
+                            setEditing({
+                              ...editing,
+                              name: evt.target.value,
+                            })
+                          }
+                          style={{
+                            border: "1px solid var(--color-border-default)",
+                            borderRadius: "var(--radius-md)",
+                            padding: "var(--space-2) var(--space-3)",
+                            background: "var(--color-bg-surface)",
+                            color: "var(--color-fg-default)",
+                            fontSize: 12,
+                          }}
+                        />
+                        <input
+                          value={editing.entityType}
+                          onChange={(evt) =>
+                            setEditing({
+                              ...editing,
+                              entityType: evt.target.value,
+                            })
+                          }
+                          style={{
+                            border: "1px solid var(--color-border-default)",
+                            borderRadius: "var(--radius-md)",
+                            padding: "var(--space-2) var(--space-3)",
+                            background: "var(--color-bg-surface)",
+                            color: "var(--color-fg-default)",
+                            fontSize: 12,
+                          }}
+                        />
+                        <input
+                          value={editing.description}
+                          onChange={(evt) =>
+                            setEditing({
+                              ...editing,
+                              description: evt.target.value,
+                            })
+                          }
+                          style={{
+                            border: "1px solid var(--color-border-default)",
+                            borderRadius: "var(--radius-md)",
+                            padding: "var(--space-2) var(--space-3)",
+                            background: "var(--color-bg-surface)",
+                            color: "var(--color-fg-default)",
+                            fontSize: 12,
+                          }}
+                        />
+                      </>
+                    ) : (
+                      <>
+                        <div style={{ fontSize: 12 }}>
+                          {entityLabel({ name: e.name, entityType: e.entityType })}
+                        </div>
+                        {e.description ? (
+                          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+                            {e.description}
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+
+                    <div style={{ display: "flex", gap: 8 }}>
+                      {isEditing ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => void onSaveEdit()}
+                            style={{
+                              border: "1px solid var(--color-border-default)",
+                              borderRadius: 6,
+                              padding: "2px 8px",
+                              background: "var(--color-bg-surface)",
+                              color: "var(--color-fg-default)",
+                              cursor: "pointer",
+                              fontSize: 12,
+                            }}
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setEditing({ mode: "idle" })}
+                            style={{
+                              border: "1px solid var(--color-border-default)",
+                              borderRadius: 6,
+                              padding: "2px 8px",
+                              background: "transparent",
+                              color: "var(--color-fg-muted)",
+                              cursor: "pointer",
+                              fontSize: 12,
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setEditing({
+                                mode: "entity",
+                                entityId: e.entityId,
+                                name: e.name,
+                                entityType: e.entityType ?? "",
+                                description: e.description ?? "",
+                              })
+                            }
+                            style={{
+                              border: "1px solid var(--color-border-default)",
+                              borderRadius: 6,
+                              padding: "2px 8px",
+                              background: "transparent",
+                              color: "var(--color-fg-muted)",
+                              cursor: "pointer",
+                              fontSize: 12,
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            data-testid={`kg-entity-delete-${e.entityId}`}
+                            onClick={() => void onDeleteEntity(e.entityId)}
+                            style={{
+                              border: "1px solid var(--color-border-default)",
+                              borderRadius: 6,
+                              padding: "2px 8px",
+                              background: "transparent",
+                              color: "var(--color-fg-muted)",
+                              cursor: "pointer",
+                              fontSize: 12,
+                            }}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <div style={{ marginTop: "var(--space-4)" }}>
+            <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+              Relations
+            </div>
+
+            <div
+              style={{
+                marginTop: "var(--space-2)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--space-2)",
+                paddingBottom: "var(--space-3)",
+                borderBottom: "1px solid var(--color-separator)",
+              }}
+            >
+              <select
+                value={relFromId}
+                onChange={(e) => setRelFromId(e.target.value)}
+                disabled={!isReady || entities.length === 0}
+                style={{
+                  border: "1px solid var(--color-border-default)",
+                  borderRadius: "var(--radius-md)",
+                  padding: "var(--space-2) var(--space-3)",
+                  background: "var(--color-bg-surface)",
+                  color: "var(--color-fg-default)",
+                  fontSize: 12,
+                }}
+              >
+                {entities.map((e) => (
+                  <option key={e.entityId} value={e.entityId}>
+                    {entityLabel({ name: e.name, entityType: e.entityType })}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                value={relToId}
+                onChange={(e) => setRelToId(e.target.value)}
+                disabled={!isReady || entities.length === 0}
+                style={{
+                  border: "1px solid var(--color-border-default)",
+                  borderRadius: "var(--radius-md)",
+                  padding: "var(--space-2) var(--space-3)",
+                  background: "var(--color-bg-surface)",
+                  color: "var(--color-fg-default)",
+                  fontSize: 12,
+                }}
+              >
+                {entities.map((e) => (
+                  <option key={e.entityId} value={e.entityId}>
+                    {entityLabel({ name: e.name, entityType: e.entityType })}
+                  </option>
+                ))}
+              </select>
+
+              <input
+                data-testid="kg-relation-type"
+                placeholder="Relation type (e.g. knows)"
+                value={relType}
+                onChange={(e) => setRelType(e.target.value)}
+                disabled={!isReady}
+                style={{
+                  border: "1px solid var(--color-border-default)",
+                  borderRadius: "var(--radius-md)",
+                  padding: "var(--space-2) var(--space-3)",
+                  background: "var(--color-bg-surface)",
+                  color: "var(--color-fg-default)",
+                  fontSize: 12,
+                }}
+              />
+
+              <button
+                type="button"
+                data-testid="kg-relation-create"
+                onClick={() => void onCreateRelation()}
+                disabled={!isReady}
+                style={{
+                  alignSelf: "flex-start",
+                  fontSize: 12,
+                  padding: "var(--space-2) var(--space-3)",
+                  borderRadius: "var(--radius-md)",
+                  border: "1px solid var(--color-border-default)",
+                  background: "var(--color-bg-surface)",
+                  color: "var(--color-fg-default)",
+                  cursor: !isReady ? "not-allowed" : "pointer",
+                  opacity: !isReady ? 0.6 : 1,
+                }}
+              >
+                Create relation
+              </button>
+            </div>
+
+            {relations.length === 0 ? (
+              <div
+                style={{
+                  marginTop: "var(--space-3)",
+                  fontSize: 12,
+                  color: "var(--color-fg-muted)",
+                }}
+              >
+                No relations yet.
+              </div>
+            ) : (
+              <div
+                style={{
+                  marginTop: "var(--space-3)",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "var(--space-2)",
+                }}
+              >
+                {relations.map((r) => {
+                  const isEditing =
+                    editing.mode === "relation" && editing.relationId === r.relationId;
+                  return (
+                    <div
+                      key={r.relationId}
+                      data-testid={`kg-relation-row-${r.relationId}`}
+                      style={{
+                        border: "1px solid var(--color-separator)",
+                        borderRadius: 8,
+                        padding: 10,
+                        background: "var(--color-bg-base)",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 8,
+                      }}
+                    >
+                      {isEditing ? (
+                        <input
+                          value={editing.relationType}
+                          onChange={(evt) =>
+                            setEditing({
+                              ...editing,
+                              relationType: evt.target.value,
+                            })
+                          }
+                          style={{
+                            border: "1px solid var(--color-border-default)",
+                            borderRadius: "var(--radius-md)",
+                            padding: "var(--space-2) var(--space-3)",
+                            background: "var(--color-bg-surface)",
+                            color: "var(--color-fg-default)",
+                            fontSize: 12,
+                          }}
+                        />
+                      ) : (
+                        <div style={{ fontSize: 12 }}>
+                          {getEntityName(r.fromEntityId)} -({r.relationType})→{" "}
+                          {getEntityName(r.toEntityId)}
+                        </div>
+                      )}
+
+                      <div style={{ display: "flex", gap: 8 }}>
+                        {isEditing ? (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => void onSaveEdit()}
+                              style={{
+                                border: "1px solid var(--color-border-default)",
+                                borderRadius: 6,
+                                padding: "2px 8px",
+                                background: "var(--color-bg-surface)",
+                                color: "var(--color-fg-default)",
+                                cursor: "pointer",
+                                fontSize: 12,
+                              }}
+                            >
+                              Save
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setEditing({ mode: "idle" })}
+                              style={{
+                                border: "1px solid var(--color-border-default)",
+                                borderRadius: 6,
+                                padding: "2px 8px",
+                                background: "transparent",
+                                color: "var(--color-fg-muted)",
+                                cursor: "pointer",
+                                fontSize: 12,
+                              }}
+                            >
+                              Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setEditing({
+                                  mode: "relation",
+                                  relationId: r.relationId,
+                                  relationType: r.relationType,
+                                })
+                              }
+                              style={{
+                                border: "1px solid var(--color-border-default)",
+                                borderRadius: 6,
+                                padding: "2px 8px",
+                                background: "transparent",
+                                color: "var(--color-fg-muted)",
+                                cursor: "pointer",
+                                fontSize: 12,
+                              }}
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                void relationDelete({ relationId: r.relationId })
+                              }
+                              style={{
+                                border: "1px solid var(--color-border-default)",
+                                borderRadius: 6,
+                                padding: "2px 8px",
+                                background: "transparent",
+                                color: "var(--color-fg-muted)",
+                                cursor: "pointer",
+                                fontSize: 12,
+                              }}
+                            >
+                              Delete
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/renderer/src/stores/contextStore.ts
+++ b/apps/desktop/renderer/src/stores/contextStore.ts
@@ -109,7 +109,9 @@ export function createContextStore(deps: { invoke: IpcInvoke }) {
    * Why: KG injection must be explicitly enabled by the skill contract to keep
    * prompt inputs auditable and predictable.
    */
-  async function isKnowledgeGraphEnabled(skillId: string | null): Promise<boolean> {
+  async function isKnowledgeGraphEnabled(
+    skillId: string | null,
+  ): Promise<boolean> {
     if (!skillId) {
       return false;
     }

--- a/apps/desktop/renderer/src/stores/kgStore.ts
+++ b/apps/desktop/renderer/src/stores/kgStore.ts
@@ -1,0 +1,277 @@
+import React from "react";
+import { create } from "zustand";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcRequest,
+  IpcResponse,
+  IpcResponseData,
+} from "../../../../../packages/shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;
+
+export type KgEntity = IpcResponseData<"kg:graph:get">["entities"][number];
+export type KgRelation = IpcResponseData<"kg:graph:get">["relations"][number];
+
+export type KgState = {
+  projectId: string | null;
+  entities: KgEntity[];
+  relations: KgRelation[];
+  bootstrapStatus: "idle" | "loading" | "ready" | "error";
+  lastError: IpcError | null;
+};
+
+export type KgActions = {
+  bootstrapForProject: (projectId: string | null) => Promise<void>;
+  refresh: () => Promise<void>;
+  entityCreate: (args: {
+    name: string;
+    entityType?: string;
+    description?: string;
+  }) => Promise<IpcResponse<IpcResponseData<"kg:entity:create">>>;
+  entityUpdate: (args: {
+    entityId: string;
+    patch: Partial<
+      Pick<KgEntity, "name" | "entityType" | "description" | "metadataJson">
+    >;
+  }) => Promise<IpcResponse<IpcResponseData<"kg:entity:update">>>;
+  entityDelete: (args: { entityId: string }) => Promise<IpcResponse<{ deleted: true }>>;
+  relationCreate: (args: {
+    fromEntityId: string;
+    toEntityId: string;
+    relationType: string;
+  }) => Promise<IpcResponse<IpcResponseData<"kg:relation:create">>>;
+  relationUpdate: (args: {
+    relationId: string;
+    patch: Partial<
+      Pick<
+        KgRelation,
+        | "fromEntityId"
+        | "toEntityId"
+        | "relationType"
+        | "metadataJson"
+        | "evidenceJson"
+      >
+    >;
+  }) => Promise<IpcResponse<IpcResponseData<"kg:relation:update">>>;
+  relationDelete: (args: {
+    relationId: string;
+  }) => Promise<IpcResponse<{ deleted: true }>>;
+  clearError: () => void;
+};
+
+export type KgStore = KgState & KgActions;
+
+export type UseKgStore = ReturnType<typeof createKgStore>;
+
+const KgStoreContext = React.createContext<UseKgStore | null>(null);
+
+/**
+ * Create a zustand store for Knowledge Graph CRUD (project-scoped).
+ *
+ * Why: KG must be driven through typed IPC while keeping the renderer state
+ * machine deterministic for Windows E2E assertions.
+ */
+export function createKgStore(deps: { invoke: IpcInvoke }) {
+  async function loadGraph(
+    projectId: string,
+  ): Promise<IpcInvokeResult<"kg:graph:get">> {
+    return await deps.invoke("kg:graph:get", { projectId });
+  }
+
+  function missingProjectError(): IpcError {
+    return { code: "INVALID_ARGUMENT", message: "projectId is required" };
+  }
+
+  return create<KgStore>((set, get) => ({
+    projectId: null,
+    entities: [],
+    relations: [],
+    bootstrapStatus: "idle",
+    lastError: null,
+
+    clearError: () => set({ lastError: null }),
+
+    bootstrapForProject: async (projectId) => {
+      const state = get();
+      if (
+        state.bootstrapStatus === "loading" &&
+        state.projectId === projectId
+      ) {
+        return;
+      }
+
+      if (!projectId) {
+        set({
+          projectId: null,
+          entities: [],
+          relations: [],
+          bootstrapStatus: "idle",
+          lastError: null,
+        });
+        return;
+      }
+
+      set({
+        projectId,
+        entities: [],
+        relations: [],
+        bootstrapStatus: "loading",
+        lastError: null,
+      });
+
+      const res = await loadGraph(projectId);
+      if (!res.ok) {
+        set({ bootstrapStatus: "error", lastError: res.error });
+        return;
+      }
+
+      set({
+        bootstrapStatus: "ready",
+        entities: res.data.entities,
+        relations: res.data.relations,
+        lastError: null,
+      });
+    },
+
+    refresh: async () => {
+      const state = get();
+      if (!state.projectId) {
+        return;
+      }
+
+      const res = await loadGraph(state.projectId);
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return;
+      }
+
+      set({
+        entities: res.data.entities,
+        relations: res.data.relations,
+        lastError: null,
+      });
+    },
+
+    entityCreate: async ({ name, entityType, description }) => {
+      const state = get();
+      if (!state.projectId) {
+        const error = missingProjectError();
+        set({ lastError: error });
+        return { ok: false, error };
+      }
+
+      const res = await deps.invoke("kg:entity:create", {
+        projectId: state.projectId,
+        name,
+        entityType,
+        description,
+      });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+
+    entityUpdate: async ({ entityId, patch }) => {
+      const res = await deps.invoke("kg:entity:update", { entityId, patch });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+
+    entityDelete: async ({ entityId }) => {
+      const res = await deps.invoke("kg:entity:delete", { entityId });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+
+    relationCreate: async ({ fromEntityId, toEntityId, relationType }) => {
+      const state = get();
+      if (!state.projectId) {
+        const error = missingProjectError();
+        set({ lastError: error });
+        return { ok: false, error };
+      }
+
+      const res = await deps.invoke("kg:relation:create", {
+        projectId: state.projectId,
+        fromEntityId,
+        toEntityId,
+        relationType,
+      });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+
+    relationUpdate: async ({ relationId, patch }) => {
+      const res = await deps.invoke("kg:relation:update", { relationId, patch });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+
+    relationDelete: async ({ relationId }) => {
+      const res = await deps.invoke("kg:relation:delete", { relationId });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return res;
+      }
+
+      void get().refresh();
+      return res;
+    },
+  }));
+}
+
+/**
+ * Provide a KG store instance for the Workbench UI.
+ */
+export function KgStoreProvider(props: {
+  store: UseKgStore;
+  children: React.ReactNode;
+}): JSX.Element {
+  return React.createElement(
+    KgStoreContext.Provider,
+    { value: props.store },
+    props.children,
+  );
+}
+
+/**
+ * Read values from the injected KG store.
+ */
+export function useKgStore<T>(selector: (state: KgStore) => T): T {
+  const store = React.useContext(KgStoreContext);
+  if (!store) {
+    throw new Error("KgStoreProvider is missing");
+  }
+  return store(selector);
+}
+

--- a/apps/desktop/renderer/src/stores/kgStore.ts
+++ b/apps/desktop/renderer/src/stores/kgStore.ts
@@ -40,7 +40,9 @@ export type KgActions = {
       Pick<KgEntity, "name" | "entityType" | "description" | "metadataJson">
     >;
   }) => Promise<IpcResponse<IpcResponseData<"kg:entity:update">>>;
-  entityDelete: (args: { entityId: string }) => Promise<IpcResponse<{ deleted: true }>>;
+  entityDelete: (args: {
+    entityId: string;
+  }) => Promise<IpcResponse<{ deleted: true }>>;
   relationCreate: (args: {
     fromEntityId: string;
     toEntityId: string;
@@ -227,7 +229,10 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
     },
 
     relationUpdate: async ({ relationId, patch }) => {
-      const res = await deps.invoke("kg:relation:update", { relationId, patch });
+      const res = await deps.invoke("kg:relation:update", {
+        relationId,
+        patch,
+      });
       if (!res.ok) {
         set({ lastError: res.error });
         return res;
@@ -274,4 +279,3 @@ export function useKgStore<T>(selector: (state: KgStore) => T): T {
   }
   return store(selector);
 }
-

--- a/apps/desktop/tests/e2e/knowledge-graph.spec.ts
+++ b/apps/desktop/tests/e2e/knowledge-graph.spec.ts
@@ -75,7 +75,9 @@ test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", a
   });
   expect(project.ok).toBe(true);
   if (!project.ok) {
-    throw new Error(`Expected ok project:getCurrent, got: ${project.error.code}`);
+    throw new Error(
+      `Expected ok project:getCurrent, got: ${project.error.code}`,
+    );
   }
   const projectId = project.data.projectId;
 
@@ -169,7 +171,9 @@ test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", a
         relationType: "knows",
       });
       if (!res.ok) {
-        throw new Error(`Expected ok kg:relation:create, got: ${res.error.code}`);
+        throw new Error(
+          `Expected ok kg:relation:create, got: ${res.error.code}`,
+        );
       }
       return res.data;
     },
@@ -218,7 +222,9 @@ test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", a
       `Expected ok skill:list, got: ${skillsAfterWrite.error.code}`,
     );
   }
-  const polish = skillsAfterWrite.data.items.find((s) => s.id === "builtin:polish");
+  const polish = skillsAfterWrite.data.items.find(
+    (s) => s.id === "builtin:polish",
+  );
   if (!polish) {
     throw new Error("Missing builtin:polish after write");
   }

--- a/apps/desktop/tests/e2e/knowledge-graph.spec.ts
+++ b/apps/desktop/tests/e2e/knowledge-graph.spec.ts
@@ -1,0 +1,245 @@
+import {
+  _electron as electron,
+  expect,
+  test,
+  type Page,
+} from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and must not touch a developer profile.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+/**
+ * Resolve app root for Playwright Electron launch.
+ *
+ * Why: tests run from compiled JS paths and must be location-independent.
+ */
+function getAppRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, "../..");
+}
+
+async function launchApp(args: { userDataDir: string }) {
+  const appRoot = getAppRoot();
+  const electronApp = await electron.launch({
+    args: [appRoot],
+    env: {
+      ...process.env,
+      CREONOW_E2E: "1",
+      CREONOW_OPEN_DEVTOOLS: "0",
+      CREONOW_USER_DATA_DIR: args.userDataDir,
+      CREONOW_AI_PROVIDER: "anthropic",
+    },
+  });
+
+  const page = await electronApp.firstWindow();
+  await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+  return { electronApp, page };
+}
+
+async function createProjectViaUi(page: Page): Promise<void> {
+  await expect(page.getByTestId("welcome-screen")).toBeVisible();
+  await page.getByTestId("welcome-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.getByTestId("create-project-name").fill("Demo Project");
+  await page.getByTestId("create-project-submit").click();
+  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+}
+
+test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", async () => {
+  const userDataDir = await createIsolatedUserDataDir();
+  const { electronApp, page } = await launchApp({ userDataDir });
+
+  await createProjectViaUi(page);
+
+  const project = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(project.ok).toBe(true);
+  if (!project.ok) {
+    throw new Error(`Expected ok project:getCurrent, got: ${project.error.code}`);
+  }
+  const projectId = project.data.projectId;
+
+  await page.getByRole("button", { name: "KG" }).click();
+  await expect(page.getByTestId("sidebar-kg")).toBeVisible();
+  await expect(page.getByTestId("kg-entity-create")).toBeEnabled();
+
+  await page.getByTestId("kg-entity-name").fill("Alice");
+  await page.getByTestId("kg-entity-create").click();
+
+  const entityId = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    const res = await window.creonow.invoke("kg:entity:list", {
+      projectId: projectIdParam,
+    });
+    if (!res.ok) {
+      throw new Error(`Expected ok kg:entity:list, got: ${res.error.code}`);
+    }
+    const item = res.data.items.find((e) => e.name === "Alice") ?? null;
+    if (!item) {
+      throw new Error("Missing created entity in list");
+    }
+    return item.entityId;
+  }, projectId);
+
+  await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toBeVisible();
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId(`kg-entity-delete-${entityId}`).click();
+  await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toHaveCount(0);
+
+  const tooLarge = JSON.stringify({ x: "a".repeat(33_000) });
+  const oversize = await page.evaluate(
+    async ({ projectIdParam, tooLargeParam }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("kg:entity:create", {
+        projectId: projectIdParam,
+        name: "Big",
+        metadataJson: tooLargeParam,
+      });
+    },
+    { projectIdParam: projectId, tooLargeParam: tooLarge },
+  );
+  expect(oversize.ok).toBe(false);
+  if (oversize.ok) {
+    throw new Error("Expected INVALID_ARGUMENT on oversize metadataJson");
+  }
+  expect(oversize.error.code).toBe("INVALID_ARGUMENT");
+
+  const alice = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    const res = await window.creonow.invoke("kg:entity:create", {
+      projectId: projectIdParam,
+      name: "Alice",
+    });
+    if (!res.ok) {
+      throw new Error(`Expected ok kg:entity:create, got: ${res.error.code}`);
+    }
+    return res.data;
+  }, projectId);
+
+  const bob = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    const res = await window.creonow.invoke("kg:entity:create", {
+      projectId: projectIdParam,
+      name: "Bob",
+    });
+    if (!res.ok) {
+      throw new Error(`Expected ok kg:entity:create, got: ${res.error.code}`);
+    }
+    return res.data;
+  }, projectId);
+
+  const relation = await page.evaluate(
+    async ({ projectIdParam, fromId, toId }) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      const res = await window.creonow.invoke("kg:relation:create", {
+        projectId: projectIdParam,
+        fromEntityId: fromId,
+        toEntityId: toId,
+        relationType: "knows",
+      });
+      if (!res.ok) {
+        throw new Error(`Expected ok kg:relation:create, got: ${res.error.code}`);
+      }
+      return res.data;
+    },
+    { projectIdParam: projectId, fromId: alice.entityId, toId: bob.entityId },
+  );
+  expect(relation.relationType).toBe("knows");
+
+  const skillRead = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("skill:read", { id: "builtin:polish" });
+  });
+  expect(skillRead.ok).toBe(true);
+  if (!skillRead.ok) {
+    throw new Error(`Expected ok skill:read, got: ${skillRead.error.code}`);
+  }
+
+  const patched = skillRead.data.content
+    .replace(/(^\s*knowledge_graph:\s*)false\s*$/m, "$1true")
+    .replace(/(^scope:\s*)builtin\s*$/m, "$1project");
+
+  const skillWrite = await page.evaluate(async (content) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("skill:write", {
+      id: "builtin:polish",
+      content,
+    });
+  }, patched);
+  expect(skillWrite.ok).toBe(true);
+  if (!skillWrite.ok) {
+    throw new Error(`Expected ok skill:write, got: ${skillWrite.error.code}`);
+  }
+
+  const skillsAfterWrite = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("skill:list", { includeDisabled: true });
+  });
+  expect(skillsAfterWrite.ok).toBe(true);
+  if (!skillsAfterWrite.ok) {
+    throw new Error(
+      `Expected ok skill:list, got: ${skillsAfterWrite.error.code}`,
+    );
+  }
+  const polish = skillsAfterWrite.data.items.find((s) => s.id === "builtin:polish");
+  if (!polish) {
+    throw new Error("Missing builtin:polish after write");
+  }
+  expect(polish.valid).toBe(true);
+  expect(polish.enabled).toBe(true);
+
+  await page.getByTestId("ai-input").fill("hello");
+  await page.getByTestId("ai-run").click();
+  await expect(page.getByTestId("ai-output")).toContainText("E2E_RESULT");
+
+  await page.getByTestId("ai-context-toggle").click();
+  await expect(page.getByTestId("ai-context-panel")).toBeVisible();
+  await expect(page.getByTestId("ai-context-layer-retrieved")).toContainText(
+    "Knowledge Graph (project)",
+  );
+  await expect(page.getByTestId("ai-context-layer-retrieved")).toContainText(
+    "Alice",
+  );
+  await expect(page.getByTestId("ai-context-layer-retrieved")).toContainText(
+    "knows",
+  );
+
+  await electronApp.close();
+});

--- a/openspec/_ops/task_runs/ISSUE-51.md
+++ b/openspec/_ops/task_runs/ISSUE-51.md
@@ -1,7 +1,7 @@
 # ISSUE-51
 - Issue: #51
 - Branch: task/51-p0-011-knowledge-graph
-- PR: <fill>
+- PR: https://github.com/Leeky1017/CreoNow/pull/52
 
 ## Plan
 - Add KG schema + IPC + service with stable errors

--- a/openspec/_ops/task_runs/ISSUE-51.md
+++ b/openspec/_ops/task_runs/ISSUE-51.md
@@ -1,0 +1,40 @@
+# ISSUE-51
+- Issue: #51
+- Branch: task/51-p0-011-knowledge-graph
+- PR: <fill>
+
+## Plan
+- Add KG schema + IPC + service with stable errors
+- Build KG sidebar panel (CRUD) and store
+- Inject KG into context + add E2E coverage
+
+## Runs
+### 2026-01-31 14:11 setup
+- Command: `gh issue create -t "P0-011: Knowledge Graph (CRUD + UI + context integration)" ...`
+- Key output: `https://github.com/Leeky1017/CreoNow/issues/51`
+- Evidence: `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-011-knowledge-graph-crud-ui-context.md`
+
+### 2026-01-31 14:12 worktree
+- Command: `scripts/agent_worktree_setup.sh "51" "p0-011-knowledge-graph"`
+- Key output: `Worktree created: .worktrees/issue-51-p0-011-knowledge-graph`
+- Evidence: `AGENTS.md`
+
+### 2026-01-31 22:35 deps
+- Command: `pnpm install`
+- Key output: `Packages: +687`
+- Evidence: `package.json`
+
+### 2026-01-31 22:46 codegen
+- Command: `pnpm contract:generate`
+- Key output: `packages/shared/types/ipc-generated.ts updated`
+- Evidence: `apps/desktop/main/src/ipc/contract/ipc-contract.ts`
+
+### 2026-01-31 22:47 verify
+- Command: `pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:integration`
+- Key output: `PASS`
+- Evidence: `apps/desktop/tests/unit/*`
+
+### 2026-01-31 22:58 e2e
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/knowledge-graph.spec.ts`
+- Key output: `1 passed`
+- Evidence: `apps/desktop/tests/e2e/knowledge-graph.spec.ts`

--- a/openspec/_ops/task_runs/ISSUE-51.md
+++ b/openspec/_ops/task_runs/ISSUE-51.md
@@ -1,40 +1,49 @@
 # ISSUE-51
+
 - Issue: #51
 - Branch: task/51-p0-011-knowledge-graph
 - PR: https://github.com/Leeky1017/CreoNow/pull/52
 
 ## Plan
+
 - Add KG schema + IPC + service with stable errors
 - Build KG sidebar panel (CRUD) and store
 - Inject KG into context + add E2E coverage
 
 ## Runs
+
 ### 2026-01-31 14:11 setup
+
 - Command: `gh issue create -t "P0-011: Knowledge Graph (CRUD + UI + context integration)" ...`
 - Key output: `https://github.com/Leeky1017/CreoNow/issues/51`
 - Evidence: `openspec/specs/creonow-v1-workbench/task_cards/p0/P0-011-knowledge-graph-crud-ui-context.md`
 
 ### 2026-01-31 14:12 worktree
+
 - Command: `scripts/agent_worktree_setup.sh "51" "p0-011-knowledge-graph"`
 - Key output: `Worktree created: .worktrees/issue-51-p0-011-knowledge-graph`
 - Evidence: `AGENTS.md`
 
 ### 2026-01-31 22:35 deps
+
 - Command: `pnpm install`
 - Key output: `Packages: +687`
 - Evidence: `package.json`
 
 ### 2026-01-31 22:46 codegen
+
 - Command: `pnpm contract:generate`
 - Key output: `packages/shared/types/ipc-generated.ts updated`
 - Evidence: `apps/desktop/main/src/ipc/contract/ipc-contract.ts`
 
 ### 2026-01-31 22:47 verify
+
 - Command: `pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:integration`
 - Key output: `PASS`
 - Evidence: `apps/desktop/tests/unit/*`
 
 ### 2026-01-31 22:58 e2e
+
 - Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/knowledge-graph.spec.ts`
 - Key output: `1 passed`
 - Evidence: `apps/desktop/tests/e2e/knowledge-graph.spec.ts`

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -74,6 +74,15 @@ export const IPC_CHANNELS = [
   "file:document:write",
   "judge:model:ensure",
   "judge:model:getState",
+  "kg:entity:create",
+  "kg:entity:delete",
+  "kg:entity:list",
+  "kg:entity:update",
+  "kg:graph:get",
+  "kg:relation:create",
+  "kg:relation:delete",
+  "kg:relation:list",
+  "kg:relation:update",
   "memory:create",
   "memory:delete",
   "memory:injection:preview",
@@ -428,6 +437,170 @@ export type IpcChannelSpec = {
             };
             status: "error";
           };
+    };
+  };
+  "kg:entity:create": {
+    request: {
+      description?: string;
+      entityType?: string;
+      metadataJson?: string;
+      name: string;
+      projectId: string;
+    };
+    response: {
+      createdAt: number;
+      description?: string;
+      entityId: string;
+      entityType?: string;
+      metadataJson: string;
+      name: string;
+      projectId: string;
+      updatedAt: number;
+    };
+  };
+  "kg:entity:delete": {
+    request: {
+      entityId: string;
+    };
+    response: {
+      deleted: true;
+    };
+  };
+  "kg:entity:list": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      items: Array<{
+        createdAt: number;
+        description?: string;
+        entityId: string;
+        entityType?: string;
+        metadataJson: string;
+        name: string;
+        projectId: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "kg:entity:update": {
+    request: {
+      entityId: string;
+      patch: {
+        description?: string;
+        entityType?: string;
+        metadataJson?: string;
+        name?: string;
+      };
+    };
+    response: {
+      createdAt: number;
+      description?: string;
+      entityId: string;
+      entityType?: string;
+      metadataJson: string;
+      name: string;
+      projectId: string;
+      updatedAt: number;
+    };
+  };
+  "kg:graph:get": {
+    request: {
+      projectId: string;
+      purpose?: "ui" | "context";
+    };
+    response: {
+      entities: Array<{
+        createdAt: number;
+        description?: string;
+        entityId: string;
+        entityType?: string;
+        metadataJson: string;
+        name: string;
+        projectId: string;
+        updatedAt: number;
+      }>;
+      relations: Array<{
+        createdAt: number;
+        evidenceJson: string;
+        fromEntityId: string;
+        metadataJson: string;
+        projectId: string;
+        relationId: string;
+        relationType: string;
+        toEntityId: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "kg:relation:create": {
+    request: {
+      evidenceJson?: string;
+      fromEntityId: string;
+      metadataJson?: string;
+      projectId: string;
+      relationType: string;
+      toEntityId: string;
+    };
+    response: {
+      createdAt: number;
+      evidenceJson: string;
+      fromEntityId: string;
+      metadataJson: string;
+      projectId: string;
+      relationId: string;
+      relationType: string;
+      toEntityId: string;
+      updatedAt: number;
+    };
+  };
+  "kg:relation:delete": {
+    request: {
+      relationId: string;
+    };
+    response: {
+      deleted: true;
+    };
+  };
+  "kg:relation:list": {
+    request: {
+      projectId: string;
+    };
+    response: {
+      items: Array<{
+        createdAt: number;
+        evidenceJson: string;
+        fromEntityId: string;
+        metadataJson: string;
+        projectId: string;
+        relationId: string;
+        relationType: string;
+        toEntityId: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "kg:relation:update": {
+    request: {
+      patch: {
+        evidenceJson?: string;
+        fromEntityId?: string;
+        metadataJson?: string;
+        relationType?: string;
+        toEntityId?: string;
+      };
+      relationId: string;
+    };
+    response: {
+      createdAt: number;
+      evidenceJson: string;
+      fromEntityId: string;
+      metadataJson: string;
+      projectId: string;
+      relationId: string;
+      relationType: string;
+      toEntityId: string;
+      updatedAt: number;
     };
   };
   "memory:create": {


### PR DESCRIPTION
Closes #51

Summary:
- Add SQLite schema for kg_entities/kg_relations + indexes (incl. migration v5)
- Add main-process kgService + IPC channels (kg:graph:get, kg:entity:*, kg:relation:*)
- Add renderer KG sidebar panel/store + tab
- Inject KG into context viewer when skill context_rules.knowledge_graph is true (logs kg_injected)
- Add Windows E2E coverage

Test plan:
- pnpm typecheck
- pnpm lint
- pnpm test:unit
- pnpm test:integration
- pnpm -C apps/desktop test:e2e -- tests/e2e/knowledge-graph.spec.ts