### PR TITLE
docs: backfill Issue-54 completion links (#54)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-54.md
+++ b/openspec/_ops/task_runs/ISSUE-54.md
@@ -2,7 +2,7 @@
 
 - Issue: #54
 - Branch: task/54-cnwb-p1-batch
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/55
 
 ## Goal
 
@@ -10,13 +10,13 @@
 
 ## Status
 
-- CURRENT: P1 implementation complete; local typecheck/lint/unit/integration/e2e green; preparing docs close-out + PR.
+- CURRENT: MERGED (#55); controlplane synced; worktree cleaned.
 
 ## Next Actions
 
-- [ ] Close out P1 task cards (Status/Acceptance/Completion) + update Rulebook tasks checkboxes.
-- [ ] Commit/push branch + open PR with `Closes #54` and enable auto-merge.
-- [ ] Watch required checks and confirm merge; then backfill PR link into RUN_LOG + task cards.
+- [x] Close out P1 task cards (Status/Acceptance/Completion) + update Rulebook tasks checkboxes.
+- [x] Commit/push branch + open PR with `Closes #54` and enable auto-merge.
+- [x] Watch required checks and confirm merge; then backfill PR link into RUN_LOG + task cards.
 
 ## Decisions Made
 
@@ -108,3 +108,15 @@
 - Command: `pnpm desktop:test:e2e`
 - Key output: `25 passed`
 - Evidence: `apps/desktop/tests/e2e/*.spec.ts`
+
+### 2026-02-01 02:34 contract/check
+
+- Command: `pnpm contract:check`
+- Key output: `exit 0`
+- Evidence: `packages/shared/types/ipc-generated.ts`
+
+### 2026-02-01 02:40 merge verification
+
+- Command: `gh pr view 55 --json number,state,mergedAt --jq '"'"'"#"'"'"'+(.number|tostring)+" "+.state+" "+(.mergedAt // "")'`
+- Key output: `#55 MERGED 2026-01-31T18:39:01Z`
+- Evidence: https://github.com/Leeky1017/CreoNow/pull/55

--- a/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-001-light-theme.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-001-light-theme.md
@@ -45,5 +45,5 @@ Status: done
 ## Completion
 
 - Issue: #54
-- PR: <fill-after-created>
+- PR: #55
 - RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-002-analytics-and-writing-stats.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-002-analytics-and-writing-stats.md
@@ -47,5 +47,5 @@ Status: done
 ## Completion
 
 - Issue: #54
-- PR: <fill-after-created>
+- PR: #55
 - RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-003-export-markdown-pdf-docx.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-003-export-markdown-pdf-docx.md
@@ -44,5 +44,5 @@ Status: done
 ## Completion
 
 - Issue: #54
-- PR: <fill-after-created>
+- PR: #55
 - RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-004-user-memory-semantic-recall.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-004-user-memory-semantic-recall.md
@@ -52,5 +52,5 @@ Status: done
 ## Completion
 
 - Issue: #54
-- PR: <fill-after-created>
+- PR: #55
 - RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`

--- a/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-005-litellm-proxy-optional.md
+++ b/openspec/specs/creonow-v1-workbench/task_cards/p1/P1-005-litellm-proxy-optional.md
@@ -47,5 +47,5 @@ Status: done
 ## Completion
 
 - Issue: #54
-- PR: <fill-after-created>
+- PR: #55
 - RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`

--- a/rulebook/tasks/issue-54-cnwb-p1-batch/tasks.md
+++ b/rulebook/tasks/issue-54-cnwb-p1-batch/tasks.md
@@ -5,14 +5,14 @@
 - [x] 1.4 P1-003: Export (markdown) IPC/service + command palette commands + E2E
 - [x] 1.5 P1-004: user_memory_vec semantic recall + deterministic fallback + tests
 - [x] 1.6 P1-005: LiteLLM proxy settings IPC + AI service single-chain + Settings UI + E2E
-- [ ] 1.7 Docs: P1 task cards close-out（Status/Acceptance/Completion）+ index 确认
+- [x] 1.7 Docs: P1 task cards close-out（Status/Acceptance/Completion）+ index 确认
 
 ## 2. Testing
-- [ ] 2.1 Contract/codegen: `pnpm contract:generate && pnpm contract:check`
+- [x] 2.1 Contract/codegen: `pnpm contract:generate && pnpm contract:check`
 - [x] 2.2 Typecheck/lint: `pnpm typecheck && pnpm lint`
 - [x] 2.3 Unit/integration: `pnpm test:unit && pnpm test:integration`
 - [x] 2.4 E2E (Windows-first): `pnpm desktop:test:e2e`
 
 ## 3. Documentation
-- [ ] 3.1 RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`（append-only）
-- [ ] 3.2 PR: body 包含 `Closes #54` + test plan
+- [x] 3.1 RUN_LOG: `openspec/_ops/task_runs/ISSUE-54.md`（append-only）
+- [x] 3.2 PR: body 包含 `Closes #54` + test plan


### PR DESCRIPTION
Closes #54

## Summary
- Backfill PR link (#55) into `openspec/_ops/task_runs/ISSUE-54.md` and P1 task cards
- Mark Rulebook checkboxes complete for issue-54 task
