### PR TITLE
feat: 创建 Radix 组件库（Dialog/Popover/Select/Checkbox/Tabs）(#63)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Checkbox.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Checkbox.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+
+/**
+ * Checkbox component props
+ *
+ * A checkbox component built on Radix UI Checkbox primitive.
+ * Supports checked, unchecked, and indeterminate states.
+ */
+export interface CheckboxProps {
+  /** Controlled checked state */
+  checked?: boolean | "indeterminate";
+  /** Callback when checked state changes */
+  onCheckedChange?: (checked: boolean | "indeterminate") => void;
+  /** Default checked state (uncontrolled) */
+  defaultChecked?: boolean;
+  /** Disabled state */
+  disabled?: boolean;
+  /** Required for form validation */
+  required?: boolean;
+  /** Name for form submission */
+  name?: string;
+  /** Value for form submission */
+  value?: string;
+  /** ID for label association */
+  id?: string;
+  /** Optional label text */
+  label?: string;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Checkbox root styles
+ *
+ * Uses "group" class to allow child icons to respond to data-state
+ */
+const checkboxStyles = [
+  "group",
+  "peer",
+  "shrink-0",
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "w-5",
+  "h-5",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-sm)]",
+  "cursor-pointer",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  // Hover
+  "hover:border-[var(--color-border-hover)]",
+  // Checked state
+  "data-[state=checked]:bg-[var(--color-fg-default)]",
+  "data-[state=checked]:border-[var(--color-fg-default)]",
+  "data-[state=indeterminate]:bg-[var(--color-fg-default)]",
+  "data-[state=indeterminate]:border-[var(--color-fg-default)]",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+  // Disabled
+  "disabled:opacity-50",
+  "disabled:cursor-not-allowed",
+].join(" ");
+
+/**
+ * Indicator styles (the check mark container)
+ */
+const indicatorStyles = [
+  "flex",
+  "items-center",
+  "justify-center",
+  "text-[var(--color-fg-inverse)]",
+].join(" ");
+
+/**
+ * Label styles
+ */
+const labelStyles = [
+  "text-[13px]",
+  "text-[var(--color-fg-default)]",
+  "select-none",
+  "cursor-pointer",
+  // Disabled peer state
+  "peer-disabled:opacity-50",
+  "peer-disabled:cursor-not-allowed",
+].join(" ");
+
+/**
+ * Check icon (for checked state)
+ *
+ * Hidden when parent has data-state="indeterminate"
+ */
+function CheckIcon() {
+  return (
+    <svg
+      className="hidden group-data-[state=checked]:block"
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 7L6 10L11 4" />
+    </svg>
+  );
+}
+
+/**
+ * Minus icon (for indeterminate state)
+ *
+ * Hidden when parent has data-state="checked"
+ */
+function MinusIcon() {
+  return (
+    <svg
+      className="hidden group-data-[state=indeterminate]:block"
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M3 7H11" />
+    </svg>
+  );
+}
+
+/**
+ * Checkbox component
+ *
+ * A checkbox built on Radix UI Checkbox for proper accessibility and keyboard support.
+ * Supports checked, unchecked, and indeterminate states.
+ *
+ * @example
+ * ```tsx
+ * // Simple checkbox
+ * <Checkbox label="Accept terms" />
+ *
+ * // Controlled checkbox
+ * <Checkbox
+ *   checked={accepted}
+ *   onCheckedChange={setAccepted}
+ *   label="I agree to the terms"
+ * />
+ *
+ * // Indeterminate state (useful for "select all")
+ * <Checkbox
+ *   checked={allSelected ? true : someSelected ? 'indeterminate' : false}
+ *   onCheckedChange={(checked) => setAll(checked === true)}
+ *   label="Select all"
+ * />
+ * ```
+ */
+export function Checkbox({
+  checked,
+  onCheckedChange,
+  defaultChecked,
+  disabled = false,
+  required = false,
+  name,
+  value,
+  id,
+  label,
+  className = "",
+}: CheckboxProps): JSX.Element {
+  const generatedId = React.useId();
+  const checkboxId = id ?? generatedId;
+
+  const checkboxElement = (
+    <CheckboxPrimitive.Root
+      id={checkboxId}
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      defaultChecked={defaultChecked}
+      disabled={disabled}
+      required={required}
+      name={name}
+      value={value}
+      className={`${checkboxStyles} ${className}`}
+    >
+      <CheckboxPrimitive.Indicator className={indicatorStyles} forceMount>
+        <CheckIcon />
+        <MinusIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+
+  if (label) {
+    return (
+      <div className="flex items-center gap-2">
+        {checkboxElement}
+        <label htmlFor={checkboxId} className={labelStyles}>
+          {label}
+        </label>
+      </div>
+    );
+  }
+
+  return checkboxElement;
+}

--- a/apps/desktop/renderer/src/components/primitives/Dialog.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Dialog.tsx
@@ -1,0 +1,226 @@
+import React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+
+/**
+ * Dialog component props as defined in design spec §11.5
+ *
+ * A modal dialog component built on Radix UI Dialog primitive.
+ * Implements proper z-index (modal: 400), shadows (xl), and scrim overlay.
+ */
+export interface DialogProps {
+  /** Controlled open state */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Dialog title (required for accessibility) */
+  title: string;
+  /** Optional description below title */
+  description?: string;
+  /** Dialog content */
+  children: React.ReactNode;
+  /** Optional footer (typically action buttons) */
+  footer?: React.ReactNode;
+  /** Close on Escape key press. Default: true */
+  closeOnEscape?: boolean;
+  /** Close on overlay click. Default: true */
+  closeOnOverlayClick?: boolean;
+}
+
+/**
+ * Overlay styles - scrim with z-index modal (§5.1)
+ *
+ * Uses CSS transitions for animation (no tailwindcss-animate dependency).
+ * Radix handles the mounting/unmounting, we just style opacity.
+ */
+const overlayStyles = [
+  "fixed",
+  "inset-0",
+  "z-[var(--z-modal)]",
+  "bg-[var(--color-scrim)]",
+  // Animation via CSS transition
+  "transition-opacity",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=closed]:opacity-0",
+].join(" ");
+
+/**
+ * Content styles - modal with shadow-xl (§3.7, §5.2)
+ *
+ * Uses CSS transitions for animation (no tailwindcss-animate dependency).
+ */
+const contentStyles = [
+  "fixed",
+  "left-1/2",
+  "top-1/2",
+  "-translate-x-1/2",
+  "-translate-y-1/2",
+  "z-[var(--z-modal)]",
+  // Visual
+  "bg-[var(--color-bg-raised)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-lg)]",
+  "shadow-[var(--shadow-xl)]",
+  // Sizing
+  "w-full",
+  "max-w-md",
+  "max-h-[85vh]",
+  "overflow-hidden",
+  // Animation via CSS transition
+  "transition-[opacity,transform]",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=open]:scale-100",
+  "data-[state=closed]:opacity-0",
+  "data-[state=closed]:scale-95",
+  // Focus
+  "focus:outline-none",
+].join(" ");
+
+/**
+ * Title styles - card title typography (§4.2)
+ */
+const titleStyles = [
+  "text-base",
+  "font-semibold",
+  "text-[var(--color-fg-default)]",
+  "leading-[1.3]",
+  "tracking-[-0.01em]",
+].join(" ");
+
+/**
+ * Description styles - muted text
+ */
+const descriptionStyles = [
+  "text-[13px]",
+  "text-[var(--color-fg-muted)]",
+  "leading-[1.5]",
+  "mt-2",
+].join(" ");
+
+/**
+ * Close button styles
+ */
+const closeButtonStyles = [
+  "absolute",
+  "right-4",
+  "top-4",
+  "w-8",
+  "h-8",
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "rounded-[var(--radius-sm)]",
+  "text-[var(--color-fg-muted)]",
+  "hover:text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+/**
+ * Dialog component following design spec §11.5
+ *
+ * A modal dialog built on Radix UI Dialog for proper accessibility and focus management.
+ * Uses z-index modal (400), shadow-xl, and scrim overlay.
+ *
+ * @example
+ * ```tsx
+ * <Dialog
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   title="Confirm Delete"
+ *   description="This action cannot be undone."
+ *   footer={
+ *     <>
+ *       <Button variant="ghost" onClick={() => setIsOpen(false)}>Cancel</Button>
+ *       <Button variant="danger">Delete</Button>
+ *     </>
+ *   }
+ * >
+ *   <p>Are you sure you want to delete this item?</p>
+ * </Dialog>
+ * ```
+ */
+export function Dialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  closeOnEscape = true,
+  closeOnOverlayClick = true,
+}: DialogProps): JSX.Element {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className={overlayStyles} />
+        <DialogPrimitive.Content
+          className={contentStyles}
+          onEscapeKeyDown={
+            closeOnEscape ? undefined : (e) => e.preventDefault()
+          }
+          onPointerDownOutside={
+            closeOnOverlayClick ? undefined : (e) => e.preventDefault()
+          }
+        >
+          {/* Header */}
+          <div className="px-6 pt-6 pb-4">
+            <DialogPrimitive.Title className={titleStyles}>
+              {title}
+            </DialogPrimitive.Title>
+            {description && (
+              <DialogPrimitive.Description className={descriptionStyles}>
+                {description}
+              </DialogPrimitive.Description>
+            )}
+          </div>
+
+          {/* Body */}
+          <div className="px-6 pb-4 overflow-y-auto max-h-[calc(85vh-160px)]">
+            {children}
+          </div>
+
+          {/* Footer */}
+          {footer && (
+            <div className="px-6 py-4 border-t border-[var(--color-separator)] flex justify-end gap-3">
+              {footer}
+            </div>
+          )}
+
+          {/* Close button */}
+          <DialogPrimitive.Close className={closeButtonStyles}>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M4 4L12 12M12 4L4 12" />
+            </svg>
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+/**
+ * DialogTrigger - Wraps a button that opens the dialog
+ *
+ * Use when you need an uncontrolled trigger button.
+ */
+export const DialogTrigger = DialogPrimitive.Trigger;

--- a/apps/desktop/renderer/src/components/primitives/Popover.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Popover.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+/**
+ * Popover component props
+ *
+ * A floating popover component built on Radix UI Popover primitive.
+ * Implements z-index popover (300) and shadow-md (§3.7, §5.2).
+ */
+export interface PopoverProps {
+  /** Controlled open state */
+  open?: boolean;
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /** Default open state (uncontrolled) */
+  defaultOpen?: boolean;
+  /** Trigger element */
+  trigger: React.ReactNode;
+  /** Popover content */
+  children: React.ReactNode;
+  /** Preferred side of the trigger to render. Default: "bottom" */
+  side?: "top" | "right" | "bottom" | "left";
+  /** Offset from trigger in pixels. Default: 8 */
+  sideOffset?: number;
+  /** Alignment relative to trigger. Default: "center" */
+  align?: "start" | "center" | "end";
+}
+
+/**
+ * Content styles - popover with shadow-md (§3.7, §5.2)
+ *
+ * Uses CSS transitions for animation (no tailwindcss-animate dependency).
+ */
+const contentStyles = [
+  "z-[var(--z-popover)]",
+  // Visual
+  "bg-[var(--color-bg-raised)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-md)]",
+  "shadow-[var(--shadow-md)]",
+  // Sizing
+  "min-w-[200px]",
+  "max-w-[320px]",
+  "p-4",
+  // Animation via CSS transition
+  "transition-[opacity,transform]",
+  "duration-[var(--duration-fast)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=open]:scale-100",
+  "data-[state=closed]:opacity-0",
+  "data-[state=closed]:scale-95",
+  // Focus
+  "focus:outline-none",
+].join(" ");
+
+/**
+ * Popover component following design spec §5.2
+ *
+ * A floating popover built on Radix UI Popover for proper positioning and focus management.
+ * Uses z-index popover (300) and shadow-md.
+ *
+ * @example
+ * ```tsx
+ * <Popover trigger={<Button variant="ghost">Open Menu</Button>}>
+ *   <div>Popover content here</div>
+ * </Popover>
+ * ```
+ */
+export function Popover({
+  open,
+  onOpenChange,
+  defaultOpen,
+  trigger,
+  children,
+  side = "bottom",
+  sideOffset = 8,
+  align = "center",
+}: PopoverProps): JSX.Element {
+  return (
+    <PopoverPrimitive.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      defaultOpen={defaultOpen}
+    >
+      <PopoverPrimitive.Trigger asChild>{trigger}</PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          className={contentStyles}
+          side={side}
+          sideOffset={sideOffset}
+          align={align}
+          collisionPadding={8}
+        >
+          {children}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}
+
+/**
+ * PopoverClose - Wraps an element that closes the popover
+ */
+export const PopoverClose = PopoverPrimitive.Close;
+
+/**
+ * PopoverAnchor - Anchors the popover to a different element than the trigger
+ */
+export const PopoverAnchor = PopoverPrimitive.Anchor;

--- a/apps/desktop/renderer/src/components/primitives/Select.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Select.tsx
@@ -54,7 +54,7 @@ export interface SelectProps {
  * Check if options are grouped
  */
 function isGrouped(
-  options: SelectOption[] | SelectGroup[]
+  options: SelectOption[] | SelectGroup[],
 ): options is SelectGroup[] {
   return options.length > 0 && "options" in options[0];
 }

--- a/apps/desktop/renderer/src/components/primitives/Select.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Select.tsx
@@ -1,0 +1,320 @@
+import React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+
+/**
+ * Select option item
+ */
+export interface SelectOption {
+  /** Unique value for this option */
+  value: string;
+  /** Display label */
+  label: string;
+  /** Optional disabled state */
+  disabled?: boolean;
+}
+
+/**
+ * Select option group
+ */
+export interface SelectGroup {
+  /** Group label */
+  label: string;
+  /** Options in this group */
+  options: SelectOption[];
+}
+
+/**
+ * Select component props
+ *
+ * A dropdown select component built on Radix UI Select primitive.
+ * Implements z-index dropdown (200) and shadow-md (§3.7, §5.2).
+ */
+export interface SelectProps {
+  /** Current value (controlled) */
+  value?: string;
+  /** Callback when value changes */
+  onValueChange?: (value: string) => void;
+  /** Default value (uncontrolled) */
+  defaultValue?: string;
+  /** Placeholder text when no value selected */
+  placeholder?: string;
+  /** Options or grouped options */
+  options: SelectOption[] | SelectGroup[];
+  /** Disabled state */
+  disabled?: boolean;
+  /** Name for form submission */
+  name?: string;
+  /** Full width */
+  fullWidth?: boolean;
+  /** Custom class name for trigger */
+  className?: string;
+}
+
+/**
+ * Check if options are grouped
+ */
+function isGrouped(
+  options: SelectOption[] | SelectGroup[]
+): options is SelectGroup[] {
+  return options.length > 0 && "options" in options[0];
+}
+
+/**
+ * Trigger styles - matches Input style (§6.2)
+ */
+const triggerStyles = [
+  "inline-flex",
+  "items-center",
+  "justify-between",
+  "gap-2",
+  "h-10",
+  "px-3",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-sm)]",
+  "text-[13px]",
+  "text-[var(--color-fg-default)]",
+  "cursor-pointer",
+  "select-none",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  // Hover
+  "hover:border-[var(--color-border-hover)]",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+  "focus-visible:border-[var(--color-border-focus)]",
+  // Disabled
+  "disabled:opacity-50",
+  "disabled:cursor-not-allowed",
+  // Placeholder
+  "data-[placeholder]:text-[var(--color-fg-placeholder)]",
+].join(" ");
+
+/**
+ * Content styles - dropdown with shadow-md (§3.7, §5.2)
+ *
+ * Uses CSS transitions for animation (no tailwindcss-animate dependency).
+ */
+const contentStyles = [
+  "z-[var(--z-dropdown)]",
+  "overflow-hidden",
+  // Visual
+  "bg-[var(--color-bg-raised)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-md)]",
+  "shadow-[var(--shadow-md)]",
+  // Animation via CSS transition
+  "transition-[opacity,transform]",
+  "duration-[var(--duration-fast)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=open]:scale-100",
+  "data-[state=closed]:opacity-0",
+  "data-[state=closed]:scale-95",
+].join(" ");
+
+/**
+ * Viewport styles
+ */
+const viewportStyles = "p-1 max-h-[300px] overflow-y-auto";
+
+/**
+ * Item styles - list item (§6.4)
+ */
+const itemStyles = [
+  "relative",
+  "flex",
+  "items-center",
+  "h-8",
+  "px-8",
+  "pr-3",
+  "text-[13px]",
+  "text-[var(--color-fg-default)]",
+  "rounded-[var(--radius-sm)]",
+  "cursor-pointer",
+  "select-none",
+  "outline-none",
+  // Hover & Focus
+  "data-[highlighted]:bg-[var(--color-bg-hover)]",
+  // Selected
+  "data-[state=checked]:text-[var(--color-fg-default)]",
+  "data-[state=checked]:font-medium",
+  // Disabled
+  "data-[disabled]:text-[var(--color-fg-disabled)]",
+  "data-[disabled]:pointer-events-none",
+].join(" ");
+
+/**
+ * Group label styles
+ */
+const groupLabelStyles = [
+  "px-8",
+  "py-2",
+  "text-xs",
+  "font-medium",
+  "text-[var(--color-fg-subtle)]",
+  "uppercase",
+  "tracking-[0.1em]",
+].join(" ");
+
+/**
+ * Separator styles
+ */
+const separatorStyles = "h-px my-1 bg-[var(--color-separator)]";
+
+/**
+ * Chevron icon
+ */
+function ChevronDownIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 6L8 10L12 6" />
+    </svg>
+  );
+}
+
+/**
+ * Check icon for selected item
+ */
+function CheckIcon() {
+  return (
+    <svg
+      className="absolute left-2 w-4 h-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 8L6.5 11.5L13 5" />
+    </svg>
+  );
+}
+
+/**
+ * Select component following design spec §5.2, §6.2
+ *
+ * A dropdown select built on Radix UI Select for proper accessibility and keyboard navigation.
+ * Supports flat options or grouped options.
+ *
+ * @example
+ * ```tsx
+ * <Select
+ *   placeholder="Select a color"
+ *   options={[
+ *     { value: 'red', label: 'Red' },
+ *     { value: 'blue', label: 'Blue' },
+ *     { value: 'green', label: 'Green' },
+ *   ]}
+ *   value={color}
+ *   onValueChange={setColor}
+ * />
+ *
+ * // With groups
+ * <Select
+ *   placeholder="Select a fruit"
+ *   options={[
+ *     { label: 'Citrus', options: [{ value: 'orange', label: 'Orange' }] },
+ *     { label: 'Berries', options: [{ value: 'strawberry', label: 'Strawberry' }] },
+ *   ]}
+ * />
+ * ```
+ */
+export function Select({
+  value,
+  onValueChange,
+  defaultValue,
+  placeholder = "Select...",
+  options,
+  disabled = false,
+  name,
+  fullWidth = false,
+  className = "",
+}: SelectProps): JSX.Element {
+  const triggerClasses = [triggerStyles, fullWidth ? "w-full" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <SelectPrimitive.Root
+      value={value}
+      onValueChange={onValueChange}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      name={name}
+    >
+      <SelectPrimitive.Trigger className={triggerClasses}>
+        <SelectPrimitive.Value placeholder={placeholder} />
+        <SelectPrimitive.Icon>
+          <ChevronDownIcon className="text-[var(--color-fg-muted)]" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content className={contentStyles} position="popper">
+          <SelectPrimitive.Viewport className={viewportStyles}>
+            {isGrouped(options)
+              ? options.map((group, groupIndex) => (
+                  <React.Fragment key={group.label}>
+                    {groupIndex > 0 && (
+                      <SelectPrimitive.Separator className={separatorStyles} />
+                    )}
+                    <SelectPrimitive.Group>
+                      <SelectPrimitive.Label className={groupLabelStyles}>
+                        {group.label}
+                      </SelectPrimitive.Label>
+                      {group.options.map((option) => (
+                        <SelectPrimitive.Item
+                          key={option.value}
+                          value={option.value}
+                          disabled={option.disabled}
+                          className={itemStyles}
+                        >
+                          <SelectPrimitive.ItemIndicator>
+                            <CheckIcon />
+                          </SelectPrimitive.ItemIndicator>
+                          <SelectPrimitive.ItemText>
+                            {option.label}
+                          </SelectPrimitive.ItemText>
+                        </SelectPrimitive.Item>
+                      ))}
+                    </SelectPrimitive.Group>
+                  </React.Fragment>
+                ))
+              : options.map((option) => (
+                  <SelectPrimitive.Item
+                    key={option.value}
+                    value={option.value}
+                    disabled={option.disabled}
+                    className={itemStyles}
+                  >
+                    <SelectPrimitive.ItemIndicator>
+                      <CheckIcon />
+                    </SelectPrimitive.ItemIndicator>
+                    <SelectPrimitive.ItemText>
+                      {option.label}
+                    </SelectPrimitive.ItemText>
+                  </SelectPrimitive.Item>
+                ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Tabs.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Tabs.tsx
@@ -111,10 +111,7 @@ const triggerStyles = [
  * Note: Tab panels use simple opacity transition. Complex slide animations
  * would require additional CSS keyframes.
  */
-const panelStyles = [
-  "mt-4",
-  "focus:outline-none",
-].join(" ");
+const panelStyles = ["mt-4", "focus:outline-none"].join(" ");
 
 /**
  * Tabs component

--- a/apps/desktop/renderer/src/components/primitives/Tabs.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Tabs.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+/**
+ * Tab item definition
+ */
+export interface TabItem {
+  /** Unique value for this tab */
+  value: string;
+  /** Display label */
+  label: React.ReactNode;
+  /** Optional disabled state */
+  disabled?: boolean;
+  /** Tab panel content */
+  content: React.ReactNode;
+}
+
+/**
+ * Tabs component props
+ *
+ * A tabbed interface component built on Radix UI Tabs primitive.
+ */
+export interface TabsProps {
+  /** Tab items */
+  tabs: TabItem[];
+  /** Current active tab value (controlled) */
+  value?: string;
+  /** Callback when active tab changes */
+  onValueChange?: (value: string) => void;
+  /** Default active tab (uncontrolled) */
+  defaultValue?: string;
+  /** Orientation of tabs. Default: "horizontal" */
+  orientation?: "horizontal" | "vertical";
+  /** Full width tabs (stretch to fill container) */
+  fullWidth?: boolean;
+  /** Custom class name for root */
+  className?: string;
+  /** Custom class name for tab list */
+  listClassName?: string;
+  /** Custom class name for tab panels */
+  panelClassName?: string;
+}
+
+/**
+ * Tab list styles (horizontal)
+ */
+const listStylesHorizontal = [
+  "inline-flex",
+  "items-center",
+  "gap-1",
+  "p-1",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-md)]",
+].join(" ");
+
+/**
+ * Tab list styles (vertical)
+ */
+const listStylesVertical = [
+  "flex",
+  "flex-col",
+  "gap-1",
+  "p-1",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-md)]",
+].join(" ");
+
+/**
+ * Tab trigger styles
+ */
+const triggerStyles = [
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "whitespace-nowrap",
+  "px-4",
+  "py-2",
+  "text-[13px]",
+  "font-medium",
+  "text-[var(--color-fg-muted)]",
+  "rounded-[var(--radius-sm)]",
+  "cursor-pointer",
+  "select-none",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  // Hover
+  "hover:text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  // Active/Selected state
+  "data-[state=active]:text-[var(--color-fg-default)]",
+  "data-[state=active]:bg-[var(--color-bg-raised)]",
+  "data-[state=active]:shadow-sm",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+  // Disabled
+  "disabled:opacity-50",
+  "disabled:cursor-not-allowed",
+  "disabled:hover:bg-transparent",
+].join(" ");
+
+/**
+ * Tab panel styles
+ *
+ * Note: Tab panels use simple opacity transition. Complex slide animations
+ * would require additional CSS keyframes.
+ */
+const panelStyles = [
+  "mt-4",
+  "focus:outline-none",
+].join(" ");
+
+/**
+ * Tabs component
+ *
+ * A tabbed interface built on Radix UI Tabs for proper accessibility and keyboard navigation.
+ * Supports horizontal and vertical orientations.
+ *
+ * @example
+ * ```tsx
+ * <Tabs
+ *   defaultValue="general"
+ *   tabs={[
+ *     { value: 'general', label: 'General', content: <GeneralSettings /> },
+ *     { value: 'appearance', label: 'Appearance', content: <AppearanceSettings /> },
+ *     { value: 'advanced', label: 'Advanced', content: <AdvancedSettings />, disabled: true },
+ *   ]}
+ * />
+ *
+ * // Controlled
+ * <Tabs
+ *   value={activeTab}
+ *   onValueChange={setActiveTab}
+ *   tabs={tabs}
+ * />
+ *
+ * // Vertical orientation
+ * <Tabs
+ *   orientation="vertical"
+ *   tabs={tabs}
+ * />
+ * ```
+ */
+export function Tabs({
+  tabs,
+  value,
+  onValueChange,
+  defaultValue,
+  orientation = "horizontal",
+  fullWidth = false,
+  className = "",
+  listClassName = "",
+  panelClassName = "",
+}: TabsProps): JSX.Element {
+  // Use first tab as default if not specified
+  const effectiveDefaultValue = defaultValue ?? tabs[0]?.value;
+
+  const listBaseStyles =
+    orientation === "horizontal" ? listStylesHorizontal : listStylesVertical;
+  const listClasses = [listBaseStyles, fullWidth ? "w-full" : "", listClassName]
+    .filter(Boolean)
+    .join(" ");
+
+  const triggerClasses = [triggerStyles, fullWidth ? "flex-1" : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  const panelClasses = [panelStyles, panelClassName].filter(Boolean).join(" ");
+
+  return (
+    <TabsPrimitive.Root
+      value={value}
+      onValueChange={onValueChange}
+      defaultValue={effectiveDefaultValue}
+      orientation={orientation}
+      className={`${orientation === "vertical" ? "flex gap-4" : ""} ${className}`}
+    >
+      <TabsPrimitive.List className={listClasses}>
+        {tabs.map((tab) => (
+          <TabsPrimitive.Trigger
+            key={tab.value}
+            value={tab.value}
+            disabled={tab.disabled}
+            className={triggerClasses}
+          >
+            {tab.label}
+          </TabsPrimitive.Trigger>
+        ))}
+      </TabsPrimitive.List>
+
+      <div className={orientation === "vertical" ? "flex-1" : ""}>
+        {tabs.map((tab) => (
+          <TabsPrimitive.Content
+            key={tab.value}
+            value={tab.value}
+            className={panelClasses}
+          >
+            {tab.content}
+          </TabsPrimitive.Content>
+        ))}
+      </div>
+    </TabsPrimitive.Root>
+  );
+}
+
+/**
+ * Export primitives for custom implementations
+ */
+export const TabsRoot = TabsPrimitive.Root;
+export const TabsList = TabsPrimitive.List;
+export const TabsTrigger = TabsPrimitive.Trigger;
+export const TabsContent = TabsPrimitive.Content;

--- a/apps/desktop/renderer/src/components/primitives/index.ts
+++ b/apps/desktop/renderer/src/components/primitives/index.ts
@@ -58,11 +58,5 @@ export type { SelectProps, SelectOption, SelectGroup } from "./Select";
 export { Checkbox } from "./Checkbox";
 export type { CheckboxProps } from "./Checkbox";
 
-export {
-  Tabs,
-  TabsRoot,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from "./Tabs";
+export { Tabs, TabsRoot, TabsList, TabsTrigger, TabsContent } from "./Tabs";
 export type { TabsProps, TabItem } from "./Tabs";

--- a/apps/desktop/renderer/src/components/primitives/index.ts
+++ b/apps/desktop/renderer/src/components/primitives/index.ts
@@ -44,3 +44,25 @@ export type { TextProps, TextSize, TextColor } from "./Text";
 
 export { Heading } from "./Heading";
 export type { HeadingProps, HeadingLevel, HeadingColor } from "./Heading";
+
+// Radix-based components
+export { Dialog, DialogTrigger } from "./Dialog";
+export type { DialogProps } from "./Dialog";
+
+export { Popover, PopoverClose, PopoverAnchor } from "./Popover";
+export type { PopoverProps } from "./Popover";
+
+export { Select } from "./Select";
+export type { SelectProps, SelectOption, SelectGroup } from "./Select";
+
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";
+
+export {
+  Tabs,
+  TabsRoot,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "./Tabs";
+export type { TabsProps, TabItem } from "./Tabs";

--- a/openspec/_ops/task_runs/ISSUE-63.md
+++ b/openspec/_ops/task_runs/ISSUE-63.md
@@ -2,7 +2,7 @@
 
 - Issue: #63
 - Branch: task/63-radix-primitives
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/64
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-63.md
+++ b/openspec/_ops/task_runs/ISSUE-63.md
@@ -1,0 +1,35 @@
+# ISSUE-63
+
+- Issue: #63
+- Branch: task/63-radix-primitives
+- PR: <fill-after-created>
+
+## Plan
+
+1. 创建基于 Radix UI 的组件库（Dialog、Popover、Select、Checkbox、Tabs）
+2. 所有组件遵循 `design/DESIGN_DECISIONS.md` 设计规范
+3. 更新 `primitives/index.ts` 导出新组件
+
+## Runs
+
+### 2026-02-01 创建 Radix 组件
+
+- Command: 创建 5 个 Radix 组件文件
+- Key output:
+  - `Dialog.tsx` - 模态对话框，z-index modal(400)，shadow-xl
+  - `Popover.tsx` - 浮动弹出层，z-index popover(300)，shadow-md
+  - `Select.tsx` - 下拉选择器，z-index dropdown(200)，shadow-md
+  - `Checkbox.tsx` - 复选框，支持 checked/unchecked/indeterminate 三态
+  - `Tabs.tsx` - 标签页，支持水平/垂直方向
+- Evidence: `apps/desktop/renderer/src/components/primitives/`
+
+### 2026-02-01 验证
+
+- Command: `pnpm typecheck && pnpm lint && pnpm build`
+- Key output:
+  ```
+  ✓ TypeScript 类型检查通过
+  ✓ ESLint 检查通过
+  ✓ 构建成功 (renderer: 250 modules, 2.36s)
+  ```
+- Evidence: 构建产物 `dist/renderer/`


### PR DESCRIPTION
Closes #63

## Summary

创建基于 Radix UI 的组件库，续 #57（Tailwind CSS 4 + Radix UI 集成）和 #61（基础组件库）：

- **Dialog**: 模态对话框，z-index modal(400)，shadow-xl，scrim 遮罩
- **Popover**: 浮动弹出层，z-index popover(300)，shadow-md
- **Select**: 下拉选择器，支持扁平/分组选项，z-index dropdown(200)
- **Checkbox**: 复选框，支持 checked/unchecked/indeterminate 三态
- **Tabs**: 标签页，支持水平/垂直方向，全宽模式

所有组件遵循 `design/DESIGN_DECISIONS.md` 规范：
- 使用 Tailwind CSS 类名 + CSS Variables
- 实现 focus-visible 状态（outline 方式，§3.5）
- 使用 CSS transition 动画（无 tailwindcss-animate 依赖）

## Test Plan

- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [x] Prettier 格式检查通过
- [x] 构建成功

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-63.md`