### PR TITLE
refactor: migrate layout components to Tailwind CSS (#67)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -152,16 +152,12 @@ export function AppShell(): JSX.Element {
   return (
     <div
       data-testid="app-shell"
-      style={{
-        display: "flex",
-        height: "100%",
-        background: "var(--color-bg-base)",
-      }}
+      className="flex h-full bg-[var(--color-bg-base)]"
     >
       <IconBar />
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-        <div style={{ flex: 1, display: "flex", minWidth: 0 }}>
+      <div className="flex flex-1 flex-col">
+        <div className="flex flex-1 min-w-0">
           <Sidebar
             width={effectiveSidebarWidth}
             collapsed={sidebarCollapsed}
@@ -187,16 +183,12 @@ export function AppShell(): JSX.Element {
           ) : null}
 
           <main
-            style={{
-              flex: 1,
-              minWidth: LAYOUT_DEFAULTS.mainMinWidth,
-              background: "var(--color-bg-base)",
-              display: "flex",
-              alignItems: currentProject ? "stretch" : "center",
-              justifyContent: currentProject ? "stretch" : "center",
-              color: "var(--color-fg-muted)",
-              fontSize: 13,
-            }}
+            className={`flex flex-1 bg-[var(--color-bg-base)] text-[var(--color-fg-muted)] text-[13px] ${
+              currentProject
+                ? "items-stretch justify-stretch"
+                : "items-center justify-center"
+            }`}
+            style={{ minWidth: LAYOUT_DEFAULTS.mainMinWidth }}
           >
             {currentProject ? (
               <EditorPane projectId={currentProject.projectId} />

--- a/apps/desktop/renderer/src/components/layout/IconBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/IconBar.tsx
@@ -3,6 +3,8 @@ import { useLayoutStore, LAYOUT_DEFAULTS } from "../../stores/layoutStore";
 /**
  * IconBar is the fixed 48px navigation rail. For P0 it provides a minimal
  * toggle for the sidebar and stable sizing for layout E2E.
+ *
+ * Design spec §5.2: Icon Bar width is 48px, icons are 24px, click area is 40x40px.
  */
 export function IconBar(): JSX.Element {
   const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed);
@@ -10,29 +12,13 @@ export function IconBar(): JSX.Element {
 
   return (
     <div
-      style={{
-        width: LAYOUT_DEFAULTS.iconBarWidth,
-        background: "var(--color-bg-surface)",
-        borderRight: "1px solid var(--color-separator)",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        paddingTop: 8,
-        gap: 8,
-      }}
+      className="flex flex-col items-center pt-2 gap-2 bg-[var(--color-bg-surface)] border-r border-[var(--color-separator)]"
+      style={{ width: LAYOUT_DEFAULTS.iconBarWidth }}
     >
       <button
         type="button"
         onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-        style={{
-          width: 40,
-          height: 40,
-          borderRadius: "var(--radius-sm)",
-          background: "transparent",
-          color: "var(--color-fg-muted)",
-          border: "1px solid var(--color-border-default)",
-          cursor: "pointer",
-        }}
+        className="w-10 h-10 rounded-[var(--radius-sm)] bg-transparent text-[var(--color-fg-muted)] border border-[var(--color-border-default)] cursor-pointer hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-default)] transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]"
         aria-label="Toggle sidebar"
       >
         ≡

--- a/apps/desktop/renderer/src/components/layout/Resizer.tsx
+++ b/apps/desktop/renderer/src/components/layout/Resizer.tsx
@@ -10,6 +10,9 @@ type ResizerProps = {
 
 /**
  * Resizer implements the 8px hit-area drag handle between panels.
+ *
+ * Design spec §7.3: Resizer has 8px hit area, 1px visual line (2px on hover).
+ * Uses cn-resizer class defined in main.css.
  */
 export function Resizer(props: ResizerProps): JSX.Element {
   const draggingRef = React.useRef(false);

--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -6,34 +6,31 @@ import { SettingsPanel } from "../../features/settings/SettingsPanel";
 /**
  * RightPanel is the right-side panel container (AI/Info). P0 wires visibility
  * and resizing; feature content comes in later task cards.
+ *
+ * Design spec §5.3: Right panel default width 320px, min 240px, max 600px.
  */
 export function RightPanel(props: {
   width: number;
   collapsed: boolean;
 }): JSX.Element {
   if (props.collapsed) {
-    return (
-      <aside data-testid="layout-panel" style={{ width: 0, display: "none" }} />
-    );
+    return <aside data-testid="layout-panel" className="hidden w-0" />;
   }
 
   return (
     <aside
       data-testid="layout-panel"
+      className="flex flex-col bg-[var(--color-bg-surface)] border-l border-[var(--color-separator)]"
       style={{
         width: props.width,
         minWidth: LAYOUT_DEFAULTS.panel.min,
         maxWidth: LAYOUT_DEFAULTS.panel.max,
-        background: "var(--color-bg-surface)",
-        borderLeft: "1px solid var(--color-separator)",
-        display: "flex",
-        flexDirection: "column",
       }}
     >
       <SettingsPanel />
-      <div style={{ height: 1, background: "var(--color-separator)" }} />
+      <div className="h-px bg-[var(--color-separator)]" />
       <MemoryPanel />
-      <div style={{ height: 1, background: "var(--color-separator)" }} />
+      <div className="h-px bg-[var(--color-separator)]" />
       <AiPanel />
     </aside>
   );

--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -8,6 +8,32 @@ import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
 type SidebarTab = "files" | "search" | "kg";
 
 /**
+ * Sidebar tab button styles.
+ * Active state uses focus border + selected background.
+ */
+const tabButtonBase = [
+  "text-xs",
+  "px-2",
+  "py-1",
+  "rounded-[var(--radius-md)]",
+  "border",
+  "text-[var(--color-fg-default)]",
+  "cursor-pointer",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+const tabButtonActive =
+  "border-[var(--color-border-focus)] bg-[var(--color-bg-selected)]";
+const tabButtonInactive =
+  "border-[var(--color-border-default)] bg-[var(--color-bg-surface)]";
+
+/**
  * Sidebar is the left panel container (Files/Outline/etc).
  *
  * Why: P0 wires the Files tab as the minimal documents entry point with stable
@@ -21,101 +47,46 @@ export function Sidebar(props: {
   const [activeTab, setActiveTab] = React.useState<SidebarTab>("files");
 
   if (props.collapsed) {
-    return (
-      <aside
-        data-testid="layout-sidebar"
-        style={{ width: 0, display: "none" }}
-      />
-    );
+    return <aside data-testid="layout-sidebar" className="hidden w-0" />;
   }
 
   return (
     <aside
       data-testid="layout-sidebar"
+      className="flex flex-col bg-[var(--color-bg-surface)] border-r border-[var(--color-separator)]"
       style={{
         width: props.width,
         minWidth: LAYOUT_DEFAULTS.sidebar.min,
         maxWidth: LAYOUT_DEFAULTS.sidebar.max,
-        background: "var(--color-bg-surface)",
-        borderRight: "1px solid var(--color-separator)",
-        display: "flex",
-        flexDirection: "column",
       }}
     >
-      <div
-        style={{
-          display: "flex",
-          gap: "var(--space-1)",
-          padding: "var(--space-2)",
-          borderBottom: "1px solid var(--color-separator)",
-        }}
-      >
+      {/* Tab bar */}
+      <div className="flex gap-1 p-2 border-b border-[var(--color-separator)]">
         <button
           type="button"
           onClick={() => setActiveTab("files")}
-          style={{
-            fontSize: 12,
-            padding: "var(--space-1) var(--space-2)",
-            borderRadius: "var(--radius-md)",
-            border:
-              activeTab === "files"
-                ? "1px solid var(--color-border-focus)"
-                : "1px solid var(--color-border-default)",
-            background:
-              activeTab === "files"
-                ? "var(--color-bg-selected)"
-                : "var(--color-bg-surface)",
-            color: "var(--color-fg-default)",
-            cursor: "pointer",
-          }}
+          className={`${tabButtonBase} ${activeTab === "files" ? tabButtonActive : tabButtonInactive}`}
         >
           Files
         </button>
         <button
           type="button"
           onClick={() => setActiveTab("search")}
-          style={{
-            fontSize: 12,
-            padding: "var(--space-1) var(--space-2)",
-            borderRadius: "var(--radius-md)",
-            border:
-              activeTab === "search"
-                ? "1px solid var(--color-border-focus)"
-                : "1px solid var(--color-border-default)",
-            background:
-              activeTab === "search"
-                ? "var(--color-bg-selected)"
-                : "var(--color-bg-surface)",
-            color: "var(--color-fg-default)",
-            cursor: "pointer",
-          }}
+          className={`${tabButtonBase} ${activeTab === "search" ? tabButtonActive : tabButtonInactive}`}
         >
           Search
         </button>
         <button
           type="button"
           onClick={() => setActiveTab("kg")}
-          style={{
-            fontSize: 12,
-            padding: "var(--space-1) var(--space-2)",
-            borderRadius: "var(--radius-md)",
-            border:
-              activeTab === "kg"
-                ? "1px solid var(--color-border-focus)"
-                : "1px solid var(--color-border-default)",
-            background:
-              activeTab === "kg"
-                ? "var(--color-bg-selected)"
-                : "var(--color-bg-surface)",
-            color: "var(--color-fg-default)",
-            cursor: "pointer",
-          }}
+          className={`${tabButtonBase} ${activeTab === "kg" ? tabButtonActive : tabButtonInactive}`}
         >
           KG
         </button>
       </div>
 
-      <div style={{ flex: 1, minHeight: 0 }}>
+      {/* Tab content */}
+      <div className="flex-1 min-h-0">
         {props.projectId && activeTab === "files" ? (
           <FileTreePanel projectId={props.projectId} />
         ) : props.projectId && activeTab === "search" ? (
@@ -123,13 +94,7 @@ export function Sidebar(props: {
         ) : props.projectId && activeTab === "kg" ? (
           <KnowledgeGraphPanel projectId={props.projectId} />
         ) : (
-          <div
-            style={{
-              padding: "var(--space-3)",
-              fontSize: 12,
-              color: "var(--color-fg-muted)",
-            }}
-          >
+          <div className="p-3 text-xs text-[var(--color-fg-muted)]">
             Sidebar (no project)
           </div>
         )}

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -4,36 +4,30 @@ import { useEditorStore } from "../../stores/editorStore";
 /**
  * StatusBar is the fixed 28px bottom bar. P0 keeps it minimal but stable for
  * layout E2E selectors.
+ *
+ * Design spec §5.4: Status bar height is 28px.
  */
 export function StatusBar(): JSX.Element {
   const autosaveStatus = useEditorStore((s) => s.autosaveStatus);
   const retryLastAutosave = useEditorStore((s) => s.retryLastAutosave);
+
+  const isError = autosaveStatus === "error";
+
   return (
     <div
       data-testid="layout-statusbar"
-      style={{
-        height: LAYOUT_DEFAULTS.statusBarHeight,
-        background: "var(--color-bg-surface)",
-        borderTop: "1px solid var(--color-separator)",
-        display: "flex",
-        alignItems: "center",
-        padding: "0 12px",
-        fontSize: 11,
-        color: "var(--color-fg-muted)",
-      }}
+      className="flex items-center px-3 text-[11px] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator)]"
+      style={{ height: LAYOUT_DEFAULTS.statusBarHeight }}
     >
       <span
         data-testid="editor-autosave-status"
         data-status={autosaveStatus}
         onClick={() => {
-          if (autosaveStatus === "error") {
+          if (isError) {
             void retryLastAutosave();
           }
         }}
-        style={{
-          cursor: autosaveStatus === "error" ? "pointer" : "default",
-          textDecoration: autosaveStatus === "error" ? "underline" : "none",
-        }}
+        className={isError ? "cursor-pointer underline" : "cursor-default"}
       >
         {autosaveStatus}
       </span>

--- a/openspec/_ops/task_runs/ISSUE-67.md
+++ b/openspec/_ops/task_runs/ISSUE-67.md
@@ -1,0 +1,36 @@
+# ISSUE-67
+
+- Issue: #67
+- Branch: task/67-layout-tailwind-migration
+- PR: <fill-after-created>
+
+## Plan
+
+- 将 6 个布局组件（AppShell、IconBar、Sidebar、StatusBar、Resizer、RightPanel）从内联样式迁移到 Tailwind CSS 类
+- 保留动态值（如宽度、高度）的内联样式
+- 验证 TypeScript、ESLint、单元测试、集成测试全部通过
+
+## Runs
+
+### 2026-02-01 迁移布局组件
+
+- Command: `pnpm run typecheck && pnpm run lint && pnpm run test:unit && pnpm run test:integration`
+- Key output:
+  ```
+  typecheck: ✓ passed
+  lint: ✓ passed
+  test:unit: ✓ passed
+  test:integration: ✓ passed
+  ```
+- Evidence: 6 个布局组件文件已修改
+
+### 变更摘要
+
+| 组件           | 变更                                                  |
+| -------------- | ----------------------------------------------------- |
+| AppShell.tsx   | 根容器和 flex 布局使用 Tailwind 类                    |
+| IconBar.tsx    | 容器和按钮样式使用 Tailwind 类，添加 hover/focus 状态 |
+| Sidebar.tsx    | 提取 Tab 按钮样式为复用常量，容器使用 Tailwind 类     |
+| StatusBar.tsx  | 容器使用 Tailwind 类，状态指示器使用条件 className    |
+| RightPanel.tsx | 容器使用 Tailwind 类，分割线使用 `h-px`               |
+| Resizer.tsx    | 已使用 CSS 类，仅添加 JSDoc 注释                      |

--- a/openspec/_ops/task_runs/ISSUE-67.md
+++ b/openspec/_ops/task_runs/ISSUE-67.md
@@ -2,7 +2,7 @@
 
 - Issue: #67
 - Branch: task/67-layout-tailwind-migration
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/68
 
 ## Plan
 
@@ -26,11 +26,11 @@
 
 ### 变更摘要
 
-| 组件           | 变更                                                  |
-| -------------- | ----------------------------------------------------- |
-| AppShell.tsx   | 根容器和 flex 布局使用 Tailwind 类                    |
-| IconBar.tsx    | 容器和按钮样式使用 Tailwind 类，添加 hover/focus 状态 |
-| Sidebar.tsx    | 提取 Tab 按钮样式为复用常量，容器使用 Tailwind 类     |
-| StatusBar.tsx  | 容器使用 Tailwind 类，状态指示器使用条件 className    |
-| RightPanel.tsx | 容器使用 Tailwind 类，分割线使用 `h-px`               |
-| Resizer.tsx    | 已使用 CSS 类，仅添加 JSDoc 注释                      |
+| 组件 | 变更 |
+|------|------|
+| AppShell.tsx | 根容器和 flex 布局使用 Tailwind 类 |
+| IconBar.tsx | 容器和按钮样式使用 Tailwind 类，添加 hover/focus 状态 |
+| Sidebar.tsx | 提取 Tab 按钮样式为复用常量，容器使用 Tailwind 类 |
+| StatusBar.tsx | 容器使用 Tailwind 类，状态指示器使用条件 className |
+| RightPanel.tsx | 容器使用 Tailwind 类，分割线使用 `h-px` |
+| Resizer.tsx | 已使用 CSS 类，仅添加 JSDoc 注释 |


### PR DESCRIPTION
Closes #67

## Summary

- 将 6 个布局组件从内联样式迁移到 Tailwind CSS 类
- AppShell: flex 布局使用 Tailwind 类
- IconBar: 容器和按钮样式，添加 hover/focus 状态
- Sidebar: 提取 Tab 按钮样式为复用常量
- StatusBar: 容器使用条件 className 处理错误状态
- RightPanel: 容器和分割线使用 Tailwind 类
- Resizer: 添加设计规范引用的 JSDoc 注释

动态值（宽度、高度来自 layout store）保留内联样式。

## Test plan

- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [x] Prettier 格式检查通过
- [x] 单元测试通过
- [x] 集成测试通过

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-67.md`