### PR TITLE
refactor: 迁移低复杂度组件到 Tailwind CSS + 组件库 (#69)

### DIFF
--- a/apps/desktop/renderer/src/features/ai/DiffView.tsx
+++ b/apps/desktop/renderer/src/features/ai/DiffView.tsx
@@ -1,3 +1,5 @@
+import { Text } from "../../components/primitives";
+
 /**
  * DiffView renders a unified diff text block.
  *
@@ -7,27 +9,15 @@ export function DiffView(props: { diffText: string }): JSX.Element {
   return (
     <div
       data-testid="ai-diff"
-      style={{
-        border: "1px solid var(--color-separator)",
-        borderRadius: 8,
-        background: "var(--color-bg-base)",
-        padding: 10,
-        overflow: "auto",
-      }}
+      className="border border-[var(--color-separator)] rounded-[var(--radius-md)] bg-[var(--color-bg-base)] p-2.5 overflow-auto"
     >
-      <pre
-        style={{
-          margin: 0,
-          whiteSpace: "pre-wrap",
-          wordBreak: "break-word",
-          fontSize: 12,
-          lineHeight: "18px",
-          color: "var(--color-fg-base)",
-          fontFamily: "var(--font-mono)",
-        }}
+      <Text
+        as="div"
+        size="code"
+        className="whitespace-pre-wrap break-words leading-[18px]"
       >
         {props.diffText}
-      </pre>
+      </Text>
     </div>
   );
 }

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
@@ -1,4 +1,5 @@
 import type { SkillListItem } from "../../stores/aiStore";
+import { Text } from "../../components/primitives";
 
 /**
  * SkillPicker renders the AI Panel skills popup list.
@@ -18,50 +19,19 @@ export function SkillPicker(props: {
     <div
       role="presentation"
       onClick={() => props.onOpenChange(false)}
-      style={{
-        position: "absolute",
-        inset: 0,
-        zIndex: 20,
-      }}
+      className="absolute inset-0 z-20"
     >
       <div
         role="dialog"
         aria-label="Skills"
         onClick={(e) => e.stopPropagation()}
-        style={{
-          position: "absolute",
-          top: 36,
-          right: 0,
-          width: 280,
-          maxWidth: "100%",
-          background: "var(--color-bg-raised)",
-          border: "1px solid var(--color-border-default)",
-          borderRadius: "var(--radius-lg)",
-          padding: 10,
-          boxShadow: "0 18px 48px rgba(0,0,0,0.45)",
-        }}
+        className="absolute top-9 right-0 w-70 max-w-full p-2.5 bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[0_18px_48px_rgba(0,0,0,0.45)]"
       >
-        <div
-          style={{
-            fontSize: 11,
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
-            color: "var(--color-fg-muted)",
-          }}
-        >
+        <Text size="label" color="muted">
           Skills
-        </div>
+        </Text>
 
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            marginTop: 8,
-            gap: 6,
-            maxHeight: 260,
-            overflow: "auto",
-          }}
-        >
+        <div className="flex flex-col mt-2 gap-1.5 max-h-65 overflow-auto">
           {props.items.map((s) => {
             const selected = s.id === props.selectedSkillId;
             const disabled = !s.enabled || !s.valid;
@@ -77,29 +47,27 @@ export function SkillPicker(props: {
                 type="button"
                 disabled={disabled}
                 onClick={() => props.onSelectSkillId(s.id)}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 2,
-                  textAlign: "left",
-                  padding: "8px 10px",
-                  borderRadius: 10,
-                  border: selected
-                    ? "1px solid var(--color-border-accent)"
-                    : "1px solid var(--color-border-default)",
-                  background: selected
-                    ? "var(--color-bg-base)"
-                    : "var(--color-bg-raised)",
-                  color: disabled
-                    ? "var(--color-fg-muted)"
-                    : "var(--color-fg-default)",
-                  cursor: disabled ? "not-allowed" : "pointer",
-                }}
+                className={`
+                  flex flex-col gap-0.5 text-left px-2.5 py-2 rounded-[10px] border
+                  transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)]
+                  ${
+                    selected
+                      ? "border-[var(--color-border-accent)] bg-[var(--color-bg-base)]"
+                      : "border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
+                  }
+                  ${
+                    disabled
+                      ? "text-[var(--color-fg-muted)] cursor-not-allowed"
+                      : "text-[var(--color-fg-default)] cursor-pointer hover:border-[var(--color-border-hover)]"
+                  }
+                `}
               >
-                <div style={{ fontSize: 12, fontWeight: 600 }}>{s.name}</div>
-                <div style={{ fontSize: 11, color: "var(--color-fg-muted)" }}>
+                <Text size="small" weight="semibold" color={disabled ? "muted" : "default"}>
+                  {s.name}
+                </Text>
+                <Text size="tiny" color="muted">
                   {subtitle}
-                </div>
+                </Text>
               </button>
             );
           })}

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -4,6 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 
 import { useEditorStore } from "../../stores/editorStore";
 import { useAutosave } from "./useAutosave";
+import { Text } from "../../components/primitives";
 
 /**
  * EditorPane mounts TipTap editor and wires autosave to the DB SSOT.
@@ -24,8 +25,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
     editorProps: {
       attributes: {
         "data-testid": "tiptap-editor",
-        style:
-          "height:100%; outline:none; padding: 16px; color: var(--color-fg-default);",
+        class: "h-full outline-none p-4 text-[var(--color-fg-default)]",
       },
     },
     content: { type: "doc", content: [{ type: "paragraph" }] },
@@ -107,31 +107,25 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
 
   if (bootstrapStatus !== "ready") {
     return (
-      <div
-        style={{ padding: 16, color: "var(--color-fg-muted)", fontSize: 13 }}
-      >
+      <Text as="div" size="body" color="muted" className="p-4">
         Loading editor…
-      </div>
+      </Text>
     );
   }
 
   if (!documentId) {
     return (
-      <div
-        style={{ padding: 16, color: "var(--color-fg-muted)", fontSize: 13 }}
-      >
+      <Text as="div" size="body" color="muted" className="p-4">
         No document selected.
-      </div>
+      </Text>
     );
   }
 
   if (!contentReady) {
     return (
-      <div
-        style={{ padding: 16, color: "var(--color-fg-muted)", fontSize: 13 }}
-      >
+      <Text as="div" size="body" color="muted" className="p-4">
         Loading document…
-      </div>
+      </Text>
     );
   }
 
@@ -139,7 +133,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
     <div
       data-testid="editor-pane"
       data-document-id={documentId}
-      style={{ width: "100%", height: "100%", minWidth: 0 }}
+      className="w-full h-full min-w-0"
     >
       <EditorContent editor={editor} />
     </div>

--- a/apps/desktop/renderer/src/features/settings/AppearanceSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/AppearanceSection.tsx
@@ -1,4 +1,6 @@
 import { useThemeStore } from "../../stores/themeStore";
+import { Button } from "../../components/primitives";
+import { Heading, Text } from "../../components/primitives";
 
 /**
  * AppearanceSection controls theme preferences.
@@ -13,62 +15,44 @@ export function AppearanceSection(): JSX.Element {
   return (
     <section
       data-testid="settings-appearance-section"
-      style={{
-        padding: 12,
-        borderRadius: "var(--radius-lg)",
-        border: "1px solid var(--color-border-default)",
-        background: "var(--color-bg-raised)",
-        display: "flex",
-        flexDirection: "column",
-        gap: 10,
-      }}
+      className="flex flex-col gap-2.5 p-3 rounded-[var(--radius-lg)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
     >
-      <div style={{ fontSize: 13, fontWeight: 700 }}>Appearance</div>
+      <Heading level="h4" className="font-bold">
+        Appearance
+      </Heading>
 
-      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>Theme</div>
+      <div className="flex items-center gap-2">
+        <Text size="small" color="muted">
+          Theme
+        </Text>
 
-        <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-          <button
+        <div className="ml-auto flex gap-2">
+          <Button
             data-testid="theme-mode-dark"
-            type="button"
+            variant={mode === "dark" ? "primary" : "secondary"}
+            size="sm"
             onClick={() => setMode("dark")}
-            style={{
-              height: 28,
-              padding: "0 var(--space-3)",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--color-border-default)",
-              background:
-                mode === "dark"
-                  ? "var(--color-bg-selected)"
-                  : "var(--color-bg-surface)",
-              color: "var(--color-fg-default)",
-              cursor: "pointer",
-              fontSize: 12,
-            }}
+            className={
+              mode === "dark"
+                ? "bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]"
+                : ""
+            }
           >
             Dark
-          </button>
-          <button
+          </Button>
+          <Button
             data-testid="theme-mode-light"
-            type="button"
+            variant={mode === "light" ? "primary" : "secondary"}
+            size="sm"
             onClick={() => setMode("light")}
-            style={{
-              height: 28,
-              padding: "0 var(--space-3)",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--color-border-default)",
-              background:
-                mode === "light"
-                  ? "var(--color-bg-selected)"
-                  : "var(--color-bg-surface)",
-              color: "var(--color-fg-default)",
-              cursor: "pointer",
-              fontSize: 12,
-            }}
+            className={
+              mode === "light"
+                ? "bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]"
+                : ""
+            }
           >
             Light
-          </button>
+          </Button>
         </div>
       </div>
     </section>

--- a/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { IpcChannelSpec } from "../../../../../../packages/shared/types/ipc-generated";
 import { invoke } from "../../lib/ipcClient";
+import { Button, Heading, Text } from "../../components/primitives";
 
 type JudgeModelState =
   IpcChannelSpec["judge:model:getState"]["response"]["state"];
@@ -72,60 +73,35 @@ export function JudgeSection(): JSX.Element {
   return (
     <section
       data-testid="settings-judge-section"
-      style={{
-        padding: 12,
-        borderRadius: "var(--radius-lg)",
-        border: "1px solid var(--color-border-default)",
-        background: "var(--color-bg-raised)",
-      }}
+      className="p-3 rounded-[var(--radius-lg)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
     >
-      <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>
+      <Heading level="h4" className="mb-1.5 font-bold">
         Judge model
-      </div>
-      <div
-        style={{
-          fontSize: 12,
-          color: "var(--color-fg-muted)",
-          marginBottom: 10,
-        }}
-      >
+      </Heading>
+      <Text size="small" color="muted" as="div" className="mb-2.5">
         Status:{" "}
-        <span
-          data-testid="judge-status"
-          style={{ color: "var(--color-fg-default)" }}
-        >
+        <Text data-testid="judge-status" size="small" color="default" as="span">
           {state ? formatState(state) : "loading"}
-        </span>
-      </div>
+        </Text>
+      </Text>
 
-      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-        <button
+      <div className="flex items-center gap-2">
+        <Button
           data-testid="judge-ensure"
-          type="button"
+          variant="secondary"
+          size="sm"
           onClick={() => void ensure()}
           disabled={ensureBusy}
-          style={{
-            height: 32,
-            padding: "0 var(--space-3)",
-            borderRadius: "var(--radius-md)",
-            border: "1px solid var(--color-border-default)",
-            background: "var(--color-bg-selected)",
-            color: "var(--color-fg-default)",
-            cursor: ensureBusy ? "not-allowed" : "pointer",
-            fontSize: 13,
-            opacity: ensureBusy ? 0.7 : 1,
-          }}
+          loading={ensureBusy}
+          className="bg-[var(--color-bg-selected)]"
         >
           Ensure
-        </button>
+        </Button>
 
         {errorText ? (
-          <div
-            data-testid="judge-error"
-            style={{ fontSize: 12, color: "var(--color-fg-muted)" }}
-          >
+          <Text data-testid="judge-error" size="small" color="muted">
             {errorText}
-          </div>
+          </Text>
         ) : null}
       </div>
     </section>

--- a/apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx
+++ b/apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { CreateProjectDialog } from "../projects/CreateProjectDialog";
 import { useProjectStore } from "../../stores/projectStore";
+import { Button, Card, Heading, Text } from "../../components/primitives";
 
 /**
  * Welcome entry for a fresh profile.
@@ -23,59 +24,37 @@ export function WelcomeScreen(): JSX.Element {
 
   if (current) {
     return (
-      <div
-        style={{
-          width: "100%",
-          padding: "var(--space-6)",
-          color: "var(--color-fg-muted)",
-          fontSize: 13,
-        }}
-      >
+      <Text as="div" size="body" color="muted" className="w-full p-6">
         Current project: {current.projectId}
-      </div>
+      </Text>
     );
   }
 
   return (
     <>
-      <div
+      <Card
         data-testid="welcome-screen"
-        style={{
-          width: "100%",
-          maxWidth: 640,
-          padding: "var(--space-6)",
-          borderRadius: "var(--radius-lg)",
-          border: "1px solid var(--color-border-default)",
-          background: "var(--color-bg-surface)",
-        }}
+        className="w-full max-w-[640px] rounded-[var(--radius-lg)]"
       >
-        <div style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>
+        <Heading level="h2" className="mb-2 text-lg font-bold">
           Welcome to CreoNow
-        </div>
-        <div style={{ fontSize: 13, color: "var(--color-fg-muted)" }}>
+        </Heading>
+        <Text size="body" color="muted">
           Create a local project to start.
-        </div>
+        </Text>
 
-        <div style={{ marginTop: "var(--space-6)", display: "flex", gap: 8 }}>
-          <button
+        <div className="mt-6 flex gap-2">
+          <Button
             data-testid="welcome-create-project"
-            type="button"
+            variant="secondary"
+            size="sm"
             onClick={() => setDialogOpen(true)}
-            style={{
-              height: 32,
-              padding: "0 var(--space-3)",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--color-border-default)",
-              background: "var(--color-bg-selected)",
-              color: "var(--color-fg-default)",
-              cursor: "pointer",
-              fontSize: 13,
-            }}
+            className="bg-[var(--color-bg-selected)]"
           >
             Create project
-          </button>
+          </Button>
         </div>
-      </div>
+      </Card>
 
       <CreateProjectDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </>

--- a/openspec/_ops/task_runs/ISSUE-69.md
+++ b/openspec/_ops/task_runs/ISSUE-69.md
@@ -1,0 +1,38 @@
+# ISSUE-69
+
+- Issue: #69
+- Branch: task/69-migrate-low-components
+- PR: https://github.com/Leeky1017/CreoNow/pull/70
+
+## Plan
+
+- 迁移低复杂度组件（AppearanceSection、JudgeSection、SkillPicker、DiffView、EditorPane、WelcomeScreen）到 Tailwind CSS + 组件库
+- 验证 TypeScript 类型检查和构建
+
+## Runs
+
+### 2026-02-01 15:30 组件迁移
+
+- Command: `StrReplace` 工具批量替换6个组件文件
+- Key output: 所有6个文件已从内联样式迁移到 Tailwind CSS 类 + primitives 组件库
+- Evidence: 
+  - `apps/desktop/renderer/src/features/settings/AppearanceSection.tsx`
+  - `apps/desktop/renderer/src/features/settings/JudgeSection.tsx`
+  - `apps/desktop/renderer/src/features/ai/SkillPicker.tsx`
+  - `apps/desktop/renderer/src/features/ai/DiffView.tsx`
+  - `apps/desktop/renderer/src/features/editor/EditorPane.tsx`
+  - `apps/desktop/renderer/src/features/welcome/WelcomeScreen.tsx`
+
+### 2026-02-01 15:32 验证
+
+- Command: `pnpm tsc --noEmit`
+- Key output: Exit code 0 (无类型错误)
+
+- Command: `pnpm build`
+- Key output: 
+  ```
+  ✓ built in 434ms (main)
+  ✓ built in 28ms (preload)
+  ✓ built in 2.42s (renderer)
+  ```
+- Evidence: 构建成功，无错误


### PR DESCRIPTION
Closes #69

## Summary

- 迁移 6 个低复杂度组件从内联样式到 Tailwind CSS 类 + primitives 组件库
- AppearanceSection: 使用 Button, Heading, Text 组件
- JudgeSection: 使用 Button, Heading, Text 组件（含 loading 状态）
- SkillPicker: 使用 Text 组件实现标签样式
- DiffView: 使用 Text 组件的 code 变体
- EditorPane: 使用 Text 组件实现加载状态
- WelcomeScreen: 使用 Card, Button, Heading, Text 组件

## Test plan

- [x] TypeScript 类型检查通过 (`pnpm tsc --noEmit`)
- [x] 构建成功 (`pnpm build`)
- [ ] CI checks 通过

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-69.md`