### PR TITLE
refactor: migrate high-complexity components to Tailwind + primitives (#73)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Checkbox.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Checkbox.tsx
@@ -7,27 +7,13 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
  * A checkbox component built on Radix UI Checkbox primitive.
  * Supports checked, unchecked, and indeterminate states.
  */
-export interface CheckboxProps {
-  /** Controlled checked state */
-  checked?: boolean | "indeterminate";
-  /** Callback when checked state changes */
-  onCheckedChange?: (checked: boolean | "indeterminate") => void;
-  /** Default checked state (uncontrolled) */
-  defaultChecked?: boolean;
-  /** Disabled state */
-  disabled?: boolean;
-  /** Required for form validation */
-  required?: boolean;
-  /** Name for form submission */
-  name?: string;
-  /** Value for form submission */
-  value?: string;
-  /** ID for label association */
-  id?: string;
+export interface CheckboxProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
+    "children" | "asChild"
+  > {
   /** Optional label text */
   label?: string;
-  /** Custom class name */
-  className?: string;
 }
 
 /**
@@ -163,30 +149,18 @@ function MinusIcon() {
  * ```
  */
 export function Checkbox({
-  checked,
-  onCheckedChange,
-  defaultChecked,
-  disabled = false,
-  required = false,
-  name,
-  value,
   id,
   label,
   className = "",
+  ...rootProps
 }: CheckboxProps): JSX.Element {
   const generatedId = React.useId();
   const checkboxId = id ?? generatedId;
 
   const checkboxElement = (
     <CheckboxPrimitive.Root
+      {...rootProps}
       id={checkboxId}
-      checked={checked}
-      onCheckedChange={onCheckedChange}
-      defaultChecked={defaultChecked}
-      disabled={disabled}
-      required={required}
-      name={name}
-      value={value}
       className={`${checkboxStyles} ${className}`}
     >
       <CheckboxPrimitive.Indicator className={indicatorStyles} forceMount>

--- a/apps/desktop/renderer/src/components/primitives/Input.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Input.tsx
@@ -56,28 +56,30 @@ const errorStyles = [
  * Input component following design spec §6.2
  *
  * Single-line text input with proper focus and error states.
+ * Supports ref forwarding for focus management.
  *
  * @example
  * ```tsx
  * <Input placeholder="Enter text..." />
  * <Input error placeholder="Invalid input" />
  * <Input disabled value="Disabled" />
+ * <Input ref={inputRef} /> // Ref forwarding
  * ```
  */
-export function Input({
-  error = false,
-  fullWidth = false,
-  className = "",
-  ...props
-}: InputProps): JSX.Element {
-  const classes = [
-    baseStyles,
-    error ? errorStyles : "",
-    fullWidth ? "w-full" : "",
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  function Input(
+    { error = false, fullWidth = false, className = "", ...props },
+    ref,
+  ) {
+    const classes = [
+      baseStyles,
+      error ? errorStyles : "",
+      fullWidth ? "w-full" : "",
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
 
-  return <input className={classes} {...props} />;
-}
+    return <input ref={ref} className={classes} {...props} />;
+  },
+);

--- a/apps/desktop/renderer/src/components/primitives/Select.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Select.tsx
@@ -29,7 +29,11 @@ export interface SelectGroup {
  * A dropdown select component built on Radix UI Select primitive.
  * Implements z-index dropdown (200) and shadow-md (§3.7, §5.2).
  */
-export interface SelectProps {
+export interface SelectProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>,
+    "children" | "asChild"
+  > {
   /** Current value (controlled) */
   value?: string;
   /** Callback when value changes */
@@ -246,6 +250,7 @@ export function Select({
   name,
   fullWidth = false,
   className = "",
+  ...triggerProps
 }: SelectProps): JSX.Element {
   const triggerClasses = [triggerStyles, fullWidth ? "w-full" : "", className]
     .filter(Boolean)
@@ -259,7 +264,11 @@ export function Select({
       disabled={disabled}
       name={name}
     >
-      <SelectPrimitive.Trigger className={triggerClasses}>
+      <SelectPrimitive.Trigger
+        {...triggerProps}
+        disabled={disabled}
+        className={triggerClasses}
+      >
         <SelectPrimitive.Value placeholder={placeholder} />
         <SelectPrimitive.Icon>
           <ChevronDownIcon className="text-[var(--color-fg-muted)]" />

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Button, Card, Text, Textarea } from "../../components/primitives";
 import { useAiStore, type AiStatus } from "../../stores/aiStore";
 import { useContextStore } from "../../stores/contextStore";
 import { useEditorStore } from "../../stores/editorStore";
@@ -188,28 +189,15 @@ export function AiPanel(): JSX.Element {
   return (
     <section
       data-testid="ai-panel"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-        padding: 12,
-        minHeight: 0,
-        position: "relative",
-      }}
+      className="flex flex-col gap-3 p-3 min-h-0 relative"
     >
-      <header style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>AI</div>
-        <div
-          style={{
-            marginLeft: "auto",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          <button
+      <header className="flex items-center gap-2">
+        <Text size="small" color="muted">AI</Text>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
             data-testid="ai-context-toggle"
-            type="button"
+            variant="ghost"
+            size="sm"
             onClick={() =>
               void toggleViewer({
                 projectId: currentProject?.projectId ?? projectId ?? null,
@@ -217,48 +205,23 @@ export function AiPanel(): JSX.Element {
                 immediateInput: input,
               })
             }
-            style={{
-              border: "1px solid var(--color-separator)",
-              background: viewerOpen ? "var(--color-bg-base)" : "transparent",
-              color: "var(--color-fg-muted)",
-              borderRadius: 8,
-              padding: "4px 8px",
-              fontSize: 12,
-              cursor: "pointer",
-            }}
+            className={viewerOpen ? "bg-[var(--color-bg-base)]" : ""}
           >
             Context
-          </button>
-          <button
+          </Button>
+          <Button
             data-testid="ai-skills-toggle"
-            type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => setSkillsOpen((v) => !v)}
-            style={{
-              border: "1px solid var(--color-separator)",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              borderRadius: 8,
-              padding: "4px 8px",
-              fontSize: 12,
-              cursor: "pointer",
-              maxWidth: 220,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
+            className="max-w-[220px] overflow-hidden text-ellipsis whitespace-nowrap"
             title={selectedSkillName}
           >
             {skillsStatus === "loading" ? "Skills…" : selectedSkillName}
-          </button>
-          <div
-            data-testid="ai-status"
-            style={{
-              fontSize: 11,
-              color: "var(--color-fg-muted)",
-            }}
-          >
+          </Button>
+          <Text data-testid="ai-status" size="tiny" color="muted">
             {status}
-          </div>
+          </Text>
         </div>
       </header>
 
@@ -274,210 +237,120 @@ export function AiPanel(): JSX.Element {
       />
 
       {applyStatus === "applied" ? (
-        <div
-          data-testid="ai-apply-status"
-          style={{ fontSize: 12, color: "var(--color-fg-muted)" }}
-        >
+        <Text data-testid="ai-apply-status" size="small" color="muted">
           Applied &amp; saved
-        </div>
+        </Text>
       ) : null}
 
       {skillsLastError ? (
-        <div
-          style={{
-            border: "1px solid var(--color-separator)",
-            borderRadius: 8,
-            padding: 10,
-            background: "var(--color-bg-base)",
-            color: "var(--color-fg-muted)",
-            fontSize: 12,
-          }}
-        >
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
-            {skillsLastError.code}
-          </div>
-          <div style={{ marginTop: 6 }}>{skillsLastError.message}</div>
-        </div>
+        <Card noPadding className="p-2.5">
+          <Text size="code" color="muted">{skillsLastError.code}</Text>
+          <Text size="small" color="muted" className="mt-1.5 block">
+            {skillsLastError.message}
+          </Text>
+        </Card>
       ) : null}
 
       {lastError ? (
-        <div
-          style={{
-            border: "1px solid var(--color-separator)",
-            borderRadius: 8,
-            padding: 10,
-            background: "var(--color-bg-base)",
-            color: "var(--color-fg-muted)",
-            fontSize: 12,
-          }}
-        >
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <div
-              data-testid="ai-error-code"
-              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
-            >
+        <Card noPadding className="p-2.5">
+          <div className="flex gap-2 items-center">
+            <Text data-testid="ai-error-code" size="code" color="muted">
               {lastError.code}
-            </div>
-            <button
-              type="button"
+            </Text>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={clearError}
-              style={{
-                marginLeft: "auto",
-                border: "1px solid var(--color-separator)",
-                background: "transparent",
-                color: "var(--color-fg-muted)",
-                borderRadius: 6,
-                padding: "2px 8px",
-                fontSize: 12,
-                cursor: "pointer",
-              }}
+              className="ml-auto"
             >
               Dismiss
-            </button>
+            </Button>
           </div>
-          <div style={{ marginTop: 6 }}>{lastError.message}</div>
-        </div>
+          <Text size="small" color="muted" className="mt-1.5 block">
+            {lastError.message}
+          </Text>
+        </Card>
       ) : null}
 
-      <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      <label className="flex items-center gap-2">
         <input
           data-testid="ai-stream-toggle"
           type="checkbox"
           checked={stream}
           onChange={(e) => setStream(e.target.checked)}
           disabled={isRunning(status)}
+          className="h-4 w-4 accent-[var(--color-fg-default)]"
         />
-        <span style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
+        <Text size="small" color="muted">
           Stream
-        </span>
+        </Text>
       </label>
 
-      <textarea
+      <Textarea
         data-testid="ai-input"
         value={input}
         onChange={(e) => setInput(e.target.value)}
         placeholder="Type E2E_DELAY / E2E_TIMEOUT / E2E_UPSTREAM_ERROR markers to drive fake server."
-        style={{
-          width: "100%",
-          minHeight: 92,
-          resize: "vertical",
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          padding: 10,
-          background: "var(--color-bg-base)",
-          color: "var(--color-fg-base)",
-          outline: "none",
-          fontSize: 12,
-          lineHeight: "18px",
-        }}
+        fullWidth
+        className="min-h-[92px]"
       />
 
-      <div style={{ display: "flex", gap: 8 }}>
-        <button
+      <div className="flex gap-2">
+        <Button
           data-testid="ai-run"
-          type="button"
+          variant="secondary"
+          size="md"
           onClick={() => void onRun()}
           disabled={isRunning(status)}
-          style={{
-            border: "1px solid var(--color-separator)",
-            background: "var(--color-bg-base)",
-            color: "var(--color-fg-base)",
-            borderRadius: 8,
-            padding: "8px 10px",
-            fontSize: 12,
-            cursor: isRunning(status) ? "not-allowed" : "pointer",
-            flex: 1,
-          }}
+          className="flex-1"
         >
           Run
-        </button>
-        <button
+        </Button>
+        <Button
           data-testid="ai-cancel"
-          type="button"
+          variant="ghost"
+          size="md"
           onClick={() => void cancel()}
           disabled={!isRunning(status)}
-          style={{
-            border: "1px solid var(--color-separator)",
-            background: "transparent",
-            color: "var(--color-fg-muted)",
-            borderRadius: 8,
-            padding: "8px 10px",
-            fontSize: 12,
-            cursor: !isRunning(status) ? "not-allowed" : "pointer",
-          }}
         >
           Cancel
-        </button>
+        </Button>
       </div>
 
       {viewerOpen ? <ContextViewer /> : null}
 
-      <div
-        style={{
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          background: "var(--color-bg-base)",
-          padding: 10,
-          minHeight: 120,
-          flex: 1,
-          overflow: "auto",
-        }}
-      >
+      <Card noPadding className="p-2.5 min-h-[120px] flex-1 overflow-auto">
         <pre
           data-testid="ai-output"
-          style={{
-            margin: 0,
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-            fontSize: 12,
-            lineHeight: "18px",
-            color: "var(--color-fg-base)",
-            fontFamily: "var(--font-mono)",
-          }}
+          className="m-0 whitespace-pre-wrap break-words text-xs leading-[18px] text-[var(--color-fg-base)] font-[var(--font-family-mono)]"
         >
           {outputText}
         </pre>
-      </div>
+      </Card>
 
       {proposal ? (
         <>
           <DiffView diffText={diffText} />
-          <div style={{ display: "flex", gap: 8 }}>
-            <button
+          <div className="flex gap-2">
+            <Button
               data-testid="ai-apply"
-              type="button"
+              variant="secondary"
+              size="md"
               onClick={() => void onApply()}
               disabled={!canApply}
-              style={{
-                border: "1px solid var(--color-separator)",
-                background: "var(--color-bg-base)",
-                color: "var(--color-fg-base)",
-                borderRadius: 8,
-                padding: "8px 10px",
-                fontSize: 12,
-                cursor: !canApply ? "not-allowed" : "pointer",
-                flex: 1,
-              }}
+              className="flex-1"
             >
               Apply
-            </button>
-            <button
+            </Button>
+            <Button
               data-testid="ai-reject"
-              type="button"
+              variant="ghost"
+              size="md"
               onClick={onReject}
               disabled={applyStatus === "applying"}
-              style={{
-                border: "1px solid var(--color-separator)",
-                background: "transparent",
-                color: "var(--color-fg-muted)",
-                borderRadius: 8,
-                padding: "8px 10px",
-                fontSize: 12,
-                cursor: applyStatus === "applying" ? "not-allowed" : "pointer",
-              }}
             >
               Reject
-            </button>
+            </Button>
           </div>
         </>
       ) : null}

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Button, Input, ListItem, Text } from "../../components/primitives";
 import { useEditorStore } from "../../stores/editorStore";
 import { useFileStore } from "../../stores/fileStore";
 
@@ -91,135 +92,73 @@ export function FileTreePanel(props: { projectId: string }): JSX.Element {
   return (
     <div
       data-testid="sidebar-files"
-      style={{ display: "flex", flexDirection: "column", minHeight: 0 }}
+      className="flex flex-col min-h-0"
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "var(--space-3)",
-          borderBottom: "1px solid var(--color-separator)",
-        }}
-      >
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Files
-        </div>
-        <button
-          type="button"
+      <div className="flex items-center justify-between p-3 border-b border-[var(--color-separator)]">
+        <Text size="small" color="muted">Files</Text>
+        <Button
           data-testid="file-create"
+          variant="secondary"
+          size="sm"
           onClick={() => void onCreate()}
-          style={{
-            fontSize: 12,
-            padding: "var(--space-2) var(--space-3)",
-            borderRadius: "var(--radius-md)",
-            border: "1px solid var(--color-border-default)",
-            background: "var(--color-bg-surface)",
-            color: "var(--color-fg-default)",
-            cursor: "pointer",
-          }}
         >
           New
-        </button>
+        </Button>
       </div>
 
       {lastError ? (
         <div
           role="alert"
-          style={{
-            padding: "var(--space-3)",
-            fontSize: 12,
-            color: "var(--color-fg-default)",
-            borderBottom: "1px solid var(--color-separator)",
-          }}
+          className="p-3 border-b border-[var(--color-separator)]"
         >
-          <div style={{ marginBottom: "var(--space-2)" }}>
+          <Text size="small" className="mb-2 block">
             {lastError.code}: {lastError.message}
-          </div>
-          <button
-            type="button"
+          </Text>
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => clearError()}
-            style={{
-              fontSize: 12,
-              padding: "var(--space-2) var(--space-3)",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--color-border-default)",
-              background: "var(--color-bg-surface)",
-              color: "var(--color-fg-default)",
-              cursor: "pointer",
-            }}
           >
             Dismiss
-          </button>
+          </Button>
         </div>
       ) : null}
 
-      <div style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
+      <div className="flex-1 overflow-auto min-h-0">
         {bootstrapStatus !== "ready" ? (
-          <div
-            style={{
-              padding: "var(--space-3)",
-              fontSize: 12,
-              color: "var(--color-fg-muted)",
-            }}
-          >
+          <Text size="small" color="muted" className="p-3 block">
             Loading files…
-          </div>
+          </Text>
         ) : items.length === 0 ? (
-          <div
-            style={{
-              padding: "var(--space-3)",
-              fontSize: 12,
-              color: "var(--color-fg-muted)",
-            }}
-          >
+          <Text size="small" color="muted" className="p-3 block">
             No documents yet.
-          </div>
+          </Text>
         ) : (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "var(--space-1)",
-            }}
-          >
+          <div className="flex flex-col gap-1 p-2">
             {items.map((item) => {
               const selected = item.documentId === currentDocumentId;
               const isRenaming =
                 editing.mode === "rename" &&
                 editing.documentId === item.documentId;
               return (
-                <div
+                <ListItem
                   key={item.documentId}
                   data-testid={`file-row-${item.documentId}`}
                   aria-selected={selected}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "var(--space-2)",
-                    padding: "var(--space-2) var(--space-3)",
-                    margin: `0 var(--space-2)`,
-                    borderRadius: "var(--radius-md)",
-                    border: `1px solid ${
-                      selected
-                        ? "var(--color-border-focus)"
-                        : "var(--color-border-default)"
-                    }`,
-                    background: selected
-                      ? "var(--color-bg-selected)"
-                      : "transparent",
-                    cursor: isRenaming ? "default" : "pointer",
-                  }}
+                  selected={selected}
+                  interactive={!isRenaming}
+                  compact
                   onClick={() => {
                     if (isRenaming) {
                       return;
                     }
                     void onSelect(item.documentId);
                   }}
+                  className={`border ${selected ? "border-[var(--color-border-focus)]" : "border-[var(--color-border-default)]"}`}
                 >
-                  <div style={{ flex: 1, minWidth: 0 }}>
+                  <div className="flex-1 min-w-0">
                     {isRenaming ? (
-                      <input
+                      <Input
                         ref={inputRef}
                         data-testid={`file-rename-input-${item.documentId}`}
                         value={editing.title}
@@ -240,120 +179,73 @@ export function FileTreePanel(props: { projectId: string }): JSX.Element {
                             void onCommitRename();
                           }
                         }}
-                        style={{
-                          width: "100%",
-                          fontSize: 12,
-                          padding: "var(--space-1) var(--space-2)",
-                          borderRadius: "var(--radius-sm)",
-                          border: "1px solid var(--color-border-default)",
-                          background: "var(--color-bg-base)",
-                          color: "var(--color-fg-default)",
-                        }}
+                        fullWidth
+                        className="h-7 text-xs"
                       />
                     ) : (
-                      <div
-                        style={{
-                          fontSize: 12,
-                          color: "var(--color-fg-default)",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
+                      <Text size="small" className="block overflow-hidden text-ellipsis whitespace-nowrap">
                         {item.title}
-                      </div>
+                      </Text>
                     )}
                   </div>
 
-                  <div style={{ display: "flex", gap: "var(--space-1)" }}>
-                      {isRenaming ? (
-                        <>
-                          <button
-                            type="button"
-                            data-testid={`file-rename-confirm-${item.documentId}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void onCommitRename();
-                            }}
-                            style={{
-                              fontSize: 12,
-                              padding: "var(--space-1) var(--space-2)",
-                              borderRadius: "var(--radius-md)",
-                              border: "1px solid var(--color-border-default)",
-                              background: "var(--color-bg-surface)",
-                              color: "var(--color-fg-default)",
-                              cursor: "pointer",
-                            }}
-                          >
-                            Save
-                          </button>
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setEditing({ mode: "idle" });
-                            }}
-                            style={{
-                              fontSize: 12,
-                              padding: "var(--space-1) var(--space-2)",
-                              borderRadius: "var(--radius-md)",
-                              border: "1px solid var(--color-border-default)",
-                              background: "var(--color-bg-surface)",
-                              color: "var(--color-fg-default)",
-                              cursor: "pointer",
-                            }}
-                          >
-                            Cancel
-                          </button>
-                        </>
-                      ) : (
-                        <>
-                          <button
-                            type="button"
-                            data-testid={`file-rename-${item.documentId}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setEditing({
-                                mode: "rename",
-                                documentId: item.documentId,
-                                title: item.title,
-                              });
-                            }}
-                            style={{
-                              fontSize: 12,
-                              padding: "var(--space-1) var(--space-2)",
-                              borderRadius: "var(--radius-md)",
-                              border: "1px solid var(--color-border-default)",
-                              background: "var(--color-bg-surface)",
-                              color: "var(--color-fg-default)",
-                              cursor: "pointer",
-                            }}
-                          >
-                            Rename
-                          </button>
-                          <button
-                            type="button"
-                            data-testid={`file-delete-${item.documentId}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void onDelete(item.documentId);
-                            }}
-                            style={{
-                              fontSize: 12,
-                              padding: "var(--space-1) var(--space-2)",
-                              borderRadius: "var(--radius-md)",
-                              border: "1px solid var(--color-border-default)",
-                              background: "var(--color-bg-surface)",
-                              color: "var(--color-fg-default)",
-                              cursor: "pointer",
-                            }}
+                  <div className="flex gap-1">
+                    {isRenaming ? (
+                      <>
+                        <Button
+                          data-testid={`file-rename-confirm-${item.documentId}`}
+                          variant="secondary"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void onCommitRename();
+                          }}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditing({ mode: "idle" });
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                      </>
+                    ) : (
+                      <>
+                        <Button
+                          data-testid={`file-rename-${item.documentId}`}
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditing({
+                              mode: "rename",
+                              documentId: item.documentId,
+                              title: item.title,
+                            });
+                          }}
+                        >
+                          Rename
+                        </Button>
+                        <Button
+                          data-testid={`file-delete-${item.documentId}`}
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void onDelete(item.documentId);
+                          }}
                         >
                           Delete
-                        </button>
+                        </Button>
                       </>
                     )}
                   </div>
-                </div>
+                </ListItem>
               );
             })}
           </div>

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Button, Card, Input, Select, Text } from "../../components/primitives";
 import { useKgStore } from "../../stores/kgStore";
 
 type EditingState =
@@ -149,184 +150,90 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   return (
     <section
       data-testid="sidebar-kg"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-        minHeight: 0,
-      }}
+      className="flex flex-col gap-3 min-h-0"
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "var(--space-3)",
-          borderBottom: "1px solid var(--color-separator)",
-        }}
-      >
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Knowledge Graph
-        </div>
-        <div style={{ fontSize: 11, color: "var(--color-fg-muted)" }}>
-          {bootstrapStatus}
-        </div>
+      <div className="flex items-center justify-between p-3 border-b border-[var(--color-separator)]">
+        <Text size="small" color="muted">Knowledge Graph</Text>
+        <Text size="tiny" color="muted">{bootstrapStatus}</Text>
       </div>
 
       {lastError ? (
         <div
           role="alert"
-          style={{
-            padding: "var(--space-3)",
-            fontSize: 12,
-            color: "var(--color-fg-default)",
-            borderBottom: "1px solid var(--color-separator)",
-          }}
+          className="p-3 border-b border-[var(--color-separator)]"
         >
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <div
-              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
-              data-testid="kg-error-code"
-            >
+          <div className="flex gap-2 items-center">
+            <Text data-testid="kg-error-code" size="code" color="muted">
               {lastError.code}
-            </div>
-            <button
-              type="button"
+            </Text>
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={clearError}
-              style={{
-                marginLeft: "auto",
-                border: "1px solid var(--color-border-default)",
-                borderRadius: 6,
-                padding: "2px 8px",
-                background: "var(--color-bg-surface)",
-                color: "var(--color-fg-default)",
-                cursor: "pointer",
-                fontSize: 12,
-              }}
+              className="ml-auto"
             >
               Dismiss
-            </button>
+            </Button>
           </div>
-          <div style={{ marginTop: 6 }}>{lastError.message}</div>
+          <Text size="small" className="mt-1.5 block">{lastError.message}</Text>
         </div>
       ) : null}
 
-      <div style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
-        <div style={{ padding: "var(--space-3)" }}>
-          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Entities
-          </div>
+      <div className="flex-1 overflow-auto min-h-0">
+        <div className="p-3">
+          <Text size="small" color="muted">Entities</Text>
 
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "var(--space-2)",
-              marginTop: "var(--space-2)",
-              paddingBottom: "var(--space-3)",
-              borderBottom: "1px solid var(--color-separator)",
-            }}
-          >
-            <input
+          <div className="flex flex-col gap-2 mt-2 pb-3 border-b border-[var(--color-separator)]">
+            <Input
               data-testid="kg-entity-name"
               placeholder="Name"
               value={createName}
               onChange={(e) => setCreateName(e.target.value)}
-              style={{
-                border: "1px solid var(--color-border-default)",
-                borderRadius: "var(--radius-md)",
-                padding: "var(--space-2) var(--space-3)",
-                background: "var(--color-bg-surface)",
-                color: "var(--color-fg-default)",
-                fontSize: 12,
-              }}
+              fullWidth
             />
-            <input
+            <Input
               placeholder="Type (optional)"
               value={createType}
               onChange={(e) => setCreateType(e.target.value)}
-              style={{
-                border: "1px solid var(--color-border-default)",
-                borderRadius: "var(--radius-md)",
-                padding: "var(--space-2) var(--space-3)",
-                background: "var(--color-bg-surface)",
-                color: "var(--color-fg-default)",
-                fontSize: 12,
-              }}
+              fullWidth
             />
-            <input
+            <Input
               placeholder="Description (optional)"
               value={createDescription}
               onChange={(e) => setCreateDescription(e.target.value)}
-              style={{
-                border: "1px solid var(--color-border-default)",
-                borderRadius: "var(--radius-md)",
-                padding: "var(--space-2) var(--space-3)",
-                background: "var(--color-bg-surface)",
-                color: "var(--color-fg-default)",
-                fontSize: 12,
-              }}
+              fullWidth
             />
-            <button
-              type="button"
+            <Button
               data-testid="kg-entity-create"
+              variant="secondary"
+              size="sm"
               onClick={() => void onCreateEntity()}
               disabled={!isReady}
-              style={{
-                alignSelf: "flex-start",
-                fontSize: 12,
-                padding: "var(--space-2) var(--space-3)",
-                borderRadius: "var(--radius-md)",
-                border: "1px solid var(--color-border-default)",
-                background: "var(--color-bg-surface)",
-                color: "var(--color-fg-default)",
-                cursor: !isReady ? "not-allowed" : "pointer",
-                opacity: !isReady ? 0.6 : 1,
-              }}
+              className="self-start"
             >
               Create entity
-            </button>
+            </Button>
           </div>
 
           {entities.length === 0 ? (
-            <div
-              style={{
-                marginTop: "var(--space-3)",
-                fontSize: 12,
-                color: "var(--color-fg-muted)",
-              }}
-            >
+            <Text size="small" color="muted" className="mt-3 block">
               No entities yet.
-            </div>
+            </Text>
           ) : (
-            <div
-              style={{
-                marginTop: "var(--space-3)",
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-2)",
-              }}
-            >
+            <div className="mt-3 flex flex-col gap-2">
               {entities.map((e) => {
                 const isEditing =
                   editing.mode === "entity" && editing.entityId === e.entityId;
                 return (
-                  <div
+                  <Card
                     key={e.entityId}
                     data-testid={`kg-entity-row-${e.entityId}`}
-                    style={{
-                      border: "1px solid var(--color-separator)",
-                      borderRadius: 8,
-                      padding: 10,
-                      background: "var(--color-bg-base)",
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 8,
-                    }}
+                    noPadding
+                    className="p-2.5 flex flex-col gap-2"
                   >
                     {isEditing ? (
                       <>
-                        <input
+                        <Input
                           value={editing.name}
                           onChange={(evt) =>
                             setEditing({
@@ -334,16 +241,9 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                               name: evt.target.value,
                             })
                           }
-                          style={{
-                            border: "1px solid var(--color-border-default)",
-                            borderRadius: "var(--radius-md)",
-                            padding: "var(--space-2) var(--space-3)",
-                            background: "var(--color-bg-surface)",
-                            color: "var(--color-fg-default)",
-                            fontSize: 12,
-                          }}
+                          fullWidth
                         />
-                        <input
+                        <Input
                           value={editing.entityType}
                           onChange={(evt) =>
                             setEditing({
@@ -351,16 +251,9 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                               entityType: evt.target.value,
                             })
                           }
-                          style={{
-                            border: "1px solid var(--color-border-default)",
-                            borderRadius: "var(--radius-md)",
-                            padding: "var(--space-2) var(--space-3)",
-                            background: "var(--color-bg-surface)",
-                            color: "var(--color-fg-default)",
-                            fontSize: 12,
-                          }}
+                          fullWidth
                         />
-                        <input
+                        <Input
                           value={editing.description}
                           onChange={(evt) =>
                             setEditing({
@@ -368,75 +261,48 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                               description: evt.target.value,
                             })
                           }
-                          style={{
-                            border: "1px solid var(--color-border-default)",
-                            borderRadius: "var(--radius-md)",
-                            padding: "var(--space-2) var(--space-3)",
-                            background: "var(--color-bg-surface)",
-                            color: "var(--color-fg-default)",
-                            fontSize: 12,
-                          }}
+                          fullWidth
                         />
                       </>
                     ) : (
                       <>
-                        <div style={{ fontSize: 12 }}>
+                        <Text size="small">
                           {entityLabel({
                             name: e.name,
                             entityType: e.entityType,
                           })}
-                        </div>
+                        </Text>
                         {e.description ? (
-                          <div
-                            style={{
-                              fontSize: 12,
-                              color: "var(--color-fg-muted)",
-                            }}
-                          >
+                          <Text size="small" color="muted">
                             {e.description}
-                          </div>
+                          </Text>
                         ) : null}
                       </>
                     )}
 
-                    <div style={{ display: "flex", gap: 8 }}>
+                    <div className="flex gap-2">
                       {isEditing ? (
                         <>
-                          <button
-                            type="button"
+                          <Button
+                            variant="secondary"
+                            size="sm"
                             onClick={() => void onSaveEdit()}
-                            style={{
-                              border: "1px solid var(--color-border-default)",
-                              borderRadius: 6,
-                              padding: "2px 8px",
-                              background: "var(--color-bg-surface)",
-                              color: "var(--color-fg-default)",
-                              cursor: "pointer",
-                              fontSize: 12,
-                            }}
                           >
                             Save
-                          </button>
-                          <button
-                            type="button"
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={() => setEditing({ mode: "idle" })}
-                            style={{
-                              border: "1px solid var(--color-border-default)",
-                              borderRadius: 6,
-                              padding: "2px 8px",
-                              background: "transparent",
-                              color: "var(--color-fg-muted)",
-                              cursor: "pointer",
-                              fontSize: 12,
-                            }}
                           >
                             Cancel
-                          </button>
+                          </Button>
                         </>
                       ) : (
                         <>
-                          <button
-                            type="button"
+                          <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={() =>
                               setEditing({
                                 mode: "entity",
@@ -446,174 +312,94 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                                 description: e.description ?? "",
                               })
                             }
-                            style={{
-                              border: "1px solid var(--color-border-default)",
-                              borderRadius: 6,
-                              padding: "2px 8px",
-                              background: "transparent",
-                              color: "var(--color-fg-muted)",
-                              cursor: "pointer",
-                              fontSize: 12,
-                            }}
                           >
                             Edit
-                          </button>
-                          <button
-                            type="button"
+                          </Button>
+                          <Button
                             data-testid={`kg-entity-delete-${e.entityId}`}
+                            variant="ghost"
+                            size="sm"
                             onClick={() => void onDeleteEntity(e.entityId)}
-                            style={{
-                              border: "1px solid var(--color-border-default)",
-                              borderRadius: 6,
-                              padding: "2px 8px",
-                              background: "transparent",
-                              color: "var(--color-fg-muted)",
-                              cursor: "pointer",
-                              fontSize: 12,
-                            }}
                           >
                             Delete
-                          </button>
+                          </Button>
                         </>
                       )}
                     </div>
-                  </div>
+                  </Card>
                 );
               })}
             </div>
           )}
 
-          <div style={{ marginTop: "var(--space-4)" }}>
-            <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-              Relations
-            </div>
+          <div className="mt-4">
+            <Text size="small" color="muted">Relations</Text>
 
-            <div
-              style={{
-                marginTop: "var(--space-2)",
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-2)",
-                paddingBottom: "var(--space-3)",
-                borderBottom: "1px solid var(--color-separator)",
-              }}
-            >
-              <select
+            <div className="mt-2 flex flex-col gap-2 pb-3 border-b border-[var(--color-separator)]">
+              <Select
                 value={relFromId}
-                onChange={(e) => setRelFromId(e.target.value)}
+                onValueChange={(value) => setRelFromId(value)}
                 disabled={!isReady || entities.length === 0}
-                style={{
-                  border: "1px solid var(--color-border-default)",
-                  borderRadius: "var(--radius-md)",
-                  padding: "var(--space-2) var(--space-3)",
-                  background: "var(--color-bg-surface)",
-                  color: "var(--color-fg-default)",
-                  fontSize: 12,
-                }}
-              >
-                {entities.map((e) => (
-                  <option key={e.entityId} value={e.entityId}>
-                    {entityLabel({ name: e.name, entityType: e.entityType })}
-                  </option>
-                ))}
-              </select>
+                options={entities.map((e) => ({
+                  value: e.entityId,
+                  label: entityLabel({ name: e.name, entityType: e.entityType }),
+                }))}
+                placeholder="Select entity..."
+                fullWidth
+              />
 
-              <select
+              <Select
                 value={relToId}
-                onChange={(e) => setRelToId(e.target.value)}
+                onValueChange={(value) => setRelToId(value)}
                 disabled={!isReady || entities.length === 0}
-                style={{
-                  border: "1px solid var(--color-border-default)",
-                  borderRadius: "var(--radius-md)",
-                  padding: "var(--space-2) var(--space-3)",
-                  background: "var(--color-bg-surface)",
-                  color: "var(--color-fg-default)",
-                  fontSize: 12,
-                }}
-              >
-                {entities.map((e) => (
-                  <option key={e.entityId} value={e.entityId}>
-                    {entityLabel({ name: e.name, entityType: e.entityType })}
-                  </option>
-                ))}
-              </select>
+                options={entities.map((e) => ({
+                  value: e.entityId,
+                  label: entityLabel({ name: e.name, entityType: e.entityType }),
+                }))}
+                placeholder="Select entity..."
+                fullWidth
+              />
 
-              <input
+              <Input
                 data-testid="kg-relation-type"
                 placeholder="Relation type (e.g. knows)"
                 value={relType}
                 onChange={(e) => setRelType(e.target.value)}
                 disabled={!isReady}
-                style={{
-                  border: "1px solid var(--color-border-default)",
-                  borderRadius: "var(--radius-md)",
-                  padding: "var(--space-2) var(--space-3)",
-                  background: "var(--color-bg-surface)",
-                  color: "var(--color-fg-default)",
-                  fontSize: 12,
-                }}
+                fullWidth
               />
 
-              <button
-                type="button"
+              <Button
                 data-testid="kg-relation-create"
+                variant="secondary"
+                size="sm"
                 onClick={() => void onCreateRelation()}
                 disabled={!isReady}
-                style={{
-                  alignSelf: "flex-start",
-                  fontSize: 12,
-                  padding: "var(--space-2) var(--space-3)",
-                  borderRadius: "var(--radius-md)",
-                  border: "1px solid var(--color-border-default)",
-                  background: "var(--color-bg-surface)",
-                  color: "var(--color-fg-default)",
-                  cursor: !isReady ? "not-allowed" : "pointer",
-                  opacity: !isReady ? 0.6 : 1,
-                }}
+                className="self-start"
               >
                 Create relation
-              </button>
+              </Button>
             </div>
 
             {relations.length === 0 ? (
-              <div
-                style={{
-                  marginTop: "var(--space-3)",
-                  fontSize: 12,
-                  color: "var(--color-fg-muted)",
-                }}
-              >
+              <Text size="small" color="muted" className="mt-3 block">
                 No relations yet.
-              </div>
+              </Text>
             ) : (
-              <div
-                style={{
-                  marginTop: "var(--space-3)",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-2)",
-                }}
-              >
+              <div className="mt-3 flex flex-col gap-2">
                 {relations.map((r) => {
                   const isEditing =
                     editing.mode === "relation" &&
                     editing.relationId === r.relationId;
                   return (
-                    <div
+                    <Card
                       key={r.relationId}
                       data-testid={`kg-relation-row-${r.relationId}`}
-                      style={{
-                        border: "1px solid var(--color-separator)",
-                        borderRadius: 8,
-                        padding: 10,
-                        background: "var(--color-bg-base)",
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 8,
-                      }}
+                      noPadding
+                      className="p-2.5 flex flex-col gap-2"
                     >
                       {isEditing ? (
-                        <input
+                        <Input
                           value={editing.relationType}
                           onChange={(evt) =>
                             setEditing({
@@ -621,60 +407,38 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                               relationType: evt.target.value,
                             })
                           }
-                          style={{
-                            border: "1px solid var(--color-border-default)",
-                            borderRadius: "var(--radius-md)",
-                            padding: "var(--space-2) var(--space-3)",
-                            background: "var(--color-bg-surface)",
-                            color: "var(--color-fg-default)",
-                            fontSize: 12,
-                          }}
+                          fullWidth
                         />
                       ) : (
-                        <div style={{ fontSize: 12 }}>
+                        <Text size="small">
                           {getEntityName(r.fromEntityId)} -({r.relationType})→{" "}
                           {getEntityName(r.toEntityId)}
-                        </div>
+                        </Text>
                       )}
 
-                      <div style={{ display: "flex", gap: 8 }}>
+                      <div className="flex gap-2">
                         {isEditing ? (
                           <>
-                            <button
-                              type="button"
+                            <Button
+                              variant="secondary"
+                              size="sm"
                               onClick={() => void onSaveEdit()}
-                              style={{
-                                border: "1px solid var(--color-border-default)",
-                                borderRadius: 6,
-                                padding: "2px 8px",
-                                background: "var(--color-bg-surface)",
-                                color: "var(--color-fg-default)",
-                                cursor: "pointer",
-                                fontSize: 12,
-                              }}
                             >
                               Save
-                            </button>
-                            <button
-                              type="button"
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               onClick={() => setEditing({ mode: "idle" })}
-                              style={{
-                                border: "1px solid var(--color-border-default)",
-                                borderRadius: 6,
-                                padding: "2px 8px",
-                                background: "transparent",
-                                color: "var(--color-fg-muted)",
-                                cursor: "pointer",
-                                fontSize: 12,
-                              }}
                             >
                               Cancel
-                            </button>
+                            </Button>
                           </>
                         ) : (
                           <>
-                            <button
-                              type="button"
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               onClick={() =>
                                 setEditing({
                                   mode: "relation",
@@ -682,41 +446,24 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                                   relationType: r.relationType,
                                 })
                               }
-                              style={{
-                                border: "1px solid var(--color-border-default)",
-                                borderRadius: 6,
-                                padding: "2px 8px",
-                                background: "transparent",
-                                color: "var(--color-fg-muted)",
-                                cursor: "pointer",
-                                fontSize: 12,
-                              }}
                             >
                               Edit
-                            </button>
-                            <button
-                              type="button"
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               onClick={() =>
                                 void relationDelete({
                                   relationId: r.relationId,
                                 })
                               }
-                              style={{
-                                border: "1px solid var(--color-border-default)",
-                                borderRadius: 6,
-                                padding: "2px 8px",
-                                background: "transparent",
-                                color: "var(--color-fg-muted)",
-                                cursor: "pointer",
-                                fontSize: 12,
-                              }}
                             >
                               Delete
-                            </button>
+                            </Button>
                           </>
                         )}
                       </div>
-                    </div>
+                    </Card>
                   );
                 })}
               </div>

--- a/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { Button, Card, Checkbox, Input, Select, Text, Textarea } from "../../components/primitives";
 import { useProjectStore } from "../../stores/projectStore";
 import { useMemoryStore } from "../../stores/memoryStore";
 
@@ -46,139 +47,78 @@ export function MemoryPanel(): JSX.Element {
   return (
     <section
       data-testid="memory-panel"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-        padding: 12,
-        minHeight: 0,
-      }}
+      className="flex flex-col gap-3 p-3 min-h-0"
     >
-      <header style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Memory
-        </div>
-        <div
-          style={{
-            marginLeft: "auto",
-            fontSize: 11,
-            color: "var(--color-fg-muted)",
-          }}
-        >
+      <header className="flex items-center gap-2">
+        <Text size="small" color="muted">Memory</Text>
+        <Text size="tiny" color="muted" className="ml-auto">
           {bootstrapStatus}
-        </div>
+        </Text>
       </header>
 
       {lastError ? (
-        <div
-          style={{
-            border: "1px solid var(--color-separator)",
-            borderRadius: 8,
-            padding: 10,
-            background: "var(--color-bg-base)",
-            color: "var(--color-fg-muted)",
-            fontSize: 12,
-          }}
-        >
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <div
-              data-testid="memory-error-code"
-              style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
-            >
+        <Card noPadding className="p-2.5">
+          <div className="flex gap-2 items-center">
+            <Text data-testid="memory-error-code" size="code" color="muted">
               {lastError.code}
-            </div>
-            <button
-              type="button"
+            </Text>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={clearError}
-              style={{
-                marginLeft: "auto",
-                border: "1px solid var(--color-separator)",
-                background: "transparent",
-                color: "var(--color-fg-muted)",
-                borderRadius: 6,
-                padding: "2px 8px",
-                fontSize: 12,
-                cursor: "pointer",
-              }}
+              className="ml-auto"
             >
               Dismiss
-            </button>
+            </Button>
           </div>
-          <div style={{ marginTop: 6 }}>{lastError.message}</div>
-        </div>
+          <Text size="small" color="muted" className="mt-1.5 block">
+            {lastError.message}
+          </Text>
+        </Card>
       ) : null}
 
-      <div
-        style={{
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          background: "var(--color-bg-base)",
-          padding: 10,
-          display: "flex",
-          flexDirection: "column",
-          gap: 8,
-        }}
-      >
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Settings
-        </div>
+      <Card noPadding className="p-2.5 flex flex-col gap-2">
+        <Text size="small" color="muted">Settings</Text>
 
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <input
-            data-testid="memory-settings-injection"
-            type="checkbox"
-            checked={settings?.injectionEnabled ?? true}
-            onChange={(e) =>
-              void updateSettings({
-                patch: { injectionEnabled: e.target.checked },
-              })
-            }
-            disabled={!settings}
-          />
-          <span style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Injection enabled
-          </span>
-        </label>
+        <Checkbox
+          data-testid="memory-settings-injection"
+          checked={settings?.injectionEnabled ?? true}
+          onCheckedChange={(checked) =>
+            void updateSettings({
+              patch: { injectionEnabled: checked === true },
+            })
+          }
+          disabled={!settings}
+          label="Injection enabled"
+        />
 
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <input
-            data-testid="memory-settings-learning"
-            type="checkbox"
-            checked={settings?.preferenceLearningEnabled ?? true}
-            onChange={(e) =>
-              void updateSettings({
-                patch: { preferenceLearningEnabled: e.target.checked },
-              })
-            }
-            disabled={!settings}
-          />
-          <span style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Preference learning enabled
-          </span>
-        </label>
+        <Checkbox
+          data-testid="memory-settings-learning"
+          checked={settings?.preferenceLearningEnabled ?? true}
+          onCheckedChange={(checked) =>
+            void updateSettings({
+              patch: { preferenceLearningEnabled: checked === true },
+            })
+          }
+          disabled={!settings}
+          label="Preference learning enabled"
+        />
 
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <input
-            data-testid="memory-settings-privacy"
-            type="checkbox"
-            checked={settings?.privacyModeEnabled ?? false}
-            onChange={(e) =>
-              void updateSettings({
-                patch: { privacyModeEnabled: e.target.checked },
-              })
-            }
-            disabled={!settings}
-          />
-          <span style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Privacy mode
-          </span>
-        </label>
+        <Checkbox
+          data-testid="memory-settings-privacy"
+          checked={settings?.privacyModeEnabled ?? false}
+          onCheckedChange={(checked) =>
+            void updateSettings({
+              patch: { privacyModeEnabled: checked === true },
+            })
+          }
+          disabled={!settings}
+          label="Privacy mode"
+        />
 
-        <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <span style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Threshold
-          </span>
-          <input
+        <div className="flex gap-2 items-center">
+          <Text size="small" color="muted">Threshold</Text>
+          <Input
             data-testid="memory-settings-threshold"
             type="number"
             min={1}
@@ -190,99 +130,52 @@ export function MemoryPanel(): JSX.Element {
               })
             }
             disabled={!settings}
-            style={{
-              width: 80,
-              marginLeft: "auto",
-              border: "1px solid var(--color-separator)",
-              borderRadius: 6,
-              padding: "2px 6px",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              fontSize: 12,
-            }}
+            className="ml-auto w-20 h-7"
           />
-        </label>
-      </div>
-
-      <div
-        style={{
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          background: "var(--color-bg-base)",
-          padding: 10,
-          display: "flex",
-          flexDirection: "column",
-          gap: 8,
-        }}
-      >
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Create
         </div>
+      </Card>
 
-        <div style={{ display: "flex", gap: 8 }}>
-          <select
+      <Card noPadding className="p-2.5 flex flex-col gap-2">
+        <Text size="small" color="muted">Create</Text>
+
+        <div className="flex gap-2">
+          <Select
             data-testid="memory-create-type"
             value={createType}
-            onChange={(e) => setCreateType(e.target.value as MemoryType)}
-            style={{
-              border: "1px solid var(--color-separator)",
-              borderRadius: 6,
-              padding: "4px 6px",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              fontSize: 12,
-              flex: 1,
-            }}
-          >
-            <option value="preference">preference</option>
-            <option value="fact">fact</option>
-            <option value="note">note</option>
-          </select>
+            onValueChange={(value) => setCreateType(value as MemoryType)}
+            options={[
+              { value: "preference", label: "preference" },
+              { value: "fact", label: "fact" },
+              { value: "note", label: "note" },
+            ]}
+            className="flex-1"
+          />
 
-          <select
+          <Select
             data-testid="memory-create-scope"
             value={createScope}
-            onChange={(e) => setCreateScope(e.target.value as MemoryScope)}
-            style={{
-              border: "1px solid var(--color-separator)",
-              borderRadius: 6,
-              padding: "4px 6px",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              fontSize: 12,
-              flex: 1,
-            }}
-          >
-            <option value="global">global</option>
-            <option value="project" disabled={disabledProjectScope}>
-              project
-            </option>
-          </select>
+            onValueChange={(value) => setCreateScope(value as MemoryScope)}
+            options={[
+              { value: "global", label: "global" },
+              { value: "project", label: "project", disabled: disabledProjectScope },
+            ]}
+            className="flex-1"
+          />
         </div>
 
-        <textarea
+        <Textarea
           data-testid="memory-create-content"
           value={createContent}
           onChange={(e) => setCreateContent(e.target.value)}
           placeholder="Write a preference / fact / note..."
-          style={{
-            width: "100%",
-            minHeight: 54,
-            resize: "vertical",
-            border: "1px solid var(--color-separator)",
-            borderRadius: 8,
-            padding: 10,
-            background: "transparent",
-            color: "var(--color-fg-base)",
-            outline: "none",
-            fontSize: 12,
-            lineHeight: "18px",
-          }}
+          fullWidth
+          className="min-h-[54px]"
         />
 
-        <button
+        <Button
           data-testid="memory-create-submit"
-          type="button"
+          variant="ghost"
+          size="md"
           onClick={() =>
             void (async () => {
               const res = await create({
@@ -295,197 +188,93 @@ export function MemoryPanel(): JSX.Element {
               }
             })()
           }
-          style={{
-            border: "1px solid var(--color-separator)",
-            background: "transparent",
-            color: "var(--color-fg-muted)",
-            borderRadius: 8,
-            padding: "8px 10px",
-            fontSize: 12,
-            cursor: "pointer",
-          }}
         >
           Add
-        </button>
-      </div>
+        </Button>
+      </Card>
 
-      <div
-        style={{
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          background: "var(--color-bg-base)",
-          padding: 10,
-          minHeight: 120,
-          flex: 1,
-          overflow: "auto",
-          display: "flex",
-          flexDirection: "column",
-          gap: 8,
-        }}
-      >
-        <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-          Items ({items.length})
-        </div>
+      <Card noPadding className="p-2.5 min-h-[120px] flex-1 overflow-auto flex flex-col gap-2">
+        <Text size="small" color="muted">Items ({items.length})</Text>
 
         {items.length === 0 ? (
-          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            No memories yet.
-          </div>
+          <Text size="small" color="muted">No memories yet.</Text>
         ) : null}
 
         {items.map((item) => (
-          <div
+          <Card
             key={item.memoryId}
             data-testid={`memory-item-${item.memoryId}`}
-            style={{
-              border: "1px solid var(--color-separator)",
-              borderRadius: 8,
-              padding: 8,
-              display: "flex",
-              gap: 8,
-              alignItems: "flex-start",
-            }}
+            noPadding
+            className="p-2 flex gap-2 items-start"
           >
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div
-                style={{
-                  display: "flex",
-                  gap: 6,
-                  fontSize: 11,
-                  color: "var(--color-fg-muted)",
-                  fontFamily: "var(--font-mono)",
-                }}
-              >
-                <span>{item.type}</span>
-                <span>{item.scope}</span>
-                <span>{item.origin}</span>
+            <div className="flex-1 min-w-0">
+              <div className="flex gap-1.5">
+                <Text size="code" color="muted">{item.type}</Text>
+                <Text size="code" color="muted">{item.scope}</Text>
+                <Text size="code" color="muted">{item.origin}</Text>
               </div>
-              <div
-                style={{
-                  marginTop: 6,
-                  fontSize: 12,
-                  color: "var(--color-fg-base)",
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                }}
-              >
+              <Text size="small" className="mt-1.5 block whitespace-pre-wrap break-words">
                 {item.content}
-              </div>
+              </Text>
             </div>
-            <button
+            <Button
               data-testid={`memory-delete-${item.memoryId}`}
-              type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => void remove({ memoryId: item.memoryId })}
-              style={{
-                border: "1px solid var(--color-separator)",
-                background: "transparent",
-                color: "var(--color-fg-muted)",
-                borderRadius: 6,
-                padding: "2px 8px",
-                fontSize: 12,
-                cursor: "pointer",
-              }}
             >
               Delete
-            </button>
-          </div>
+            </Button>
+          </Card>
         ))}
-      </div>
+      </Card>
 
-      <div
-        style={{
-          border: "1px solid var(--color-separator)",
-          borderRadius: 8,
-          background: "var(--color-bg-base)",
-          padding: 10,
-          display: "flex",
-          flexDirection: "column",
-          gap: 8,
-        }}
-      >
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <div style={{ fontSize: 12, color: "var(--color-fg-muted)" }}>
-            Injection preview
-          </div>
-          <button
+      <Card noPadding className="p-2.5 flex flex-col gap-2">
+        <div className="flex gap-2 items-center">
+          <Text size="small" color="muted">Injection preview</Text>
+          <Button
             data-testid="memory-preview-run"
-            type="button"
+            variant="ghost"
+            size="sm"
             onClick={() => void previewInjection({ queryText })}
-            style={{
-              marginLeft: "auto",
-              border: "1px solid var(--color-separator)",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              borderRadius: 6,
-              padding: "2px 8px",
-              fontSize: 12,
-              cursor: "pointer",
-            }}
+            className="ml-auto"
           >
             Preview
-          </button>
-          <button
+          </Button>
+          <Button
             data-testid="memory-preview-clear"
-            type="button"
+            variant="ghost"
+            size="sm"
             onClick={clearPreview}
-            style={{
-              border: "1px solid var(--color-separator)",
-              background: "transparent",
-              color: "var(--color-fg-muted)",
-              borderRadius: 6,
-              padding: "2px 8px",
-              fontSize: 12,
-              cursor: "pointer",
-            }}
           >
             Clear
-          </button>
+          </Button>
         </div>
 
-        <input
+        <Input
           data-testid="memory-preview-query"
           type="text"
           value={queryText}
           onChange={(e) => setQueryText(e.target.value)}
           placeholder="queryText (optional)"
-          style={{
-            width: "100%",
-            border: "1px solid var(--color-separator)",
-            borderRadius: 8,
-            padding: "8px 10px",
-            background: "transparent",
-            color: "var(--color-fg-base)",
-            outline: "none",
-            fontSize: 12,
-          }}
+          fullWidth
         />
 
         {preview ? (
-          <div
+          <Card
             data-testid="memory-preview-result"
-            style={{
-              border: "1px solid var(--color-separator)",
-              borderRadius: 8,
-              padding: 8,
-              fontSize: 12,
-              color: "var(--color-fg-muted)",
-            }}
+            noPadding
+            className="p-2"
           >
-            <div>
-              mode:{" "}
-              <span style={{ fontFamily: "var(--font-mono)" }}>
-                {preview.mode}
-              </span>
-            </div>
-            <div style={{ marginTop: 6 }}>
-              items:{" "}
-              <span style={{ fontFamily: "var(--font-mono)" }}>
-                {preview.items.length}
-              </span>
-            </div>
-          </div>
+            <Text size="small" color="muted">
+              mode: <Text size="code" color="muted">{preview.mode}</Text>
+            </Text>
+            <Text size="small" color="muted" className="mt-1.5 block">
+              items: <Text size="code" color="muted">{preview.items.length}</Text>
+            </Text>
+          </Card>
         ) : null}
-      </div>
+      </Card>
     </section>
   );
 }

--- a/openspec/_ops/task_runs/ISSUE-73.md
+++ b/openspec/_ops/task_runs/ISSUE-73.md
@@ -2,7 +2,7 @@
 
 - Issue: #73
 - Branch: task/73-migrate-high-complexity-components
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/74
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-73.md
+++ b/openspec/_ops/task_runs/ISSUE-73.md
@@ -1,0 +1,42 @@
+# ISSUE-73
+
+- Issue: #73
+- Branch: task/73-migrate-high-complexity-components
+- PR: <fill-after-created>
+
+## Plan
+
+- 迁移 AiPanel、FileTreePanel、MemoryPanel、KnowledgeGraphPanel 到 Tailwind CSS + 组件库
+- 更新 Input/Checkbox/Select 组件支持 forwardRef 和 data-testid 透传
+- 验证 TypeScript、ESLint、单元测试、集成测试全部通过
+
+## Runs
+
+### 2026-02-01 迁移实现
+
+- Command: `pnpm tsc --noEmit`
+- Key output: `Exit code: 0` (TypeScript 编译通过)
+
+- Command: `pnpm lint`
+- Key output: `Exit code: 0` (ESLint 检查通过)
+
+- Command: `pnpm test:unit`
+- Key output: `Exit code: 0` (8 个单元测试文件全部通过)
+
+- Command: `pnpm test:integration`
+- Key output: `Exit code: 0` (3 个集成测试文件全部通过)
+
+- Evidence: 
+  - 迁移文件: `apps/desktop/renderer/src/features/ai/AiPanel.tsx`
+  - 迁移文件: `apps/desktop/renderer/src/features/files/FileTreePanel.tsx`
+  - 迁移文件: `apps/desktop/renderer/src/features/memory/MemoryPanel.tsx`
+  - 迁移文件: `apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx`
+  - 组件增强: `apps/desktop/renderer/src/components/primitives/Input.tsx` (forwardRef)
+  - 组件增强: `apps/desktop/renderer/src/components/primitives/Checkbox.tsx` (扩展 props)
+  - 组件增强: `apps/desktop/renderer/src/components/primitives/Select.tsx` (扩展 props)
+
+### 质量审计
+
+- 确认所有 `data-testid` 选择器保持稳定（E2E 测试依赖）
+- 确认 `ai-stream-toggle` 使用原生 checkbox 以保持 Playwright `.isChecked()` 兼容性
+- 确认无内联样式残留（grep 验证）


### PR DESCRIPTION
Closes #73

## Summary

- 迁移 AiPanel (~50 处)、FileTreePanel (~50 处)、MemoryPanel (~60 处)、KnowledgeGraphPanel (~70 处) 从内联样式到 Tailwind CSS + 组件库
- 增强 Input 组件支持 forwardRef（用于焦点管理）
- 扩展 Checkbox/Select 组件 props 类型支持 data-testid 透传
- 保持所有 E2E 选择器稳定（`ai-stream-toggle` 使用原生 checkbox 保持 Playwright `.isChecked()` 兼容）

## Test Plan

- [x] TypeScript 编译通过 (`pnpm tsc --noEmit`)
- [x] ESLint 检查通过 (`pnpm lint`)
- [x] 单元测试通过 (`pnpm test:unit`)
- [x] 集成测试通过 (`pnpm test:integration`)
- [x] 无内联样式残留（grep 验证）
- [x] E2E 选择器保持稳定

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-73.md`