### PR TITLE
docs: 添加布局高度约束与滚动行为规范 (#77)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-77.md
+++ b/openspec/_ops/task_runs/ISSUE-77.md
@@ -2,7 +2,7 @@
 
 - Issue: #77
 - Branch: task/77-design-decisions-layout
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/78
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-77.md
+++ b/openspec/_ops/task_runs/ISSUE-77.md
@@ -1,0 +1,26 @@
+# ISSUE-77
+
+- Issue: #77
+- Branch: task/77-design-decisions-layout
+- PR: <fill-after-created>
+
+## Plan
+
+- 修正 DESIGN_DECISIONS.md 中 4 处问题：浅色主题优先级、布局高度约束、滚动行为规范、按钮状态矩阵
+
+## Runs
+
+### 2026-02-01 修改 DESIGN_DECISIONS.md
+
+- Command: `StrReplace` (4 次)
+- Key output:
+  - 浅色主题优先级改为 P1+（第 1039 行）
+  - 新增 §1.4 布局高度分配（第 54 行）
+  - 新增 §2.6 滚动行为（第 136 行）
+  - 按钮状态改为状态矩阵表格（第 517 行）
+- Evidence: `design/DESIGN_DECISIONS.md` 行数从 1089 增加到 1169（+80 行）
+
+### 2026-02-01 验证修改
+
+- Command: `grep -E "### 1\.4|### 2\.6|浅色主题 \(P1|状态矩阵" design/DESIGN_DECISIONS.md`
+- Key output: 4 处修改全部匹配


### PR DESCRIPTION
Closes #77

## 变更内容

1. **浅色主题优先级**：从 P0 改为 P1+（与 V1 规范对齐）
2. **新增 §1.4 布局高度分配**：明确 `min-height: 0` 约束，解决"面板随内容无限延伸"问题
3. **新增 §2.6 滚动行为**：明确各面板独立滚动，禁止整页滚动
4. **按钮状态矩阵**：从文字列表改为完整状态矩阵表格（6 种状态）

## 测试计划

- [x] 浅色主题标注为 P1+
- [x] §1.4 包含 Flex 布局结构图和 min-height: 0 说明
- [x] §2.6 包含滚动行为禁止事项
- [x] 按钮状态矩阵包含 6 种状态

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-77.md`