### PR TITLE
feat: 更新设计规范强调色为纯白 + 设计稿规范命名 (#79)

### DIFF
--- a/design/DESIGN_DECISIONS.md
+++ b/design/DESIGN_DECISIONS.md
@@ -330,10 +330,33 @@ Tailwind 映射: tailwind.config.ts 中通过 theme.extend.colors 引用 CSS Var
 - 避免与 `--shadow-*`（elevation）争用 `box-shadow`（否则需要组合多层 shadow，容易导致实现分裂）
 - 注意：若祖先容器开启 overflow 裁切，ring 仍可能被裁切；此时 SHOULD 将 focus ring 绘制在外层 wrapper 上或避免在可聚焦区域使用 overflow 裁切
 
-### 3.6 颜色系统 - 功能色
+### 3.6 颜色系统 - 强调色与功能色
+
+**强调色（纯白系，极简主义）:**
+
+深色主题下使用纯白作为强调色，让内容成为焦点：
 
 ```css
-/* 功能色（两个主题共用，MAY 微调亮度） */
+:root[data-theme="dark"] {
+  /* 主强调色（纯白系） */
+  --color-accent: #ffffff;
+  --color-accent-hover: rgba(255, 255, 255, 0.9);
+  --color-accent-muted: rgba(255, 255, 255, 0.6);
+  --color-accent-subtle: rgba(255, 255, 255, 0.1);
+}
+
+:root[data-theme="light"] {
+  /* 浅色主题使用深色强调 */
+  --color-accent: #1a1a1a;
+  --color-accent-hover: rgba(26, 26, 26, 0.9);
+  --color-accent-muted: rgba(26, 26, 26, 0.6);
+  --color-accent-subtle: rgba(26, 26, 26, 0.1);
+}
+```
+
+**功能色（两个主题共用，MAY 微调亮度）:**
+
+```css
 --color-error: #ef4444;
 --color-error-subtle: rgba(239, 68, 68, 0.1);
 --color-success: #22c55e;
@@ -342,13 +365,16 @@ Tailwind 映射: tailwind.config.ts 中通过 theme.extend.colors 引用 CSS Var
 --color-warning-subtle: rgba(245, 158, 11, 0.1);
 --color-info: #3b82f6;
 --color-info-subtle: rgba(59, 130, 246, 0.1);
+```
 
-/* 强调色（知识图谱节点） */
---color-accent-blue: #3b82f6;       /* 角色 */
---color-accent-green: #22c55e;      /* 地点 */
---color-accent-orange: #f97316;     /* 事件 */
---color-accent-cyan: #06b6d4;       /* 物品 */
---color-accent-purple: #8b5cf6;     /* 其他 */
+**知识图谱节点色（功能需求，非主强调色）:**
+
+```css
+--color-node-character: #3b82f6;    /* 角色 - 蓝色 */
+--color-node-location: #22c55e;     /* 地点 - 绿色 */
+--color-node-event: #f97316;        /* 事件 - 橙色 */
+--color-node-item: #06b6d4;         /* 物品 - 青色 */
+--color-node-other: #8b5cf6;        /* 其他 - 紫色 */
 ```
 
 ### 3.7 阴影系统
@@ -622,7 +648,7 @@ textarea:focus-visible {
 
 **文件树拖拽:**
 - 拖拽开始: 源项目 opacity: 0.5
-- 拖拽中: 目标位置显示 2px 蓝色指示线
+- 拖拽中: 目标位置显示 2px 指示线（使用 --color-accent）
 - 放置区域: 目标文件夹 background: var(--color-bg-hover)
 
 **面板宽度拖拽:**
@@ -1167,3 +1193,37 @@ export default {
 - MUST 通过 className 添加 Tailwind 类
 - MUST NOT 使用 Radix 的默认主题
 - SHOULD 封装成业务组件，统一样式
+
+---
+
+## 附录 B: Agent 参考说明
+
+### B.1 设计稿与规范的关系
+
+`design/Variant/designs/` 目录下的 HTML 设计稿（包括原有的 01-19 号和后续补充的设计稿）**仅作为布局和交互参考**。
+
+**规范优先级:**
+
+1. **本文档 (DESIGN_DECISIONS.md)** 是前端实现的唯一真相源
+2. 设计稿中的颜色值、间距数值等 **以本文档定义为准**
+3. 设计稿主要参考价值：布局结构、组件组合、交互流程
+
+### B.2 设计稿颜色映射
+
+设计稿中可能存在蓝色（#3b82f6）或紫色（#5E6AD2）强调色，实现时 **MUST 替换为本文档定义的强调色**：
+
+| 设计稿中的颜色 | 实现时使用 |
+|---------------|-----------|
+| #3b82f6（蓝色） | --color-accent（纯白） |
+| #5E6AD2 / #5D3FD3（紫色） | --color-accent（纯白） |
+| rgba(59, 130, 246, ...) | --color-accent-subtle 或 --color-accent-muted |
+| rgba(94, 106, 210, ...) | --color-accent-subtle 或 --color-accent-muted |
+
+**例外:** 知识图谱节点保持多色区分，使用 `--color-node-*` 变量。
+
+### B.3 Agent 开发时的颜色使用原则
+
+1. **强调色场景**（激活状态、选中项、主按钮）→ 使用 `--color-accent`
+2. **功能反馈**（成功/错误/警告/信息）→ 使用对应功能色
+3. **知识图谱节点**→ 使用 `--color-node-*` 变量
+4. **禁止硬编码颜色值**，所有颜色 MUST 使用 CSS Variable

--- a/design/Variant/MISSING_DESIGNS_PROMPTS.md
+++ b/design/Variant/MISSING_DESIGNS_PROMPTS.md
@@ -1,0 +1,1287 @@
+# CreoNow Missing Designs Prompts
+
+> Status: Ready for Generation
+> Created: 2026-02-01
+> Total: 25 Design Specs
+
+---
+
+## Design System Constants
+
+All designs must adhere to these foundational specifications:
+
+**Color Palette**
+- Base background: #080808
+- Panel background: #0f0f0f
+- Hover state: #1a1a1a
+- Selected state: #222222
+- Border: rgba(255, 255, 255, 0.06)
+- Primary text: #ffffff
+- Secondary text: #888888
+- Tertiary text: #444444
+- Accent purple: #5D3FD3
+- Accent blue: #3b82f6
+- Error: #ef4444
+- Success: #22c55e
+- Warning: #f59e0b
+
+**Typography**
+- UI font: Inter, system-ui, sans-serif
+- Code font: JetBrains Mono, monospace
+- Body/serif: Newsreader, Georgia, serif
+
+**Spacing Grid**
+- Base unit: 4px
+- Common values: 4, 8, 12, 16, 24, 32, 48px
+
+**Border Radius**
+- Small: 4px (inputs, small buttons)
+- Medium: 8px (cards, dropdowns)
+- Large: 12px (modals, dialogs)
+
+**Visual Effects**
+- Glass panels: backdrop-filter blur 12px with semi-transparent background
+- Gradient glow: subtle purple/indigo radial gradients in background
+- Noise texture overlay at 5% opacity
+- Shadows: rgba(0,0,0,0.5) with varying blur radius
+
+---
+
+## Section 1: Functional Panels (7 Designs)
+
+---
+
+### 01. Memory Panel
+
+**Purpose**
+Right-side panel for managing user memories. Allows CRUD operations on memory entries, toggling injection settings, and previewing what memories will be injected into AI context.
+
+**Layout**
+- Width: 320px, matching the existing right panel dimensions
+- Header: 48px height with tabs for Memory and Settings sub-views
+- Body: scrollable list of memory entries
+- Footer: input area for adding new memories
+
+**Content Structure**
+
+Panel Header:
+- Tab bar with two tabs: Memories (active) and Settings
+- Icon button for collapse panel on the right
+- Pill counter showing total memory count
+
+Memory List:
+- Each memory card displays:
+  - Category icon on the left (preferences, facts, style, context)
+  - Memory text content (truncated to 2 lines)
+  - Timestamp in tertiary text
+  - Three-dot menu button on hover for edit/delete
+- Selected memory has left border accent line (2px purple)
+- Hover state with background color shift
+
+Empty State:
+- Centered illustration placeholder
+- Text: No memories yet
+- Subtext: Add your first memory to help AI understand you better
+- Primary button: Add Memory
+
+Settings Sub-view:
+- Toggle switches for:
+  - Enable memory injection (with description text)
+  - Auto-learn from conversations
+  - Include project-specific memories
+- Each toggle row: 48px height, label on left, switch on right
+
+Add Memory Input:
+- Textarea with placeholder: What should the AI remember about you?
+- Category selector dropdown (small, inline)
+- Send button on the right
+
+**Interactions**
+- Hover on memory card: show delete and edit icons
+- Click memory: expand to show full text
+- Drag to reorder memories (optional visual)
+
+---
+
+### 02. Skills Picker
+
+**Purpose**
+Popup or panel for selecting and managing AI skills. Displays available skills with enable/disable toggles, skill descriptions, and scope indicators.
+
+**Layout**
+- Modal popup: 480px width, centered
+- Or inline panel: 320px width in right sidebar
+
+**Content Structure**
+
+Header:
+- Title: Skills
+- Close button (X icon) on the right
+- Search input below title
+
+Skill Categories:
+- Section headers: Builtin, Global, Project
+- Each section collapsible with chevron
+
+Skill Card:
+- 64px height per skill row
+- Left: colored dot indicator (active/inactive)
+- Skill name in primary text
+- Brief description in secondary text below name
+- Right side: toggle switch for enable/disable
+- Chevron for expand to show full description
+
+Expanded Skill View:
+- Full description text
+- Author and version info in tertiary text
+- Tags as small pills
+- Button: View Details or Configure
+
+Empty State (for Project section):
+- Text: No project skills configured
+- Button: Browse Skills
+
+Footer:
+- Secondary button: Manage Skills
+- Primary button: Done
+
+**Interactions**
+- Toggle switch animates between states
+- Search filters list in real-time
+- Clicking skill row expands details
+
+---
+
+### 03. Context Viewer
+
+**Purpose**
+Debug and transparency panel showing what context is being sent to AI. Displays layered context with token counts, redaction indicators, and source attribution.
+
+**Layout**
+- Right panel or modal: 400px width
+- Full height with internal scroll
+
+**Content Structure**
+
+Header:
+- Title: Context Viewer
+- Subtitle: Debug view of AI context
+- Total token count badge
+- Close button
+
+Context Layers Section:
+- Accordion-style expandable sections for each layer:
+  - System Rules (token count badge)
+  - Project Settings (token count badge)
+  - Retrieved Context (token count badge)
+  - Immediate Context (token count badge)
+
+Layer Content:
+- Monospace text display
+- Syntax highlighting for markdown/code
+- Redacted content shown as: [REDACTED: api_key] in orange/warning color
+- Source file paths in tertiary text
+
+Token Budget Bar:
+- Horizontal progress bar showing usage
+- Segments colored by layer type
+- Labels: Used X / Budget Y tokens
+
+Redaction Summary:
+- Count of redacted items
+- Expandable list showing what was redacted and why
+
+Footer:
+- Checkbox: Show raw prompt
+- Button: Copy to Clipboard
+- Button: Export as JSON
+
+**Visual Details**
+- Each layer has a distinct left border color
+- Redacted items pulse subtly to draw attention
+- Monospace font for all context content
+
+---
+
+### 04. Version History Panel
+
+**Purpose**
+Sidebar panel showing document version history. Lists snapshots with timestamps, actor attribution, and restore/diff actions.
+
+**Layout**
+- Right panel: 320px width
+- Or modal for focused view: 600px width
+
+**Content Structure**
+
+Header:
+- Title: Version History
+- Document name in secondary text
+- Close button
+
+Timeline List:
+- Chronological list of versions, newest first
+- Each version entry:
+  - Timestamp (relative: 2 hours ago, or absolute for older)
+  - Actor badge: User (white), Auto (gray), AI (purple)
+  - Preview text: first 50 chars of changes
+  - Word count delta: +24 words or -12 words
+
+Version Entry States:
+- Default: standard row
+- Hover: background highlight, show action buttons
+- Selected: left accent border, expanded view
+
+Action Buttons (on hover):
+- Restore: revert to this version
+- Compare: open diff view with current
+- Preview: read-only view of this version
+
+Current Version Indicator:
+- Top of list with Current label
+- Distinct styling (no restore button)
+
+Empty State:
+- Text: No version history
+- Subtext: Save your document to create the first version
+
+Footer:
+- Auto-save indicator with last save time
+- Link: Configure auto-save settings
+
+---
+
+### 05. Diff View
+
+**Purpose**
+Split or unified view comparing two document versions. Shows additions, deletions, and unchanged text with clear visual distinction.
+
+**Layout**
+- Full editor area or modal: 800px minimum width
+- Two modes: Split (side-by-side) and Unified (inline)
+
+**Content Structure**
+
+Header Bar:
+- Left version selector dropdown: Version from 2 hours ago
+- Right version selector dropdown: Current version
+- Toggle: Split | Unified view
+- Close button
+
+Split View Layout:
+- Left pane: older version (labeled Before)
+- Right pane: newer version (labeled After)
+- Synchronized scrolling
+- Line numbers on both sides
+
+Diff Highlighting:
+- Deleted text: red background (#ef4444 at 10% opacity), strikethrough
+- Added text: green background (#22c55e at 10% opacity)
+- Modified lines: yellow left border indicator
+- Unchanged text: normal styling
+
+Unified View Layout:
+- Single column with inline diff
+- Deleted lines prefixed with minus, red background
+- Added lines prefixed with plus, green background
+- Context lines in normal styling
+
+Navigation:
+- Jump to next change button
+- Jump to previous change button
+- Change counter: Change 3 of 12
+
+Footer:
+- Summary: +42 words, -18 words, 3 paragraphs modified
+- Button: Restore Before Version
+- Button: Close
+
+---
+
+### 06. Search Panel
+
+**Purpose**
+Unified search panel for full-text and semantic search across documents, memories, and knowledge graph entities.
+
+**Layout**
+- Left sidebar panel: 320px width
+- Or Command Palette style modal: 600px width
+
+**Content Structure**
+
+Search Header:
+- Large search input with icon
+- Placeholder: Search documents, memories, knowledge...
+- Clear button when input has value
+
+Filter Row:
+- Pill toggles: All | Documents | Memories | Knowledge
+- Active filter has filled background
+
+Search Options (collapsible):
+- Toggle: Include semantic search
+- Toggle: Search in archived
+- Scope selector: Current Project | All Projects
+
+Results List:
+- Grouped by type with section headers
+- Each result shows:
+  - Type icon (document, memory, entity)
+  - Title or primary text
+  - Match preview with highlighted terms
+  - Location path in tertiary text
+  - Relevance score indicator (optional)
+
+Result States:
+- Hover: background change, show preview button
+- Click: navigate to item
+
+No Results State:
+- Illustration placeholder
+- Text: No results found
+- Suggestions: Try different keywords or broaden filters
+
+Recent Searches:
+- Shown when input is empty
+- List of recent search terms
+- Clear all link
+
+Footer:
+- Result count: 24 results
+- Keyboard hints: arrows to navigate, enter to open
+
+---
+
+### 07. Constraints Panel
+
+**Purpose**
+Quality gate configuration panel. Shows active constraints, validation status, and allows toggling constraint checks.
+
+**Layout**
+- Right panel or settings sub-panel: 320px width
+
+**Content Structure**
+
+Header:
+- Title: Quality Gates
+- Status badge: All Passing (green) or 2 Issues (red)
+- Refresh button
+
+Constraint Categories:
+- Sections: Style, Consistency, Completeness
+- Each section with item count
+
+Constraint Row:
+- Checkbox for enable/disable
+- Constraint name
+- Status icon: check (green), warning (yellow), error (red)
+- Chevron for expand
+
+Expanded Constraint:
+- Description text
+- Current status with details
+- Last checked timestamp
+- Button: Run Check
+
+Issues List (when issues exist):
+- Warning/error items with description
+- Location link to navigate to issue
+- Button: Fix or Ignore
+
+Settings Section:
+- Toggle: Run checks on save
+- Toggle: Block save on errors
+- Dropdown: Check frequency
+
+Footer:
+- Button: Run All Checks
+- Last full check timestamp
+
+---
+
+## Section 2: State Designs (7 Designs)
+
+---
+
+### 08. Empty State: Project
+
+**Purpose**
+Displayed when user has no projects or opens app for first time.
+
+**Layout**
+- Centered in main content area
+- Maximum width: 400px
+
+**Content Structure**
+
+Illustration:
+- Abstract geometric shape or document stack icon
+- Subtle gradient or glow effect
+- Size: 120px square area
+
+Heading:
+- Text: Start Your Creative Journey
+- Large, bold, primary text color
+
+Description:
+- Text: Create your first project to begin writing with AI assistance
+- Secondary text color, centered
+
+Primary Action:
+- Button: Create New Project
+- Full width or auto width centered
+- Primary style (white background, dark text)
+
+Secondary Action:
+- Link text: Import existing project
+- Tertiary text color
+
+Optional:
+- Recent templates carousel below
+- Quick start tips in muted text
+
+---
+
+### 09. Empty State: FileTree
+
+**Purpose**
+Displayed in sidebar when current project has no documents.
+
+**Layout**
+- Contained within sidebar content area
+- Centered vertically in available space
+
+**Content Structure**
+
+Icon:
+- Document with plus icon
+- Size: 48px
+- Muted color with subtle opacity
+
+Heading:
+- Text: No documents yet
+- Small bold text
+
+Description:
+- Text: Create your first document to start writing
+- Very small, tertiary text
+
+Action Button:
+- Button: New Document
+- Small size, secondary style
+- Icon: plus
+
+Alternative:
+- Or drop text below for drag-drop hint
+- Text: or drag files here
+
+---
+
+### 10. Empty State: Search
+
+**Purpose**
+Displayed when search returns no matching results.
+
+**Layout**
+- Centered in search results area
+- Compact vertical layout
+
+**Content Structure**
+
+Icon:
+- Magnifying glass with question mark or empty state
+- Size: 64px
+- Muted styling
+
+Heading:
+- Text: No results found
+- Medium weight, primary text
+
+Search Term Echo:
+- Text: for [search term]
+- Italicized, secondary text
+
+Suggestions:
+- Bulleted list:
+  - Check your spelling
+  - Try different keywords
+  - Broaden your search filters
+- Tertiary text, small size
+
+Action:
+- Link: Clear search
+- Secondary button: Search in all projects
+
+---
+
+### 11. Loading States
+
+**Purpose**
+Collection of loading indicators for different contexts.
+
+**Layout**
+- Multiple examples on single design sheet
+
+**Content Variants**
+
+Top Progress Bar:
+- Full width, 2px height
+- Positioned at window top edge
+- Animated gradient sliding left to right
+- Indeterminate animation style
+
+Content Skeleton:
+- Sidebar skeleton: animated pulse rectangles for file tree
+- Editor skeleton: heading placeholder, paragraph lines
+- Card skeleton: image area, title bar, description lines
+- Use #1a1a1a for skeleton shapes, animated opacity pulse
+
+Button Loading:
+- Spinner icon replaces button text
+- Button disabled state
+- Spinner: 16px, spinning animation
+
+Panel Loading:
+- Centered spinner with loading text below
+- Spinner: 24px
+- Text: Loading...
+
+Inline Loading:
+- Three dots bouncing animation
+- Used in chat/AI responses
+- Small, 8px dots
+
+Full Page Loading:
+- Centered large spinner: 48px
+- App logo above (optional)
+- Text: Starting CreoNow...
+
+---
+
+### 12. Error Dialog
+
+**Purpose**
+Modal dialog for displaying error messages requiring user acknowledgment.
+
+**Layout**
+- Centered modal: 400px width
+- Scrim overlay behind
+
+**Content Structure**
+
+Header:
+- Error icon (circle with exclamation) in red
+- Title: Something went wrong
+- Optional: error code in monospace
+
+Body:
+- Error message description
+- Technical details in collapsible section
+- Monospace text for stack traces or codes
+
+Actions:
+- Primary button: Try Again or OK
+- Secondary button: Report Issue (optional)
+- Link: View Details
+
+Visual Style:
+- Modal has standard dark background
+- Error icon has red color with subtle glow
+- Border top or accent in error red
+
+---
+
+### 13. Template Picker Dialog
+
+**Purpose**
+Modal for selecting document or project templates when creating new items.
+
+**Layout**
+- Centered modal: 640px width
+- Grid layout for template cards
+
+**Content Structure**
+
+Header:
+- Title: Choose a Template
+- Subtitle: Start with a pre-configured structure
+- Close button
+
+Search/Filter:
+- Search input for filtering templates
+- Category pills: All | Novel | Article | Script | Custom
+
+Template Grid:
+- 2-column grid of template cards
+- Each card: 180px height
+  - Preview thumbnail or icon
+  - Template name
+  - Brief description (1 line)
+  - Badge: Popular or New (optional)
+
+Card States:
+- Hover: border highlight, slight scale
+- Selected: accent border, checkmark overlay
+
+Blank Template Option:
+- First card always: Blank Document
+- Plus icon, minimal styling
+
+Footer:
+- Selected template name display
+- Button: Cancel (secondary)
+- Button: Create (primary)
+
+---
+
+### 14. Export Dialog
+
+**Purpose**
+Modal for configuring and initiating document export.
+
+**Layout**
+- Centered modal: 480px width
+
+**Content Structure**
+
+Header:
+- Title: Export Document
+- Document name in secondary text
+- Close button
+
+Format Selection:
+- Radio group with format options:
+  - Markdown (.md)
+  - PDF (.pdf)
+  - Word Document (.docx)
+  - Plain Text (.txt)
+- Each option with icon and brief description
+
+Options Section:
+- Checkbox: Include metadata
+- Checkbox: Include version history
+- Checkbox: Embed images (for PDF)
+- Dropdown: Page size (for PDF)
+
+Preview:
+- Small preview area showing export sample
+- Text: Preview of exported content
+
+Progress (during export):
+- Progress bar with percentage
+- Current step text: Generating PDF...
+
+Footer:
+- File size estimate
+- Button: Cancel
+- Button: Export
+
+---
+
+## Section 3: Interaction Details (4 Designs)
+
+---
+
+### 15. Zen Mode
+
+**Purpose**
+Distraction-free writing mode with minimal UI. Full-screen focus on content.
+
+**Layout**
+- Full viewport coverage
+- Centered content column: 720px maximum width
+
+**Content Structure**
+
+Background:
+- Pure dark: #050505
+- Optional: very subtle gradient glow in center
+- No visible UI chrome
+
+Content Area:
+- Generous vertical padding: 120px top and bottom
+- Horizontal padding: 80px minimum
+- Content centered in viewport
+
+Editor:
+- Title in large serif font
+- Body text in comfortable reading size
+- Cursor and selection visible
+- No toolbar visible
+
+Minimal Controls (appears on mouse movement):
+- Fade in from top: exit button (X or Esc hint)
+- Fade in from bottom: word count, save status
+- Auto-hide after 2 seconds of no movement
+
+Transition:
+- Smooth fade in when entering zen mode
+- Panels slide out, content expands
+
+Exit Hint:
+- Small text in corner: Press Esc or F11 to exit
+- Very low opacity, disappears after first few seconds
+
+---
+
+### 16. Selection Toolbar
+
+**Purpose**
+Floating toolbar appearing when user selects text in editor.
+
+**Layout**
+- Floating bar positioned above selection
+- Auto-positions to stay within viewport
+- Height: 36px
+
+**Content Structure**
+
+Toolbar Container:
+- Dark background with slight transparency
+- Rounded corners: 8px
+- Subtle shadow for elevation
+- Border: standard panel border
+
+Formatting Buttons:
+- Bold (B)
+- Italic (I)
+- Underline (U)
+- Strikethrough (S)
+- Link icon
+- Separator line
+- Highlight/color icon
+
+AI Actions:
+- Sparkle icon button: AI Actions
+- Clicking opens submenu
+
+AI Submenu (dropdown below toolbar):
+- Options: Improve, Expand, Shorten, Rephrase, Explain
+- Each with icon and keyboard shortcut hint
+
+Button States:
+- Default: icon in muted color
+- Hover: icon brightens, background highlight
+- Active (format applied): accent color
+
+Arrow Pointer:
+- Small triangle pointing down to selection
+- Centered on toolbar
+
+---
+
+### 17. Resizer Indicator
+
+**Purpose**
+Visual feedback for panel width adjustment via drag handle.
+
+**Layout**
+- Vertical line between resizable panels
+- Multiple states shown
+
+**Content Structure**
+
+Default State:
+- 1px vertical line using border color
+- Cursor area: 8px wide (invisible hit area)
+
+Hover State:
+- Line becomes 2px wide
+- Color brightens to #444444
+- Cursor changes to col-resize
+
+Dragging State:
+- Line becomes 2px wide
+- Color becomes accent blue
+- Optional: width tooltip appears
+- Tooltip shows: 320px (current width)
+
+Width Tooltip:
+- Small pill above or beside cursor
+- Dark background, white text
+- Updates in real-time during drag
+
+Snap Indicators (optional):
+- When approaching default width, line pulses
+- Visual snap feedback at preset widths
+
+Constraints Visual:
+- At minimum width: line turns warning orange
+- At maximum width: line turns warning orange
+- Prevents further movement
+
+---
+
+### 18. Context Menus
+
+**Purpose**
+Right-click context menus for various UI elements.
+
+**Layout**
+- Floating menu positioned at click location
+- Adjusts to stay within viewport
+
+**Content Variants**
+
+File Tree Context Menu:
+- New File
+- New Folder
+- Separator
+- Rename (with F2 shortcut)
+- Duplicate
+- Move to...
+- Separator
+- Cut, Copy, Paste
+- Separator
+- Delete (in red/warning color)
+
+Editor Context Menu:
+- Cut, Copy, Paste
+- Separator
+- AI Actions submenu arrow
+- Separator
+- Find in Document
+- Add to Memories
+- Separator
+- Format submenu arrow
+
+AI Panel Context Menu (on message):
+- Copy
+- Copy as Markdown
+- Separator
+- Regenerate
+- Edit and Resend
+- Separator
+- Delete Message
+
+**Visual Style**
+- Menu container: #0f0f0f background
+- Border: standard panel border
+- Rounded corners: 8px
+- Shadow: elevation shadow
+- Item height: 32px
+- Item hover: #1a1a1a background
+- Separator: 1px line with margin
+- Shortcut text: right-aligned, tertiary color
+- Danger items: red text color
+- Submenu arrow: chevron right icon
+
+---
+
+## Section 4: AI Related (4 Designs)
+
+---
+
+### 19. AI Streaming States
+
+**Purpose**
+Visual states during AI response streaming, including cancel and timeout handling.
+
+**Layout**
+- Within AI Panel message area
+- Multiple states on single design
+
+**Content Variants**
+
+Streaming Active:
+- AI message bubble with growing content
+- Blinking cursor at end of text
+- Thinking text above: Generating response...
+- Cancel button visible below message
+
+Cancel Button:
+- Position: below streaming message
+- Text: Stop Generating
+- Icon: square (stop) icon
+- Secondary button style
+- Hover state visible
+
+Cancellation Feedback:
+- Message ends with: [Generation stopped]
+- Muted italic text
+- No error styling
+
+Timeout State:
+- Message shows: Response timed out
+- Warning icon
+- Retry button: Try Again
+- Link: Report Issue
+
+Thinking Indicator:
+- Before first content arrives
+- Three bouncing dots animation
+- Text: AI is thinking...
+- Model name badge
+
+Progress Hint (for long operations):
+- Subtle progress bar under message
+- Indeterminate animation
+- Text: Processing large context...
+
+---
+
+### 20. AI Apply Confirmation
+
+**Purpose**
+UI flow for reviewing and accepting/rejecting AI-suggested document changes.
+
+**Layout**
+- Inline in editor or modal overlay
+- Diff-style presentation
+
+**Content Structure**
+
+Inline Suggestion:
+- Changed text highlighted with accent background
+- Gutter icon indicating AI change
+- Floating action bar attached to change
+
+Floating Action Bar:
+- Accept button (checkmark, green tint)
+- Reject button (X, red tint)
+- View Diff button
+- Positioned above or below changed text
+
+Diff Modal (for larger changes):
+- Split view: Before | After
+- Standard diff coloring
+- Summary: This will modify 3 paragraphs
+- Buttons: Apply Changes, Reject, Edit Manually
+
+Multiple Changes:
+- Navigation: Change 1 of 4
+- Previous/Next arrows
+- Accept All button
+- Reject All button
+
+Change Types:
+- Addition: green background, plus indicator
+- Deletion: red background, minus indicator
+- Modification: yellow border
+
+Undo Available:
+- Toast after accepting: Changes applied
+- Action button: Undo
+- Timeout: 5 seconds
+
+---
+
+### 21. AI Error States
+
+**Purpose**
+Error displays for AI-related failures: network, timeout, quota, upstream errors.
+
+**Layout**
+- Within AI Panel message area
+- Multiple error types
+
+**Content Variants**
+
+Network Error:
+- Icon: wifi-off or cloud-off
+- Title: Connection Failed
+- Description: Unable to reach AI service. Check your internet connection.
+- Button: Retry
+
+Timeout Error:
+- Icon: clock
+- Title: Request Timed Out
+- Description: The AI service took too long to respond.
+- Button: Try Again
+
+Rate Limit Error:
+- Icon: speedometer or clock
+- Title: Too Many Requests
+- Description: Please wait a moment before sending another message.
+- Countdown: Try again in 30 seconds
+
+Quota Exceeded:
+- Icon: alert-triangle
+- Title: Usage Limit Reached
+- Description: You have reached your monthly AI usage limit.
+- Button: Upgrade Plan
+- Link: View Usage
+
+Upstream Error:
+- Icon: server
+- Title: AI Service Error
+- Description: The AI provider is experiencing issues. This is not your fault.
+- Error code in monospace: upstream_error_503
+- Button: Retry
+- Link: Check Status
+
+**Visual Style**
+- Error container: subtle red tint background
+- Icon: warning/error colors
+- Clearly not user-caused tone in messaging
+- Always provide actionable next step
+
+---
+
+### 22. Confirm/Alert Dialog
+
+**Purpose**
+General-purpose confirmation and alert dialogs.
+
+**Layout**
+- Centered modal: 400px width
+- Scrim overlay
+
+**Content Variants**
+
+Delete Confirmation:
+- Icon: trash in red
+- Title: Delete Document?
+- Description: This action cannot be undone. The document and its version history will be permanently deleted.
+- Secondary button: Cancel
+- Danger button: Delete (red styling)
+
+Unsaved Changes Alert:
+- Icon: alert-triangle in warning color
+- Title: Unsaved Changes
+- Description: You have unsaved changes. Do you want to save before leaving?
+- Three buttons: Discard, Cancel, Save
+
+Success Confirmation:
+- Icon: checkmark in green
+- Title: Export Complete
+- Description: Your document has been exported successfully.
+- File location path
+- Button: Open File
+- Button: Done
+
+Information Alert:
+- Icon: info circle in blue
+- Title: About Memories
+- Description: Informational text explaining a feature.
+- Single button: Got It
+
+**Visual Style**
+- Danger actions: red button background or red text
+- Confirm actions: standard primary button
+- Icon colors match intent: red (danger), yellow (warning), green (success), blue (info)
+- Modal has subtle shadow and border
+
+---
+
+## Section 5: Component Primitives (3 Designs)
+
+---
+
+### 23. Toast Collection
+
+**Purpose**
+Notification toasts for various feedback types.
+
+**Layout**
+- Position: top-right corner of viewport
+- Stack vertically with 8px gap
+- Each toast: 320px width
+
+**Content Variants**
+
+Info Toast:
+- Left border accent: blue
+- Icon: info circle
+- Message: Document saved successfully
+- Auto-dismiss: 3 seconds
+
+Success Toast:
+- Left border accent: green
+- Icon: checkmark circle
+- Message: Export complete
+- Optional action: View File
+
+Warning Toast:
+- Left border accent: yellow/orange
+- Icon: alert-triangle
+- Message: Large document may slow performance
+- Dismiss button (X)
+
+Error Toast:
+- Left border accent: red
+- Icon: X circle
+- Message: Failed to save document
+- Action button: Retry
+- Does not auto-dismiss
+
+Toast with Progress:
+- Standard toast container
+- Progress bar below message
+- Text: Exporting... 45%
+
+**Visual Style**
+- Background: #0f0f0f with slight transparency
+- Border: standard panel border
+- Left accent border: 3px width
+- Shadow: elevation shadow for floating effect
+- Entry animation: slide in from right
+- Exit animation: fade out and slide right
+
+---
+
+### 24. Tooltip and Popover
+
+**Purpose**
+Tooltip hints and popover content containers.
+
+**Layout**
+- Multiple examples on design sheet
+
+**Content Variants**
+
+Simple Tooltip:
+- Small text container
+- Maximum width: 200px
+- Arrow pointing to trigger element
+- Text: Descriptive text for the element
+- Background: #1a1a1a
+- Border: subtle panel border
+- Delay before show: 300ms
+
+Tooltip with Shortcut:
+- Text: Save Document
+- Shortcut badge: Cmd+S (styled like keyboard key)
+
+Rich Tooltip:
+- Title in bold
+- Description paragraph
+- Learn more link
+- Maximum width: 280px
+
+Popover:
+- Larger container: 320px width
+- Header with title and close button
+- Body content with padding
+- Optional footer with actions
+- Arrow pointing to trigger
+
+Popover Example (Profile):
+- User avatar and name
+- Email address
+- Separator
+- Menu items: Settings, Help, Sign Out
+- Arrow positioning based on trigger location
+
+**Visual Style**
+- Tooltip: compact, no border or subtle border
+- Popover: full panel styling with border
+- Both: shadow for elevation
+- Arrow: matches background color, proper rotation
+- Animations: fade in with slight scale
+
+---
+
+### 25. Settings Details
+
+**Purpose**
+Detailed settings panel layout with various control types.
+
+**Layout**
+- Full panel or page: 600px content width
+- Sectioned layout with scroll
+
+**Content Structure**
+
+Settings Header:
+- Title: Settings
+- Close or back button
+- Search settings input
+
+Navigation Sidebar (optional):
+- List of setting categories
+- Active item highlighted
+- Categories: General, Editor, AI, Appearance, Keyboard
+
+Settings Section:
+- Section title with description
+- Grouped related settings
+
+Control Types:
+
+Toggle Setting:
+- Label on left
+- Description below label
+- Toggle switch on right
+- Row height: 56px
+
+Dropdown Setting:
+- Label on left
+- Description below
+- Dropdown on right showing current value
+
+Input Setting:
+- Label above
+- Description below label
+- Full-width input field
+
+Slider Setting:
+- Label with current value
+- Full-width slider
+- Min/max labels at ends
+
+Radio Group:
+- Label and description
+- Vertical list of radio options
+- Each option with label and description
+
+Button Setting:
+- Label and description
+- Action button on right
+- Example: Reset to Defaults
+
+**Visual Grouping**
+- Sections separated by 32px spacing
+- Section titles: 10px uppercase, tertiary color
+- Subtle separator lines between sections
+- Hover on row: subtle background highlight
+
+Footer:
+- Save status indicator
+- Changes saved automatically text
+- Or Save/Cancel buttons if manual save
+
+---
+
+## Appendix: Naming Convention
+
+Generated HTML files should follow this naming pattern:
+
+```
+20-memory-panel.html
+21-skills-picker.html
+22-context-viewer.html
+23-version-history.html
+24-diff-view.html
+25-search-panel.html
+26-constraints-panel.html
+27-empty-state-project.html
+28-empty-state-filetree.html
+29-empty-state-search.html
+30-loading-states.html
+31-error-dialog.html
+32-template-picker.html
+33-export-dialog.html
+34-zen-mode.html
+35-selection-toolbar.html
+36-resizer-indicator.html
+37-context-menus.html
+38-ai-streaming-states.html
+39-ai-apply-confirmation.html
+40-ai-error-states.html
+41-confirm-dialog.html
+42-toast-collection.html
+43-tooltip-popover.html
+44-settings-details.html
+```
+
+---
+
+## Generation Notes
+
+- Each design should be a standalone HTML file using Tailwind CSS CDN
+- Include all interactive states in a single design where applicable
+- Use the same font imports as existing designs: Inter, JetBrains Mono, Newsreader
+- Maintain visual consistency with the 19 existing design files
+- Include realistic placeholder content, not lorem ipsum
+- All designs are for dark theme only

--- a/design/Variant/designs/20-memory-panel-alt.html
+++ b/design/Variant/designs/20-memory-panel-alt.html
@@ -1,0 +1,343 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Memory Panel</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400&amp;family=Newsreader:ital,wght@0,400;0,500;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6', 
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                        serif: ['Newsreader', 'serif'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+        
+        .glass-panel {
+            backdrop-filter: blur(12px);
+            background-color: rgba(15, 15, 15, 0.8);
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans h-screen w-screen overflow-hidden flex selection:bg-accent selection:text-white" vid="9">
+
+    
+    <aside class="w-64 border-r border-border flex flex-col h-full bg-background flex-shrink-0" vid="10">
+        
+        <div class="h-14 px-6 flex items-center mb-6" vid="11">
+            <span class="font-bold tracking-tight text-lg" vid="12">CREO</span><span class="font-thin ml-1 text-secondary" vid="13">NOW</span>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto px-4 space-y-8" vid="14">
+            
+            <div vid="15">
+                <h3 class="text-[10px] tracking-widest text-tertiary font-semibold mb-2 px-2 uppercase" vid="16">Workspace</h3>
+                <nav class="space-y-0.5" vid="17">
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-primary rounded hover:bg-hover group" vid="18">
+                        <span class="w-1.5 h-1.5 rounded-full bg-accent mr-2.5" vid="19"></span>
+                        Recent Drafts
+                    </a>
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="20">
+                        Published
+                    </a>
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="21">
+                        Archive
+                    </a>
+                </nav>
+            </div>
+
+            
+            <div vid="22">
+                <div class="flex items-center justify-between px-2 mb-2" vid="23">
+                    <h3 class="text-[10px] tracking-widest text-tertiary font-semibold uppercase" vid="24">Collections</h3>
+                    <button class="text-tertiary hover:text-primary transition-colors" vid="25">
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="26">
+                            <path d="M12 5v14M5 12h14" vid="27"></path>
+                        </svg>
+                    </button>
+                </div>
+                <nav class="space-y-0.5" vid="28">
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="29">
+                        Design Theory
+                    </a>
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="30">
+                        Visual Essays
+                    </a>
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="31">
+                        Typography
+                    </a>
+                    <a href="#" class="flex items-center px-2 py-1.5 text-sm text-secondary hover:text-primary rounded hover:bg-hover transition-colors" vid="32">
+                        Photography
+                    </a>
+                </nav>
+            </div>
+        </div>
+
+        
+        <div class="p-4 border-t border-border mt-auto" vid="33">
+            <div class="flex items-center gap-3" vid="34">
+                <div class="w-8 h-8 rounded bg-gradient-to-br from-gray-700 to-gray-900 flex items-center justify-center text-xs font-medium border border-border" vid="35">AM</div>
+                <div class="flex flex-col" vid="36">
+                    <span class="text-sm font-medium" vid="37">Alex M.</span>
+                    <span class="text-xs text-secondary" vid="38">Pro Plan</span>
+                </div>
+            </div>
+        </div>
+    </aside>
+
+    
+    <main class="flex-1 flex flex-col bg-background relative z-0" vid="39">
+        
+        <header class="h-14 border-b border-border flex items-center justify-between px-6" vid="40">
+            <div class="flex items-center gap-2 text-sm text-secondary" vid="41">
+                <span class="hover:text-primary cursor-pointer transition-colors" vid="42">Drafts</span>
+                <span class="text-tertiary" vid="43">/</span>
+                <span class="text-primary" vid="44">The Architecture of Silence</span>
+                <span class="ml-3 px-1.5 py-0.5 text-[10px] border border-border rounded text-secondary uppercase tracking-wider" vid="45">Draft</span>
+            </div>
+            
+            <div class="flex items-center gap-4" vid="46">
+                <span class="text-xs text-secondary" vid="47">Last edited 2m ago</span>
+                <button class="px-4 py-1.5 bg-primary text-background text-sm font-medium rounded hover:bg-gray-200 transition-colors" vid="48">Publish</button>
+            </div>
+        </header>
+
+        
+        <div class="flex-1 overflow-y-auto p-12 max-w-4xl mx-auto w-full opacity-40 hover:opacity-100 transition-opacity duration-500" vid="49">
+            <h1 class="text-5xl font-serif font-medium mb-8" vid="50">The Architecture of Silence</h1>
+            <p class="text-xl text-secondary font-serif leading-relaxed mb-8" vid="51">
+                Intrigued by beauty, fascinated by technology and fueled with an everlasting devotion to digital craftsmanship.
+            </p>
+            <p class="text-lg text-secondary/80 font-serif leading-relaxed mb-6" vid="52">
+                Design is not just about making things look good. It is about how things work. In the digital realm, this translates to the seamless integration of form and function. We build immersive environments where typography leads the eye and imagery sets the mood.
+            </p>
+            <div class="w-full h-64 bg-panel border border-border rounded-lg mb-8 flex items-center justify-center" vid="53">
+                <span class="text-tertiary text-sm" vid="54">Image Placeholder</span>
+            </div>
+        </div>
+    </main>
+
+    
+    <aside class="w-[320px] bg-panel border-l border-border flex flex-col h-full z-10 shadow-2xl shadow-black/50" vid="55">
+        
+        
+        <div class="h-12 border-b border-border flex items-center justify-between px-4 flex-shrink-0" vid="56">
+            <div class="flex items-center gap-4" vid="57">
+                <button class="text-sm font-medium text-primary border-b-2 border-primary h-12 relative top-[1px]" vid="58">
+                    Memories
+                </button>
+                <button class="text-sm font-medium text-secondary hover:text-primary transition-colors h-12 border-b-2 border-transparent relative top-[1px]" vid="59">
+                    Settings
+                </button>
+                <span class="bg-hover text-secondary text-[10px] font-medium px-1.5 py-0.5 rounded-full border border-border ml-1" vid="60">12</span>
+            </div>
+            <button class="text-secondary hover:text-primary transition-colors p-1 rounded hover:bg-hover" vid="61">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="62">
+                    <path d="M18 6L6 18M6 6l12 12" vid="63"></path> 
+                </svg>
+            </button>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto p-4 space-y-3" vid="64">
+            
+            
+            <div class="group relative p-3 bg-background border border-border border-l-2 border-l-accent rounded-r-lg hover:bg-hover transition-all cursor-pointer" vid="65">
+                <div class="flex gap-3" vid="66">
+                    <div class="mt-0.5 flex-shrink-0 text-accent" vid="67">
+                        
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="68">
+                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" vid="69"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="70">
+                        <p class="text-sm text-primary leading-snug line-clamp-2 mb-1.5" vid="71">Prefer concise, technical language when discussing architectural metaphors.</p>
+                        <div class="flex items-center justify-between" vid="72">
+                            <span class="text-xs text-tertiary" vid="73">Just now</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <button class="absolute top-2 right-2 p-1 text-secondary opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-panel rounded transition-all" vid="74">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="75">
+                        <circle cx="12" cy="12" r="1" vid="76"></circle>
+                        <circle cx="19" cy="12" r="1" vid="77"></circle>
+                        <circle cx="5" cy="12" r="1" vid="78"></circle>
+                    </svg>
+                </button>
+            </div>
+
+            
+            <div class="group relative p-3 bg-panel border border-border rounded-lg hover:bg-hover transition-all cursor-pointer" vid="79">
+                <div class="flex gap-3" vid="80">
+                    <div class="mt-0.5 flex-shrink-0 text-secondary" vid="81">
+                        
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="82">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" vid="83"></path>
+                            <circle cx="12" cy="7" r="4" vid="84"></circle>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="85">
+                        <p class="text-sm text-secondary leading-snug line-clamp-2 mb-1.5" vid="86">Always format code blocks with line numbers in documentation.</p>
+                        <div class="flex items-center justify-between" vid="87">
+                            <span class="text-xs text-tertiary" vid="88">2h ago</span>
+                        </div>
+                    </div>
+                </div>
+                <button class="absolute top-2 right-2 p-1 text-secondary opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-panel rounded transition-all" vid="89">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="90">
+                        <circle cx="12" cy="12" r="1" vid="91"></circle>
+                        <circle cx="19" cy="12" r="1" vid="92"></circle>
+                        <circle cx="5" cy="12" r="1" vid="93"></circle>
+                    </svg>
+                </button>
+            </div>
+
+            
+            <div class="group relative p-3 bg-panel border border-border rounded-lg hover:bg-hover transition-all cursor-pointer" vid="94">
+                <div class="flex gap-3" vid="95">
+                    <div class="mt-0.5 flex-shrink-0 text-secondary" vid="96">
+                        
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="97">
+                            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" vid="98"></path>
+                            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" vid="99"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="100">
+                        <p class="text-sm text-secondary leading-snug line-clamp-2 mb-1.5" vid="101">Project deadline is set for October 24th, 2024.</p>
+                        <div class="flex items-center justify-between" vid="102">
+                            <span class="text-xs text-tertiary" vid="103">Yesterday</span>
+                        </div>
+                    </div>
+                </div>
+                <button class="absolute top-2 right-2 p-1 text-secondary opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-panel rounded transition-all" vid="104">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="105">
+                        <circle cx="12" cy="12" r="1" vid="106"></circle>
+                        <circle cx="19" cy="12" r="1" vid="107"></circle>
+                        <circle cx="5" cy="12" r="1" vid="108"></circle>
+                    </svg>
+                </button>
+            </div>
+
+            
+            <div class="group relative p-3 bg-panel border border-border rounded-lg hover:bg-hover transition-all cursor-pointer" vid="109">
+                <div class="flex gap-3" vid="110">
+                    <div class="mt-0.5 flex-shrink-0 text-secondary" vid="111">
+                        
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="112">
+                            <circle cx="12" cy="12" r="10" vid="113"></circle>
+                            <line x1="2" y1="12" x2="22" y2="12" vid="114"></line>
+                            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" vid="115"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="116">
+                        <p class="text-sm text-secondary leading-snug line-clamp-2 mb-1.5" vid="117">Use "Inter" for UI elements and "Newsreader" for long-form content.</p>
+                        <div class="flex items-center justify-between" vid="118">
+                            <span class="text-xs text-tertiary" vid="119">3d ago</span>
+                        </div>
+                    </div>
+                </div>
+                <button class="absolute top-2 right-2 p-1 text-secondary opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-panel rounded transition-all" vid="120">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="121">
+                        <circle cx="12" cy="12" r="1" vid="122"></circle>
+                        <circle cx="19" cy="12" r="1" vid="123"></circle>
+                        <circle cx="5" cy="12" r="1" vid="124"></circle>
+                    </svg>
+                </button>
+            </div>
+
+             
+             <div class="group relative p-3 bg-panel border border-border rounded-lg hover:bg-hover transition-all cursor-pointer" vid="125">
+                <div class="flex gap-3" vid="126">
+                    <div class="mt-0.5 flex-shrink-0 text-secondary" vid="127">
+                        
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="128">
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" vid="129"></path>
+                            <circle cx="12" cy="7" r="4" vid="130"></circle>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="131">
+                        <p class="text-sm text-secondary leading-snug line-clamp-2 mb-1.5" vid="132">Avoid using passive voice in marketing copy.</p>
+                        <div class="flex items-center justify-between" vid="133">
+                            <span class="text-xs text-tertiary" vid="134">1w ago</span>
+                        </div>
+                    </div>
+                </div>
+                <button class="absolute top-2 right-2 p-1 text-secondary opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-panel rounded transition-all" vid="135">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="136">
+                        <circle cx="12" cy="12" r="1" vid="137"></circle>
+                        <circle cx="19" cy="12" r="1" vid="138"></circle>
+                        <circle cx="5" cy="12" r="1" vid="139"></circle>
+                    </svg>
+                </button>
+            </div>
+
+        </div>
+
+        
+        <div class="p-4 border-t border-border bg-panel flex-shrink-0" vid="140">
+            <div class="bg-hover border border-border rounded-lg p-2 focus-within:border-white/20 transition-colors" vid="141">
+                <textarea placeholder="What should the AI remember about you?" class="w-full bg-transparent text-sm text-primary placeholder-secondary/50 resize-none outline-none h-16 mb-2 custom-scrollbar" vid="142"></textarea>
+                
+                <div class="flex items-center justify-between" vid="143">
+                    
+                    <div class="relative group" vid="144">
+                        <button class="flex items-center gap-1.5 px-2 py-1 rounded text-xs text-secondary hover:text-primary hover:bg-panel transition-colors" vid="145">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="146">
+                                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" vid="147"></path>
+                                <circle cx="12" cy="7" r="4" vid="148"></circle>
+                            </svg>
+                            <span vid="149">Preference</span>
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="150">
+                                <path d="M6 9l6 6 6-6" vid="151"></path>
+                            </svg>
+                        </button>
+                    </div>
+
+                    
+                    <button class="bg-accent hover:bg-blue-600 text-white p-1.5 rounded-md transition-colors flex items-center justify-center" vid="152">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="153">
+                            <line x1="22" y1="2" x2="11" y2="13" vid="154"></line>
+                            <polygon points="22 2 15 22 11 13 2 9 22 2" vid="155"></polygon>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+    </aside>
+
+
+</body></html>

--- a/design/Variant/designs/20-memory-panel.html
+++ b/design/Variant/designs/20-memory-panel.html
@@ -1,0 +1,353 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Memory Panel</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;family=Newsreader:ital,wght@0,300;0,400;0,500;1,300;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6', 
+                        error: '#ef4444',
+                        success: '#22c55e',
+                        warning: '#f59e0b'
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        serif: ['Newsreader', 'Georgia', 'serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    boxShadow: {
+                        'glow': '0 0 20px rgba(59, 130, 246, 0.1)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+        
+        .glass-panel {
+            background: rgba(15, 15, 15, 0.7);
+            backdrop-filter: blur(12px);
+        }
+
+        .noise-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            opacity: 0.03;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+            z-index: 9999;
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans h-screen w-screen overflow-hidden flex selection:bg-accent selection:text-white" vid="9">
+
+    <div class="noise-overlay" vid="10"></div>
+
+    
+    <aside class="w-64 border-r border-border flex flex-col flex-shrink-0 bg-background z-20" vid="11">
+        <div class="h-14 flex items-center px-6 border-b border-transparent" vid="12">
+            <div class="flex items-center gap-2" vid="13">
+                <span class="font-semibold tracking-tight text-lg" vid="14">CREO</span>
+                <span class="text-secondary font-light" vid="15">NOW</span>
+            </div>
+        </div>
+
+        <div class="flex-1 overflow-y-auto py-6 px-4 space-y-8" vid="16">
+            
+            <div class="space-y-1" vid="17">
+                <div class="px-2 text-[10px] font-medium tracking-widest text-tertiary uppercase mb-3" vid="18">Workspace</div>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-primary rounded-md bg-selected/50 group" vid="19">
+                    <svg class="w-4 h-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="20">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" vid="21"></path>
+                    </svg>
+                    <span vid="22">Recent Drafts</span>
+                </button>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-secondary hover:text-primary rounded-md hover:bg-hover transition-colors" vid="23">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" vid="25"></path>
+                    </svg>
+                    <span vid="26">Published</span>
+                </button>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-secondary hover:text-primary rounded-md hover:bg-hover transition-colors" vid="27">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="28">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" vid="29"></path>
+                    </svg>
+                    <span vid="30">Archive</span>
+                </button>
+            </div>
+
+            
+            <div class="space-y-1" vid="31">
+                <div class="flex items-center justify-between px-2 mb-3" vid="32">
+                    <div class="text-[10px] font-medium tracking-widest text-tertiary uppercase" vid="33">Collections</div>
+                    <button class="text-tertiary hover:text-primary transition-colors" vid="34">
+                        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="35">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" vid="36"></path>
+                        </svg>
+                    </button>
+                </div>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-secondary hover:text-primary rounded-md hover:bg-hover transition-colors" vid="37">
+                    <span class="w-1.5 h-1.5 rounded-full bg-neutral-700" vid="38"></span>
+                    <span vid="39">Design Theory</span>
+                </button>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-secondary hover:text-primary rounded-md hover:bg-hover transition-colors" vid="40">
+                    <span class="w-1.5 h-1.5 rounded-full bg-neutral-700" vid="41"></span>
+                    <span vid="42">Visual Essays</span>
+                </button>
+                <button class="w-full flex items-center gap-3 px-2 py-1.5 text-sm text-secondary hover:text-primary rounded-md hover:bg-hover transition-colors" vid="43">
+                    <span class="w-1.5 h-1.5 rounded-full bg-neutral-700" vid="44"></span>
+                    <span vid="45">Typography</span>
+                </button>
+            </div>
+        </div>
+
+        
+        <div class="p-4 border-t border-border" vid="46">
+            <div class="flex items-center gap-3" vid="47">
+                <div class="w-8 h-8 rounded bg-gradient-to-tr from-neutral-800 to-neutral-700 flex items-center justify-center border border-border" vid="48">
+                    <span class="text-xs font-medium" vid="49">ST</span>
+                </div>
+                <div class="flex flex-col" vid="50">
+                    <span class="text-xs font-medium text-primary" vid="51">Studio Team</span>
+                    <span class="text-[10px] text-tertiary" vid="52">Pro Plan</span>
+                </div>
+            </div>
+        </div>
+    </aside>
+
+    
+    <main class="flex-1 flex flex-col relative z-10 bg-background" vid="53">
+        
+        <header class="h-14 border-b border-border flex items-center justify-between px-8 bg-background/50 backdrop-blur-sm sticky top-0 z-30" vid="54">
+            <div class="flex items-center gap-4 text-sm" vid="55">
+                <span class="text-secondary" vid="56">Drafts</span>
+                <span class="text-tertiary" vid="57">/</span>
+                <span class="text-primary" vid="58">The Architecture of Silence</span>
+                <span class="px-2 py-0.5 rounded text-[10px] border border-border text-tertiary ml-2" vid="59">DRAFT</span>
+            </div>
+            
+            <div class="flex items-center gap-4" vid="60">
+                <span class="text-xs text-secondary hover:text-primary cursor-pointer transition-colors" vid="61">History</span>
+                <span class="text-xs text-secondary hover:text-primary cursor-pointer transition-colors" vid="62">Preview</span>
+                <button class="px-4 py-1.5 bg-white text-black text-xs font-medium rounded hover:bg-gray-200 transition-colors" vid="63">Publish</button>
+            </div>
+        </header>
+
+        
+        <div class="flex-1 overflow-y-auto" vid="64">
+            <div class="max-w-3xl mx-auto py-16 px-12" vid="65">
+                <h1 class="font-sans text-5xl font-semibold tracking-tight mb-8 text-white leading-[1.1]" vid="66">The Architecture of Silence</h1>
+                
+                <p class="font-serif text-xl text-secondary leading-relaxed mb-12 font-light" vid="67">
+                    Intrigued by beauty, fascinated by technology and fuelled with an everlasting devotion to digital craftsmanship.
+                </p>
+
+                <div class="prose prose-invert prose-lg max-w-none font-serif text-[#a0a0a0]" vid="68">
+                    <p class="mb-6 leading-8" vid="69">
+                        Design is not just about making things look good. It is about how things work. In the digital realm, this translates to the seamless integration of form and function. <span class="text-white bg-white/5 px-1 rounded" vid="70">We build immersive environments</span> where typography leads the eye and imagery sets the mood.
+                    </p>
+                    <p class="mb-6 leading-8" vid="71">
+                        Silence in design is not the absence of sound, but the absence of noise. It is the careful curation of elements to create a space where the user can focus, breathe, and experience the content without distraction.
+                    </p>
+                    <h2 class="font-sans text-2xl font-medium text-white mt-12 mb-6" vid="72">The Aesthetic of Silence</h2>
+                    <p class="mb-6 leading-8" vid="73">
+                        When we strip away the superfluous, we are left with the essential. This reductionist approach is not about limitation, but about clarity. It requires a disciplined eye and a steady hand to remove what is not needed, until only the truth remains.
+                    </p>
+                    <p class="leading-8" vid="74">
+                        The result is an interface that feels inevitable. As if it could not have been designed any other way.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    
+    <aside class="w-[320px] bg-panel border-l border-border flex flex-col flex-shrink-0 z-20 shadow-2xl shadow-black" vid="75">
+        
+        <div class="h-12 flex items-center justify-between px-4 border-b border-border bg-panel" vid="76">
+            <div class="flex items-center h-full gap-6" vid="77">
+                <button class="h-full relative flex items-center gap-2 group" vid="78">
+                    <span class="text-sm font-medium text-white" vid="79">Memories</span>
+                    <span class="bg-white/10 text-secondary text-[10px] px-1.5 py-0.5 rounded-full group-hover:bg-white/20 transition-colors" vid="80">12</span>
+                    <div class="absolute bottom-0 left-0 w-full h-[2px] bg-accent" vid="81"></div>
+                </button>
+                <button class="h-full relative flex items-center text-sm text-secondary hover:text-white transition-colors" vid="82">
+                    Settings
+                </button>
+            </div>
+            <button class="text-secondary hover:text-white transition-colors p-1 rounded hover:bg-hover" vid="83">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="84">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" vid="85"></path>
+                </svg>
+            </button>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto p-4 space-y-3" vid="86">
+            
+            
+            <div class="group relative bg-hover rounded-lg border-l-2 border-accent p-3 hover:bg-[#222] transition-all cursor-pointer shadow-sm" vid="87">
+                <div class="flex items-start gap-3" vid="88">
+                    <div class="mt-0.5 text-accent" vid="89">
+                        
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="90">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" vid="91"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="92">
+                        <p class="text-sm text-gray-200 line-clamp-2 leading-relaxed" vid="93">Prefer Oxford commas in all lists and avoid using passive voice in technical documentation.</p>
+                        <div class="flex items-center justify-between mt-2" vid="94">
+                            <span class="text-[10px] text-tertiary" vid="95">Style • 2m ago</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1 bg-[#222] pl-2" vid="96">
+                    <button class="p-1 hover:text-white text-secondary rounded" vid="97">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="98">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" vid="99"></path>
+                        </svg>
+                    </button>
+                    <button class="p-1 hover:text-error text-secondary rounded" vid="100">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="101">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" vid="102"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="group relative border border-border rounded-lg p-3 hover:bg-hover transition-all cursor-pointer" vid="103">
+                <div class="flex items-start gap-3" vid="104">
+                    <div class="mt-0.5 text-secondary" vid="105">
+                        
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="106">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" vid="107"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="108">
+                        <p class="text-sm text-secondary group-hover:text-gray-300 transition-colors line-clamp-2 leading-relaxed" vid="109">The project "Orion" targets Q3 2024 launch. All marketing copy should reflect a futuristic tone.</p>
+                        <div class="flex items-center justify-between mt-2" vid="110">
+                            <span class="text-[10px] text-tertiary" vid="111">Context • 1h ago</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity" vid="112">
+                     <button class="p-1 hover:bg-white/10 rounded text-secondary hover:text-white" vid="113">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="114">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" vid="115"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="group relative border border-border rounded-lg p-3 hover:bg-hover transition-all cursor-pointer" vid="116">
+                <div class="flex items-start gap-3" vid="117">
+                    <div class="mt-0.5 text-secondary" vid="118">
+                        
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="119">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" vid="120"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="121">
+                        <p class="text-sm text-secondary group-hover:text-gray-300 transition-colors line-clamp-2 leading-relaxed" vid="122">Always generate code snippets in TypeScript unless specified otherwise. Use strict typing.</p>
+                        <div class="flex items-center justify-between mt-2" vid="123">
+                            <span class="text-[10px] text-tertiary" vid="124">Preferences • Yesterday</span>
+                        </div>
+                    </div>
+                </div>
+                 <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity" vid="125">
+                     <button class="p-1 hover:bg-white/10 rounded text-secondary hover:text-white" vid="126">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="127">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" vid="128"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="group relative border border-border rounded-lg p-3 hover:bg-hover transition-all cursor-pointer" vid="129">
+                <div class="flex items-start gap-3" vid="130">
+                    <div class="mt-0.5 text-secondary" vid="131">
+                        
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="132">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" vid="133"></path>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0" vid="134">
+                        <p class="text-sm text-secondary group-hover:text-gray-300 transition-colors line-clamp-2 leading-relaxed" vid="135">User is based in UTC+1 timezone. Meeting hours should align with 10:00 - 18:00 CET.</p>
+                        <div class="flex items-center justify-between mt-2" vid="136">
+                            <span class="text-[10px] text-tertiary" vid="137">Facts • Oct 24</span>
+                        </div>
+                    </div>
+                </div>
+                 <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity" vid="138">
+                     <button class="p-1 hover:bg-white/10 rounded text-secondary hover:text-white" vid="139">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="140">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" vid="141"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+        </div>
+
+        
+        <div class="p-4 border-t border-border bg-panel" vid="142">
+            <div class="relative" vid="143">
+                <textarea placeholder="What should AI remember about you?" class="w-full bg-hover border border-border rounded-lg p-3 text-sm text-white placeholder-tertiary focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent transition-all resize-none h-24 mb-2" vid="144"></textarea>
+                
+                <div class="flex items-center justify-between" vid="145">
+                    <div class="relative group" vid="146">
+                        <button class="flex items-center gap-1.5 text-xs text-secondary hover:text-white bg-hover hover:bg-selected px-2 py-1 rounded border border-border transition-colors" vid="147">
+                            <span class="w-2 h-2 rounded-full bg-accent" vid="148"></span>
+                            <span vid="149">Style</span>
+                            <svg class="w-3 h-3 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="150">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" vid="151"></path>
+                            </svg>
+                        </button>
+                    </div>
+
+                    <button class="flex items-center justify-center p-1.5 bg-accent text-white rounded hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/20" vid="152">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="153">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" vid="154"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </aside>
+
+
+</body></html>

--- a/design/Variant/designs/21-skills-picker.html
+++ b/design/Variant/designs/21-skills-picker.html
@@ -1,0 +1,328 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Skills Picker</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="8">
+    <script vid="9">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            green: '#22c55e',
+                        }
+                    },
+                    backgroundImage: {
+                        'grid-pattern': 'radial-gradient(circle, #222 1px, transparent 1px)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="10">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+        }
+        
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+
+        
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        
+        
+        .glass-panel {
+            background: rgba(15, 15, 15, 0.95);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+        }
+
+        
+        .bg-grid {
+            background-size: 24px 24px;
+            background-image: radial-gradient(rgba(255, 255, 255, 0.1) 1px, transparent 1px);
+        }
+    </style>
+</head>
+<body class="h-screen w-full flex items-center justify-center overflow-hidden relative" vid="11">
+
+    
+    <div class="absolute inset-0 bg-base bg-grid opacity-20 pointer-events-none" vid="12"></div>
+    
+    
+    <div class="relative w-[480px] flex flex-col glass-panel rounded-xl shadow-2xl overflow-hidden animate-fade-in max-h-[85vh]" vid="13">
+        
+        
+        <div class="flex items-center justify-between px-6 py-5 border-b border-white/5 bg-panel" vid="14">
+            <h2 class="text-lg font-medium text-primary tracking-tight" vid="15">Skills</h2>
+            <button class="text-secondary hover:text-primary transition-colors p-1 rounded hover:bg-white/5" vid="16">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="17"><line x1="18" y1="6" x2="6" y2="18" vid="18"></line><line x1="6" y1="6" x2="18" y2="18" vid="19"></line></svg>
+            </button>
+        </div>
+
+        
+        <div class="px-6 py-4 bg-panel" vid="20">
+            <div class="relative group" vid="21">
+                <div class="absolute inset-y-0 left-3 flex items-center pointer-events-none" vid="22">
+                    <svg class="w-4 h-4 text-secondary group-focus-within:text-accent-blue transition-colors" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="23">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" vid="24"></path>
+                    </svg>
+                </div>
+                <input type="text" class="w-full bg-[#080808] border border-border text-sm rounded text-primary placeholder-secondary/50 pl-10 pr-4 py-2.5 focus:outline-none focus:border-accent-blue focus:ring-1 focus:ring-accent-blue transition-all" placeholder="Search skills..." vid="25">
+            </div>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto custom-scrollbar" vid="26">
+            
+            
+            <div class="mb-2" vid="27">
+                <button class="w-full flex items-center justify-between px-6 py-2 text-xs font-medium text-secondary uppercase tracking-wider hover:bg-white/5 transition-colors group" vid="28">
+                    <span vid="29">Built-in</span>
+                    <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors transform rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="30">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" vid="31"></path>
+                    </svg>
+                </button>
+
+                
+                <div class="bg-selected/50 border-l-2 border-accent-blue" vid="32">
+                    
+                    <div class="flex items-start px-6 py-4 hover:bg-white/5 transition-colors cursor-pointer" vid="33">
+                        
+                        <div class="mt-1.5 mr-4" vid="34">
+                            <div class="w-2 h-2 rounded-full bg-accent-green shadow-[0_0_8px_rgba(34,197,94,0.4)]" vid="35"></div>
+                        </div>
+                        
+                        
+                        <div class="flex-1 mr-4" vid="36">
+                            <div class="flex items-center gap-2" vid="37">
+                                <h3 class="text-sm font-medium text-primary" vid="38">Creative Copywriter</h3>
+                            </div>
+                            <p class="text-xs text-secondary mt-1" vid="39">Enhances tone and creativity in prose.</p>
+                        </div>
+
+                        
+                        <div class="flex items-center gap-3" vid="40">
+                            
+                            <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="41">
+                                <input type="checkbox" name="toggle" id="toggle1" class="toggle-checkbox absolute block w-4 h-4 rounded-full bg-white border-4 appearance-none cursor-pointer right-0 border-accent-blue" vid="42">
+                                <label for="toggle1" class="toggle-label block overflow-hidden h-4 rounded-full bg-accent-blue cursor-pointer" vid="43"></label>
+                            </div>
+                            
+                            <svg class="w-4 h-4 text-primary transform rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="44">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" vid="45"></path>
+                            </svg>
+                        </div>
+                    </div>
+
+                    
+                    <div class="px-6 pb-5 pl-12" vid="46">
+                        <p class="text-sm text-secondary leading-relaxed mb-4" vid="47">
+                            A highly tuned model for creative writing tasks. It emphasizes varied sentence structure, evocative vocabulary, and narrative flow. Best used for storytelling and blog posts.
+                        </p>
+                        
+                        <div class="flex flex-wrap gap-2 mb-4" vid="48">
+                            <span class="px-2 py-1 rounded bg-white/5 border border-white/5 text-[10px] text-secondary font-mono" vid="49">Writing</span>
+                            <span class="px-2 py-1 rounded bg-white/5 border border-white/5 text-[10px] text-secondary font-mono" vid="50">Creative</span>
+                            <span class="px-2 py-1 rounded bg-white/5 border border-white/5 text-[10px] text-secondary font-mono" vid="51">v2.1.0</span>
+                        </div>
+
+                        <div class="flex items-center justify-between pt-3 border-t border-white/5" vid="52">
+                            <div class="text-xs text-tertiary" vid="53">
+                                By <span class="text-secondary hover:underline cursor-pointer" vid="54">Creo Team</span> • Updated 2d ago
+                            </div>
+                            <button class="text-xs text-accent-blue hover:text-blue-400 font-medium transition-colors" vid="55">
+                                View Details
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="border-b border-transparent" vid="56">
+                    <div class="flex items-center px-6 py-4 hover:bg-hover transition-colors cursor-pointer group" vid="57">
+                        
+                        <div class="mr-4" vid="58">
+                            <div class="w-2 h-2 rounded-full bg-tertiary" vid="59"></div>
+                        </div>
+                        
+                        
+                        <div class="flex-1 mr-4" vid="60">
+                            <h3 class="text-sm font-medium text-primary" vid="61">Logic Engine</h3>
+                            <p class="text-xs text-secondary mt-0.5 line-clamp-1" vid="62">Analyzes arguments and checks for fallacies.</p>
+                        </div>
+
+                        
+                        <div class="flex items-center gap-3" vid="63">
+                            
+                            <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="64">
+                                <input type="checkbox" name="toggle" id="toggle2" class="toggle-checkbox absolute block w-4 h-4 rounded-full bg-white border-4 appearance-none cursor-pointer left-0 border-gray-600" vid="65">
+                                <label for="toggle2" class="toggle-label block overflow-hidden h-4 rounded-full bg-gray-700 cursor-pointer" vid="66"></label>
+                            </div>
+                            
+                            <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="67">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" vid="68"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="mb-2" vid="69">
+                <button class="w-full flex items-center justify-between px-6 py-2 text-xs font-medium text-secondary uppercase tracking-wider hover:bg-white/5 transition-colors group" vid="70">
+                    <span vid="71">Global</span>
+                    <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors transform rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="72">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" vid="73"></path>
+                    </svg>
+                </button>
+
+                 
+                 <div class="border-b border-transparent" vid="74">
+                    <div class="flex items-center px-6 py-4 hover:bg-hover transition-colors cursor-pointer group" vid="75">
+                        
+                        <div class="mr-4" vid="76">
+                            <div class="w-2 h-2 rounded-full bg-accent-green shadow-[0_0_8px_rgba(34,197,94,0.4)]" vid="77"></div>
+                        </div>
+                        
+                        
+                        <div class="flex-1 mr-4" vid="78">
+                            <h3 class="text-sm font-medium text-primary" vid="79">Polyglot Mode</h3>
+                            <p class="text-xs text-secondary mt-0.5 line-clamp-1" vid="80">Real-time translation and localization context.</p>
+                        </div>
+
+                        
+                        <div class="flex items-center gap-3" vid="81">
+                            
+                            <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="82">
+                                <input type="checkbox" checked="" name="toggle" id="toggle3" class="toggle-checkbox absolute block w-4 h-4 rounded-full bg-white border-4 appearance-none cursor-pointer right-0 border-accent-blue" vid="83">
+                                <label for="toggle3" class="toggle-label block overflow-hidden h-4 rounded-full bg-accent-blue cursor-pointer" vid="84"></label>
+                            </div>
+                            
+                            <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="85">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" vid="86"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+                 
+                 <div class="border-b border-transparent" vid="87">
+                    <div class="flex items-center px-6 py-4 hover:bg-hover transition-colors cursor-pointer group" vid="88">
+                        
+                        <div class="mr-4" vid="89">
+                            <div class="w-2 h-2 rounded-full bg-tertiary" vid="90"></div>
+                        </div>
+                        
+                        
+                        <div class="flex-1 mr-4" vid="91">
+                            <h3 class="text-sm font-medium text-primary" vid="92">Sentiment Monitor</h3>
+                            <p class="text-xs text-secondary mt-0.5 line-clamp-1" vid="93">Highlights emotional tone shifts in text.</p>
+                        </div>
+
+                        
+                        <div class="flex items-center gap-3" vid="94">
+                            
+                            <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="95">
+                                <input type="checkbox" name="toggle" id="toggle4" class="toggle-checkbox absolute block w-4 h-4 rounded-full bg-white border-4 appearance-none cursor-pointer left-0 border-gray-600" vid="96">
+                                <label for="toggle4" class="toggle-label block overflow-hidden h-4 rounded-full bg-gray-700 cursor-pointer" vid="97"></label>
+                            </div>
+                            
+                            <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="98">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" vid="99"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div vid="100">
+                <button class="w-full flex items-center justify-between px-6 py-2 text-xs font-medium text-secondary uppercase tracking-wider hover:bg-white/5 transition-colors group" vid="101">
+                    <span vid="102">Project</span>
+                    <svg class="w-4 h-4 text-tertiary group-hover:text-secondary transition-colors transform rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="103">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" vid="104"></path>
+                    </svg>
+                </button>
+
+                <div class="px-6 py-12 flex flex-col items-center justify-center text-center border-t border-transparent" vid="105">
+                    <div class="w-12 h-12 rounded-xl bg-white/5 flex items-center justify-center mb-4 border border-white/5 text-secondary" vid="106">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="107">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.384-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" vid="108"></path>
+                        </svg>
+                    </div>
+                    <p class="text-sm text-secondary mb-4" vid="109">No project skills configured</p>
+                    <button class="px-4 py-2 text-xs font-medium text-primary bg-white/5 hover:bg-white/10 border border-white/10 rounded-md transition-all" vid="110">
+                        Browse Skills
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        
+        <div class="p-6 border-t border-white/5 bg-panel flex justify-end gap-3 z-10" vid="111">
+            <button class="px-4 py-2 text-sm font-medium text-secondary hover:text-primary transition-colors" vid="112">
+                Manage Skills
+            </button>
+            <button class="px-5 py-2 bg-accent-blue hover:bg-blue-600 text-white text-sm font-medium rounded shadow-lg shadow-blue-500/20 transition-all" vid="113">
+                Done
+            </button>
+        </div>
+
+    </div>
+
+    
+    <style vid="114">
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        .toggle-checkbox {
+            right: 1rem; 
+            border-color: #4b5563; 
+        }
+        .toggle-checkbox + .toggle-label {
+            background-color: #374151; 
+        }
+    </style>
+
+</body></html>

--- a/design/Variant/designs/22-context-viewer.html
+++ b/design/Variant/designs/22-context-viewer.html
@@ -1,0 +1,323 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">Context Viewer Panel</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;600&amp;display=swap" rel="stylesheet" vid="8">
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="9"></script>
+    <style vid="10">
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #080808;
+            color: #ffffff;
+        }
+        .font-mono {
+            font-family: 'JetBrains Mono', monospace;
+        }
+        
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.15);
+        }
+
+        
+        .token-keyword { color: #3b82f6; } 
+        .token-string { color: #22c55e; }  
+        .token-func { color: #fbbf24; }    
+        .token-comment { color: #6b7280; } 
+        .token-redacted { color: #f59e0b; } 
+        .token-operator { color: #94a3b8; }
+        .token-number { color: #60a5fa; }
+    </style>
+</head>
+<body class="w-full h-screen overflow-hidden flex relative" vid="11">
+
+    
+    <div class="flex-1 h-full flex flex-col opacity-30 select-none pointer-events-none transition-opacity duration-700" vid="12">
+        
+        <div class="h-12 border-b border-white/10 flex items-center px-4 gap-4" vid="13">
+            <div class="flex gap-2" vid="14">
+                <div class="w-3 h-3 rounded-full bg-red-500/50" vid="15"></div>
+                <div class="w-3 h-3 rounded-full bg-yellow-500/50" vid="16"></div>
+                <div class="w-3 h-3 rounded-full bg-green-500/50" vid="17"></div>
+            </div>
+            <div class="h-4 w-32 bg-white/10 rounded" vid="18"></div>
+        </div>
+        
+        <div class="flex-1 p-8 font-mono text-sm leading-7 text-gray-500" vid="19">
+            <div class="flex gap-4" vid="20">
+                <span class="text-gray-700 w-6 text-right" vid="21">1</span>
+                <span vid="22"><span class="text-blue-800" vid="23">import</span> React <span class="text-blue-800" vid="24">from</span> 'react';</span>
+            </div>
+            <div class="flex gap-4" vid="25">
+                <span class="text-gray-700 w-6 text-right" vid="26">2</span>
+                <span vid="27"><span class="text-blue-800" vid="28">import</span> { useState, useEffect } <span class="text-blue-800" vid="29">from</span> 'react';</span>
+            </div>
+            <div class="flex gap-4" vid="30">
+                <span class="text-gray-700 w-6 text-right" vid="31">3</span>
+                <span vid="32"></span>
+            </div>
+            <div class="flex gap-4" vid="33">
+                <span class="text-gray-700 w-6 text-right" vid="34">4</span>
+                <span vid="35"><span class="text-gray-600" vid="36">// AI Context Debugging Interface</span></span>
+            </div>
+            <div class="flex gap-4" vid="37">
+                <span class="text-gray-700 w-6 text-right" vid="38">5</span>
+                <span vid="39"><span class="text-blue-800" vid="40">export default function</span> <span class="text-yellow-700" vid="41">ContextViewer</span>() {</span>
+            </div>
+            <div class="flex gap-4" vid="42">
+                <span class="text-gray-700 w-6 text-right" vid="43">6</span>
+                <span vid="44">&nbsp;&nbsp;<span class="text-blue-800" vid="45">const</span> [activeLayer, setActiveLayer] = <span class="text-blue-800" vid="46">useState</span>('system');</span>
+            </div>
+            <div class="flex gap-4" vid="47">
+                <span class="text-gray-700 w-6 text-right" vid="48">7</span>
+                <span vid="49">&nbsp;&nbsp;<span class="text-blue-800" vid="50">return</span> (</span>
+            </div>
+            <div class="flex gap-4" vid="51">
+                <span class="text-gray-700 w-6 text-right" vid="52">8</span>
+                <span vid="53">&nbsp;&nbsp;&nbsp;&nbsp;&lt;<span class="text-blue-800" vid="54">div</span> className="panel-container"&gt;</span>
+            </div>
+             
+            <div class="opacity-50 mt-2 space-y-2" vid="55">
+                <div class="h-3 w-1/3 bg-white/5 rounded" vid="56"></div>
+                <div class="h-3 w-1/2 bg-white/5 rounded" vid="57"></div>
+                <div class="h-3 w-2/3 bg-white/5 rounded" vid="58"></div>
+                <div class="h-3 w-1/4 bg-white/5 rounded" vid="59"></div>
+            </div>
+        </div>
+    </div>
+
+    
+    <aside class="w-[400px] h-full bg-[#0f0f0f] border-l border-white/[0.06] flex flex-col shadow-2xl relative z-50" vid="60">
+        
+        
+        <header class="flex flex-col px-5 py-5 border-b border-white/[0.06] gap-3 shrink-0" vid="61">
+            <div class="flex items-start justify-between" vid="62">
+                <div vid="63">
+                    <h1 class="text-base font-semibold text-white tracking-tight" vid="64">Context Viewer</h1>
+                    <p class="text-xs text-gray-500 mt-0.5" vid="65">Debug view of AI context</p>
+                </div>
+                <button class="text-gray-500 hover:text-white transition-colors rounded p-1 hover:bg-white/[0.05]" vid="66">
+                    <i class="ph ph-x text-lg" vid="67"></i>
+                </button>
+            </div>
+            
+            <div class="flex items-center gap-2 mt-1" vid="68">
+                <span class="inline-flex items-center px-2 py-1 rounded bg-[#1a1a1a] border border-white/[0.06] text-[10px] font-medium text-gray-400" vid="69">
+                    <i class="ph-fill ph-circles-three-plus mr-1.5 text-blue-500" vid="70"></i>
+                    14,205 tokens total
+                </span>
+                <span class="inline-flex items-center px-2 py-1 rounded bg-[#1a1a1a] border border-white/[0.06] text-[10px] font-medium text-gray-400" vid="71">
+                    gpt-4-turbo
+                </span>
+            </div>
+        </header>
+
+        
+        <div class="flex-1 overflow-y-auto overflow-x-hidden" vid="72">
+            
+            
+            <div class="border-b border-white/[0.06]" vid="73">
+                <button class="w-full flex items-center justify-between px-5 py-4 hover:bg-white/[0.02] transition-colors group text-left border-l-[3px] border-[#3b82f6]" vid="74">
+                    <div class="flex flex-col gap-0.5" vid="75">
+                        <span class="text-sm font-medium text-gray-200 group-hover:text-white transition-colors" vid="76">System Rules</span>
+                        <span class="text-[10px] text-gray-500" vid="77">Base behavioral directives</span>
+                    </div>
+                    <div class="flex items-center gap-3" vid="78">
+                        <span class="text-[10px] font-mono text-gray-600 bg-black/40 px-1.5 py-0.5 rounded" vid="79">840 tk</span>
+                        <i class="ph ph-caret-down text-gray-500 group-hover:text-gray-300" vid="80"></i>
+                    </div>
+                </button>
+                
+                
+                <div class="px-5 pb-5" vid="81">
+                    <div class="bg-[#0a0a0a] border border-white/[0.06] rounded-lg p-3 overflow-hidden" vid="82">
+                        <div class="font-mono text-[11px] leading-relaxed text-gray-400" vid="83">
+                            <span class="token-comment" vid="84">// Core identity instructions</span><br vid="85">
+                            <span class="token-keyword" vid="86">const</span> SYSTEM_PROMPT = <span class="token-string" vid="87">`You are an advanced coding assistant specialized in modern web frameworks.`</span>;<br vid="88">
+                            <br vid="89">
+                            <span class="token-comment" vid="90">// Security Constraints</span><br vid="91">
+                            <span class="token-keyword" vid="92">const</span> SECURITY_RULES = [<br vid="93">
+                            &nbsp;&nbsp;<span class="token-string" vid="94">"Do not output personal data"</span>,<br vid="95">
+                            &nbsp;&nbsp;<span class="token-string" vid="96">"Redact all API keys"</span><br vid="97">
+                            ];<br vid="98">
+                            <br vid="99">
+                            <span class="token-keyword" vid="100">function</span> <span class="token-func" vid="101">enforceSafety</span>(ctx) {<br vid="102">
+                            &nbsp;&nbsp;<span class="token-keyword" vid="103">if</span> (ctx.hasKey) {<br vid="104">
+                            &nbsp;&nbsp;&nbsp;&nbsp;<span class="token-keyword" vid="105">return</span> <span class="token-redacted" vid="106">[REDACTED: api_key]</span>;<br vid="107">
+                            &nbsp;&nbsp;}<br vid="108">
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="border-b border-white/[0.06]" vid="109">
+                <button class="w-full flex items-center justify-between px-5 py-4 hover:bg-white/[0.02] transition-colors group text-left border-l-[3px] border-[#3b82f6]" vid="110">
+                    <div class="flex flex-col gap-0.5" vid="111">
+                        <span class="text-sm font-medium text-gray-200 group-hover:text-white transition-colors" vid="112">Project Settings</span>
+                        <span class="text-[10px] text-gray-500" vid="113">Environment &amp; Config</span>
+                    </div>
+                    <div class="flex items-center gap-3" vid="114">
+                        <span class="text-[10px] font-mono text-gray-600 bg-black/40 px-1.5 py-0.5 rounded" vid="115">1,205 tk</span>
+                        <i class="ph ph-caret-right text-gray-500 group-hover:text-gray-300" vid="116"></i>
+                    </div>
+                </button>
+            </div>
+
+            
+            <div class="border-b border-white/[0.06]" vid="117">
+                <button class="w-full flex items-center justify-between px-5 py-4 hover:bg-white/[0.02] transition-colors group text-left border-l-[3px] border-[#22c55e]" vid="118">
+                    <div class="flex flex-col gap-0.5" vid="119">
+                        <span class="text-sm font-medium text-gray-200 group-hover:text-white transition-colors" vid="120">Retrieved Context</span>
+                        <span class="text-[10px] text-gray-500" vid="121">RAG chunks from vector store</span>
+                    </div>
+                    <div class="flex items-center gap-3" vid="122">
+                        <span class="text-[10px] font-mono text-gray-600 bg-black/40 px-1.5 py-0.5 rounded" vid="123">4,850 tk</span>
+                        <i class="ph ph-caret-down text-gray-500 group-hover:text-gray-300" vid="124"></i>
+                    </div>
+                </button>
+
+                
+                <div class="px-5 pb-5 flex flex-col gap-3" vid="125">
+                    
+                    <div class="bg-[#0a0a0a] border border-white/[0.06] rounded-lg p-3" vid="126">
+                        <div class="flex items-center justify-between mb-2 pb-2 border-b border-white/[0.06]" vid="127">
+                            <div class="flex items-center gap-2" vid="128">
+                                <i class="ph-fill ph-file-ts text-blue-500 text-xs" vid="129"></i>
+                                <span class="text-[10px] font-medium text-gray-400" vid="130">src/utils/auth.ts</span>
+                            </div>
+                            <div class="flex items-center gap-1.5" vid="131">
+                                <span class="w-1.5 h-1.5 rounded-full bg-green-500" vid="132"></span>
+                                <span class="text-[10px] text-gray-600 font-mono" vid="133">Sim: 0.92</span>
+                            </div>
+                        </div>
+                        <div class="font-mono text-[11px] leading-relaxed text-gray-400" vid="134">
+                            <span class="token-keyword" vid="135">export</span> <span class="token-keyword" vid="136">const</span> <span class="token-func" vid="137">getAuthHeaders</span> = () =&gt; {<br vid="138">
+                            &nbsp;&nbsp;<span class="token-keyword" vid="139">const</span> key = process.env.API_KEY;<br vid="140">
+                            &nbsp;&nbsp;<span class="token-keyword" vid="141">return</span> {<br vid="142">
+                            &nbsp;&nbsp;&nbsp;&nbsp;<span class="token-string" vid="143">'Authorization'</span>: <span class="token-string" vid="144">`Bearer </span><span class="token-redacted" vid="145">[REDACTED: api_key]</span><span class="token-string" vid="146">`</span><br vid="147">
+                            &nbsp;&nbsp;};<br vid="148">
+                            };
+                        </div>
+                    </div>
+
+                    
+                    <div class="bg-[#0a0a0a] border border-white/[0.06] rounded-lg p-3" vid="149">
+                        <div class="flex items-center justify-between mb-2 pb-2 border-b border-white/[0.06]" vid="150">
+                            <div class="flex items-center gap-2" vid="151">
+                                <i class="ph-fill ph-file-text text-gray-500 text-xs" vid="152"></i>
+                                <span class="text-[10px] font-medium text-gray-400" vid="153">docs/README.md</span>
+                            </div>
+                            <div class="flex items-center gap-1.5" vid="154">
+                                <span class="w-1.5 h-1.5 rounded-full bg-yellow-600" vid="155"></span>
+                                <span class="text-[10px] text-gray-600 font-mono" vid="156">Sim: 0.78</span>
+                            </div>
+                        </div>
+                        <div class="font-mono text-[11px] leading-relaxed text-gray-400" vid="157">
+                            <span class="token-comment" vid="158"># Authentication Flow</span><br vid="159">
+                            The system uses JWT for stateless auth.<br vid="160">
+                            Ensure tokens are refreshed every <span class="token-number" vid="161">15</span> minutes.<br vid="162">
+                            See <span class="token-string" vid="163">`auth.ts`</span> for implementation details.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="border-b border-white/[0.06]" vid="164">
+                <button class="w-full flex items-center justify-between px-5 py-4 hover:bg-white/[0.02] transition-colors group text-left border-l-[3px] border-[#22c55e]" vid="165">
+                    <div class="flex flex-col gap-0.5" vid="166">
+                        <span class="text-sm font-medium text-gray-200 group-hover:text-white transition-colors" vid="167">Immediate Context</span>
+                        <span class="text-[10px] text-gray-500" vid="168">Active file &amp; Cursor position</span>
+                    </div>
+                    <div class="flex items-center gap-3" vid="169">
+                        <span class="text-[10px] font-mono text-gray-600 bg-black/40 px-1.5 py-0.5 rounded" vid="170">7,310 tk</span>
+                        <i class="ph ph-caret-right text-gray-500 group-hover:text-gray-300" vid="171"></i>
+                    </div>
+                </button>
+            </div>
+            
+        </div>
+
+        
+        <div class="bg-[#0f0f0f] border-t border-white/[0.06] p-5 shrink-0" vid="172">
+            
+            
+            <div class="mb-5" vid="173">
+                <div class="flex items-center justify-between mb-2.5" vid="174">
+                    <span class="text-[11px] font-medium text-gray-400" vid="175">Token Budget</span>
+                    <span class="text-[10px] font-mono text-gray-500" vid="176">14,205 / 32,000</span>
+                </div>
+                
+                <div class="h-1.5 w-full bg-[#1a1a1a] rounded-full overflow-hidden flex" vid="177">
+                    
+                    <div class="h-full bg-[#3b82f6] w-[5%] hover:opacity-80 transition-opacity" title="System Rules" vid="178"></div>
+                    
+                    <div class="h-full bg-[#60a5fa] w-[8%] hover:opacity-80 transition-opacity" title="Project Settings" vid="179"></div>
+                    
+                    <div class="h-full bg-[#22c55e] w-[20%] hover:opacity-80 transition-opacity" title="Retrieved Context" vid="180"></div>
+                    
+                    <div class="h-full bg-[#4ade80] w-[15%] hover:opacity-80 transition-opacity" title="Immediate Context" vid="181"></div>
+                    
+                    <div class="h-full bg-transparent flex-1" vid="182"></div>
+                </div>
+                
+                <div class="flex items-center gap-4 mt-2.5" vid="183">
+                    <div class="flex items-center gap-1.5" vid="184">
+                        <div class="w-1.5 h-1.5 rounded-full bg-[#3b82f6]" vid="185"></div>
+                        <span class="text-[10px] text-gray-500" vid="186">System</span>
+                    </div>
+                    <div class="flex items-center gap-1.5" vid="187">
+                        <div class="w-1.5 h-1.5 rounded-full bg-[#22c55e]" vid="188"></div>
+                        <span class="text-[10px] text-gray-500" vid="189">Context</span>
+                    </div>
+                    <div class="flex-1 text-right" vid="190">
+                        <span class="text-[10px] text-gray-600" vid="191">44% Used</span>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="flex items-center justify-between mb-4" vid="192">
+                <label class="flex items-center gap-2 cursor-pointer group select-none" vid="193">
+                    <div class="relative flex items-center justify-center w-4 h-4 rounded border border-gray-700 bg-[#1a1a1a] group-hover:border-gray-500 transition-colors" vid="194">
+                        <input type="checkbox" class="peer appearance-none w-full h-full absolute opacity-0 cursor-pointer" vid="195">
+                        <i class="ph-bold ph-check text-white text-[10px] opacity-0 peer-checked:opacity-100 transition-opacity" vid="196"></i>
+                    </div>
+                    <span class="text-xs text-gray-400 group-hover:text-gray-300 transition-colors" vid="197">Show raw prompt</span>
+                </label>
+            </div>
+
+            
+            <div class="grid grid-cols-2 gap-3" vid="198">
+                <button class="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-white/[0.06] bg-[#1a1a1a] hover:bg-white/[0.08] hover:border-white/10 transition-all group" vid="199">
+                    <i class="ph ph-clipboard-text text-gray-400 group-hover:text-white transition-colors" vid="200"></i>
+                    <span class="text-xs font-medium text-gray-300 group-hover:text-white transition-colors" vid="201">Copy</span>
+                </button>
+                <button class="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-white/[0.06] bg-[#1a1a1a] hover:bg-white/[0.08] hover:border-white/10 transition-all group" vid="202">
+                    <i class="ph ph-export text-gray-400 group-hover:text-white transition-colors" vid="203"></i>
+                    <span class="text-xs font-medium text-gray-300 group-hover:text-white transition-colors" vid="204">Export JSON</span>
+                </button>
+            </div>
+            
+        </div>
+
+    </aside>
+
+
+</body></html>

--- a/design/Variant/designs/23-version-history.html
+++ b/design/Variant/designs/23-version-history.html
@@ -1,0 +1,349 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">Version History Panel</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;display=swap" rel="stylesheet" vid="8">
+    <style vid="9">
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #080808;
+            color: #ffffff;
+            overflow: hidden;
+        }
+        
+        
+        .custom-scrollbar::-webkit-scrollbar {
+            width: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        .version-card {
+            transition: all 0.2s ease;
+        }
+        
+        
+        .version-actions {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+        }
+        .version-card:hover .version-actions {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        
+        .selected-version {
+            background-color: #151515;
+            border-left: 2px solid #3b82f6;
+        }
+    </style>
+</head>
+<body class="flex h-screen w-full" vid="10">
+
+    
+    <div class="flex-1 h-full flex flex-col relative bg-[#080808]" vid="11">
+        
+        <div class="h-14 border-b border-[rgba(255,255,255,0.06)] flex items-center px-6 justify-between" vid="12">
+            <div class="flex items-center gap-4" vid="13">
+                <div class="w-6 h-6 rounded bg-blue-500/20 text-blue-500 flex items-center justify-center" vid="14">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 256 256" vid="15"><path fill="currentColor" d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" vid="16"></path><path fill="currentColor" d="M176,88H80a8,8,0,0,0,0,16h96a8,8,0,0,0,0-16Z" opacity="0.5" vid="17"></path><path fill="currentColor" d="M176,120H80a8,8,0,0,0,0,16h96a8,8,0,0,0,0-16Z" opacity="0.5" vid="18"></path><path fill="currentColor" d="M136,152H80a8,8,0,0,0,0,16h56a8,8,0,0,0,0-16Z" opacity="0.5" vid="19"></path></svg>
+                </div>
+                <span class="text-sm font-medium text-gray-300" vid="20">Project Requirements.docx</span>
+            </div>
+            <div class="flex items-center gap-3" vid="21">
+                <div class="w-8 h-8 rounded-full bg-gray-800 border border-gray-700" vid="22"></div>
+                <div class="w-20 h-8 rounded bg-blue-600 text-white text-xs font-medium flex items-center justify-center" vid="23">Share</div>
+            </div>
+        </div>
+
+        
+        <div class="flex-1 p-12 overflow-hidden flex justify-center bg-[#080808]" vid="24">
+            <div class="w-full max-w-3xl h-full bg-[#121212] rounded-t-lg border-x border-t border-[rgba(255,255,255,0.06)] shadow-2xl p-16 relative" vid="25">
+                
+                <div class="w-1/3 h-8 bg-[rgba(255,255,255,0.08)] rounded mb-10" vid="26"></div>
+                <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="27"></div>
+                <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="28"></div>
+                <div class="w-5/6 h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="29"></div>
+                <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded mb-8" vid="30"></div>
+                
+                <div class="w-1/4 h-5 bg-[rgba(255,255,255,0.06)] rounded mb-6" vid="31"></div>
+                <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="32"></div>
+                <div class="w-11/12 h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="33"></div>
+                <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded mb-4" vid="34"></div>
+                
+                
+                <div class="absolute top-64 left-16 right-16 h-24 bg-blue-500/5 border-l-2 border-blue-500/30" vid="35"></div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="w-[320px] bg-[#0f0f0f] border-l border-[rgba(255,255,255,0.06)] flex flex-col h-full shadow-2xl z-10 shrink-0" vid="36">
+        
+        
+        <div class="px-5 py-5 border-b border-[rgba(255,255,255,0.06)] flex justify-between items-start bg-[#0f0f0f]" vid="37">
+            <div vid="38">
+                <h2 class="text-[15px] font-semibold text-white tracking-tight" vid="39">Version History</h2>
+                <p class="text-xs text-[#888888] mt-1 font-medium truncate max-w-[200px]" vid="40">Project Requirements.docx</p>
+            </div>
+            <button class="text-[#888888] hover:text-white transition-colors p-1 -mr-1 rounded-md hover:bg-white/5" vid="41">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="42"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="43"></path></svg>
+            </button>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto custom-scrollbar p-3 space-y-2" vid="44">
+
+            
+            <div class="version-card group relative p-3 rounded-lg bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a] transition-colors" vid="45">
+                <div class="flex justify-between items-start mb-2" vid="46">
+                    <div class="flex items-center gap-2" vid="47">
+                        <span class="text-[10px] font-bold uppercase tracking-wider text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded" vid="48">Current</span>
+                        <span class="text-xs text-[#666]" vid="49">Just now</span>
+                    </div>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="50">
+                    <div class="h-5 px-1.5 rounded bg-white/10 flex items-center gap-1.5 text-white border border-white/5" vid="51">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="52"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z" vid="53"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="54">You</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-400 leading-snug mb-2 font-light" vid="55">
+                    Fixed typo in the executive summary and updated...
+                </p>
+
+                <div class="flex items-center justify-between text-[11px]" vid="56">
+                    <span class="text-gray-500 font-medium" vid="57">0 words changed</span>
+                </div>
+            </div>
+
+            
+            <div class="px-2 py-1" vid="58">
+                <span class="text-[10px] font-medium text-[#444] uppercase tracking-wider" vid="59">Earlier Today</span>
+            </div>
+
+            
+            <div class="version-card selected-version relative p-3 rounded-r-lg rounded-l-none pl-[10px] border-t border-r border-b border-l-0 border-t-[rgba(255,255,255,0.06)] border-b-[rgba(255,255,255,0.06)] border-r-[rgba(255,255,255,0.06)]" vid="60">
+                <div class="flex justify-between items-start mb-2" vid="61">
+                    <span class="text-xs text-[#888] font-medium" vid="62">10:42 AM</span>
+                    <span class="text-[10px] text-green-500 font-mono bg-green-500/10 px-1 rounded" vid="63">+124 words</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2.5" vid="64">
+                    <div class="h-5 px-1.5 rounded bg-blue-500/10 border border-blue-500/20 flex items-center gap-1.5 text-blue-400" vid="65">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="66"><path d="M216,40V216a16,16,0,0,1-16,16H56a16,16,0,0,1-16-16V40A16,16,0,0,1,56,24H200A16,16,0,0,1,216,40Zm-16,0H56V216H200V40ZM96,128a16,16,0,1,1,16,16A16,16,0,0,1,96,128Zm64,0a16,16,0,1,1,16,16A16,16,0,0,1,160,128Z" vid="67"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="68">AI Assistant</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-300 leading-snug mb-3" vid="69">
+                    Generated new section on "Security Protocols" based on compliance requirements...
+                </p>
+
+                
+                <div class="grid grid-cols-3 gap-2 mt-2" vid="70">
+                    <button class="flex items-center justify-center gap-1.5 h-7 rounded bg-[#222] hover:bg-[#2a2a2a] text-[10px] font-medium text-gray-300 border border-white/5 transition-colors" vid="71">
+                        Restore
+                    </button>
+                    <button class="flex items-center justify-center gap-1.5 h-7 rounded bg-[#222] hover:bg-[#2a2a2a] text-[10px] font-medium text-gray-300 border border-white/5 transition-colors" vid="72">
+                        Compare
+                    </button>
+                    <button class="flex items-center justify-center gap-1.5 h-7 rounded bg-[#222] hover:bg-[#2a2a2a] text-[10px] font-medium text-gray-300 border border-white/5 transition-colors" vid="73">
+                        Preview
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="version-card group relative p-3 rounded-lg border border-transparent hover:border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a]" vid="74">
+                <div class="flex justify-between items-start mb-2" vid="75">
+                    <span class="text-xs text-[#666] group-hover:text-[#888]" vid="76">9:15 AM</span>
+                    <span class="text-[10px] text-red-400 font-mono bg-red-500/10 px-1 rounded" vid="77">-12 words</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="78">
+                    <div class="h-5 px-1.5 rounded bg-white/10 flex items-center gap-1.5 text-white border border-white/5" vid="79">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="80"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM74.08,197.5a64,64,0,0,1,107.84,0,87.83,87.83,0,0,1-127.84,0ZM96,120a32,32,0,1,1,32,32A32,32,0,0,1,96,120Zm97.76,66.41a79.66,79.66,0,0,0-36.06-28.75,48,48,0,1,0-59.4,0,79.66,79.66,0,0,0-36.06,28.75,88,88,0,1,1,131.52,0Z" vid="81"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="82">Sarah M.</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-500 group-hover:text-gray-400 leading-snug mb-1" vid="83">
+                    Removed redundant paragraph in introduction. Cleaned up formatting.
+                </p>
+
+                <div class="version-actions absolute inset-0 bg-[#1a1a1a]/95 backdrop-blur-sm rounded-lg flex items-center justify-center gap-2 z-10" vid="84">
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Restore" vid="85">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="86"><path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L45.87,91H80a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V48a8,8,0,0,1,16,0V77.25l32.56-30a96,96,0,0,1,159.44,80.75Z" vid="87"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Compare" vid="88">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="89"><path d="M224,128a96,96,0,1,1-96-96A96,96,0,0,1,224,128Zm-16,0a80,80,0,1,0-80,80A80,80,0,0,0,208,128Zm-72-40a8,8,0,0,0-16,0v32H88a8,8,0,0,0,0,16h32v32a8,8,0,0,0,16,0V136h32a8,8,0,0,0,0-16H136Z" opacity="0" vid="90"></path><path d="M136,120v-8a8,8,0,0,0-16,0v8H88a8,8,0,0,0,0,16h32v32a8,8,0,0,0,16,0V136h32a8,8,0,0,0,0-16Z" vid="91"></path><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="92"></path><path d="M192,120H152V80a8,8,0,0,0-16,0v40H96a8,8,0,0,0,0,16h40v40a8,8,0,0,0,16,0V136h40a8,8,0,0,0,0-16ZM208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="93"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Preview" vid="94">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="95"><path d="M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z" vid="96"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="version-card group relative p-3 rounded-lg border border-transparent hover:border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a]" vid="97">
+                <div class="flex justify-between items-start mb-2" vid="98">
+                    <span class="text-xs text-[#666] group-hover:text-[#888]" vid="99">8:00 AM</span>
+                    <span class="text-[10px] text-gray-500 font-mono bg-white/5 px-1 rounded" vid="100">No changes</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="101">
+                    <div class="h-5 px-1.5 rounded bg-white/5 border border-white/5 flex items-center gap-1.5 text-gray-400" vid="102">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="103"><path d="M222.14,61.76a8,8,0,0,0-5.9-7.86l-88-24a8,8,0,0,0-4.48,0l-88,24a8,8,0,0,0-5.9,7.86l24,168A8,8,0,0,0,61.7,236.9L128,218.82l66.3,18.08a8,8,0,0,0,7.84-7.14ZM128,202.18l-59,16.08L49.09,69.57,128,48.05l78.91,21.52L187,218.26Z" vid="104"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="105">Auto-Save</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-500 group-hover:text-gray-400 leading-snug mb-1" vid="106">
+                    System checkpoint created automatically.
+                </p>
+
+                <div class="version-actions absolute inset-0 bg-[#1a1a1a]/95 backdrop-blur-sm rounded-lg flex items-center justify-center gap-2 z-10" vid="107">
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Restore" vid="108">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="109"><path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L45.87,91H80a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V48a8,8,0,0,1,16,0V77.25l32.56-30a96,96,0,0,1,159.44,80.75Z" vid="110"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Compare" vid="111">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="112"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="113"></path><path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="114"></path><path d="M112,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,112,80Z" vid="115"></path><path d="M160,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,160,80Z" vid="116"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Preview" vid="117">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="118"><path d="M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z" vid="119"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="px-2 py-1 mt-2" vid="120">
+                <span class="text-[10px] font-medium text-[#444] uppercase tracking-wider" vid="121">Yesterday</span>
+            </div>
+
+            
+            <div class="version-card group relative p-3 rounded-lg border border-transparent hover:border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a]" vid="122">
+                <div class="flex justify-between items-start mb-2" vid="123">
+                    <span class="text-xs text-[#666] group-hover:text-[#888]" vid="124">4:20 PM</span>
+                    <span class="text-[10px] text-green-500 font-mono bg-green-500/10 px-1 rounded" vid="125">+54 words</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="126">
+                    <div class="h-5 px-1.5 rounded bg-white/10 flex items-center gap-1.5 text-white border border-white/5" vid="127">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="128"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM74.08,197.5a64,64,0,0,1,107.84,0,87.83,87.83,0,0,1-127.84,0ZM96,120a32,32,0,1,1,32,32A32,32,0,0,1,96,120Zm97.76,66.41a79.66,79.66,0,0,0-36.06-28.75,48,48,0,1,0-59.4,0,79.66,79.66,0,0,0-36.06,28.75,88,88,0,1,1,131.52,0Z" vid="129"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="130">You</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-500 group-hover:text-gray-400 leading-snug mb-1" vid="131">
+                    Added initial scope definitions and stakeholder requirements...
+                </p>
+
+                <div class="version-actions absolute inset-0 bg-[#1a1a1a]/95 backdrop-blur-sm rounded-lg flex items-center justify-center gap-2 z-10" vid="132">
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Restore" vid="133">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="134"><path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L45.87,91H80a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V48a8,8,0,0,1,16,0V77.25l32.56-30a96,96,0,0,1,159.44,80.75Z" vid="135"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Compare" vid="136">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="137"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="138"></path><path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="139"></path><path d="M112,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,112,80Z" vid="140"></path><path d="M160,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,160,80Z" vid="141"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Preview" vid="142">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="143"><path d="M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z" vid="144"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="version-card group relative p-3 rounded-lg border border-transparent hover:border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a]" vid="145">
+                <div class="flex justify-between items-start mb-2" vid="146">
+                    <span class="text-xs text-[#666] group-hover:text-[#888]" vid="147">2:45 PM</span>
+                    <span class="text-[10px] text-green-500 font-mono bg-green-500/10 px-1 rounded" vid="148">+312 words</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="149">
+                    <div class="h-5 px-1.5 rounded bg-blue-500/10 border border-blue-500/20 flex items-center gap-1.5 text-blue-400" vid="150">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="151"><path d="M216,40V216a16,16,0,0,1-16,16H56a16,16,0,0,1-16-16V40A16,16,0,0,1,56,24H200A16,16,0,0,1,216,40Zm-16,0H56V216H200V40ZM96,128a16,16,0,1,1,16,16A16,16,0,0,1,96,128Zm64,0a16,16,0,1,1,16,16A16,16,0,0,1,160,128Z" vid="152"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="153">AI Assistant</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-500 group-hover:text-gray-400 leading-snug mb-1" vid="154">
+                    First draft generation of the technical specifications outline.
+                </p>
+
+                <div class="version-actions absolute inset-0 bg-[#1a1a1a]/95 backdrop-blur-sm rounded-lg flex items-center justify-center gap-2 z-10" vid="155">
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Restore" vid="156">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="157"><path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L45.87,91H80a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V48a8,8,0,0,1,16,0V77.25l32.56-30a96,96,0,0,1,159.44,80.75Z" vid="158"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Compare" vid="159">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="160"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="161"></path><path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="162"></path><path d="M112,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,112,80Z" vid="163"></path><path d="M160,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,160,80Z" vid="164"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Preview" vid="165">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="166"><path d="M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z" vid="167"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="version-card group relative p-3 rounded-lg border border-transparent hover:border-[rgba(255,255,255,0.06)] hover:bg-[#1a1a1a]" vid="168">
+                <div class="flex justify-between items-start mb-2" vid="169">
+                    <span class="text-xs text-[#666] group-hover:text-[#888]" vid="170">11:00 AM</span>
+                    <span class="text-[10px] text-green-500 font-mono bg-green-500/10 px-1 rounded" vid="171">+15 words</span>
+                </div>
+                
+                <div class="flex items-center gap-2 mb-2" vid="172">
+                    <div class="h-5 px-1.5 rounded bg-white/10 flex items-center gap-1.5 text-white border border-white/5" vid="173">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="174"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM74.08,197.5a64,64,0,0,1,107.84,0,87.83,87.83,0,0,1-127.84,0ZM96,120a32,32,0,1,1,32,32A32,32,0,0,1,96,120Zm97.76,66.41a79.66,79.66,0,0,0-36.06-28.75,48,48,0,1,0-59.4,0,79.66,79.66,0,0,0-36.06,28.75,88,88,0,1,1,131.52,0Z" vid="175"></path></svg>
+                        <span class="text-[10px] font-medium leading-none mt-px" vid="176">You</span>
+                    </div>
+                </div>
+
+                <p class="text-[13px] text-gray-500 group-hover:text-gray-400 leading-snug mb-1" vid="177">
+                    Created blank document.
+                </p>
+
+                <div class="version-actions absolute inset-0 bg-[#1a1a1a]/95 backdrop-blur-sm rounded-lg flex items-center justify-center gap-2 z-10" vid="178">
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Restore" vid="179">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="180"><path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L45.87,91H80a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V48a8,8,0,0,1,16,0V77.25l32.56-30a96,96,0,0,1,159.44,80.75Z" vid="181"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Compare" vid="182">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="183"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="184"></path><path d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="185"></path><path d="M112,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,112,80Z" vid="186"></path><path d="M160,80a8,8,0,0,0-8,8v96a8,8,0,0,0,16,0V88A8,8,0,0,0,160,80Z" vid="187"></path></svg>
+                    </button>
+                    <button class="p-1.5 rounded-md hover:bg-white/10 text-gray-400 hover:text-white transition-colors" title="Preview" vid="188">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="189"><path d="M247.31,124.76c-.35-.79-8.82-19.58-27.65-38.41C194.57,61.26,162.88,48,128,48S61.43,61.26,36.34,86.35C17.51,105.18,9,124,8.69,124.76a8,8,0,0,0,0,6.5c.35.79,8.82,19.57,27.65,38.4C61.43,194.74,93.12,208,128,208s66.57-13.26,91.66-38.34c18.83-18.83,27.3-37.61,27.65-38.4A8,8,0,0,0,247.31,124.76ZM128,192c-30.78,0-57.67-11.19-79.93-33.25A133.47,133.47,0,0,1,25,128,133.33,133.33,0,0,1,48.07,97.25C70.33,75.19,97.22,64,128,64s57.67,11.19,79.93,33.25A133.46,133.46,0,0,1,231.05,128C223.84,141.46,192.43,192,128,192Zm0-112a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Z" vid="190"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="h-2" vid="191"></div>
+        </div>
+
+        
+        <div class="px-5 py-4 border-t border-[rgba(255,255,255,0.06)] bg-[#0f0f0f]" vid="192">
+            <div class="flex items-center gap-2 mb-1.5" vid="193">
+                <div class="w-1.5 h-1.5 rounded-full bg-green-500" vid="194"></div>
+                <span class="text-xs text-gray-400" vid="195">Auto-save on (last saved 2m ago)</span>
+            </div>
+            <a href="#" class="text-[11px] text-blue-500 hover:text-blue-400 transition-colors hover:underline" vid="196">
+                Configure auto-save settings
+            </a>
+        </div>
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/24-diff-view.html
+++ b/design/Variant/designs/24-diff-view.html
@@ -1,0 +1,620 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Split Diff View</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="8">
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="9"></script>
+    <script vid="10">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            green: '#22c55e',
+                            red: '#ef4444',
+                            yellow: '#f59e0b'
+                        }
+                    },
+                    boxShadow: {
+                        'glow': '0 0 20px rgba(59, 130, 246, 0.1)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="11">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+        }
+        
+        ::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #0f0f0f;
+            border-left: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 5px;
+            border: 2px solid #0f0f0f;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+
+        .diff-added {
+            background-color: rgba(34, 197, 94, 0.1);
+        }
+        .diff-removed {
+            background-color: rgba(239, 68, 68, 0.1);
+            text-decoration: line-through;
+            text-decoration-color: rgba(239, 68, 68, 0.4);
+        }
+        .diff-modified-marker {
+            border-left: 2px solid #f59e0b;
+        }
+        
+        .code-line {
+            counter-increment: line;
+        }
+    </style>
+</head>
+<body class="h-screen w-full flex items-center justify-center relative overflow-hidden bg-grid-pattern" vid="12">
+
+    
+    <div class="absolute inset-0 bg-[radial-gradient(#222_1px,transparent_1px)] [background-size:24px_24px] opacity-20 pointer-events-none" vid="13"></div>
+
+    
+    <div class="w-[1200px] h-[85vh] flex flex-col bg-panel border border-border rounded-xl shadow-2xl overflow-hidden z-10" vid="14">
+
+        
+        <header class="h-16 flex items-center justify-between px-6 border-b border-border bg-panel shrink-0" vid="15">
+            
+            <div class="flex items-center gap-4" vid="16">
+                
+                <div class="relative group" vid="17">
+                    <button class="flex items-center gap-2 px-3 py-1.5 bg-hover rounded border border-border text-sm text-secondary hover:text-primary transition-colors" vid="18">
+                        <i class="ph ph-clock-counter-clockwise" vid="19"></i>
+                        <span vid="20">Version from 2h ago</span>
+                        <i class="ph ph-caret-down text-tertiary" vid="21"></i>
+                    </button>
+                    <div class="absolute top-full left-0 mt-2 w-64 bg-panel border border-border rounded-lg shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 p-1" vid="22">
+                        <div class="px-3 py-2 text-xs text-tertiary uppercase tracking-wider font-medium" vid="23">History</div>
+                        <div class="flex items-center gap-2 px-3 py-2 bg-hover rounded cursor-pointer" vid="24">
+                            <div class="w-1.5 h-1.5 rounded-full bg-accent-blue" vid="25"></div>
+                            <div class="flex-1" vid="26">
+                                <div class="text-xs text-primary" vid="27">Version from 2h ago</div>
+                                <div class="text-[10px] text-tertiary" vid="28">Auto-saved</div>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2 px-3 py-2 hover:bg-white/5 rounded cursor-pointer group/item" vid="29">
+                            <div class="w-1.5 h-1.5 rounded-full bg-transparent group-hover/item:bg-tertiary" vid="30"></div>
+                            <div class="flex-1" vid="31">
+                                <div class="text-xs text-secondary group-hover/item:text-primary" vid="32">Yesterday, 4:20 PM</div>
+                                <div class="text-[10px] text-tertiary" vid="33">Manual save</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <i class="ph ph-arrow-right text-tertiary" vid="34"></i>
+
+                
+                <div class="relative" vid="35">
+                    <button class="flex items-center gap-2 px-3 py-1.5 bg-hover rounded border border-border text-sm text-primary hover:border-white/10 transition-colors" vid="36">
+                        <div class="w-2 h-2 rounded-full bg-accent-green shadow-[0_0_8px_rgba(34,197,94,0.4)]" vid="37"></div>
+                        <span vid="38">Current Version</span>
+                        <i class="ph ph-caret-down text-tertiary" vid="39"></i>
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="flex items-center gap-6" vid="40">
+                
+                <div class="flex items-center gap-3 bg-base p-1 rounded-lg border border-border" vid="41">
+                    <button class="px-3 py-1 bg-panel shadow-sm text-xs font-medium text-primary rounded border border-border transition-all" vid="42">Split</button>
+                    <button class="px-3 py-1 text-xs font-medium text-secondary hover:text-primary transition-colors" vid="43">Unified</button>
+                </div>
+
+                
+                <div class="h-4 w-px bg-border" vid="44"></div>
+
+                
+                <div class="flex items-center gap-2" vid="45">
+                    <button class="w-8 h-8 flex items-center justify-center rounded hover:bg-hover text-secondary hover:text-primary transition-colors tooltip" title="Previous Change" vid="46">
+                        <i class="ph ph-caret-up" vid="47"></i>
+                    </button>
+                    <span class="text-xs font-mono text-secondary px-2" vid="48">Change <span class="text-primary" vid="49">3</span> of <span class="text-primary" vid="50">12</span></span>
+                    <button class="w-8 h-8 flex items-center justify-center rounded hover:bg-hover text-secondary hover:text-primary transition-colors tooltip" title="Next Change" vid="51">
+                        <i class="ph ph-caret-down" vid="52"></i>
+                    </button>
+                </div>
+
+                
+                <div class="h-4 w-px bg-border" vid="53"></div>
+
+                
+                <button class="text-secondary hover:text-primary transition-colors p-2 rounded hover:bg-white/5" vid="54">
+                    <i class="ph ph-x text-lg" vid="55"></i>
+                </button>
+            </div>
+        </header>
+
+        
+        <div class="flex-1 flex overflow-hidden font-mono text-sm leading-6" vid="56">
+            
+            
+            <div class="w-1/2 flex flex-col border-r border-border" vid="57">
+                <div class="h-8 flex items-center px-4 bg-hover/50 border-b border-border text-xs text-secondary font-medium tracking-wide uppercase" vid="58">
+                    Before
+                </div>
+                <div class="flex-1 overflow-y-auto custom-scrollbar flex bg-[#0c0c0c]" vid="59">
+                    
+                    <div class="w-12 shrink-0 bg-base border-r border-border flex flex-col text-right py-4 select-none text-tertiary text-xs" vid="60">
+                        <div class="px-3" vid="61">42</div>
+                        <div class="px-3" vid="62">43</div>
+                        <div class="px-3" vid="63">44</div>
+                        <div class="px-3" vid="64">45</div>
+                        <div class="px-3" vid="65">46</div>
+                        <div class="px-3" vid="66">47</div>
+                        <div class="px-3" vid="67">48</div>
+                        <div class="px-3" vid="68">49</div>
+                        <div class="px-3" vid="69">50</div>
+                        <div class="px-3" vid="70">51</div>
+                        <div class="px-3" vid="71">52</div>
+                        <div class="px-3" vid="72">53</div>
+                        <div class="px-3" vid="73">54</div>
+                        <div class="px-3" vid="74">55</div>
+                        <div class="px-3" vid="75">56</div>
+                    </div>
+                    
+                    <div class="flex-1 py-4" vid="76">
+                        <div class="px-4 text-secondary" vid="77"></div>
+                        <div class="px-4 text-secondary" vid="78"><span class="text-primary" vid="79"># The Architecture of Silence</span></div>
+                        <div class="px-4 text-secondary" vid="80"></div>
+                        <div class="px-4 text-secondary diff-removed" vid="81">Intrigued by beauty, fascinated by technology and</div>
+                        <div class="px-4 text-secondary diff-removed" vid="82">fuelled with an everlasting devotion to digital</div>
+                        <div class="px-4 text-secondary diff-removed" vid="83">craftsmanship.</div>
+                        <div class="px-4 text-secondary" vid="84"></div>
+                        <div class="px-4 text-secondary diff-modified-marker" vid="85">Design is not just about making things look good. It is</div>
+                        <div class="px-4 text-secondary" vid="86">about how things work. In the digital realm, this</div>
+                        <div class="px-4 text-secondary" vid="87">translates to the seamless integration of form and</div>
+                        <div class="px-4 text-secondary" vid="88">function.</div>
+                        <div class="px-4 text-secondary" vid="89"></div>
+                        <div class="px-4 text-secondary" vid="90">We build immersive environments where typography</div>
+                        <div class="px-4 text-secondary" vid="91">leads the eye and imagery sets the mood.</div>
+                        <div class="px-4 text-secondary" vid="92"></div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="w-1/2 flex flex-col bg-base" vid="93">
+                <div class="h-8 flex items-center px-4 bg-hover/50 border-b border-border text-xs text-secondary font-medium tracking-wide uppercase" vid="94">
+                    After
+                </div>
+                <div class="flex-1 overflow-y-auto custom-scrollbar flex" vid="95">
+                    
+                    <div class="w-12 shrink-0 bg-base border-r border-border flex flex-col text-right py-4 select-none text-tertiary text-xs" vid="96">
+                        <div class="px-3" vid="97">42</div>
+                        <div class="px-3" vid="98">43</div>
+                        <div class="px-3" vid="99">44</div>
+                        <div class="px-3" vid="100">45</div>
+                        <div class="px-3" vid="101">46</div>
+                        <div class="px-3" vid="102">47</div>
+                        <div class="px-3" vid="103">48</div>
+                        <div class="px-3" vid="104">49</div>
+                        <div class="px-3" vid="105">50</div>
+                        <div class="px-3" vid="106">51</div>
+                        <div class="px-3" vid="107">52</div>
+                        <div class="px-3" vid="108">53</div>
+                        <div class="px-3" vid="109">54</div>
+                        <div class="px-3" vid="110">55</div>
+                        <div class="px-3" vid="111">56</div>
+                        <div class="px-3" vid="112">57</div>
+                    </div>
+                    
+                    <div class="flex-1 py-4" vid="113">
+                        <div class="px-4 text-secondary" vid="114"></div>
+                        <div class="px-4 text-secondary" vid="115"><span class="text-primary" vid="116"># The Architecture of Silence</span></div>
+                        <div class="px-4 text-secondary" vid="117"></div>
+                        <div class="px-4 text-secondary diff-added" vid="118">Driven by aesthetics, fascinated by AI and fueled</div>
+                        <div class="px-4 text-secondary diff-added" vid="119">with an eternal devotion to digital art.</div>
+                        <div class="px-4 text-secondary" vid="120"></div>
+                        <div class="px-4 text-secondary" vid="121"></div>
+                        <div class="px-4 text-secondary diff-modified-marker" vid="122">Design isn't merely about aesthetics. It is fundamentally</div>
+                        <div class="px-4 text-secondary" vid="123">about how things work. In the digital sphere, this</div>
+                        <div class="px-4 text-secondary" vid="124">translates to the seamless integration of form,</div>
+                        <div class="px-4 text-secondary diff-added" vid="125">function, and emotion.</div>
+                        <div class="px-4 text-secondary" vid="126"></div>
+                        <div class="px-4 text-secondary" vid="127">We build immersive environments where typography</div>
+                        <div class="px-4 text-secondary" vid="128">leads the eye and imagery sets the mood.</div>
+                        <div class="px-4 text-secondary" vid="129"></div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        
+        <footer class="h-16 flex items-center justify-between px-6 border-t border-border bg-panel shrink-0" vid="130">
+            <div class="flex items-center gap-4 text-xs" vid="131">
+                <div class="flex items-center gap-1.5" vid="132">
+                    <span class="text-accent-green" vid="133">+42 words</span>
+                </div>
+                <div class="w-1 h-1 rounded-full bg-tertiary" vid="134"></div>
+                <div class="flex items-center gap-1.5" vid="135">
+                    <span class="text-accent-red" vid="136">-18 words</span>
+                </div>
+                <div class="w-1 h-1 rounded-full bg-tertiary" vid="137"></div>
+                <div class="text-secondary" vid="138">3 paragraphs modified</div>
+            </div>
+
+            <div class="flex items-center gap-3" vid="139">
+                <button class="px-4 py-2 rounded text-xs font-medium text-secondary hover:text-primary hover:bg-white/5 transition-colors" vid="140">
+                    Close
+                </button>
+                <button class="px-4 py-2 rounded text-xs font-medium bg-accent-blue text-white hover:bg-blue-600 shadow-glow transition-all flex items-center gap-2" vid="141">
+                    <i class="ph-bold ph-arrow-u-up-left" vid="142"></i>
+                    Restore Before Version
+                </button>
+            </div>
+        </footer>
+
+    </div>
+
+&lt;|CONTENT:IMAGE|&gt;**Design 2: Unified Diff View Component**
+
+This variation displays the same content in a unified view, often preferred for quick scanning of changes without looking back and forth. It uses a single column layout where deletions and additions are stacked. The gutter area is used to indicate line numbers for both the old (left column in gutter) and new (right column in gutter) versions, along with +/- indicators for changes.
+
+&lt;|CONTENT:CODE|&gt;&lt;|VERSIONID:4e580e0c-96b9-4f9c-bd61-125021ed25eb|&gt;&lt;|GENERATIONID:e0d86922-2621-4d1c-8c7a-9076067b55f1|&gt;&lt;|FORMAT:desktop|&gt;&lt;|DESIGNIMAGE:true|&gt;&lt;|SELECTEDTAGVID:null|&gt;
+    <meta charset="UTF-8" vid="143">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="144">
+    <title vid="145">CreoNow - Unified Diff View</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="146"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="147">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="148">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="149">
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="150"></script>
+    <script vid="151">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            green: '#22c55e',
+                            red: '#ef4444',
+                            yellow: '#f59e0b'
+                        }
+                    },
+                    boxShadow: {
+                        'glow': '0 0 20px rgba(59, 130, 246, 0.1)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="152">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+        }
+        
+        ::-webkit-scrollbar {
+            width: 10px;
+            height: 10px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #0f0f0f;
+            border-left: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 5px;
+            border: 2px solid #0f0f0f;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+
+        .diff-added {
+            background-color: rgba(34, 197, 94, 0.1);
+        }
+        .diff-removed {
+            background-color: rgba(239, 68, 68, 0.1);
+        }
+        
+        
+        .gutter {
+            display: flex;
+            user-select: none;
+            width: 80px;
+            color: #444;
+            font-size: 11px;
+            border-right: 1px solid rgba(255, 255, 255, 0.06);
+            background-color: #0c0c0c;
+        }
+        .gutter-num {
+            width: 50%;
+            text-align: right;
+            padding: 0 8px;
+        }
+        .gutter-icon {
+            position: absolute;
+            left: 8px;
+            width: 16px;
+            display: flex;
+            justify-content: center;
+        }
+    </style>
+
+
+
+    
+    <div class="absolute inset-0 bg-[radial-gradient(#222_1px,transparent_1px)] [background-size:24px_24px] opacity-20 pointer-events-none" vid="153"></div>
+
+    
+    <div class="w-[1200px] h-[85vh] flex flex-col bg-panel border border-border rounded-xl shadow-2xl overflow-hidden z-10" vid="154">
+
+        
+        <header class="h-16 flex items-center justify-between px-6 border-b border-border bg-panel shrink-0" vid="155">
+            
+            <div class="flex items-center gap-4" vid="156">
+                <button class="flex items-center gap-2 px-3 py-1.5 bg-hover rounded border border-border text-sm text-secondary hover:text-primary transition-colors" vid="157">
+                    <i class="ph ph-clock-counter-clockwise" vid="158"></i>
+                    <span vid="159">Comparing: 2h ago vs Current</span>
+                    <i class="ph ph-caret-down text-tertiary" vid="160"></i>
+                </button>
+            </div>
+
+            
+            <div class="flex items-center gap-6" vid="161">
+                
+                <div class="flex items-center gap-3 bg-base p-1 rounded-lg border border-border" vid="162">
+                    <button class="px-3 py-1 text-xs font-medium text-secondary hover:text-primary transition-colors" vid="163">Split</button>
+                    <button class="px-3 py-1 bg-panel shadow-sm text-xs font-medium text-primary rounded border border-border transition-all" vid="164">Unified</button>
+                </div>
+
+                
+                <div class="h-4 w-px bg-border" vid="165"></div>
+
+                
+                <div class="flex items-center gap-2" vid="166">
+                    <button class="w-8 h-8 flex items-center justify-center rounded hover:bg-hover text-secondary hover:text-primary transition-colors tooltip" title="Previous Change" vid="167">
+                        <i class="ph ph-caret-up" vid="168"></i>
+                    </button>
+                    <span class="text-xs font-mono text-secondary px-2" vid="169">Change <span class="text-primary" vid="170">3</span> of <span class="text-primary" vid="171">12</span></span>
+                    <button class="w-8 h-8 flex items-center justify-center rounded hover:bg-hover text-secondary hover:text-primary transition-colors tooltip" title="Next Change" vid="172">
+                        <i class="ph ph-caret-down" vid="173"></i>
+                    </button>
+                </div>
+
+                
+                <div class="h-4 w-px bg-border" vid="174"></div>
+
+                
+                <button class="text-secondary hover:text-primary transition-colors p-2 rounded hover:bg-white/5" vid="175">
+                    <i class="ph ph-x text-lg" vid="176"></i>
+                </button>
+            </div>
+        </header>
+
+        
+        <div class="flex-1 overflow-y-auto custom-scrollbar font-mono text-sm leading-6" vid="177">
+            
+            
+            <div class="flex hover:bg-white/[0.01]" vid="178">
+                <div class="gutter shrink-0 py-1" vid="179">
+                    <div class="gutter-num" vid="180">42</div>
+                    <div class="gutter-num" vid="181">42</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="182"></div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="183">
+                <div class="gutter shrink-0 py-1" vid="184">
+                    <div class="gutter-num" vid="185">43</div>
+                    <div class="gutter-num" vid="186">43</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="187"><span class="text-primary" vid="188"># The Architecture of Silence</span></div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="189">
+                <div class="gutter shrink-0 py-1" vid="190">
+                    <div class="gutter-num" vid="191">44</div>
+                    <div class="gutter-num" vid="192">44</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="193"></div>
+            </div>
+
+            
+            <div class="flex diff-removed group" vid="194">
+                <div class="gutter shrink-0 py-1 bg-red-500/5 group-hover:bg-red-500/10 transition-colors" vid="195">
+                    <div class="gutter-num text-red-500/50" vid="196">45</div>
+                    <div class="gutter-num" vid="197"></div>
+                    <div class="absolute left-2 text-red-500/50" vid="198">-</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-red-200/70 line-through decoration-red-500/40" vid="199">Intrigued by beauty, fascinated by technology and</div>
+            </div>
+            <div class="flex diff-removed group" vid="200">
+                <div class="gutter shrink-0 py-1 bg-red-500/5 group-hover:bg-red-500/10 transition-colors" vid="201">
+                    <div class="gutter-num text-red-500/50" vid="202">46</div>
+                    <div class="gutter-num" vid="203"></div>
+                    <div class="absolute left-2 text-red-500/50" vid="204">-</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-red-200/70 line-through decoration-red-500/40" vid="205">fuelled with an everlasting devotion to digital</div>
+            </div>
+            <div class="flex diff-removed group" vid="206">
+                <div class="gutter shrink-0 py-1 bg-red-500/5 group-hover:bg-red-500/10 transition-colors" vid="207">
+                    <div class="gutter-num text-red-500/50" vid="208">47</div>
+                    <div class="gutter-num" vid="209"></div>
+                    <div class="absolute left-2 text-red-500/50" vid="210">-</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-red-200/70 line-through decoration-red-500/40" vid="211">craftsmanship.</div>
+            </div>
+
+            
+            <div class="flex diff-added group" vid="212">
+                <div class="gutter shrink-0 py-1 bg-green-500/5 group-hover:bg-green-500/10 transition-colors" vid="213">
+                    <div class="gutter-num" vid="214"></div>
+                    <div class="gutter-num text-green-500/50" vid="215">45</div>
+                    <div class="absolute left-2 text-green-500/50" vid="216">+</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-green-100" vid="217">Driven by aesthetics, fascinated by AI and fueled</div>
+            </div>
+            <div class="flex diff-added group" vid="218">
+                <div class="gutter shrink-0 py-1 bg-green-500/5 group-hover:bg-green-500/10 transition-colors" vid="219">
+                    <div class="gutter-num" vid="220"></div>
+                    <div class="gutter-num text-green-500/50" vid="221">46</div>
+                    <div class="absolute left-2 text-green-500/50" vid="222">+</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-green-100" vid="223">with an eternal devotion to digital art.</div>
+            </div>
+
+            
+            <div class="flex hover:bg-white/[0.01]" vid="224">
+                <div class="gutter shrink-0 py-1" vid="225">
+                    <div class="gutter-num" vid="226">48</div>
+                    <div class="gutter-num" vid="227">47</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="228"></div>
+            </div>
+
+            
+            <div class="flex diff-removed group" vid="229">
+                <div class="gutter shrink-0 py-1 bg-red-500/5 group-hover:bg-red-500/10 transition-colors" vid="230">
+                    <div class="gutter-num text-red-500/50" vid="231">49</div>
+                    <div class="gutter-num" vid="232"></div>
+                    <div class="absolute left-2 text-red-500/50" vid="233">-</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-red-200/70 line-through decoration-red-500/40" vid="234">Design is not just about making things look good. It is</div>
+            </div>
+
+             
+             <div class="flex diff-added group" vid="235">
+                <div class="gutter shrink-0 py-1 bg-green-500/5 group-hover:bg-green-500/10 transition-colors" vid="236">
+                    <div class="gutter-num" vid="237"></div>
+                    <div class="gutter-num text-green-500/50" vid="238">48</div>
+                    <div class="absolute left-2 text-green-500/50" vid="239">+</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-green-100" vid="240">Design isn't merely about aesthetics. It is fundamentally</div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="241">
+                <div class="gutter shrink-0 py-1" vid="242">
+                    <div class="gutter-num" vid="243">50</div>
+                    <div class="gutter-num" vid="244">49</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="245">about how things work. In the digital sphere, this</div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="246">
+                <div class="gutter shrink-0 py-1" vid="247">
+                    <div class="gutter-num" vid="248">51</div>
+                    <div class="gutter-num" vid="249">50</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="250">translates to the seamless integration of form and</div>
+            </div>
+            
+             <div class="flex diff-added group" vid="251">
+                <div class="gutter shrink-0 py-1 bg-green-500/5 group-hover:bg-green-500/10 transition-colors" vid="252">
+                    <div class="gutter-num" vid="253"></div>
+                    <div class="gutter-num text-green-500/50" vid="254">51</div>
+                    <div class="absolute left-2 text-green-500/50" vid="255">+</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-green-100" vid="256">function, and emotion.</div>
+            </div>
+
+            <div class="flex diff-removed group" vid="257">
+                <div class="gutter shrink-0 py-1 bg-red-500/5 group-hover:bg-red-500/10 transition-colors" vid="258">
+                    <div class="gutter-num text-red-500/50" vid="259">52</div>
+                    <div class="gutter-num" vid="260"></div>
+                    <div class="absolute left-2 text-red-500/50" vid="261">-</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-red-200/70 line-through decoration-red-500/40" vid="262">function.</div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="263">
+                <div class="gutter shrink-0 py-1" vid="264">
+                    <div class="gutter-num" vid="265">53</div>
+                    <div class="gutter-num" vid="266">52</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="267"></div>
+            </div>
+
+            <div class="flex hover:bg-white/[0.01]" vid="268">
+                <div class="gutter shrink-0 py-1" vid="269">
+                    <div class="gutter-num" vid="270">54</div>
+                    <div class="gutter-num" vid="271">53</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="272">We build immersive environments where typography</div>
+            </div>
+            
+            <div class="flex hover:bg-white/[0.01]" vid="273">
+                <div class="gutter shrink-0 py-1" vid="274">
+                    <div class="gutter-num" vid="275">55</div>
+                    <div class="gutter-num" vid="276">54</div>
+                </div>
+                <div class="flex-1 px-4 py-1 text-secondary" vid="277">leads the eye and imagery sets the mood.</div>
+            </div>
+        </div>
+
+        
+        <footer class="h-16 flex items-center justify-between px-6 border-t border-border bg-panel shrink-0" vid="278">
+            <div class="flex items-center gap-4 text-xs" vid="279">
+                <div class="flex items-center gap-1.5" vid="280">
+                    <span class="text-accent-green" vid="281">+42 words</span>
+                </div>
+                <div class="w-1 h-1 rounded-full bg-tertiary" vid="282"></div>
+                <div class="flex items-center gap-1.5" vid="283">
+                    <span class="text-accent-red" vid="284">-18 words</span>
+                </div>
+                <div class="w-1 h-1 rounded-full bg-tertiary" vid="285"></div>
+                <div class="text-secondary" vid="286">3 paragraphs modified</div>
+            </div>
+
+            <div class="flex items-center gap-3" vid="287">
+                <button class="px-4 py-2 rounded text-xs font-medium text-secondary hover:text-primary hover:bg-white/5 transition-colors" vid="288">
+                    Close
+                </button>
+                <button class="px-4 py-2 rounded text-xs font-medium bg-accent-blue text-white hover:bg-blue-600 shadow-glow transition-all flex items-center gap-2" vid="289">
+                    <i class="ph-bold ph-arrow-u-up-left" vid="290"></i>
+                    Restore Before Version
+                </button>
+            </div>
+        </footer>
+
+    </div>
+
+</body></html>

--- a/design/Variant/designs/25-search-panel.html
+++ b/design/Variant/designs/25-search-panel.html
@@ -1,0 +1,397 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Search Panel</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="6"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="7">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="8">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="9">
+    <script vid="10">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        divider: 'rgba(255, 255, 255, 0.04)',
+                        surface: '#121212',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            hover: '#2563eb',
+                            surface: 'rgba(59, 130, 246, 0.1)'
+                        }
+                    },
+                    boxShadow: {
+                        'glow': '0 0 20px rgba(0,0,0,0.5)',
+                        'modal': '0 24px 48px -12px rgba(0, 0, 0, 0.7)',
+                    },
+                    animation: {
+                        'fade-in': 'fadeIn 0.2s ease-out',
+                        'slide-down': 'slideDown 0.3s ease-out',
+                    },
+                    keyframes: {
+                        fadeIn: {
+                            '0%': { opacity: '0' },
+                            '100%': { opacity: '1' },
+                        },
+                        slideDown: {
+                            '0%': { transform: 'translateY(-10px)', opacity: '0' },
+                            '100%': { transform: 'translateY(0)', opacity: '1' },
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="11">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        .glass-panel {
+            background: #0f0f0f;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+        }
+
+        .search-highlight {
+            background-color: rgba(59, 130, 246, 0.2);
+            color: #60a5fa;
+            border-radius: 2px;
+            padding: 0 2px;
+        }
+
+        
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        .toggle-checkbox {
+            right: 14px; 
+            border-color: #4b5563; 
+            transition: all 0.2s ease;
+        }
+        .toggle-checkbox + .toggle-label {
+            background-color: #27272a; 
+            transition: all 0.2s ease;
+        }
+        
+        .result-item.active {
+            background-color: rgba(255, 255, 255, 0.03);
+            border-left-color: #3b82f6;
+        }
+    </style>
+</head>
+<body class="h-screen w-screen overflow-hidden flex relative font-sans" vid="12">
+
+    
+    <div class="absolute inset-0 z-0 flex pointer-events-none opacity-40 select-none" style="filter: blur(4px);" vid="13">
+        
+        <div class="w-64 h-full border-r border-border flex flex-col pt-12" vid="14">
+            <div class="px-6 py-4 border-b border-border" vid="15">
+                <div class="w-24 h-4 bg-white/10 rounded" vid="16"></div>
+            </div>
+            <div class="p-6 space-y-4" vid="17">
+                <div class="w-full h-8 bg-white/5 rounded" vid="18"></div>
+                <div class="w-3/4 h-8 bg-white/5 rounded" vid="19"></div>
+                <div class="w-5/6 h-8 bg-white/5 rounded" vid="20"></div>
+            </div>
+        </div>
+        
+        <div class="flex-1 bg-base p-12" vid="21">
+            <div class="max-w-3xl mx-auto space-y-8" vid="22">
+                <div class="h-12 w-1/2 bg-white/10 rounded" vid="23"></div>
+                <div class="space-y-4" vid="24">
+                    <div class="h-4 w-full bg-white/5 rounded" vid="25"></div>
+                    <div class="h-4 w-full bg-white/5 rounded" vid="26"></div>
+                    <div class="h-4 w-2/3 bg-white/5 rounded" vid="27"></div>
+                </div>
+                <div class="grid grid-cols-2 gap-8 mt-12" vid="28">
+                    <div class="h-48 bg-white/5 rounded-xl border border-border" vid="29"></div>
+                    <div class="h-48 bg-white/5 rounded-xl border border-border" vid="30"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm z-40 flex items-start justify-center pt-[10vh]" vid="31">
+        
+        
+        <div class="w-[640px] flex flex-col glass-panel rounded-xl overflow-hidden shadow-modal animate-slide-down max-h-[80vh] relative z-50" vid="32">
+            
+            
+            <div class="flex flex-col border-b border-border bg-panel" vid="33">
+                
+                <div class="flex items-center px-4 py-4 gap-3" vid="34">
+                    <i class="ph ph-magnifying-glass text-xl text-secondary" vid="35"></i>
+                    <input type="text" value="design theory" class="flex-1 bg-transparent border-none outline-none text-lg text-primary placeholder-tertiary font-light h-8" placeholder="Search documents, memories, knowledge..." autofocus="" vid="36">
+                    <button class="p-1 rounded-md text-tertiary hover:text-primary hover:bg-white/5 transition-colors" vid="37">
+                        <i class="ph ph-x text-lg" vid="38"></i>
+                    </button>
+                </div>
+
+                
+                <div class="flex items-center gap-2 px-4 pb-4 overflow-x-auto no-scrollbar" vid="39">
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-accent-blue text-white shadow-lg shadow-blue-500/20 transition-all" vid="40">All</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="41">Documents</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="42">Memories</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="43">Knowledge</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="44">Assets</button>
+                </div>
+
+                
+                <div class="px-4 py-3 bg-surface border-t border-border flex items-center justify-between" vid="45">
+                    <div class="flex items-center gap-6" vid="46">
+                        
+                        <div class="flex items-center gap-2 group cursor-pointer" vid="47">
+                            <div class="relative inline-block w-7 h-4 align-middle select-none" vid="48">
+                                <input type="checkbox" id="semantic-toggle" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-none appearance-none cursor-pointer top-0.5 left-0.5 peer checked:translate-x-3 transition-transform duration-200" vid="49">
+                                <label for="semantic-toggle" class="block overflow-hidden h-4 rounded-full bg-white/10 cursor-pointer peer-checked:bg-accent-blue transition-colors duration-200" vid="50"></label>
+                            </div>
+                            <span class="text-xs text-secondary group-hover:text-primary transition-colors" vid="51">Semantic Search</span>
+                        </div>
+
+                        
+                        <div class="flex items-center gap-2 group cursor-pointer" vid="52">
+                            <div class="relative inline-block w-7 h-4 align-middle select-none" vid="53">
+                                <input type="checkbox" id="archived-toggle" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-none appearance-none cursor-pointer top-0.5 left-0.5 peer checked:translate-x-3 transition-transform duration-200" vid="54">
+                                <label for="archived-toggle" class="block overflow-hidden h-4 rounded-full bg-white/10 cursor-pointer peer-checked:bg-accent-blue transition-colors duration-200" vid="55"></label>
+                            </div>
+                            <span class="text-xs text-secondary group-hover:text-primary transition-colors" vid="56">Include Archived</span>
+                        </div>
+                    </div>
+
+                    
+                    <div class="flex items-center gap-2" vid="57">
+                        <span class="text-[10px] text-tertiary uppercase tracking-wider font-medium" vid="58">Scope</span>
+                        <button class="flex items-center gap-1.5 px-2 py-1 rounded bg-white/5 border border-white/5 text-xs text-secondary hover:text-primary hover:border-white/10 transition-all" vid="59">
+                            <span vid="60">Current Project</span>
+                            <i class="ph-bold ph-caret-down text-[10px]" vid="61"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="flex-1 overflow-y-auto bg-panel" id="results-container" vid="62">
+                
+                
+                <div class="py-2" vid="63">
+                    <div class="px-4 py-1.5 flex items-center justify-between" vid="64">
+                        <span class="text-[10px] font-semibold text-tertiary uppercase tracking-widest" vid="65">Documents</span>
+                        <span class="text-[10px] font-mono text-tertiary" vid="66">3 matches</span>
+                    </div>
+
+                    
+                    <div class="group mx-2 p-2 rounded-lg bg-white/5 border border-white/5 cursor-pointer flex items-start gap-3 transition-all relative overflow-hidden" vid="67">
+                        <div class="absolute left-0 top-0 bottom-0 w-0.5 bg-accent-blue" vid="68"></div>
+                        
+                        <div class="mt-1 w-8 h-8 rounded bg-white/5 flex items-center justify-center text-primary border border-white/5 shrink-0" vid="69">
+                            <i class="ph ph-article text-lg" vid="70"></i>
+                        </div>
+                        
+                        <div class="flex-1 min-w-0" vid="71">
+                            <div class="flex items-center justify-between mb-0.5" vid="72">
+                                <h4 class="text-sm font-medium text-primary truncate" vid="73">The Architecture of Silence</h4>
+                                <span class="text-[10px] font-mono text-accent-blue bg-accent-surface px-1.5 py-0.5 rounded border border-blue-500/20" vid="74">98% match</span>
+                            </div>
+                            <p class="text-xs text-secondary leading-relaxed line-clamp-2" vid="75">
+                                ...visual noise. In <span class="search-highlight" vid="76">design theory</span>, this absence of clutter allows the user to focus purely on function. The aesthetic of silence is not empty...
+                            </p>
+                            <div class="flex items-center gap-2 mt-2" vid="77">
+                                <i class="ph ph-folder text-tertiary text-xs" vid="78"></i>
+                                <span class="text-[10px] text-tertiary" vid="79">Essays / Theory / Drafts</span>
+                                <span class="text-[10px] text-tertiary mx-1" vid="80">•</span>
+                                <span class="text-[10px] text-tertiary" vid="81">Edited 2m ago</span>
+                            </div>
+                        </div>
+
+                        <div class="hidden group-hover:flex items-center self-center pr-2" vid="82">
+                            <i class="ph-bold ph-arrow-right text-secondary" vid="83"></i>
+                        </div>
+                    </div>
+
+                    
+                    <div class="group mx-2 mt-1 p-2 rounded-lg border border-transparent hover:bg-white/5 hover:border-white/5 cursor-pointer flex items-start gap-3 transition-all" vid="84">
+                        <div class="mt-1 w-8 h-8 rounded bg-white/5 flex items-center justify-center text-secondary group-hover:text-primary border border-white/5 shrink-0 transition-colors" vid="85">
+                            <i class="ph ph-article text-lg" vid="86"></i>
+                        </div>
+                        
+                        <div class="flex-1 min-w-0" vid="87">
+                            <div class="flex items-center justify-between mb-0.5" vid="88">
+                                <h4 class="text-sm font-medium text-secondary group-hover:text-primary transition-colors truncate" vid="89">Minimalism in Digital Spaces</h4>
+                            </div>
+                            <p class="text-xs text-tertiary group-hover:text-secondary transition-colors leading-relaxed line-clamp-1" vid="90">
+                                ...exploring the roots of <span class="search-highlight" vid="91">design theory</span> through the lens of early 20th century functionalism...
+                            </p>
+                            <div class="flex items-center gap-2 mt-2" vid="92">
+                                <i class="ph ph-folder text-tertiary text-xs" vid="93"></i>
+                                <span class="text-[10px] text-tertiary" vid="94">Research / Historical</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="py-2 border-t border-divider" vid="95">
+                    <div class="px-4 py-1.5 flex items-center justify-between" vid="96">
+                        <span class="text-[10px] font-semibold text-tertiary uppercase tracking-widest" vid="97">Memories</span>
+                        <span class="text-[10px] font-mono text-tertiary" vid="98">5 matches</span>
+                    </div>
+
+                    
+                    <div class="group mx-2 p-2 rounded-lg border border-transparent hover:bg-white/5 hover:border-white/5 cursor-pointer flex items-start gap-3 transition-all" vid="99">
+                        <div class="mt-1 w-8 h-8 rounded bg-purple-500/0 flex items-center justify-center text-secondary group-hover:text-primary border border-white/5 shrink-0 transition-colors" vid="100">
+                            <i class="ph ph-brain text-lg" vid="101"></i>
+                        </div>
+                        
+                        <div class="flex-1 min-w-0" vid="102">
+                            <div class="flex items-center justify-between mb-0.5" vid="103">
+                                <h4 class="text-sm font-medium text-secondary group-hover:text-primary transition-colors truncate" vid="104">Concept: Negative Space</h4>
+                                <span class="text-[10px] font-mono text-emerald-500/70 bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/10 opacity-0 group-hover:opacity-100 transition-opacity" vid="105">High Relevance</span>
+                            </div>
+                            <p class="text-xs text-tertiary group-hover:text-secondary transition-colors leading-relaxed line-clamp-1" vid="106">
+                                Memory generated from <span class="search-highlight" vid="107">design theory</span> discussion on Jan 12.
+                            </p>
+                            <div class="flex items-center gap-2 mt-2" vid="108">
+                                <i class="ph ph-sparkle text-tertiary text-xs" vid="109"></i>
+                                <span class="text-[10px] text-tertiary" vid="110">Generated Insight</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="group mx-2 mt-1 p-2 rounded-lg border border-transparent hover:bg-white/5 hover:border-white/5 cursor-pointer flex items-start gap-3 transition-all" vid="111">
+                        <div class="mt-1 w-8 h-8 rounded bg-purple-500/0 flex items-center justify-center text-secondary group-hover:text-primary border border-white/5 shrink-0 transition-colors" vid="112">
+                            <i class="ph ph-brain text-lg" vid="113"></i>
+                        </div>
+                        
+                        <div class="flex-1 min-w-0" vid="114">
+                            <div class="flex items-center justify-between mb-0.5" vid="115">
+                                <h4 class="text-sm font-medium text-secondary group-hover:text-primary transition-colors truncate" vid="116">User Preference: Typography</h4>
+                            </div>
+                            <p class="text-xs text-tertiary group-hover:text-secondary transition-colors leading-relaxed line-clamp-1" vid="117">
+                                User prefers serif fonts for <span class="search-highlight" vid="118">design</span> essays.
+                            </p>
+                            <div class="flex items-center gap-2 mt-2" vid="119">
+                                <i class="ph ph-user text-tertiary text-xs" vid="120"></i>
+                                <span class="text-[10px] text-tertiary" vid="121">Implicit Preference</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="py-2 border-t border-divider" vid="122">
+                    <div class="px-4 py-1.5 flex items-center justify-between" vid="123">
+                        <span class="text-[10px] font-semibold text-tertiary uppercase tracking-widest" vid="124">Knowledge Graph</span>
+                        <span class="text-[10px] font-mono text-tertiary" vid="125">12 matches</span>
+                    </div>
+
+                    
+                    <div class="group mx-2 p-2 rounded-lg border border-transparent hover:bg-white/5 hover:border-white/5 cursor-pointer flex items-start gap-3 transition-all" vid="126">
+                        <div class="mt-1 w-8 h-8 rounded bg-white/5 flex items-center justify-center text-secondary group-hover:text-primary border border-white/5 shrink-0 transition-colors" vid="127">
+                            <i class="ph ph-graph text-lg" vid="128"></i>
+                        </div>
+                        
+                        <div class="flex-1 min-w-0" vid="129">
+                            <div class="flex items-center justify-between mb-0.5" vid="130">
+                                <h4 class="text-sm font-medium text-secondary group-hover:text-primary transition-colors truncate" vid="131">Bauhaus Movement</h4>
+                            </div>
+                            <div class="flex items-center gap-2 mt-1" vid="132">
+                                <span class="text-[10px] text-tertiary border border-white/5 px-1.5 py-0.5 rounded" vid="133">Entity</span>
+                                <span class="text-[10px] text-tertiary" vid="134">Connected to 14 documents</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="p-2 text-center border-t border-divider mt-2" vid="135">
+                    <button class="text-xs text-secondary hover:text-accent-blue transition-colors py-2 w-full" vid="136">
+                        View 16 more results
+                    </button>
+                </div>
+
+            </div>
+
+            
+            <div class="bg-surface border-t border-border px-4 py-3 flex items-center justify-between shrink-0" vid="137">
+                <div class="flex items-center gap-4" vid="138">
+                    <span class="text-xs text-secondary font-medium" vid="139">24 results</span>
+                    <div class="h-3 w-px bg-white/10" vid="140"></div>
+                    <span class="text-[10px] text-tertiary" vid="141">Search took 0.04s</span>
+                </div>
+
+                <div class="flex items-center gap-3" vid="142">
+                    <div class="flex items-center gap-1.5" vid="143">
+                        <span class="flex items-center justify-center w-5 h-5 rounded bg-white/10 border border-white/5 text-[10px] text-secondary font-mono" vid="144">
+                            <i class="ph-bold ph-arrow-up" vid="145"></i>
+                        </span>
+                        <span class="flex items-center justify-center w-5 h-5 rounded bg-white/10 border border-white/5 text-[10px] text-secondary font-mono" vid="146">
+                            <i class="ph-bold ph-arrow-down" vid="147"></i>
+                        </span>
+                        <span class="text-[10px] text-tertiary ml-1" vid="148">to navigate</span>
+                    </div>
+                    
+                    <div class="flex items-center gap-1.5" vid="149">
+                        <span class="flex items-center justify-center w-5 h-5 rounded bg-white/10 border border-white/5 text-[10px] text-secondary font-mono" vid="150">
+                            <i class="ph-bold ph-arrow-elbow-down-left" vid="151"></i>
+                        </span>
+                        <span class="text-[10px] text-tertiary ml-1" vid="152">to open</span>
+                    </div>
+
+                    <div class="flex items-center gap-1.5 ml-2" vid="153">
+                        <span class="flex items-center justify-center w-5 h-5 rounded bg-white/10 border border-white/5 text-[10px] text-secondary font-mono" vid="154">esc</span>
+                        <span class="text-[10px] text-tertiary ml-1" vid="155">to close</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="absolute bottom-6 right-6 z-50" vid="156">
+        <div class="bg-panel border border-border rounded-lg shadow-xl p-1 flex gap-1" vid="157">
+            <button class="p-2 rounded hover:bg-white/5 text-primary" title="Modal View" vid="158">
+                <i class="ph-fill ph-app-window" vid="159"></i>
+            </button>
+            <button class="p-2 rounded hover:bg-white/5 text-secondary hover:text-primary" title="Sidebar View" vid="160">
+                <i class="ph ph-sidebar-simple" vid="161"></i>
+            </button>
+        </div>
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/26-empty-states.html
+++ b/design/Variant/designs/26-empty-states.html
@@ -1,0 +1,252 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Search Empty State</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="6"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="7">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="8">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="9">
+    <script vid="10">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        divider: 'rgba(255, 255, 255, 0.04)',
+                        surface: '#121212',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            hover: '#2563eb',
+                            surface: 'rgba(59, 130, 246, 0.1)'
+                        }
+                    },
+                    boxShadow: {
+                        'glow': '0 0 20px rgba(0,0,0,0.5)',
+                        'modal': '0 24px 48px -12px rgba(0, 0, 0, 0.7)',
+                    },
+                    animation: {
+                        'fade-in': 'fadeIn 0.2s ease-out',
+                        'slide-down': 'slideDown 0.3s ease-out',
+                    },
+                    keyframes: {
+                        fadeIn: {
+                            '0%': { opacity: '0' },
+                            '100%': { opacity: '1' },
+                        },
+                        slideDown: {
+                            '0%': { transform: 'translateY(-10px)', opacity: '0' },
+                            '100%': { transform: 'translateY(0)', opacity: '1' },
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="11">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        .glass-panel {
+            background: #0f0f0f;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+        }
+
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        .toggle-checkbox {
+            right: 14px; 
+            border-color: #4b5563; 
+            transition: all 0.2s ease;
+        }
+        .toggle-checkbox + .toggle-label {
+            background-color: #27272a; 
+            transition: all 0.2s ease;
+        }
+    </style>
+</head>
+<body class="h-screen w-screen overflow-hidden flex relative font-sans" vid="12">
+
+    
+    <div class="absolute inset-0 z-0 flex pointer-events-none opacity-40 select-none" style="filter: blur(4px);" vid="13">
+        
+        <div class="w-64 h-full border-r border-border flex flex-col pt-12" vid="14">
+            <div class="px-6 py-4 border-b border-border" vid="15">
+                <div class="w-24 h-4 bg-white/10 rounded" vid="16"></div>
+            </div>
+            <div class="p-6 space-y-4" vid="17">
+                <div class="w-full h-8 bg-white/5 rounded" vid="18"></div>
+                <div class="w-3/4 h-8 bg-white/5 rounded" vid="19"></div>
+                <div class="w-5/6 h-8 bg-white/5 rounded" vid="20"></div>
+            </div>
+        </div>
+        
+        <div class="flex-1 bg-base p-12" vid="21">
+            <div class="max-w-3xl mx-auto space-y-8" vid="22">
+                <div class="h-12 w-1/2 bg-white/10 rounded" vid="23"></div>
+                <div class="space-y-4" vid="24">
+                    <div class="h-4 w-full bg-white/5 rounded" vid="25"></div>
+                    <div class="h-4 w-full bg-white/5 rounded" vid="26"></div>
+                    <div class="h-4 w-2/3 bg-white/5 rounded" vid="27"></div>
+                </div>
+                <div class="grid grid-cols-2 gap-8 mt-12" vid="28">
+                    <div class="h-48 bg-white/5 rounded-xl border border-border" vid="29"></div>
+                    <div class="h-48 bg-white/5 rounded-xl border border-border" vid="30"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm z-40 flex items-start justify-center pt-[10vh]" vid="31">
+        
+        
+        <div class="w-[640px] flex flex-col glass-panel rounded-xl overflow-hidden shadow-modal animate-slide-down max-h-[80vh] relative z-50 min-h-[500px]" vid="32">
+            
+            
+            <div class="flex flex-col border-b border-border bg-panel" vid="33">
+                
+                <div class="flex items-center px-4 py-4 gap-3" vid="34">
+                    <i class="ph ph-magnifying-glass text-xl text-secondary" vid="35"></i>
+                    <input type="text" value="quantum flux" class="flex-1 bg-transparent border-none outline-none text-lg text-primary placeholder-tertiary font-light h-8" placeholder="Search documents, memories, knowledge..." autofocus="" vid="36">
+                    <button class="p-1 rounded-md text-tertiary hover:text-primary hover:bg-white/5 transition-colors" vid="37">
+                        <i class="ph ph-x text-lg" vid="38"></i>
+                    </button>
+                </div>
+
+                
+                <div class="flex items-center gap-2 px-4 pb-4 overflow-x-auto no-scrollbar" vid="39">
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="40">All</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-accent-blue text-white shadow-lg shadow-blue-500/20 transition-all" vid="41">Documents</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="42">Memories</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="43">Knowledge</button>
+                    <button class="px-3 py-1 text-xs font-medium rounded-full bg-white/5 text-secondary border border-transparent hover:border-white/10 hover:text-primary hover:bg-white/10 transition-all" vid="44">Assets</button>
+                </div>
+
+                
+                <div class="px-4 py-3 bg-surface border-t border-border flex items-center justify-between" vid="45">
+                    <div class="flex items-center gap-6" vid="46">
+                        <div class="flex items-center gap-2 group cursor-pointer" vid="47">
+                            <div class="relative inline-block w-7 h-4 align-middle select-none" vid="48">
+                                <input type="checkbox" id="semantic-toggle" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-none appearance-none cursor-pointer top-0.5 left-0.5 peer transition-transform duration-200" vid="49">
+                                <label for="semantic-toggle" class="block overflow-hidden h-4 rounded-full bg-white/10 cursor-pointer peer-checked:bg-accent-blue transition-colors duration-200" vid="50"></label>
+                            </div>
+                            <span class="text-xs text-secondary group-hover:text-primary transition-colors" vid="51">Semantic Search</span>
+                        </div>
+                        <div class="flex items-center gap-2 group cursor-pointer" vid="52">
+                            <div class="relative inline-block w-7 h-4 align-middle select-none" vid="53">
+                                <input type="checkbox" id="archived-toggle" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-none appearance-none cursor-pointer top-0.5 left-0.5 peer transition-transform duration-200" vid="54">
+                                <label for="archived-toggle" class="block overflow-hidden h-4 rounded-full bg-white/10 cursor-pointer peer-checked:bg-accent-blue transition-colors duration-200" vid="55"></label>
+                            </div>
+                            <span class="text-xs text-secondary group-hover:text-primary transition-colors" vid="56">Include Archived</span>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2" vid="57">
+                        <span class="text-[10px] text-tertiary uppercase tracking-wider font-medium" vid="58">Scope</span>
+                        <button class="flex items-center gap-1.5 px-2 py-1 rounded bg-white/5 border border-white/5 text-xs text-secondary hover:text-primary hover:border-white/10 transition-all" vid="59">
+                            <span vid="60">Current Project</span>
+                            <i class="ph-bold ph-caret-down text-[10px]" vid="61"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="flex-1 bg-panel flex flex-col items-center justify-center p-12 text-center" vid="62">
+                
+                
+                <div class="relative mb-6" vid="63">
+                    <i class="ph ph-magnifying-glass text-[64px] text-tertiary opacity-40" vid="64"></i>
+                    <i class="ph-fill ph-question text-2xl text-tertiary absolute -right-1 -top-1 bg-panel rounded-full border border-panel" vid="65"></i>
+                </div>
+
+                
+                <h3 class="text-base font-medium text-primary mb-1" vid="66">No results found</h3>
+                <p class="text-sm text-secondary font-light italic mb-8" vid="67">for "quantum flux"</p>
+
+                
+                <div class="w-full max-w-[280px] bg-white/[0.02] border border-white/[0.04] rounded-lg p-5 text-left mb-8" vid="68">
+                    <span class="text-xs font-medium text-secondary block mb-3 uppercase tracking-wider" vid="69">Suggestions</span>
+                    <ul class="space-y-2.5" vid="70">
+                        <li class="flex items-start gap-2.5 text-xs text-tertiary" vid="71">
+                            <span class="w-1 h-1 rounded-full bg-tertiary mt-1.5 shrink-0" vid="72"></span>
+                            <span vid="73">Check your spelling</span>
+                        </li>
+                        <li class="flex items-start gap-2.5 text-xs text-tertiary" vid="74">
+                            <span class="w-1 h-1 rounded-full bg-tertiary mt-1.5 shrink-0" vid="75"></span>
+                            <span vid="76">Try different keywords</span>
+                        </li>
+                        <li class="flex items-start gap-2.5 text-xs text-tertiary" vid="77">
+                            <span class="w-1 h-1 rounded-full bg-tertiary mt-1.5 shrink-0" vid="78"></span>
+                            <span vid="79">Broaden your search filters</span>
+                        </li>
+                    </ul>
+                </div>
+
+                
+                <div class="flex flex-col items-center gap-4 w-full max-w-[200px]" vid="80">
+                    <button class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-accent-blue hover:bg-accent-hover text-white text-xs font-medium rounded-md shadow-lg shadow-blue-500/10 transition-all" vid="81">
+                        <i class="ph ph-globe" vid="82"></i>
+                        Search in all projects
+                    </button>
+                    
+                    <button class="text-xs text-secondary hover:text-primary hover:underline transition-colors" vid="83">
+                        Clear search
+                    </button>
+                </div>
+
+            </div>
+
+            
+            <div class="bg-surface border-t border-border px-4 py-3 flex items-center justify-between shrink-0" vid="84">
+                <div class="flex items-center gap-4" vid="85">
+                    <span class="text-xs text-secondary font-medium" vid="86">0 results</span>
+                    <div class="h-3 w-px bg-white/10" vid="87"></div>
+                    <span class="text-[10px] text-tertiary" vid="88">Search took 0.02s</span>
+                </div>
+
+                <div class="flex items-center gap-3" vid="89">
+                    <div class="flex items-center gap-1.5 ml-2" vid="90">
+                        <span class="flex items-center justify-center w-5 h-5 rounded bg-white/10 border border-white/5 text-[10px] text-secondary font-mono" vid="91">esc</span>
+                        <span class="text-[10px] text-tertiary ml-1" vid="92">to close</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/27-loading-states.html
+++ b/design/Variant/designs/27-loading-states.html
@@ -1,0 +1,456 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Loading States</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="6"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="7">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="8">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="9">
+    <script vid="10">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            red: '#ef4444',
+                        }
+                    },
+                    animation: {
+                        'progress-indeterminate': 'progress 1.5s infinite linear',
+                        'bounce-delay-1': 'bounce 1s infinite 100ms',
+                        'bounce-delay-2': 'bounce 1s infinite 200ms',
+                        'bounce-delay-3': 'bounce 1s infinite 300ms',
+                    },
+                    keyframes: {
+                        progress: {
+                            '0%': { transform: 'translateX(-100%)' },
+                            '100%': { transform: 'translateX(200%)' }
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="11">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+        }
+        
+        .skeleton-bg {
+            background-color: #1a1a1a;
+        }
+
+        .dot-bounce {
+            animation: bounce 0.6s infinite alternate;
+        }
+        .dot-bounce:nth-child(2) { animation-delay: 0.1s; }
+        .dot-bounce:nth-child(3) { animation-delay: 0.2s; }
+
+        @keyframes bounce {
+            to { transform: translateY(-4px); }
+        }
+
+        .progress-gradient {
+            background: linear-gradient(90deg, transparent, #3b82f6, transparent);
+        }
+    </style>
+</head>
+<body class="min-h-screen w-full flex flex-col p-8 md:p-12" vid="12">
+
+    
+    <header class="mb-12 border-b border-border pb-6" vid="13">
+        <div class="flex items-center gap-3 mb-2" vid="14">
+            <div class="w-6 h-6 rounded bg-accent-blue/20 flex items-center justify-center" vid="15">
+                <i class="ph-fill ph-spinner-gap text-accent-blue animate-spin" vid="16"></i>
+            </div>
+            <h1 class="text-xl font-medium tracking-tight" vid="17">Loading Patterns</h1>
+        </div>
+        <p class="text-secondary text-sm max-w-2xl" vid="18">
+            Standardized loading indicators for asynchronous states across the CreoNow platform. 
+            Designed to minimize perceived wait times and provide visual continuity in dark mode.
+        </p>
+    </header>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-7xl" vid="19">
+
+        
+        <section class="space-y-6" vid="20">
+            <div class="flex items-center justify-between" vid="21">
+                <h2 class="text-sm font-medium text-primary" vid="22">Top Progress Bar</h2>
+                <span class="text-xs font-mono text-tertiary" vid="23">Global / Navigation</span>
+            </div>
+            
+            <div class="border border-border rounded-lg bg-panel overflow-hidden relative h-48 flex flex-col" vid="24">
+                
+                <div class="absolute top-0 left-0 w-full h-[2px] bg-white/5 overflow-hidden z-20" vid="25">
+                    <div class="absolute top-0 left-0 w-full h-full progress-gradient animate-progress-indeterminate" vid="26"></div>
+                </div>
+
+                
+                <div class="h-10 border-b border-border flex items-center px-4 gap-3 bg-base" vid="27">
+                    <div class="w-3 h-3 rounded-full bg-white/10" vid="28"></div>
+                    <div class="w-3 h-3 rounded-full bg-white/10" vid="29"></div>
+                    <div class="flex-1" vid="30"></div>
+                    <div class="w-24 h-4 rounded bg-white/5" vid="31"></div>
+                </div>
+                <div class="flex-1 flex" vid="32">
+                    <div class="w-16 border-r border-border bg-base/50" vid="33"></div>
+                    <div class="flex-1 p-6" vid="34">
+                        <div class="w-32 h-4 rounded bg-white/5 mb-4" vid="35"></div>
+                        <div class="w-full h-2 rounded bg-white/5 mb-2" vid="36"></div>
+                        <div class="w-2/3 h-2 rounded bg-white/5" vid="37"></div>
+                    </div>
+                </div>
+            </div>
+            <p class="text-xs text-secondary" vid="38">
+                Indeterminate gradient bar fixed at the window top. Used for route transitions and background saving.
+            </p>
+        </section>
+
+        
+        <section class="space-y-6" vid="39">
+            <div class="flex items-center justify-between" vid="40">
+                <h2 class="text-sm font-medium text-primary" vid="41">Button States</h2>
+                <span class="text-xs font-mono text-tertiary" vid="42">Forms / Actions</span>
+            </div>
+
+            <div class="border border-border rounded-lg bg-panel p-8 flex flex-wrap gap-8 items-center" vid="43">
+                
+                <div class="space-y-3" vid="44">
+                    <span class="text-xs text-secondary block mb-2" vid="45">Primary Action</span>
+                    <button disabled="" class="flex items-center gap-2 px-4 py-2 rounded-md bg-white text-base text-sm font-medium opacity-80 cursor-not-allowed" vid="46">
+                        <i class="ph-bold ph-spinner animate-spin text-base" vid="47"></i>
+                        <span vid="48">Generating...</span>
+                    </button>
+                </div>
+
+                
+                <div class="space-y-3" vid="49">
+                    <span class="text-xs text-secondary block mb-2" vid="50">Secondary Action</span>
+                    <button disabled="" class="flex items-center gap-2 px-4 py-2 rounded-md bg-white/5 border border-white/5 text-secondary text-sm font-medium cursor-not-allowed" vid="51">
+                        <i class="ph-bold ph-spinner animate-spin text-secondary" vid="52"></i>
+                        <span vid="53">Saving</span>
+                    </button>
+                </div>
+
+                
+                <div class="space-y-3" vid="54">
+                    <span class="text-xs text-secondary block mb-2" vid="55">Icon Only</span>
+                    <button disabled="" class="w-9 h-9 flex items-center justify-center rounded-md bg-white/5 border border-white/5 text-secondary cursor-not-allowed" vid="56">
+                        <i class="ph-bold ph-spinner animate-spin" vid="57"></i>
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        
+        <section class="col-span-1 lg:col-span-2 space-y-6" vid="58">
+            <div class="flex items-center justify-between" vid="59">
+                <h2 class="text-sm font-medium text-primary" vid="60">Content Skeletons</h2>
+                <span class="text-xs font-mono text-tertiary" vid="61">Initial Load / Data Fetching</span>
+            </div>
+
+            <div class="border border-border rounded-lg bg-panel overflow-hidden grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-border" vid="62">
+                
+                
+                <div class="p-6 bg-base h-64" vid="63">
+                    <div class="flex flex-col h-full animate-pulse" vid="64">
+                        <div class="w-32 h-4 skeleton-bg rounded mb-8" vid="65"></div>
+                        <div class="space-y-4" vid="66">
+                            <div class="flex items-center gap-3" vid="67">
+                                <div class="w-4 h-4 skeleton-bg rounded-sm shrink-0" vid="68"></div>
+                                <div class="w-24 h-3 skeleton-bg rounded" vid="69"></div>
+                            </div>
+                            <div class="flex items-center gap-3" vid="70">
+                                <div class="w-4 h-4 skeleton-bg rounded-sm shrink-0" vid="71"></div>
+                                <div class="w-32 h-3 skeleton-bg rounded" vid="72"></div>
+                            </div>
+                            <div class="flex items-center gap-3" vid="73">
+                                <div class="w-4 h-4 skeleton-bg rounded-sm shrink-0" vid="74"></div>
+                                <div class="w-20 h-3 skeleton-bg rounded" vid="75"></div>
+                            </div>
+                            
+                            <div class="pt-4 space-y-4" vid="76">
+                                <div class="flex items-center gap-3" vid="77">
+                                    <div class="w-4 h-4 skeleton-bg rounded-sm shrink-0" vid="78"></div>
+                                    <div class="w-28 h-3 skeleton-bg rounded" vid="79"></div>
+                                </div>
+                                <div class="flex items-center gap-3" vid="80">
+                                    <div class="w-4 h-4 skeleton-bg rounded-sm shrink-0" vid="81"></div>
+                                    <div class="w-16 h-3 skeleton-bg rounded" vid="82"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="col-span-2 p-8" vid="83">
+                    <div class="max-w-2xl mx-auto space-y-8 animate-pulse" vid="84">
+                        
+                        <div class="w-2/3 h-10 skeleton-bg rounded-lg" vid="85"></div>
+                        
+                        
+                        <div class="space-y-3" vid="86">
+                            <div class="w-full h-4 skeleton-bg rounded" vid="87"></div>
+                            <div class="w-full h-4 skeleton-bg rounded" vid="88"></div>
+                            <div class="w-5/6 h-4 skeleton-bg rounded" vid="89"></div>
+                        </div>
+
+                        
+                        <div class="pt-4 grid grid-cols-2 gap-6" vid="90">
+                            <div class="aspect-video skeleton-bg rounded-lg border border-white/5" vid="91"></div>
+                            <div class="space-y-3 py-2" vid="92">
+                                <div class="w-3/4 h-5 skeleton-bg rounded" vid="93"></div>
+                                <div class="w-full h-3 skeleton-bg rounded" vid="94"></div>
+                                <div class="w-full h-3 skeleton-bg rounded" vid="95"></div>
+                                <div class="w-1/2 h-3 skeleton-bg rounded" vid="96"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        
+        <section class="space-y-6" vid="97">
+            <div class="flex items-center justify-between" vid="98">
+                <h2 class="text-sm font-medium text-primary" vid="99">Panel &amp; Inline Loading</h2>
+                <span class="text-xs font-mono text-tertiary" vid="100">Components / Chat</span>
+            </div>
+
+            <div class="grid grid-cols-2 gap-4" vid="101">
+                
+                <div class="border border-border rounded-lg bg-panel p-6 flex flex-col items-center justify-center h-48" vid="102">
+                    <i class="ph-bold ph-spinner-gap text-2xl text-secondary animate-spin mb-3" vid="103"></i>
+                    <span class="text-xs text-secondary font-medium" vid="104">Loading...</span>
+                </div>
+
+                
+                <div class="border border-border rounded-lg bg-panel p-6 flex flex-col justify-end h-48 relative overflow-hidden" vid="105">
+                    <div class="space-y-4 w-full" vid="106">
+                        <div class="flex justify-end" vid="107">
+                            <div class="bg-white/10 text-xs px-3 py-2 rounded-lg rounded-tr-none text-primary max-w-[80%]" vid="108">
+                                Refine the tone.
+                            </div>
+                        </div>
+                        <div class="flex justify-start" vid="109">
+                            <div class="bg-accent-blue/10 border border-accent-blue/20 px-3 py-3 rounded-lg rounded-tl-none flex items-center gap-1 w-fit" vid="110">
+                                <div class="w-1.5 h-1.5 rounded-full bg-accent-blue dot-bounce" vid="111"></div>
+                                <div class="w-1.5 h-1.5 rounded-full bg-accent-blue dot-bounce" vid="112"></div>
+                                <div class="w-1.5 h-1.5 rounded-full bg-accent-blue dot-bounce" vid="113"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        
+        <section class="space-y-6" vid="114">
+            <div class="flex items-center justify-between" vid="115">
+                <h2 class="text-sm font-medium text-primary" vid="116">Full Page Loading</h2>
+                <span class="text-xs font-mono text-tertiary" vid="117">App Initialization</span>
+            </div>
+
+            <div class="border border-border rounded-lg bg-base h-48 flex items-center justify-center relative overflow-hidden" vid="118">
+                <div class="flex flex-col items-center gap-4 z-10" vid="119">
+                    <div class="relative" vid="120">
+                        <div class="w-12 h-12 rounded-full border-2 border-white/5" vid="121"></div>
+                        <div class="absolute inset-0 w-12 h-12 rounded-full border-2 border-t-accent-blue border-r-transparent border-b-transparent border-l-transparent animate-spin" vid="122"></div>
+                        
+                        <div class="absolute inset-0 flex items-center justify-center" vid="123">
+                            <div class="w-2 h-2 bg-white/20 rounded-full" vid="124"></div>
+                        </div>
+                    </div>
+                    <span class="text-xs font-medium text-secondary tracking-wide animate-pulse" vid="125">Starting CreoNow...</span>
+                </div>
+                
+                
+                <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-white/5 to-transparent opacity-50" vid="126"></div>
+            </div>
+        </section>
+
+    </div>
+
+
+### Design 2: Error Dialog
+
+This design presents a critical error state in a centered modal dialog. It uses a red accent color to convey urgency while maintaining the application's dark aesthetic. The background simulates the application interface with a blur effect to focus attention on the modal.
+
+&lt;|ARTIFACT:DESIGN|&gt;&lt;|CONTENT:CODE|&gt;&lt;|VERSIONID:a96cc070-5b23-4402-8693-0182607519bb|&gt;&lt;|GENERATIONID:11b6f008-8e62-4299-81da-086e2467d305|&gt;&lt;|FORMAT:desktop|&gt;&lt;|DESIGNIMAGE:true|&gt;&lt;|SELECTEDTAGVID:null|&gt;
+    <meta charset="UTF-8" vid="127">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="128">
+    <title vid="129">CreoNow - Error Dialog</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="130"></script>
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="131"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="132">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="133">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="134">
+    <script vid="135">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            red: '#ef4444',
+                            redGlow: 'rgba(239, 68, 68, 0.15)',
+                        }
+                    },
+                    boxShadow: {
+                        'modal': '0 24px 48px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.05)',
+                        'glow-red': '0 0 20px rgba(239, 68, 68, 0.15)',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="136">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+            overflow: hidden;
+        }
+
+        .details-content[open] summary ~ * {
+            animation: slideDown 0.2s ease-out;
+        }
+
+        @keyframes slideDown {
+            0% { opacity: 0; transform: translateY(-5px); }
+            100% { opacity: 1; transform: translateY(0); }
+        }
+
+        
+        .code-block {
+            background-color: #050505;
+            border: 1px solid rgba(255,255,255,0.05);
+        }
+
+        .details-marker {
+            transition: transform 0.2s;
+        }
+        details[open] .details-marker {
+            transform: rotate(90deg);
+        }
+    </style>
+
+
+
+    
+    <div class="absolute inset-0 z-0 opacity-40 blur-sm pointer-events-none select-none" vid="137">
+        <div class="flex h-full" vid="138">
+            <div class="w-64 border-r border-border bg-panel flex flex-col p-4 gap-4" vid="139">
+                <div class="h-8 bg-white/5 rounded w-full" vid="140"></div>
+                <div class="h-4 bg-white/5 rounded w-2/3" vid="141"></div>
+                <div class="h-4 bg-white/5 rounded w-3/4" vid="142"></div>
+                <div class="h-4 bg-white/5 rounded w-1/2" vid="143"></div>
+            </div>
+            <div class="flex-1 bg-base p-8" vid="144">
+                <div class="h-12 bg-white/5 rounded w-1/3 mb-8" vid="145"></div>
+                <div class="h-4 bg-white/5 rounded w-full mb-4" vid="146"></div>
+                <div class="h-4 bg-white/5 rounded w-full mb-4" vid="147"></div>
+                <div class="h-4 bg-white/5 rounded w-5/6" vid="148"></div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm z-40 flex items-center justify-center p-4" vid="149">
+        
+        <div class="w-full max-w-[420px] bg-panel rounded-xl shadow-modal border-t-2 border-accent-red relative overflow-hidden" vid="150">
+            
+            
+            <div class="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-accent-red/50 to-transparent opacity-50" vid="151"></div>
+
+            
+            <div class="p-6 pb-2" vid="152">
+                <div class="flex items-start gap-4" vid="153">
+                    
+                    <div class="shrink-0 w-12 h-12 rounded-full bg-accent-red/10 flex items-center justify-center shadow-glow-red" vid="154">
+                        <i class="ph-fill ph-warning-circle text-2xl text-accent-red" vid="155"></i>
+                    </div>
+
+                    
+                    <div class="flex-1 pt-1" vid="156">
+                        <h2 class="text-lg font-semibold text-primary leading-tight mb-1" vid="157">Something went wrong</h2>
+                        <div class="flex items-center gap-2 mb-3" vid="158">
+                            <span class="text-xs font-mono text-accent-red bg-accent-red/10 px-1.5 py-0.5 rounded" vid="159">ERR_SYNC_504</span>
+                        </div>
+                        <p class="text-sm text-secondary leading-relaxed" vid="160">
+                            We couldn't save your changes to the cloud. This is usually caused by a temporary connection issue.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="px-6 py-2" vid="161">
+                <details class="group details-content" vid="162">
+                    <summary class="flex items-center gap-2 cursor-pointer py-2 select-none group-hover:text-primary transition-colors text-secondary" vid="163">
+                        <i class="ph-bold ph-caret-right text-xs details-marker" vid="164"></i>
+                        <span class="text-xs font-medium" vid="165">View technical details</span>
+                    </summary>
+                    
+                    <div class="mt-2" vid="166">
+                        <div class="code-block rounded-md p-3 overflow-x-auto" vid="167">
+                            <pre class="text-[10px] font-mono text-tertiary leading-relaxed" vid="168"><span class="text-accent-red" vid="169">Error: Gateway Timeout</span>
+    at WebSocket.onError (client.js:412:15)
+    at SyncManager.retry (sync.ts:89:12)
+    at async DocumentService.save (doc.ts:104:8)
+<span class="text-secondary" vid="170">Timestamp: 2023-10-24T14:32:11.042Z</span>
+<span class="text-secondary" vid="171">Region: us-east-1</span></pre>
+                        </div>
+                        <div class="mt-2 flex justify-end" vid="172">
+                            <button class="text-[10px] text-secondary hover:text-primary flex items-center gap-1 transition-colors" vid="173">
+                                <i class="ph ph-copy" vid="174"></i> Copy Trace
+                            </button>
+                        </div>
+                    </div>
+                </details>
+            </div>
+
+            
+            <div class="p-6 pt-4 flex items-center justify-between mt-2 border-t border-border bg-white/[0.01]" vid="175">
+                <button class="text-xs text-secondary hover:text-primary font-medium transition-colors flex items-center gap-1.5" vid="176">
+                    <i class="ph ph-bug" vid="177"></i> Report Issue
+                </button>
+                
+                <div class="flex items-center gap-3" vid="178">
+                    <button class="px-4 py-2 text-xs font-medium text-primary hover:text-white bg-white/5 hover:bg-white/10 border border-white/5 rounded-md transition-all" vid="179">
+                        Close
+                    </button>
+                    <button class="px-4 py-2 text-xs font-medium text-white bg-accent-red hover:bg-red-500 shadow-lg shadow-red-900/20 rounded-md transition-all flex items-center gap-2" vid="180">
+                        <i class="ph-bold ph-arrow-clockwise" vid="181"></i>
+                        Try Again
+                    </button>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</body></html>

--- a/design/Variant/designs/28-template-picker.html
+++ b/design/Variant/designs/28-template-picker.html
@@ -1,0 +1,304 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Template Picker</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400&amp;family=Newsreader:ital,wght@0,400;0,500;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        border: 'rgba(255, 255, 255, 0.08)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6', 
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                        serif: ['Newsreader', 'serif'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        ::-webkit-scrollbar {
+            width: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+        
+        .glass-overlay {
+            backdrop-filter: blur(8px);
+            background-color: rgba(5, 5, 5, 0.7);
+        }
+
+        .card-shadow {
+            box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans h-screen w-screen overflow-hidden flex selection:bg-accent selection:text-white relative" vid="9">
+
+    
+    <div class="absolute inset-0 flex z-0 pointer-events-none" aria-hidden="true" vid="10">
+        
+        <aside class="w-64 border-r border-border flex flex-col h-full bg-background flex-shrink-0 opacity-40" vid="11">
+            <div class="h-14 px-6 flex items-center mb-6 border-b border-border/50" vid="12">
+                <span class="font-bold tracking-tight text-lg" vid="13">CREO</span><span class="font-thin ml-1 text-secondary" vid="14">NOW</span>
+            </div>
+            <div class="p-4 space-y-6" vid="15">
+                <div class="space-y-1" vid="16">
+                    <div class="h-8 bg-hover rounded w-full" vid="17"></div>
+                    <div class="h-8 w-3/4" vid="18"></div>
+                    <div class="h-8 w-5/6" vid="19"></div>
+                </div>
+            </div>
+        </aside>
+
+        
+        <main class="flex-1 bg-background relative flex flex-col opacity-40" vid="20">
+            <header class="h-14 border-b border-border flex items-center justify-between px-6" vid="21">
+                <div class="w-1/3 h-4 bg-hover rounded" vid="22"></div>
+            </header>
+            <div class="p-12 grid grid-cols-3 gap-6" vid="23">
+                <div class="h-64 bg-panel border border-border rounded-lg" vid="24"></div>
+                <div class="h-64 bg-panel border border-border rounded-lg" vid="25"></div>
+                <div class="h-64 bg-panel border border-border rounded-lg" vid="26"></div>
+            </div>
+        </main>
+    </div>
+
+    
+    <div class="fixed inset-0 z-50 flex items-center justify-center glass-overlay p-4" vid="27">
+        
+        
+        <div class="w-full max-w-[640px] bg-panel border border-border rounded-xl shadow-2xl flex flex-col max-h-[90vh] card-shadow ring-1 ring-white/5 relative animation-fade-in-up" vid="28">
+            
+            
+            <div class="px-6 py-5 border-b border-border flex items-start justify-between bg-panel sticky top-0 z-10 rounded-t-xl" vid="29">
+                <div vid="30">
+                    <h2 class="text-lg font-semibold text-primary leading-tight" vid="31">Choose a Template</h2>
+                    <p class="text-sm text-secondary mt-1" vid="32">Start with a pre-configured structure for your next project.</p>
+                </div>
+                <button class="text-secondary hover:text-primary transition-colors p-1 rounded-md hover:bg-hover" vid="33">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="34">
+                        <line x1="18" y1="6" x2="6" y2="18" vid="35"></line>
+                        <line x1="6" y1="6" x2="18" y2="18" vid="36"></line>
+                    </svg>
+                </button>
+            </div>
+
+            
+            <div class="px-6 py-4 space-y-4 bg-background/50" vid="37">
+                
+                <div class="relative group" vid="38">
+                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-secondary group-focus-within:text-primary transition-colors" vid="39">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="40">
+                            <circle cx="11" cy="11" r="8" vid="41"></circle>
+                            <line x1="21" y1="21" x2="16.65" y2="16.65" vid="42"></line>
+                        </svg>
+                    </div>
+                    <input type="text" class="w-full bg-hover border border-border rounded-lg py-2 pl-10 pr-4 text-sm text-primary placeholder-secondary/50 focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all" placeholder="Search templates..." vid="43">
+                </div>
+
+                
+                <div class="flex items-center gap-2 overflow-x-auto pb-1 no-scrollbar" vid="44">
+                    <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-accent text-white border border-accent transition-colors flex-shrink-0" vid="45">
+                        All
+                    </button>
+                    <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-transparent text-secondary border border-border hover:border-secondary/50 hover:text-primary transition-colors flex-shrink-0" vid="46">
+                        Novel
+                    </button>
+                    <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-transparent text-secondary border border-border hover:border-secondary/50 hover:text-primary transition-colors flex-shrink-0" vid="47">
+                        Article
+                    </button>
+                    <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-transparent text-secondary border border-border hover:border-secondary/50 hover:text-primary transition-colors flex-shrink-0" vid="48">
+                        Script
+                    </button>
+                    <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-transparent text-secondary border border-border hover:border-secondary/50 hover:text-primary transition-colors flex-shrink-0" vid="49">
+                        Custom
+                    </button>
+                </div>
+            </div>
+
+            
+            <div class="flex-1 overflow-y-auto p-6 bg-background/30" vid="50">
+                <div class="grid grid-cols-2 gap-4" vid="51">
+                    
+                    
+                    <button class="group h-[180px] bg-panel border-2 border-dashed border-border rounded-lg p-4 flex flex-col items-center justify-center hover:border-secondary hover:bg-hover transition-all text-left relative focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent" vid="52">
+                        <div class="w-12 h-12 rounded-full bg-hover flex items-center justify-center text-secondary group-hover:text-primary group-hover:bg-background border border-border transition-colors mb-3" vid="53">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="54">
+                                <line x1="12" y1="5" x2="12" y2="19" vid="55"></line>
+                                <line x1="5" y1="12" x2="19" y2="12" vid="56"></line>
+                            </svg>
+                        </div>
+                        <span class="text-sm font-medium text-primary mb-1" vid="57">Blank Document</span>
+                        <span class="text-xs text-secondary text-center" vid="58">Start from scratch with an empty canvas</span>
+                    </button>
+
+                    
+                    <button class="group h-[180px] bg-panel border border-accent rounded-lg flex flex-col overflow-hidden text-left relative shadow-[0_0_0_1px_rgba(59,130,246,1)] transition-all" vid="59">
+                        
+                        <div class="absolute top-2 right-2 z-10 bg-accent text-white w-5 h-5 rounded-full flex items-center justify-center shadow-sm" vid="60">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" vid="61">
+                                <polyline points="20 6 9 17 4 12" vid="62"></polyline>
+                            </svg>
+                        </div>
+                        
+                        
+                        <div class="h-24 bg-[#141414] border-b border-border w-full flex items-center justify-center relative overflow-hidden group-hover:bg-[#1a1a1a] transition-colors" vid="63">
+                            <div class="absolute inset-0 opacity-20" style="background-image: radial-gradient(#333 1px, transparent 1px); background-size: 8px 8px;" vid="64"></div>
+                            <div class="w-16 h-20 bg-background border border-border shadow-lg mt-6 rounded-t px-2 py-2" vid="65">
+                                <div class="w-8 h-1 bg-secondary/30 rounded mb-1" vid="66"></div>
+                                <div class="w-full h-0.5 bg-secondary/20 rounded mb-1" vid="67"></div>
+                                <div class="w-full h-0.5 bg-secondary/20 rounded mb-1" vid="68"></div>
+                                <div class="w-2/3 h-0.5 bg-secondary/20 rounded" vid="69"></div>
+                            </div>
+                        </div>
+                        
+                        
+                        <div class="p-3 flex-1 flex flex-col justify-center" vid="70">
+                            <div class="flex items-center justify-between mb-1" vid="71">
+                                <span class="text-sm font-medium text-primary" vid="72">Visual Essay</span>
+                                <span class="text-[10px] font-bold text-accent bg-accent/10 px-1.5 py-0.5 rounded border border-accent/20" vid="73">POPULAR</span>
+                            </div>
+                            <p class="text-xs text-secondary line-clamp-2 leading-relaxed" vid="74">
+                                Layout optimized for photography and large typography headers.
+                            </p>
+                        </div>
+                    </button>
+
+                    
+                    <button class="group h-[180px] bg-panel border border-border rounded-lg flex flex-col overflow-hidden hover:border-secondary/50 hover:bg-hover transition-all text-left relative" vid="75">
+                        
+                        <div class="h-24 bg-[#141414] border-b border-border w-full flex items-center justify-center relative group-hover:bg-[#1a1a1a] transition-colors" vid="76">
+                            <div class="flex gap-2" vid="77">
+                                <div class="text-secondary/40" vid="78">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" vid="79">
+                                        <rect x="4" y="4" width="16" height="16" rx="2" vid="80"></rect>
+                                        <line x1="9" y1="9" x2="15" y2="9" vid="81"></line>
+                                        <line x1="9" y1="13" x2="15" y2="13" vid="82"></line>
+                                        <line x1="9" y1="17" x2="11" y2="17" vid="83"></line>
+                                    </svg>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <div class="p-3 flex-1 flex flex-col justify-center" vid="84">
+                            <div class="flex items-center justify-between mb-1" vid="85">
+                                <span class="text-sm font-medium text-primary" vid="86">Technical Spec</span>
+                                <span class="text-[10px] font-bold text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/20" vid="87">NEW</span>
+                            </div>
+                            <p class="text-xs text-secondary line-clamp-2 leading-relaxed" vid="88">
+                                Structured format with code blocks and versioning tables.
+                            </p>
+                        </div>
+                    </button>
+
+                    
+                    <button class="group h-[180px] bg-panel border border-border rounded-lg flex flex-col overflow-hidden hover:border-secondary/50 hover:bg-hover transition-all text-left relative" vid="89">
+                        
+                        <div class="h-24 bg-[#141414] border-b border-border w-full flex items-center justify-center relative group-hover:bg-[#1a1a1a] transition-colors" vid="90">
+                            <div class="text-secondary/40" vid="91">
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" class="transform rotate-12" vid="92">
+                                    <path d="M12 19l7-7 3 3-7 7-3-3z" vid="93"></path>
+                                    <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z" vid="94"></path>
+                                    <path d="M2 2l7.586 7.586" vid="95"></path>
+                                    <circle cx="11" cy="11" r="2" vid="96"></circle>
+                                </svg>
+                            </div>
+                        </div>
+                        
+                        <div class="p-3 flex-1 flex flex-col justify-center" vid="97">
+                            <div class="flex items-center justify-between mb-1" vid="98">
+                                <span class="text-sm font-medium text-primary" vid="99">Screenplay</span>
+                            </div>
+                            <p class="text-xs text-secondary line-clamp-2 leading-relaxed" vid="100">
+                                Industry standard formatting for scripts and dialogue.
+                            </p>
+                        </div>
+                    </button>
+
+                    
+                    <button class="group h-[180px] bg-panel border border-border rounded-lg flex flex-col overflow-hidden hover:border-secondary/50 hover:bg-hover transition-all text-left relative" vid="101">
+                        
+                        <div class="h-24 bg-[#141414] border-b border-border w-full flex items-center justify-center relative group-hover:bg-[#1a1a1a] transition-colors" vid="102">
+                            <div class="w-full px-8 flex flex-col gap-1.5 opacity-40" vid="103">
+                                <div class="h-1.5 w-full bg-secondary rounded-full" vid="104"></div>
+                                <div class="h-1.5 w-full bg-secondary rounded-full" vid="105"></div>
+                                <div class="h-1.5 w-2/3 bg-secondary rounded-full" vid="106"></div>
+                            </div>
+                        </div>
+                        
+                        <div class="p-3 flex-1 flex flex-col justify-center" vid="107">
+                            <div class="flex items-center justify-between mb-1" vid="108">
+                                <span class="text-sm font-medium text-primary" vid="109">Newsletter</span>
+                            </div>
+                            <p class="text-xs text-secondary line-clamp-2 leading-relaxed" vid="110">
+                                Engaging format optimized for email distribution.
+                            </p>
+                        </div>
+                    </button>
+
+                    
+                    <button class="group h-[180px] bg-panel border border-border rounded-lg flex flex-col overflow-hidden hover:border-secondary/50 hover:bg-hover transition-all text-left relative" vid="111">
+                        
+                        <div class="h-24 bg-[#141414] border-b border-border w-full flex items-center justify-center relative group-hover:bg-[#1a1a1a] transition-colors" vid="112">
+                            <div class="text-secondary/40" vid="113">
+                                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" vid="114">
+                                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" vid="115"></path>
+                                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" vid="116"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        
+                        <div class="p-3 flex-1 flex flex-col justify-center" vid="117">
+                            <div class="flex items-center justify-between mb-1" vid="118">
+                                <span class="text-sm font-medium text-primary" vid="119">Novel Chapter</span>
+                            </div>
+                            <p class="text-xs text-secondary line-clamp-2 leading-relaxed" vid="120">
+                                Classic serif typography for long-form fiction writing.
+                            </p>
+                        </div>
+                    </button>
+
+                </div>
+            </div>
+
+            
+            <div class="px-6 py-4 border-t border-border bg-panel flex items-center justify-between rounded-b-xl" vid="121">
+                <div class="text-sm" vid="122">
+                    <span class="text-secondary" vid="123">Selected:</span>
+                    <span class="text-primary font-medium ml-1" vid="124">Visual Essay</span>
+                </div>
+                <div class="flex items-center gap-3" vid="125">
+                    <button class="px-4 py-2 rounded-lg text-sm text-secondary hover:text-primary hover:bg-hover transition-colors font-medium" vid="126">
+                        Cancel
+                    </button>
+                    <button class="px-4 py-2 rounded-lg text-sm bg-accent text-white hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/20 font-medium border border-blue-400/20" vid="127">
+                        Create Document
+                    </button>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/29-export-dialog.html
+++ b/design/Variant/designs/29-export-dialog.html
@@ -1,0 +1,458 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Export Dialog</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400&amp;family=Newsreader:ital,wght@0,400;0,500;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6', 
+                        'accent-hover': '#2563eb',
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                        serif: ['Newsreader', 'serif'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #333;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #444;
+        }
+
+        
+        .custom-checkbox input:checked + div {
+            background-color: #3b82f6;
+            border-color: #3b82f6;
+        }
+        .custom-checkbox input:checked + div svg {
+            display: block;
+        }
+        
+        
+        @keyframes progress {
+            0% { width: 0%; }
+            100% { width: 100%; }
+        }
+        .animate-progress {
+            animation: progress 2s ease-in-out forwards;
+        }
+
+        
+        .fade-in {
+            animation: fadeIn 0.3s ease-out;
+        }
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(5px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans h-screen w-screen overflow-hidden flex selection:bg-accent/30 selection:text-white" vid="9">
+
+    
+    
+    <div class="absolute inset-0 flex opacity-40 blur-[2px] pointer-events-none select-none" aria-hidden="true" vid="10">
+        
+        <aside class="w-64 border-r border-border flex flex-col h-full bg-background flex-shrink-0" vid="11">
+            <div class="h-14 px-6 flex items-center mb-6" vid="12">
+                <span class="font-bold tracking-tight text-lg" vid="13">CREO</span><span class="font-thin ml-1 text-secondary" vid="14">NOW</span>
+            </div>
+            <div class="flex-1 px-4 space-y-6" vid="15">
+                <div vid="16">
+                    <h3 class="text-[10px] tracking-widest text-tertiary font-semibold mb-2 px-2 uppercase" vid="17">Workspace</h3>
+                    <div class="flex items-center px-2 py-1.5 text-sm text-primary rounded bg-hover" vid="18">
+                        <span class="w-1.5 h-1.5 rounded-full bg-accent mr-2.5" vid="19"></span>
+                        Recent Drafts
+                    </div>
+                    <div class="flex items-center px-2 py-1.5 text-sm text-secondary" vid="20">Published</div>
+                </div>
+                <div vid="21">
+                    <h3 class="text-[10px] tracking-widest text-tertiary font-semibold mb-2 px-2 uppercase" vid="22">Collections</h3>
+                    <div class="flex items-center px-2 py-1.5 text-sm text-secondary" vid="23">Design Theory</div>
+                    <div class="flex items-center px-2 py-1.5 text-sm text-secondary" vid="24">Visual Essays</div>
+                </div>
+            </div>
+            <div class="p-4 border-t border-border" vid="25">
+                <div class="flex items-center gap-3" vid="26">
+                    <div class="w-8 h-8 rounded bg-gradient-to-br from-gray-700 to-gray-900 flex items-center justify-center text-xs font-medium border border-border" vid="27">AM</div>
+                    <div class="flex flex-col" vid="28">
+                        <span class="text-sm font-medium" vid="29">Alex M.</span>
+                    </div>
+                </div>
+            </div>
+        </aside>
+
+        
+        <main class="flex-1 flex flex-col bg-background" vid="30">
+            <header class="h-14 border-b border-border flex items-center justify-between px-6" vid="31">
+                <div class="flex items-center gap-2 text-sm text-secondary" vid="32">
+                    <span vid="33">Drafts</span> <span class="text-tertiary" vid="34">/</span> <span class="text-primary" vid="35">The Architecture of Silence</span>
+                </div>
+            </header>
+            <div class="flex-1 p-12 max-w-4xl mx-auto w-full" vid="36">
+                <h1 class="text-5xl font-serif font-medium mb-8" vid="37">The Architecture of Silence</h1>
+                <p class="text-xl text-secondary font-serif leading-relaxed mb-8" vid="38">
+                    Intrigued by beauty, fascinated by technology and fueled with an everlasting devotion to digital craftsmanship.
+                </p>
+                <p class="text-lg text-secondary/80 font-serif leading-relaxed mb-6" vid="39">
+                    Design is not just about making things look good. It is about how things work. In the digital realm, this translates to the seamless integration of form and function.
+                </p>
+                <div class="w-full h-64 bg-panel border border-border rounded-lg mb-8" vid="40"></div>
+                <p class="text-lg text-secondary/80 font-serif leading-relaxed" vid="41">
+                    We build immersive environments where typography leads the eye and imagery sets the mood.
+                </p>
+            </div>
+        </main>
+    </div>
+
+    
+    <div class="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4" vid="42">
+        
+        
+        <div class="w-[480px] bg-panel border border-border rounded-lg shadow-2xl flex flex-col max-h-[90vh] transition-all duration-300 relative overflow-hidden" id="export-modal" vid="43">
+            
+            
+            <div id="view-config" class="flex flex-col h-full fade-in" vid="44">
+                
+                <div class="flex items-start justify-between p-6 pb-4 border-b border-border" vid="45">
+                    <div vid="46">
+                        <h2 class="text-lg font-medium text-primary mb-1" vid="47">Export Document</h2>
+                        <p class="text-sm text-secondary" vid="48">The Architecture of Silence</p>
+                    </div>
+                    <button class="text-secondary hover:text-primary transition-colors p-1 rounded-md hover:bg-hover" vid="49">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="50">
+                            <line x1="18" y1="6" x2="6" y2="18" vid="51"></line>
+                            <line x1="6" y1="6" x2="18" y2="18" vid="52"></line>
+                        </svg>
+                    </button>
+                </div>
+
+                
+                <div class="overflow-y-auto p-6 space-y-6 custom-scrollbar" vid="53">
+                    
+                    
+                    <div vid="54">
+                        <label class="text-xs font-semibold text-tertiary uppercase tracking-wider mb-3 block" vid="55">Format</label>
+                        <div class="grid grid-cols-2 gap-3" vid="56">
+                            
+                            <label class="cursor-pointer group relative" vid="57">
+                                <input type="radio" name="format" value="pdf" class="peer sr-only" checked="" vid="58">
+                                <div class="p-3 rounded-md border border-accent bg-accent/5 peer-checked:border-accent peer-checked:bg-accent/10 hover:bg-hover transition-all h-full" vid="59">
+                                    <div class="flex items-start justify-between mb-2" vid="60">
+                                        <div class="text-accent" vid="61">
+                                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" vid="62">
+                                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="63"></path>
+                                                <polyline points="14 2 14 8 20 8" vid="64"></polyline>
+                                                <path d="M10 13H8v5h2" vid="65"></path>
+                                                <path d="M15 15h-2v3h2" vid="66"></path>
+                                                <path d="M16 13h-3v5" vid="67"></path>
+                                            </svg>
+                                        </div>
+                                        <div class="w-4 h-4 rounded-full border border-accent flex items-center justify-center opacity-100" vid="68">
+                                            <div class="w-2 h-2 rounded-full bg-accent" vid="69"></div>
+                                        </div>
+                                    </div>
+                                    <div class="font-medium text-sm text-primary" vid="70">PDF</div>
+                                    <div class="text-xs text-secondary mt-0.5" vid="71">Portable Document</div>
+                                </div>
+                            </label>
+
+                            
+                            <label class="cursor-pointer group relative" vid="72">
+                                <input type="radio" name="format" value="md" class="peer sr-only" vid="73">
+                                <div class="p-3 rounded-md border border-border peer-checked:border-accent peer-checked:bg-accent/10 hover:bg-hover transition-all h-full bg-background/50" vid="74">
+                                    <div class="flex items-start justify-between mb-2" vid="75">
+                                        <div class="text-secondary group-hover:text-primary transition-colors" vid="76">
+                                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" vid="77">
+                                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="78"></path>
+                                                <polyline points="14 2 14 8 20 8" vid="79"></polyline>
+                                                <path d="M12 18v-6" vid="80"></path>
+                                                <path d="M9 15l3 3 3-3" vid="81"></path>
+                                            </svg>
+                                        </div>
+                                        <div class="w-4 h-4 rounded-full border border-border peer-checked:border-accent flex items-center justify-center opacity-0 peer-checked:opacity-100" vid="82">
+                                            <div class="w-2 h-2 rounded-full bg-accent" vid="83"></div>
+                                        </div>
+                                    </div>
+                                    <div class="font-medium text-sm text-primary" vid="84">Markdown</div>
+                                    <div class="text-xs text-secondary mt-0.5 font-mono" vid="85">.md</div>
+                                </div>
+                            </label>
+
+                            
+                            <label class="cursor-pointer group relative" vid="86">
+                                <input type="radio" name="format" value="docx" class="peer sr-only" vid="87">
+                                <div class="p-3 rounded-md border border-border peer-checked:border-accent peer-checked:bg-accent/10 hover:bg-hover transition-all h-full bg-background/50" vid="88">
+                                    <div class="flex items-start justify-between mb-2" vid="89">
+                                        <div class="text-secondary group-hover:text-primary transition-colors" vid="90">
+                                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" vid="91">
+                                                <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" vid="92"></path>
+                                                <polyline points="14 2 14 8 20 8" vid="93"></polyline>
+                                                <path d="M8 13h8" vid="94"></path>
+                                                <path d="M8 17h8" vid="95"></path>
+                                                <path d="M8 9h5" vid="96"></path>
+                                            </svg>
+                                        </div>
+                                        <div class="w-4 h-4 rounded-full border border-border peer-checked:border-accent flex items-center justify-center opacity-0 peer-checked:opacity-100" vid="97">
+                                            <div class="w-2 h-2 rounded-full bg-accent" vid="98"></div>
+                                        </div>
+                                    </div>
+                                    <div class="font-medium text-sm text-primary" vid="99">Word</div>
+                                    <div class="text-xs text-secondary mt-0.5" vid="100">.docx</div>
+                                </div>
+                            </label>
+
+                            
+                            <label class="cursor-pointer group relative" vid="101">
+                                <input type="radio" name="format" value="txt" class="peer sr-only" vid="102">
+                                <div class="p-3 rounded-md border border-border peer-checked:border-accent peer-checked:bg-accent/10 hover:bg-hover transition-all h-full bg-background/50" vid="103">
+                                    <div class="flex items-start justify-between mb-2" vid="104">
+                                        <div class="text-secondary group-hover:text-primary transition-colors" vid="105">
+                                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" vid="106">
+                                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="107"></path>
+                                                <polyline points="14 2 14 8 20 8" vid="108"></polyline>
+                                                <line x1="16" y1="13" x2="8" y2="13" vid="109"></line>
+                                                <line x1="16" y1="17" x2="8" y2="17" vid="110"></line>
+                                                <line x1="10" y1="9" x2="8" y2="9" vid="111"></line>
+                                            </svg>
+                                        </div>
+                                        <div class="w-4 h-4 rounded-full border border-border peer-checked:border-accent flex items-center justify-center opacity-0 peer-checked:opacity-100" vid="112">
+                                            <div class="w-2 h-2 rounded-full bg-accent" vid="113"></div>
+                                        </div>
+                                    </div>
+                                    <div class="font-medium text-sm text-primary" vid="114">Plain Text</div>
+                                    <div class="text-xs text-secondary mt-0.5 font-mono" vid="115">.txt</div>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+
+                    
+                    <div class="grid grid-cols-2 gap-6" vid="116">
+                        
+                        <div class="space-y-3" vid="117">
+                            <label class="text-xs font-semibold text-tertiary uppercase tracking-wider block" vid="118">Settings</label>
+                            
+                            <label class="flex items-center gap-3 cursor-pointer group custom-checkbox" vid="119">
+                                <input type="checkbox" checked="" class="hidden" vid="120">
+                                <div class="w-4 h-4 rounded border border-border group-hover:border-secondary bg-background flex items-center justify-center transition-colors" vid="121">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" class="hidden" vid="122">
+                                        <polyline points="20 6 9 17 4 12" vid="123"></polyline>
+                                    </svg>
+                                </div>
+                                <span class="text-sm text-secondary group-hover:text-primary transition-colors" vid="124">Include metadata</span>
+                            </label>
+
+                            <label class="flex items-center gap-3 cursor-pointer group custom-checkbox" vid="125">
+                                <input type="checkbox" class="hidden" vid="126">
+                                <div class="w-4 h-4 rounded border border-border group-hover:border-secondary bg-background flex items-center justify-center transition-colors" vid="127">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" class="hidden" vid="128">
+                                        <polyline points="20 6 9 17 4 12" vid="129"></polyline>
+                                    </svg>
+                                </div>
+                                <span class="text-sm text-secondary group-hover:text-primary transition-colors" vid="130">Version history</span>
+                            </label>
+
+                            <label class="flex items-center gap-3 cursor-pointer group custom-checkbox" vid="131">
+                                <input type="checkbox" checked="" class="hidden" vid="132">
+                                <div class="w-4 h-4 rounded border border-border group-hover:border-secondary bg-background flex items-center justify-center transition-colors" vid="133">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" class="hidden" vid="134">
+                                        <polyline points="20 6 9 17 4 12" vid="135"></polyline>
+                                    </svg>
+                                </div>
+                                <span class="text-sm text-secondary group-hover:text-primary transition-colors" vid="136">Embed images</span>
+                            </label>
+                        </div>
+
+                        
+                        <div class="space-y-3" vid="137">
+                            <label class="text-xs font-semibold text-tertiary uppercase tracking-wider block" vid="138">Page Size</label>
+                            <div class="relative group" vid="139">
+                                <select class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-primary appearance-none focus:outline-none focus:border-accent cursor-pointer hover:border-secondary transition-colors" vid="140">
+                                    <option vid="141">A4</option>
+                                    <option vid="142">Letter</option>
+                                    <option vid="143">Legal</option>
+                                </select>
+                                <div class="absolute right-2 top-2.5 pointer-events-none text-secondary" vid="144">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="145">
+                                        <polyline points="6 9 12 15 18 9" vid="146"></polyline>
+                                    </svg>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div vid="147">
+                        <div class="flex items-center justify-between mb-2" vid="148">
+                            <label class="text-xs font-semibold text-tertiary uppercase tracking-wider" vid="149">Preview</label>
+                            <span class="text-[10px] text-tertiary bg-hover px-1.5 py-0.5 rounded" vid="150">PDF • A4</span>
+                        </div>
+                        <div class="w-full h-32 bg-[#050505] border border-border rounded-md p-4 overflow-hidden relative" vid="151">
+                            
+                            <div class="opacity-50 select-none pointer-events-none transform scale-[0.8] origin-top-left w-[120%]" vid="152">
+                                <div class="h-4 w-3/4 bg-tertiary/40 rounded mb-3" vid="153"></div>
+                                <div class="h-2 w-full bg-tertiary/20 rounded mb-1.5" vid="154"></div>
+                                <div class="h-2 w-full bg-tertiary/20 rounded mb-1.5" vid="155"></div>
+                                <div class="h-2 w-5/6 bg-tertiary/20 rounded mb-3" vid="156"></div>
+                                <div class="h-2 w-full bg-tertiary/20 rounded mb-1.5" vid="157"></div>
+                                <div class="h-2 w-4/5 bg-tertiary/20 rounded mb-1.5" vid="158"></div>
+                                <div class="w-full h-16 bg-tertiary/10 rounded mt-4 border border-white/5" vid="159"></div>
+                            </div>
+                            
+                            <div class="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-[#050505] to-transparent" vid="160"></div>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="p-6 pt-4 border-t border-border mt-auto flex items-center justify-between bg-panel" vid="161">
+                    <span class="text-sm text-secondary" vid="162">~2.4 MB</span>
+                    <div class="flex gap-3" vid="163">
+                        <button class="px-4 py-2 text-sm font-medium text-secondary hover:text-primary transition-colors rounded-md hover:bg-hover" vid="164">Cancel</button>
+                        <button onclick="startExport()" class="px-6 py-2 text-sm font-medium bg-accent text-white rounded-md hover:bg-accent-hover transition-all shadow-lg shadow-accent/20" vid="165">
+                            Export
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div id="view-progress" class="hidden flex-col h-full items-center justify-center p-8 text-center fade-in h-[580px]" vid="166">
+                
+                <div class="w-16 h-16 rounded-2xl bg-accent/10 flex items-center justify-center text-accent mb-6 relative" vid="167">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vid="168">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="169"></path>
+                        <polyline points="14 2 14 8 20 8" vid="170"></polyline>
+                    </svg>
+                    
+                    <div class="absolute inset-0 rounded-2xl border border-accent/30 animate-ping opacity-75" vid="171"></div>
+                </div>
+
+                <h3 class="text-xl font-medium text-primary mb-2" vid="172">Exporting Document</h3>
+                <p class="text-secondary text-sm mb-8" vid="173">Converting "The Architecture of Silence" to PDF...</p>
+
+                
+                <div class="w-full max-w-xs mb-2" vid="174">
+                    <div class="h-1.5 w-full bg-hover rounded-full overflow-hidden" vid="175">
+                        <div id="progress-bar-fill" class="h-full bg-accent w-0 rounded-full transition-all duration-300" vid="176"></div>
+                    </div>
+                </div>
+                <div class="flex items-center justify-between w-full max-w-xs text-xs text-tertiary font-mono" vid="177">
+                    <span id="progress-step" vid="178">Processing images...</span>
+                    <span id="progress-percent" vid="179">0%</span>
+                </div>
+
+                
+                <button onclick="resetExport()" class="mt-8 px-4 py-2 text-sm text-secondary hover:text-primary transition-colors rounded hover:bg-hover" vid="180">
+                    Cancel
+                </button>
+            </div>
+
+            
+            <div id="view-success" class="hidden flex-col h-full items-center justify-center p-8 text-center fade-in h-[580px]" vid="181">
+                <div class="w-16 h-16 rounded-full bg-green-500/10 flex items-center justify-center text-green-500 mb-6 border border-green-500/20" vid="182">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="183">
+                        <polyline points="20 6 9 17 4 12" vid="184"></polyline>
+                    </svg>
+                </div>
+                <h3 class="text-xl font-medium text-primary mb-2" vid="185">Export Complete</h3>
+                <p class="text-secondary text-sm mb-8" vid="186">Your file has been successfully downloaded.</p>
+                <button onclick="resetExport()" class="px-6 py-2 text-sm font-medium bg-white text-black rounded-md hover:bg-gray-200 transition-colors" vid="187">
+                    Done
+                </button>
+            </div>
+
+        </div>
+    </div>
+
+    <script vid="188">
+        function startExport() {
+            const configView = document.getElementById('view-config');
+            const progressView = document.getElementById('view-progress');
+            const successView = document.getElementById('view-success');
+            const progressBar = document.getElementById('progress-bar-fill');
+            const percentText = document.getElementById('progress-percent');
+            const stepText = document.getElementById('progress-step');
+            const modal = document.getElementById('export-modal');
+
+            
+            
+            modal.style.height = configView.offsetHeight + 'px';
+
+            configView.style.display = 'none';
+            progressView.style.display = 'flex';
+            
+            
+            let progress = 0;
+            const steps = ["Preparing...", "Generating pages...", "Embedding images...", "Finalizing PDF..."];
+            
+            const interval = setInterval(() => {
+                progress += Math.random() * 5;
+                if (progress > 100) progress = 100;
+                
+                progressBar.style.width = progress + '%';
+                percentText.innerText = Math.floor(progress) + '%';
+                
+                
+                if (progress < 30) stepText.innerText = steps[0];
+                else if (progress < 60) stepText.innerText = steps[1];
+                else if (progress < 90) stepText.innerText = steps[2];
+                else stepText.innerText = steps[3];
+
+                if (progress === 100) {
+                    clearInterval(interval);
+                    setTimeout(() => {
+                        progressView.style.display = 'none';
+                        successView.style.display = 'flex';
+                    }, 600);
+                }
+            }, 100);
+        }
+
+        function resetExport() {
+            const configView = document.getElementById('view-config');
+            const progressView = document.getElementById('view-progress');
+            const successView = document.getElementById('view-success');
+            const modal = document.getElementById('export-modal');
+
+            configView.style.display = 'flex';
+            progressView.style.display = 'none';
+            successView.style.display = 'none';
+            
+            
+            modal.style.height = 'auto';
+
+            
+            document.getElementById('progress-bar-fill').style.width = '0%';
+            document.getElementById('progress-percent').innerText = '0%';
+        }
+    </script>
+
+</body></html>

--- a/design/Variant/designs/30-zen-mode.html
+++ b/design/Variant/designs/30-zen-mode.html
@@ -1,0 +1,147 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Zen Mode</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400&amp;family=Newsreader:ital,wght@0,300;0,400;0,500;1,300;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#050505', 
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6', 
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                        serif: ['Newsreader', 'serif'],
+                    },
+                    keyframes: {
+                        blink: {
+                            '0%, 100%': { opacity: '1' },
+                            '50%': { opacity: '0' },
+                        }
+                    },
+                    animation: {
+                        blink: 'blink 1s step-end infinite',
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        
+        ::-webkit-scrollbar {
+            width: 0px;
+            background: transparent;
+        }
+        
+        
+        .zen-glow {
+            background: radial-gradient(circle at center, rgba(59, 130, 246, 0.03) 0%, rgba(5, 5, 5, 0) 70%);
+        }
+
+        
+        ::selection {
+            background: #3b82f6; 
+            color: #ffffff;
+        }
+
+        .cursor-blink {
+            display: inline-block;
+            width: 2px;
+            height: 1.2em;
+            background-color: #3b82f6;
+            vertical-align: text-bottom;
+            margin-left: 1px;
+            animation: blink 1s step-end infinite;
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans h-screen w-screen overflow-hidden flex flex-col relative" vid="9">
+
+    
+    <div class="absolute inset-0 zen-glow pointer-events-none z-0" vid="10"></div>
+
+    
+    <div class="fixed top-0 left-0 w-full h-24 z-20 transition-opacity duration-300 opacity-0 hover:opacity-100 group" vid="11">
+        
+        <div class="absolute top-8 right-8 flex items-center gap-4" vid="12">
+            <span class="text-[11px] text-tertiary tracking-wide opacity-60" vid="13">Press Esc to exit</span>
+            <button class="w-8 h-8 rounded-full flex items-center justify-center text-secondary hover:text-primary hover:bg-white/5 transition-colors" vid="14">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vid="15">
+                    <line x1="18" y1="6" x2="6" y2="18" vid="16"></line>
+                    <line x1="6" y1="6" x2="18" y2="18" vid="17"></line>
+                </svg>
+            </button>
+        </div>
+    </div>
+
+    
+    
+    <div class="absolute top-8 right-8 z-10 pointer-events-none" vid="18">
+        <span class="text-[11px] text-tertiary tracking-wide opacity-40" vid="19">Press Esc or F11 to exit</span>
+    </div>
+
+
+    
+    <main class="flex-1 w-full h-full overflow-y-auto relative z-10 flex flex-col items-center" vid="20">
+        
+        <div class="w-full max-w-[720px] px-[80px] py-[120px] flex-shrink-0" vid="21">
+            
+            
+            <h1 class="font-serif text-[48px] leading-tight text-primary font-medium mb-12 tracking-tight" vid="22">
+                The Architecture of Silence
+            </h1>
+
+            
+            <div class="font-serif text-[18px] leading-[1.8] text-primary/90 space-y-8" vid="23">
+                
+                <p vid="24">
+                    Intrigued by beauty, fascinated by technology and fueled with an everlasting devotion to digital craftsmanship.
+                </p>
+
+                <p vid="25">
+                    Design is not just about making things look good. It is about how things work. In the digital realm, this translates to the seamless integration of form and function. We build immersive environments where typography leads the eye and imagery sets the mood.
+                </p>
+
+                <p vid="26">
+                    The silence of a well-designed interface is not empty; it is full of potential. It is the breath between notes in a symphony, the white space that gives meaning to the ink. When we strip away the noise—the unnecessary borders, the decorative flourishes, the redundant controls—we are left with something pure.
+                </p>
+
+                <p vid="27">
+                    <span class="bg-accent/20 text-white" vid="28">We find ourselves in a constant state of refinement.</span> The goal is never to add more, but to take away until nothing else can be removed without breaking the essence. This is the paradox of modern design: it takes immense effort to make something appear effortless.
+                </p>
+
+                <p vid="29">
+                    Consider the cursor blinking on a blank page<span class="cursor-blink" vid="30"></span>
+                </p>
+
+            </div>
+
+        </div>
+
+    </main>
+
+    
+    <div class="fixed bottom-0 left-0 w-full h-24 z-20 flex items-end justify-center pb-8 pointer-events-none" vid="31">
+        
+        <div class="opacity-40 hover:opacity-100 transition-opacity duration-300 pointer-events-auto flex items-center gap-6 px-4 py-2 rounded-full" vid="32">
+            <span class="text-xs text-secondary font-sans tabular-nums" vid="33">1,240 words</span>
+            <span class="w-1 h-1 rounded-full bg-tertiary" vid="34"></span>
+            <span class="text-xs text-secondary font-sans" vid="35">Saved</span>
+            <span class="w-1 h-1 rounded-full bg-tertiary" vid="36"></span>
+            <span class="text-xs text-secondary font-sans" vid="37">6 min read</span>
+        </div>
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/31-interaction-patterns.html
+++ b/design/Variant/designs/31-interaction-patterns.html
@@ -1,0 +1,383 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow - Interaction Design System</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;family=JetBrains+Mono:wght@400&amp;family=Newsreader:ital,wght@0,400;0,500;1,400&amp;display=swap" rel="stylesheet" vid="6">
+    <script vid="7">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        background: '#080808',
+                        panel: '#0f0f0f',
+                        hover: '#1a1a1a',
+                        selected: '#222222',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        primary: '#ffffff',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: '#3b82f6',
+                        danger: '#ef4444'
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                        serif: ['Newsreader', 'serif'],
+                    },
+                    boxShadow: {
+                        'elevation': '0 4px 20px -2px rgba(0, 0, 0, 0.5)',
+                        'glow': '0 0 15px rgba(59, 130, 246, 0.1)'
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="8">
+        .glass-panel {
+            backdrop-filter: blur(12px);
+            background-color: rgba(15, 15, 15, 0.95);
+        }
+        
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #333;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #444;
+        }
+
+        .cursor-col-resize {
+            cursor: col-resize;
+        }
+    </style>
+</head>
+<body class="bg-background text-primary font-sans w-full min-h-screen overflow-x-hidden p-12" vid="9">
+
+    
+    <header class="mb-16 border-b border-border pb-6" vid="10">
+        <h1 class="text-2xl font-semibold tracking-tight mb-2" vid="11">Interaction Components</h1>
+        <p class="text-secondary text-sm" vid="12">Design specifications for Selection Toolbar, Resize Indicators, and Context Menus.</p>
+    </header>
+
+    <div class="max-w-7xl mx-auto space-y-20" vid="13">
+
+        
+        <section vid="14">
+            <div class="flex items-center gap-2 mb-6" vid="15">
+                <span class="text-xs font-mono text-accent bg-accent/10 px-2 py-1 rounded" vid="16">01</span>
+                <h2 class="text-sm font-medium tracking-wide text-secondary uppercase" vid="17">Selection Toolbar &amp; AI Actions</h2>
+            </div>
+            
+            <div class="relative w-full h-[400px] bg-panel border border-border rounded-xl overflow-hidden flex flex-col items-center justify-center p-8 group select-none" vid="18">
+                
+                <div class="absolute inset-0 opacity-[0.03]" style="background-image: radial-gradient(#fff 1px, transparent 1px); background-size: 24px 24px;" vid="19"></div>
+
+                
+                <div class="relative z-0 max-w-2xl text-center" vid="20">
+                    <p class="font-serif text-2xl text-secondary leading-relaxed" vid="21">
+                        Design is not just about making things look good. It is about how things work. 
+                        In the digital realm, this translates to the 
+                        <span class="bg-accent/20 text-white relative px-0.5 rounded-sm" vid="22">
+                            seamless integration of form and function
+                            
+                            </span></p><div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-3 w-max" vid="23">
+                                
+                                
+                                <div class="flex flex-col items-center" vid="24">
+                                    <div class="glass-panel border border-border rounded-lg shadow-elevation flex items-center h-9 px-1 gap-0.5 z-20" vid="25">
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="26">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="27"><path d="M6 4h8a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" vid="28"></path><path d="M6 12h9a4 4 0 0 1 4 4 4 4 0 0 1-4 4H6z" vid="29"></path></svg>
+                                        </button>
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="30">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="31"><line x1="19" y1="4" x2="10" y2="4" vid="32"></line><line x1="14" y1="20" x2="5" y2="20" vid="33"></line><line x1="15" y1="4" x2="9" y2="20" vid="34"></line></svg>
+                                        </button>
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="35">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="36"><path d="M6 3v7a6 6 0 0 0 6 6 6 6 0 0 0 6-6V3" vid="37"></path><line x1="4" y1="21" x2="20" y2="21" vid="38"></line></svg>
+                                        </button>
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="39">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="40"><path d="M5 12h14" vid="41"></path><path d="M16 6a4 4 0 0 0-8 0" vid="42"></path><path d="M16 18a4 4 0 0 1-8 0" vid="43"></path></svg>
+                                        </button>
+                                        
+                                        
+                                        <div class="w-px h-3 bg-white/10 mx-1" vid="44"></div>
+
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="45">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="46"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" vid="47"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" vid="48"></path></svg>
+                                        </button>
+                                        
+                                        <button class="w-7 h-7 flex items-center justify-center text-secondary hover:text-primary hover:bg-hover rounded transition-colors" vid="49">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="50"><path d="m9.06 11.9 8.07-8.06a2.85 2.85 0 1 1 4.03 4.03l-8.06 8.08" vid="51"></path><path d="M7.07 14.94c-1.66 0-3 1.35-3 3.02 0 1.33-1.33 1.54-2 1.54 2.54.42 5.07-.62 5-3.04" vid="52"></path><path d="M9 16.51c1.88 0 1.59 4 4.36 4.48-1.55-3.83 3.98-1.87 3.78-5.32" vid="53"></path></svg>
+                                        </button>
+
+                                        
+                                        <div class="w-px h-3 bg-white/10 mx-1" vid="54"></div>
+
+                                        
+                                        <button class="flex items-center gap-1.5 px-2 py-0.5 text-accent hover:bg-hover rounded transition-colors text-xs font-medium" vid="55">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" vid="56"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" vid="57"></path></svg>
+                                            <span class="mt-0.5" vid="58">Actions</span>
+                                        </button>
+                                    </div>
+
+                                    
+                                    <div class="w-3 h-3 bg-panel border-r border-b border-border rotate-45 transform -translate-y-1.5 shadow-elevation z-10" vid="59"></div>
+
+                                    
+                                    <div class="absolute top-full left-0 right-0 mt-2 glass-panel border border-border rounded-lg shadow-elevation overflow-hidden w-48 mx-auto animate-in fade-in zoom-in-95 duration-200" vid="60">
+                                        <div class="p-1 space-y-0.5" vid="61">
+                                            
+                                            <button class="w-full flex items-center justify-between px-2 py-1.5 text-left rounded hover:bg-hover group" vid="62">
+                                                <div class="flex items-center gap-2" vid="63">
+                                                    <svg class="text-secondary group-hover:text-primary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="64"><path d="M12 2v20M2 12h20" vid="65"></path></svg>
+                                                    <span class="text-sm text-primary" vid="66">Improve</span>
+                                                </div>
+                                                <span class="text-[10px] text-tertiary" vid="67">⌘I</span>
+                                            </button>
+                                            
+                                            <button class="w-full flex items-center justify-between px-2 py-1.5 text-left rounded hover:bg-hover group" vid="68">
+                                                <div class="flex items-center gap-2" vid="69">
+                                                    <svg class="text-secondary group-hover:text-primary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="70"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" vid="71"></path></svg>
+                                                    <span class="text-sm text-primary" vid="72">Expand</span>
+                                                </div>
+                                                <span class="text-[10px] text-tertiary" vid="73">⌘E</span>
+                                            </button>
+                                            
+                                            <button class="w-full flex items-center justify-between px-2 py-1.5 text-left rounded hover:bg-hover group" vid="74">
+                                                <div class="flex items-center gap-2" vid="75">
+                                                    <svg class="text-secondary group-hover:text-primary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="76"><path d="M4 14h6v6M20 10h-6V4M14 10l7-7M10 14l-7 7" vid="77"></path></svg>
+                                                    <span class="text-sm text-primary" vid="78">Shorten</span>
+                                                </div>
+                                                <span class="text-[10px] text-tertiary" vid="79">⌘S</span>
+                                            </button>
+                                            
+                                            <div class="h-px bg-white/5 mx-2 my-1" vid="80"></div>
+                                            
+                                            <button class="w-full flex items-center justify-between px-2 py-1.5 text-left rounded hover:bg-hover group" vid="81">
+                                                <div class="flex items-center gap-2" vid="82">
+                                                    <svg class="text-secondary group-hover:text-primary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="83"><circle cx="12" cy="12" r="10" vid="84"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" vid="85"></path><line x1="12" y1="17" x2="12.01" y2="17" vid="86"></line></svg>
+                                                    <span class="text-sm text-primary" vid="87">Explain</span>
+                                                </div>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        .
+                    <p vid="88"></p>
+                </div>
+            </div>
+        </section>
+
+        
+        <section vid="89">
+            <div class="flex items-center gap-2 mb-6" vid="90">
+                <span class="text-xs font-mono text-accent bg-accent/10 px-2 py-1 rounded" vid="91">02</span>
+                <h2 class="text-sm font-medium tracking-wide text-secondary uppercase" vid="92">Resizer States</h2>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8" vid="93">
+                
+                
+                <div class="h-64 bg-background border border-border rounded-xl relative overflow-hidden flex items-center justify-center" vid="94">
+                    <span class="text-xs text-tertiary absolute top-4 left-4" vid="95">Default</span>
+                    
+                    <div class="flex w-full h-full max-w-[200px]" vid="96">
+                        <div class="flex-1 bg-panel border-r border-border rounded-l-md" vid="97"></div>
+                        <div class="relative w-px h-full bg-border" vid="98">
+                             
+                            <div class="absolute inset-y-0 -left-1 -right-1 bg-transparent hover:bg-white/5 transition-colors" vid="99"></div>
+                        </div>
+                        <div class="flex-1 bg-background" vid="100"></div>
+                    </div>
+                </div>
+
+                
+                <div class="h-64 bg-background border border-border rounded-xl relative overflow-hidden flex items-center justify-center" vid="101">
+                    <span class="text-xs text-tertiary absolute top-4 left-4" vid="102">Hover</span>
+                    
+                    <div class="flex w-full h-full max-w-[200px]" vid="103">
+                        <div class="flex-1 bg-panel border-r border-border rounded-l-md" vid="104"></div>
+                        
+                        <div class="relative w-0.5 h-full bg-[#444] shadow-glow cursor-col-resize z-10 transition-colors" vid="105"></div>
+                        <div class="flex-1 bg-background" vid="106"></div>
+                    </div>
+                    
+                    <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 pointer-events-none" vid="107">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" class="drop-shadow-lg" vid="108"><path d="M14 6l-6 6 6 6M20 6l-6 6 6 6" stroke="transparent" vid="109"></path><path d="M9 12h6M9 12l-3-3M9 12l-3 3M15 12l3-3M15 12l3 3" vid="110"></path></svg>
+                    </div>
+                </div>
+
+                
+                <div class="h-64 bg-background border border-border rounded-xl relative overflow-hidden flex items-center justify-center" vid="111">
+                    <span class="text-xs text-tertiary absolute top-4 left-4" vid="112">Dragging</span>
+                    
+                    <div class="flex w-full h-full max-w-[200px]" vid="113">
+                        <div class="flex-1 bg-panel border-r border-border rounded-l-md" vid="114"></div>
+                        
+                        <div class="relative w-0.5 h-full bg-accent shadow-glow z-10" vid="115">
+                            
+                            <div class="absolute top-1/2 -translate-y-1/2 left-4 bg-panel border border-border text-xs text-white px-2 py-1 rounded shadow-xl whitespace-nowrap" vid="116">
+                                320px
+                            </div>
+                        </div>
+                        <div class="flex-1 bg-background" vid="117"></div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        
+        <section class="pb-20" vid="118">
+            <div class="flex items-center gap-2 mb-6" vid="119">
+                <span class="text-xs font-mono text-accent bg-accent/10 px-2 py-1 rounded" vid="120">03</span>
+                <h2 class="text-sm font-medium tracking-wide text-secondary uppercase" vid="121">Context Menus</h2>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8 items-start" vid="122">
+
+                
+                <div class="flex flex-col gap-4" vid="123">
+                    <span class="text-xs text-tertiary font-mono" vid="124">File Tree Context</span>
+                    <div class="w-full bg-[#0f0f0f] border border-border rounded-lg shadow-elevation overflow-hidden py-1" vid="125">
+                        
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="126">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="127"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="128"></path><polyline points="14 2 14 8 20 8" vid="129"></polyline><line x1="12" y1="18" x2="12" y2="12" vid="130"></line><line x1="9" y1="15" x2="15" y2="15" vid="131"></line></svg>
+                            <span class="text-sm text-primary flex-1" vid="132">New File</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="133">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="134"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" vid="135"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="136">New Folder</span>
+                        </button>
+                        
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="137"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="138">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="139"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" vid="140"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" vid="141"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="142">Rename</span>
+                            <span class="text-xs text-tertiary" vid="143">F2</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="144">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="145"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" vid="146"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" vid="147"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="148">Duplicate</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="149">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="150"><polyline points="9 10 4 15 9 20" vid="151"></polyline><path d="M20 4v7a4 4 0 0 1-4 4H4" vid="152"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="153">Move to...</span>
+                        </button>
+
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="154"></div>
+                        
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="155">
+                            <svg class="text-danger group-hover:text-red-400" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="156"><polyline points="3 6 5 6 21 6" vid="157"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" vid="158"></path></svg>
+                            <span class="text-sm text-danger group-hover:text-red-400 flex-1" vid="159">Delete</span>
+                            <span class="text-xs text-danger/50 group-hover:text-red-400" vid="160">Del</span>
+                        </button>
+                    </div>
+                </div>
+
+                
+                <div class="flex flex-col gap-4" vid="161">
+                    <span class="text-xs text-tertiary font-mono" vid="162">Editor Context</span>
+                    <div class="w-full bg-[#0f0f0f] border border-border rounded-lg shadow-elevation overflow-hidden py-1" vid="163">
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="164">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="165">Cut</span>
+                            <span class="text-xs text-tertiary" vid="166">⌘X</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="167">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="168">Copy</span>
+                            <span class="text-xs text-tertiary" vid="169">⌘C</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="170">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="171">Paste</span>
+                            <span class="text-xs text-tertiary" vid="172">⌘V</span>
+                        </button>
+
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="173"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="174">
+                            <svg class="text-accent" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="175"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" vid="176"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="177">AI Actions</span>
+                            <svg class="text-tertiary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="178"><polyline points="9 18 15 12 9 6" vid="179"></polyline></svg>
+                        </button>
+
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="180"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="181">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="182">Find in Document</span>
+                            <span class="text-xs text-tertiary" vid="183">⌘F</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="184">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="185">Add to Memories</span>
+                        </button>
+
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="186"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="187">
+                            <span class="text-sm text-primary flex-1 pl-7" vid="188">Format</span>
+                            <svg class="text-tertiary" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="189"><polyline points="9 18 15 12 9 6" vid="190"></polyline></svg>
+                        </button>
+                    </div>
+                </div>
+
+                
+                <div class="flex flex-col gap-4" vid="191">
+                    <span class="text-xs text-tertiary font-mono" vid="192">AI Panel Context</span>
+                    <div class="w-full bg-[#0f0f0f] border border-border rounded-lg shadow-elevation overflow-hidden py-1" vid="193">
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="194">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="195"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" vid="196"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" vid="197"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="198">Copy</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="199">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="200"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" vid="201"></path><polyline points="14 2 14 8 20 8" vid="202"></polyline><line x1="16" y1="13" x2="8" y2="13" vid="203"></line><line x1="16" y1="17" x2="8" y2="17" vid="204"></line><polyline points="10 9 9 9 8 9" vid="205"></polyline></svg>
+                            <span class="text-sm text-primary flex-1" vid="206">Copy as Markdown</span>
+                        </button>
+                        
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="207"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="208">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="209"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" vid="210"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="211">Regenerate</span>
+                        </button>
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="212">
+                            <svg class="text-secondary group-hover:text-primary" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="213"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" vid="214"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" vid="215"></path></svg>
+                            <span class="text-sm text-primary flex-1" vid="216">Edit and Resend</span>
+                        </button>
+
+                        
+                        <div class="h-px bg-border mx-3 my-1" vid="217"></div>
+
+                        <button class="w-full flex items-center gap-3 px-3 py-1.5 hover:bg-hover text-left group" vid="218">
+                            <svg class="text-danger group-hover:text-red-400" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" vid="219"><polyline points="3 6 5 6 21 6" vid="220"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" vid="221"></path></svg>
+                            <span class="text-sm text-danger group-hover:text-red-400 flex-1" vid="222">Delete Message</span>
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/32-ai-streaming-states.html
+++ b/design/Variant/designs/32-ai-streaming-states.html
@@ -1,0 +1,311 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">AI Streaming States</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;display=swap" rel="stylesheet" vid="8">
+    <style vid="9">
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #080808;
+            color: #ffffff;
+        }
+
+        .custom-scrollbar::-webkit-scrollbar {
+            width: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        .typing-cursor::after {
+            content: '';
+            display: inline-block;
+            width: 6px;
+            height: 14px;
+            background-color: #3b82f6;
+            margin-left: 2px;
+            vertical-align: middle;
+            animation: blink 1s step-end infinite;
+        }
+
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0; }
+        }
+
+        .bounce-1 { animation: bounce 1.4s infinite ease-in-out both; animation-delay: -0.32s; }
+        .bounce-2 { animation: bounce 1.4s infinite ease-in-out both; animation-delay: -0.16s; }
+        .bounce-3 { animation: bounce 1.4s infinite ease-in-out both; }
+
+        @keyframes bounce {
+            0%, 80%, 100% { transform: scale(0); }
+            40% { transform: scale(1); }
+        }
+
+        .indeterminate-progress {
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .indeterminate-progress::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.5), transparent);
+            transform: translateX(-100%);
+            animation: shimmer 1.5s infinite;
+        }
+
+        @keyframes shimmer {
+            100% { transform: translateX(100%); }
+        }
+    </style>
+</head>
+<body class="flex h-screen w-full overflow-hidden bg-[#080808]" vid="10">
+
+    
+    <div class="flex-1 flex flex-col relative bg-[#080808] border-r border-[rgba(255,255,255,0.06)]" vid="11">
+        
+        <div class="h-14 border-b border-[rgba(255,255,255,0.06)] flex items-center px-6 justify-between" vid="12">
+            <div class="flex items-center gap-4" vid="13">
+                <div class="w-8 h-8 rounded bg-gray-800 border border-gray-700 flex items-center justify-center" vid="14">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" class="text-gray-400" vid="15"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="16"></path><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" vid="17"></path><line x1="24" y1="96" x2="232" y2="96" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" vid="18"></line></svg>
+                </div>
+                <span class="text-sm font-medium text-gray-300" vid="19">Technical Specification Draft</span>
+            </div>
+        </div>
+
+        
+        <div class="flex-1 p-12 flex justify-center bg-[#080808]" vid="20">
+            <div class="w-full max-w-3xl h-full bg-[#121212] rounded-t-lg border border-[rgba(255,255,255,0.06)] p-16" vid="21">
+                <div class="w-1/3 h-8 bg-[rgba(255,255,255,0.08)] rounded mb-10" vid="22"></div>
+                <div class="space-y-4" vid="23">
+                    <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded" vid="24"></div>
+                    <div class="w-full h-3 bg-[rgba(255,255,255,0.04)] rounded" vid="25"></div>
+                    <div class="w-3/4 h-3 bg-[rgba(255,255,255,0.04)] rounded" vid="26"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="w-[420px] bg-[#0f0f0f] flex flex-col h-full shadow-2xl z-10 shrink-0" vid="27">
+        
+        
+        <div class="px-5 py-4 border-b border-[rgba(255,255,255,0.06)] flex justify-between items-center bg-[#0f0f0f]" vid="28">
+            <div class="flex items-center gap-2" vid="29">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256" class="text-blue-500" vid="30"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11ZM120,144,95.3,168.7,70.6,144a16,16,0,0,0-22.62,0L23.28,168.7a16,16,0,0,0,0,22.62L48,216H208l24.68-24.68a16,16,0,0,0,0-22.62L208,144,183.3,168.7,158.6,144a16,16,0,0,0-22.6,0L139.3,160.7,142.6,144A16,16,0,0,0,120,144Z" opacity="0.2" vid="31"></path><path d="M227.13,109.12l-35.14,17.57-17.57,35.14a16,16,0,0,1-28.84,0l-17.57-35.14-35.14-17.57a16,16,0,0,1,0-28.84l35.14-17.57,17.57-35.14a16,16,0,0,1,28.84,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.12Zm-39.75-6.66L176,96.78l-11.38-5.68L158.94,79.72l-5.68-11.38-5.68,11.38-5.68,11.38L130.52,96.78l11.38,5.68,5.68,11.38,5.68,11.38,5.68-11.38ZM112,144a8,8,0,0,0-5.66,2.34L86.63,166.06,67.31,146.75a8,8,0,0,0-11.31,0L32.69,170.06a8,8,0,0,0,0,11.31L50.06,198.75,32.69,216.12a8,8,0,0,0,11.31,11.31L61.37,210.06,78.75,227.43a8,8,0,0,0,11.31,0l23.32-23.31,17.31,17.31a8,8,0,0,0,11.31,0l23.32-23.31,17.31,17.31a8,8,0,0,0,11.31,0l23.32-23.31,17.31,17.31a8,8,0,0,0,11.31,0l23.32-23.31a8,8,0,0,0,0-11.31L239.31,170a8,8,0,0,0-11.31,0L210.63,187.37,186,162.72l19.66-19.66a8,8,0,0,0-11.32-11.31L169.66,156.44l-26-26A8,8,0,0,0,138,128.16l-4.57,23.1L117.66,146.34A8,8,0,0,0,112,144Z" vid="32"></path></svg>
+                <h2 class="text-sm font-semibold text-white tracking-tight" vid="33">AI Assistant</h2>
+            </div>
+            <div class="flex items-center gap-3" vid="34">
+                <button class="text-[#888888] hover:text-white transition-colors" vid="35">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="36"><path d="M144,128a16,16,0,1,1-16-16A16,16,0,0,1,144,128Z" vid="37"></path><path d="M128,72a16,16,0,1,0-16-16A16,16,0,0,0,128,72Z" vid="38"></path><path d="M128,184a16,16,0,1,0,16,16A16,16,0,0,0,128,184Z" vid="39"></path></svg>
+                </button>
+                <button class="text-[#888888] hover:text-white transition-colors" vid="40">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="41"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="42"></path></svg>
+                </button>
+            </div>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto custom-scrollbar p-5 space-y-10" vid="43">
+
+            
+            <div class="group relative" vid="44">
+                <div class="absolute -top-6 left-0 text-[10px] uppercase tracking-widest text-[#444] font-medium opacity-0 group-hover:opacity-100 transition-opacity" vid="45">State: Thinking</div>
+                
+                <div class="flex items-start gap-3" vid="46">
+                    <div class="w-7 h-7 rounded bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0 shadow-lg shadow-blue-900/20" vid="47">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="#fff" viewBox="0 0 256 256" vid="48"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11Z" vid="49"></path></svg>
+                    </div>
+                    <div class="flex flex-col gap-1.5 max-w-[85%]" vid="50">
+                        <div class="flex items-center gap-2" vid="51">
+                            <span class="text-xs font-medium text-gray-400" vid="52">AI Assistant</span>
+                            <span class="px-1.5 py-0.5 rounded text-[9px] font-bold bg-blue-500/10 text-blue-400 border border-blue-500/10" vid="53">GPT-4</span>
+                        </div>
+                        
+                        
+                        <div class="p-3 bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] rounded-lg rounded-tl-none" vid="54">
+                            <div class="flex items-center gap-2 h-5" vid="55">
+                                <span class="text-[13px] text-gray-400" vid="56">AI is thinking</span>
+                                <div class="flex items-center gap-1" vid="57">
+                                    <div class="w-1 h-1 bg-blue-500 rounded-full bounce-1" vid="58"></div>
+                                    <div class="w-1 h-1 bg-blue-500 rounded-full bounce-2" vid="59"></div>
+                                    <div class="w-1 h-1 bg-blue-500 rounded-full bounce-3" vid="60"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="group relative" vid="61">
+                <div class="absolute -top-6 left-0 text-[10px] uppercase tracking-widest text-[#444] font-medium opacity-0 group-hover:opacity-100 transition-opacity" vid="62">State: Streaming Active</div>
+                
+                <div class="flex items-start gap-3" vid="63">
+                    <div class="w-7 h-7 rounded bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0 shadow-lg shadow-blue-900/20" vid="64">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="#fff" viewBox="0 0 256 256" vid="65"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11Z" vid="66"></path></svg>
+                    </div>
+                    <div class="flex flex-col gap-1.5 w-full" vid="67">
+                        <div class="flex items-center justify-between" vid="68">
+                            <div class="flex items-center gap-2" vid="69">
+                                <span class="text-xs font-medium text-gray-400" vid="70">AI Assistant</span>
+                            </div>
+                            <span class="text-[10px] text-blue-400 animate-pulse font-medium" vid="71">Generating response...</span>
+                        </div>
+                        
+                        
+                        <div class="p-3 bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] rounded-lg rounded-tl-none" vid="72">
+                            <p class="text-[13px] text-gray-200 leading-relaxed" vid="73">
+                                Based on your requirements, here's a suggested outline for the authentication flow:
+                                <br vid="74"><br vid="75">
+                                1. <strong vid="76">User Registration:</strong> Collect email, password, and optional profile data.<br vid="77">
+                                2. <strong vid="78">Verification:</strong> Send magic link to email for<span class="typing-cursor" vid="79"></span>
+                            </p>
+                        </div>
+
+                        
+                        <button class="flex items-center gap-2 px-3 py-1.5 bg-[#222] hover:bg-[#2a2a2a] border border-[rgba(255,255,255,0.06)] rounded text-[11px] text-gray-300 transition-colors w-fit mt-1 group-hover:border-[rgba(255,255,255,0.1)]" vid="80">
+                            <div class="w-2 h-2 bg-gray-400 rounded-[1px]" vid="81"></div>
+                            <span vid="82">Stop Generating</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="group relative" vid="83">
+                <div class="absolute -top-6 left-0 text-[10px] uppercase tracking-widest text-[#444] font-medium opacity-0 group-hover:opacity-100 transition-opacity" vid="84">State: Processing Context</div>
+                
+                <div class="flex items-start gap-3" vid="85">
+                    <div class="w-7 h-7 rounded bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0 shadow-lg shadow-blue-900/20" vid="86">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="#fff" viewBox="0 0 256 256" vid="87"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11Z" vid="88"></path></svg>
+                    </div>
+                    <div class="flex flex-col gap-1.5 w-full" vid="89">
+                        <div class="flex items-center gap-2" vid="90">
+                            <span class="text-xs font-medium text-gray-400" vid="91">AI Assistant</span>
+                        </div>
+                        
+                        
+                        <div class="p-3 bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] rounded-lg rounded-tl-none" vid="92">
+                            <p class="text-[13px] text-gray-200 leading-relaxed mb-3" vid="93">
+                                I'm analyzing the 15 documents you've attached to identify conflicting requirements in the "Security Protocols" section.
+                            </p>
+                            
+                            
+                            <div class="bg-white/5 h-1 w-full rounded-full overflow-hidden mb-1.5" vid="94">
+                                <div class="h-full w-2/3 bg-blue-500 rounded-full indeterminate-progress" vid="95"></div>
+                            </div>
+                            <span class="text-[10px] text-gray-500 font-medium" vid="96">Processing large context...</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="group relative" vid="97">
+                <div class="absolute -top-6 left-0 text-[10px] uppercase tracking-widest text-[#444] font-medium opacity-0 group-hover:opacity-100 transition-opacity" vid="98">State: Cancelled</div>
+                
+                <div class="flex items-start gap-3" vid="99">
+                    <div class="w-7 h-7 rounded bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0 shadow-lg shadow-blue-900/20" vid="100">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="#fff" viewBox="0 0 256 256" vid="101"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11Z" vid="102"></path></svg>
+                    </div>
+                    <div class="flex flex-col gap-1.5 max-w-[85%]" vid="103">
+                        <div class="flex items-center gap-2" vid="104">
+                            <span class="text-xs font-medium text-gray-400" vid="105">AI Assistant</span>
+                        </div>
+                        
+                        
+                        <div class="p-3 bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] rounded-lg rounded-tl-none" vid="106">
+                            <p class="text-[13px] text-gray-200 leading-relaxed" vid="107">
+                                The API endpoints should follow RESTful standards. For the user endpoint, use GET /api/v1/users to retrieve <span class="text-[#666] italic" vid="108">[Generation stopped]</span>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="group relative" vid="109">
+                <div class="absolute -top-6 left-0 text-[10px] uppercase tracking-widest text-[#444] font-medium opacity-0 group-hover:opacity-100 transition-opacity" vid="110">State: Timeout</div>
+                
+                <div class="flex items-start gap-3" vid="111">
+                    <div class="w-7 h-7 rounded bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0 shadow-lg shadow-blue-900/20" vid="112">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="#fff" viewBox="0 0 256 256" vid="113"><path d="M227.13,109.11,192,126.68l-17.57,35.14a16,16,0,0,1-28.62,0L128.24,126.68l-35.14-17.57a16,16,0,0,1,0-28.62L128.24,62.92,145.81,27.78a16,16,0,0,1,28.62,0l17.57,35.14,35.14,17.57A16,16,0,0,1,227.13,109.11Z" vid="114"></path></svg>
+                    </div>
+                    <div class="flex flex-col gap-1.5 w-full" vid="115">
+                        <div class="flex items-center gap-2" vid="116">
+                            <span class="text-xs font-medium text-gray-400" vid="117">AI Assistant</span>
+                        </div>
+                        
+                        
+                        <div class="p-3 bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.06)] rounded-lg rounded-tl-none relative overflow-hidden" vid="118">
+                            
+                            <div class="absolute left-0 top-0 bottom-0 w-[2px] bg-yellow-500/50" vid="119"></div>
+                            
+                            <div class="flex items-start gap-3" vid="120">
+                                <div class="mt-0.5 text-yellow-500" vid="121">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="122"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm56-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h40A8,8,0,0,1,184,128Z" vid="123"></path></svg>
+                                </div>
+                                <div class="flex-1" vid="124">
+                                    <h4 class="text-[13px] font-medium text-white mb-1" vid="125">Response timed out</h4>
+                                    <p class="text-[12px] text-gray-400 leading-relaxed mb-3" vid="126">
+                                        The AI service took too long to respond. This might be due to high traffic or connectivity issues.
+                                    </p>
+                                    
+                                    <div class="flex items-center gap-3" vid="127">
+                                        <button class="px-3 py-1.5 bg-[#222] hover:bg-[#2a2a2a] border border-[rgba(255,255,255,0.06)] rounded text-[11px] font-medium text-gray-300 transition-colors" vid="128">
+                                            Try Again
+                                        </button>
+                                        <a href="#" class="text-[11px] text-blue-500 hover:text-blue-400 transition-colors" vid="129">Report Issue</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="h-4" vid="130"></div>
+
+        </div>
+
+        
+        <div class="p-4 border-t border-[rgba(255,255,255,0.06)] bg-[#0f0f0f]" vid="131">
+            <div class="relative" vid="132">
+                <input type="text" placeholder="Ask AI to edit or generate..." class="w-full bg-[#1a1a1a] text-sm text-white placeholder-gray-600 rounded-lg pl-4 pr-10 py-3 border border-transparent focus:border-white/10 focus:outline-none focus:bg-[#222] transition-colors" vid="133">
+                <button class="absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded flex items-center justify-center text-gray-500 hover:text-white hover:bg-white/5 transition-colors" vid="134">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="135"><path d="M227.32,28.68a16,16,0,0,0-15.66-4.08l.15,0L19.57,82.84a16,16,0,0,0-2.42,29.84l85.62,40.55,40.55,85.62a16,16,0,0,0,14.48,9.14c.44,0,.88,0,1.32-.08a16,16,0,0,0,14-11.51l58.2-191.94A16,16,0,0,0,227.32,28.68ZM147.2,147.2,108,230,59.18,126.83h0L129.17,56.83Zm8.16-8.16L85.17,68.83l70-70,41.28,136.21Z" vid="136"></path></svg>
+                </button>
+            </div>
+            <div class="flex justify-between items-center mt-2.5 px-1" vid="137">
+                <div class="flex items-center gap-2" vid="138">
+                    <button class="w-6 h-6 rounded flex items-center justify-center text-gray-500 hover:text-white hover:bg-white/5 transition-colors" vid="139">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="140"><path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34Zm-48-29.66L189.66,80H165.66ZM200,216H56V40h96V88a8,8,0,0,0,8,8h48V216Z" vid="141"></path></svg>
+                    </button>
+                    <button class="w-6 h-6 rounded flex items-center justify-center text-gray-500 hover:text-white hover:bg-white/5 transition-colors" vid="142">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="143"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="144"></path><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" vid="145"></path><circle cx="156" cy="128" r="12" vid="146"></circle><circle cx="100" cy="128" r="12" vid="147"></circle></svg>
+                    </button>
+                </div>
+                <span class="text-[10px] text-gray-600" vid="148">Enter to send, Shift+Enter for new line</span>
+            </div>
+        </div>
+
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/33-ai-dialogs.html
+++ b/design/Variant/designs/33-ai-dialogs.html
@@ -1,0 +1,344 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">AI &amp; Dialog Components</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="8">
+    <style vid="9">
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #080808;
+            color: #ffffff;
+        }
+        .font-mono {
+            font-family: 'JetBrains Mono', monospace;
+        }
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+        
+        .glass-panel {
+            background-color: #0f0f0f;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        }
+
+        .diff-added {
+            background-color: rgba(34, 197, 94, 0.1);
+            color: #4ade80;
+        }
+        .diff-removed {
+            background-color: rgba(239, 68, 68, 0.1);
+            color: #f87171;
+            text-decoration: line-through;
+        }
+    </style>
+</head>
+<body class="min-h-screen w-full p-8 md:p-12" vid="10">
+
+    
+    <div class="max-w-[1400px] mx-auto grid grid-cols-12 gap-8" vid="11">
+        
+        
+        <div class="col-span-12 mb-4" vid="12">
+            <h1 class="text-2xl font-semibold tracking-tight text-white mb-2" vid="13">Design System: AI &amp; Feedback</h1>
+            <p class="text-gray-500 text-sm" vid="14">Components for AI interaction, error handling, and critical alerts.</p>
+        </div>
+
+        
+        <div class="col-span-12 lg:col-span-7 space-y-8" vid="15">
+            
+            
+            <div class="space-y-3" vid="16">
+                <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wider" vid="17">AI Apply Confirmation (Inline)</h3>
+                <div class="glass-panel rounded-lg p-8 relative min-h-[300px]" vid="18">
+                    
+                    <div class="max-w-2xl mx-auto space-y-6 text-gray-300 leading-relaxed font-light" vid="19">
+                        <p vid="20">
+                            The executive summary provides a high-level overview of the strategic initiative. It outlines the primary objectives, key stakeholders, and the anticipated timeline for delivery.
+                        </p>
+                        
+                        <div class="relative group" vid="21">
+                            
+                            <div class="relative bg-blue-500/10 px-1 -mx-1 rounded border-l-2 border-blue-500 py-0.5" vid="22">
+                                <span class="text-white" vid="23">Security protocols have been updated to comply with ISO 27001 standards, requiring multi-factor authentication for all administrative access points effective Q3 2024.</span>
+                                
+                                
+                                <div class="absolute -left-10 top-0.5 text-blue-500 opacity-80" vid="24">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="25"><path d="M216,40V216a16,16,0,0,1-16,16H56a16,16,0,0,1-16-16V40A16,16,0,0,1,56,24H200A16,16,0,0,1,216,40Zm-16,0H56V216H200V40ZM96,128a16,16,0,1,1,16,16A16,16,0,0,1,96,128Zm64,0a16,16,0,1,1,16,16A16,16,0,0,1,160,128Z" vid="26"></path></svg>
+                                </div>
+                            </div>
+
+                            
+                            <div class="absolute -top-12 right-0 flex items-center gap-1 bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded-lg shadow-xl p-1 z-10 transform translate-y-2 opacity-100 transition-all" vid="27">
+                                <button class="h-7 px-2 flex items-center gap-1.5 rounded hover:bg-[#22c55e]/10 text-gray-400 hover:text-[#22c55e] transition-colors" title="Accept" vid="28">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="29"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z" vid="30"></path></svg>
+                                    <span class="text-[11px] font-medium" vid="31">Accept</span>
+                                </button>
+                                <div class="w-px h-4 bg-white/10 mx-0.5" vid="32"></div>
+                                <button class="h-7 px-2 flex items-center gap-1.5 rounded hover:bg-[#ef4444]/10 text-gray-400 hover:text-[#ef4444] transition-colors" title="Reject" vid="33">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="34"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="35"></path></svg>
+                                    <span class="text-[11px] font-medium" vid="36">Reject</span>
+                                </button>
+                                <div class="w-px h-4 bg-white/10 mx-0.5" vid="37"></div>
+                                <button class="h-7 w-7 flex items-center justify-center rounded hover:bg-white/5 text-gray-400 hover:text-white transition-colors" title="View Diff" vid="38">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="39"><path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40Zm0,160H40V56H216V200Z" opacity="0.2" vid="40"></path><path d="M192,120H152V80a8,8,0,0,0-16,0v40H96a8,8,0,0,0,0,16h40v40a8,8,0,0,0,16,0V136h40a8,8,0,0,0,0-16ZM208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z" vid="41"></path></svg>
+                                </button>
+                            </div>
+                        </div>
+
+                        <p vid="42">
+                            Budget allocation for the hardware refresh cycle remains pending final board approval, expected by the end of the fiscal month.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="space-y-3" vid="43">
+                <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wider" vid="44">Diff Modal (Complex Change)</h3>
+                <div class="glass-panel rounded-lg overflow-hidden flex flex-col h-[400px]" vid="45">
+                    
+                    <div class="h-14 border-b border-[rgba(255,255,255,0.06)] px-6 flex items-center justify-between bg-[#151515]" vid="46">
+                        <div class="flex items-center gap-4" vid="47">
+                            <span class="font-medium text-sm" vid="48">Review Changes</span>
+                            <span class="text-xs text-gray-500" vid="49">This will modify 3 paragraphs</span>
+                        </div>
+                        <div class="flex items-center gap-3 bg-[#0a0a0a] rounded px-2 py-1 border border-white/5" vid="50">
+                            <button class="text-gray-500 hover:text-white transition-colors" vid="51">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="52"><path d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z" vid="53"></path></svg>
+                            </button>
+                            <span class="text-xs font-mono text-gray-400" vid="54">Change 1 of 4</span>
+                            <button class="text-gray-500 hover:text-white transition-colors" vid="55">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="56"><path d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z" vid="57"></path></svg>
+                            </button>
+                        </div>
+                        <div class="flex items-center gap-2" vid="58">
+                             <button class="text-gray-400 hover:text-white p-1" vid="59">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="60"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="61"></path></svg>
+                             </button>
+                        </div>
+                    </div>
+
+                    
+                    <div class="flex-1 flex overflow-hidden" vid="62">
+                        
+                        <div class="flex-1 border-r border-[rgba(255,255,255,0.06)] bg-[#0a0a0a] overflow-y-auto p-6" vid="63">
+                            <div class="uppercase text-[10px] font-bold text-red-500/70 mb-4 tracking-wider" vid="64">Before</div>
+                            <p class="text-sm text-gray-400 leading-relaxed font-mono" vid="65">
+                                The platform currently supports <span class="diff-removed" vid="66">XML and JSON</span> data formats for import operations. This limitation has been identified as a bottleneck for enterprise clients using legacy CSV systems.
+                            </p>
+                        </div>
+                        
+                        <div class="flex-1 bg-[#0f0f0f] overflow-y-auto p-6" vid="67">
+                            <div class="uppercase text-[10px] font-bold text-green-500/70 mb-4 tracking-wider" vid="68">After</div>
+                            <p class="text-sm text-gray-300 leading-relaxed font-mono" vid="69">
+                                The platform currently supports <span class="diff-added" vid="70">XML, JSON, and CSV</span> data formats for import operations. This expansion directly addresses requirements from enterprise clients migrating from legacy systems.
+                            </p>
+                        </div>
+                    </div>
+
+                    
+                    <div class="h-16 border-t border-[rgba(255,255,255,0.06)] px-6 flex items-center justify-between bg-[#151515]" vid="71">
+                        <div class="flex gap-2" vid="72">
+                            <button class="px-3 py-1.5 rounded text-xs font-medium text-red-400 hover:bg-red-500/10 transition-colors" vid="73">Reject All</button>
+                            <button class="px-3 py-1.5 rounded text-xs font-medium text-green-400 hover:bg-green-500/10 transition-colors" vid="74">Accept All</button>
+                        </div>
+                        <div class="flex gap-3" vid="75">
+                            <button class="px-4 py-2 rounded text-xs font-medium text-gray-300 border border-white/10 hover:bg-white/5 transition-colors" vid="76">Edit Manually</button>
+                            <button class="px-4 py-2 rounded text-xs font-medium bg-[#3b82f6] text-white hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/20" vid="77">Apply Changes</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        
+        <div class="col-span-12 lg:col-span-5 space-y-3" vid="78">
+            <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wider" vid="79">AI Error States</h3>
+            
+            
+            <div class="glass-panel rounded-lg h-full max-h-[740px] overflow-hidden flex flex-col" vid="80">
+                <div class="h-10 border-b border-[rgba(255,255,255,0.06)] bg-[#151515] px-4 flex items-center justify-between" vid="81">
+                    <span class="text-xs font-medium text-gray-400" vid="82">AI Assistant Panel</span>
+                    <div class="flex gap-1.5" vid="83">
+                        <div class="w-2 h-2 rounded-full bg-red-500/20" vid="84"></div>
+                        <div class="w-2 h-2 rounded-full bg-yellow-500/20" vid="85"></div>
+                    </div>
+                </div>
+                
+                <div class="flex-1 bg-[#080808] p-4 space-y-4 overflow-y-auto custom-scrollbar" vid="86">
+
+                    
+                    <div class="bg-red-500/5 border border-red-500/10 rounded-lg p-3" vid="87">
+                        <div class="flex items-start gap-3" vid="88">
+                            <div class="p-1.5 bg-yellow-500/10 rounded text-yellow-500 shrink-0 mt-0.5" vid="89">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="90"><path d="M235.16,66.6a10.87,10.87,0,0,0-5.26-2.45,212.57,212.57,0,0,0-203.8,0,10.91,10.91,0,0,0-5.26,2.45,9.65,9.65,0,0,0,0,14.61l26.69,29.35a9.56,9.56,0,0,0,14.15,0,144.6,144.6,0,0,1,184.64,0,9.56,9.56,0,0,0,14.15,0l26.69-29.35A9.65,9.65,0,0,0,235.16,66.6Zm-63.58,70a9.56,9.56,0,0,0-14.15,0,76.54,76.54,0,0,1-58.86,0,9.56,9.56,0,0,0-14.15,0L57.73,165.9a9.65,9.65,0,0,0,0,14.61l63.2,69.52a9.56,9.56,0,0,0,14.14,0l63.2-69.52a9.65,9.65,0,0,0,0-14.61ZM36.1,69.75l8.79,9.67a196.59,196.59,0,0,1,166.22,0l8.79-9.67A212.58,212.58,0,0,0,36.1,69.75Z" vid="91"></path></svg>
+                            </div>
+                            <div class="flex-1" vid="92">
+                                <h4 class="text-sm font-medium text-white mb-0.5" vid="93">Connection Failed</h4>
+                                <p class="text-xs text-gray-400 leading-snug mb-2" vid="94">Unable to reach AI service. Check your internet connection.</p>
+                                <button class="text-xs font-medium text-white bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded transition-colors" vid="95">Retry</button>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="bg-red-500/5 border border-red-500/10 rounded-lg p-3" vid="96">
+                        <div class="flex items-start gap-3" vid="97">
+                            <div class="p-1.5 bg-yellow-500/10 rounded text-yellow-500 shrink-0 mt-0.5" vid="98">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="99"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h48A8,8,0,0,1,192,128Z" vid="100"></path></svg>
+                            </div>
+                            <div class="flex-1" vid="101">
+                                <h4 class="text-sm font-medium text-white mb-0.5" vid="102">Request Timed Out</h4>
+                                <p class="text-xs text-gray-400 leading-snug mb-2" vid="103">The AI service took too long to respond.</p>
+                                <button class="text-xs font-medium text-white bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded transition-colors" vid="104">Try Again</button>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="bg-[#151515] border border-yellow-500/20 rounded-lg p-3" vid="105">
+                        <div class="flex items-start gap-3" vid="106">
+                            <div class="p-1.5 bg-yellow-500/10 rounded text-yellow-500 shrink-0 mt-0.5" vid="107">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="108"><path d="M228,128a100,100,0,0,1-20,60l-17,6.8a8.12,8.12,0,0,1-2.91.56,8,8,0,0,1-3.69-.9,122.56,122.56,0,0,1-112.8,0,8,8,0,0,1-6.6,1.46l-17-6.8a100,100,0,1,1,180-61.12Zm-16,0a84,84,0,0,0-159.26-36.85A107.57,107.57,0,0,0,128,140a107.57,107.57,0,0,0,75.26-48.85A83.67,83.67,0,0,0,212,128Zm-73.66,42.34a8,8,0,0,0-11.31,11.32l24,24a8,8,0,0,0,11.31-11.32Z" vid="109"></path></svg>
+                            </div>
+                            <div class="flex-1" vid="110">
+                                <h4 class="text-sm font-medium text-white mb-0.5" vid="111">Too Many Requests</h4>
+                                <p class="text-xs text-gray-400 leading-snug mb-2" vid="112">Please wait a moment before sending another message.</p>
+                                <div class="text-[10px] font-mono text-yellow-500 bg-yellow-500/5 inline-block px-1.5 py-0.5 rounded border border-yellow-500/10" vid="113">Try again in 30s</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="bg-[#151515] border border-yellow-500/20 rounded-lg p-3" vid="114">
+                        <div class="flex items-start gap-3" vid="115">
+                            <div class="p-1.5 bg-yellow-500/10 rounded text-yellow-500 shrink-0 mt-0.5" vid="116">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="117"><path d="M236.8,188.09,149.35,36.22a24.76,24.76,0,0,0-42.7,0L19.2,188.09a23.51,23.51,0,0,0,0,23.72A24.35,24.35,0,0,0,40.55,224h174.9a24.35,24.35,0,0,0,21.33-12.19A23.51,23.51,0,0,0,236.8,188.09ZM120,104a8,8,0,0,1,16,0v40a8,8,0,0,1-16,0Zm8,88a12,12,0,1,1,12-12A12,12,0,0,1,128,192Z" vid="118"></path></svg>
+                            </div>
+                            <div class="flex-1" vid="119">
+                                <h4 class="text-sm font-medium text-white mb-0.5" vid="120">Usage Limit Reached</h4>
+                                <p class="text-xs text-gray-400 leading-snug mb-2" vid="121">You have reached your monthly AI usage limit.</p>
+                                <div class="flex items-center gap-2" vid="122">
+                                    <button class="text-xs font-medium text-[#080808] bg-yellow-500 hover:bg-yellow-400 px-3 py-1.5 rounded transition-colors" vid="123">Upgrade Plan</button>
+                                    <button class="text-xs font-medium text-gray-400 hover:text-white px-2 transition-colors" vid="124">View Usage</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="bg-red-500/5 border border-red-500/20 rounded-lg p-3" vid="125">
+                        <div class="flex items-start gap-3" vid="126">
+                            <div class="p-1.5 bg-red-500/10 rounded text-red-500 shrink-0 mt-0.5" vid="127">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="128"><path d="M80,112a8,8,0,0,1,8-8h16a8,8,0,0,1,0,16H88A8,8,0,0,1,80,112Zm144-48V200a16,16,0,0,1-16,16H48a16,16,0,0,1-16-16V64A16,16,0,0,1,48,48H208A16,16,0,0,1,224,64ZM48,104H208V64H48v40Zm160,16v80H48V120Zm-16,32a8,8,0,0,0-8,8v16a8,8,0,0,0,16,0V160A8,8,0,0,0,192,152Zm-48,0a8,8,0,0,0-8,8v16a8,8,0,0,0,16,0V160A8,8,0,0,0,144,152Z" vid="129"></path></svg>
+                            </div>
+                            <div class="flex-1" vid="130">
+                                <h4 class="text-sm font-medium text-white mb-0.5" vid="131">AI Service Error</h4>
+                                <p class="text-xs text-gray-400 leading-snug mb-2" vid="132">The AI provider is experiencing issues. This is not your fault.</p>
+                                <div class="text-[10px] font-mono text-red-400 mb-2" vid="133">upstream_error_503</div>
+                                <div class="flex items-center gap-2" vid="134">
+                                    <button class="text-xs font-medium text-white bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded transition-colors" vid="135">Retry</button>
+                                    <a href="#" class="text-xs font-medium text-gray-400 hover:text-white px-2 flex items-center gap-1 transition-colors" vid="136">
+                                        Check Status
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="currentColor" viewBox="0 0 256 256" vid="137"><path d="M200,64V168a8,8,0,0,1-16,0V83.31L69.66,197.66a8,8,0,0,1-11.32-11.32L172.69,72H88a8,8,0,0,1,0-16H192A8,8,0,0,1,200,64Z" vid="138"></path></svg>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+
+        
+        <div class="col-span-12 space-y-3 mt-4" vid="139">
+            <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wider" vid="140">System Dialogs</h3>
+            
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" vid="141">
+
+                
+                <div class="glass-panel rounded-xl p-6 flex flex-col items-center text-center shadow-2xl" vid="142">
+                    <div class="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center text-red-500 mb-4 border border-red-500/20" vid="143">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256" vid="144"><path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z" vid="145"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-semibold text-white mb-2" vid="146">Delete Document?</h3>
+                    <p class="text-sm text-gray-400 mb-6 leading-relaxed" vid="147">
+                        This action cannot be undone. The document and its version history will be permanently deleted.
+                    </p>
+                    <div class="flex items-center gap-3 w-full" vid="148">
+                        <button class="flex-1 h-9 rounded-lg border border-[rgba(255,255,255,0.08)] bg-transparent hover:bg-white/5 text-sm font-medium text-gray-300 transition-colors" vid="149">
+                            Cancel
+                        </button>
+                        <button class="flex-1 h-9 rounded-lg bg-[#ef4444] hover:bg-red-600 text-sm font-medium text-white shadow-lg shadow-red-500/20 transition-colors" vid="150">
+                            Delete
+                        </button>
+                    </div>
+                </div>
+
+                
+                <div class="glass-panel rounded-xl p-6 flex flex-col items-center text-center shadow-2xl" vid="151">
+                    <div class="w-12 h-12 rounded-full bg-yellow-500/10 flex items-center justify-center text-yellow-500 mb-4 border border-yellow-500/20" vid="152">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256" vid="153"><path d="M236.8,188.09,149.35,36.22a24.76,24.76,0,0,0-42.7,0L19.2,188.09a23.51,23.51,0,0,0,0,23.72A24.35,24.35,0,0,0,40.55,224h174.9a24.35,24.35,0,0,0,21.33-12.19A23.51,23.51,0,0,0,236.8,188.09ZM120,104a8,8,0,0,1,16,0v40a8,8,0,0,1-16,0Zm8,88a12,12,0,1,1,12-12A12,12,0,0,1,128,192Z" vid="154"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-semibold text-white mb-2" vid="155">Unsaved Changes</h3>
+                    <p class="text-sm text-gray-400 mb-6 leading-relaxed" vid="156">
+                        You have unsaved changes. Do you want to save your progress before leaving?
+                    </p>
+                    <div class="flex items-center gap-3 w-full" vid="157">
+                        <button class="h-9 px-4 rounded-lg border border-red-500/20 hover:bg-red-500/10 text-sm font-medium text-red-400 transition-colors" vid="158">
+                            Discard
+                        </button>
+                        <div class="flex-1" vid="159"></div>
+                        <button class="h-9 px-4 rounded-lg border border-[rgba(255,255,255,0.08)] bg-transparent hover:bg-white/5 text-sm font-medium text-gray-300 transition-colors" vid="160">
+                            Cancel
+                        </button>
+                        <button class="h-9 px-4 rounded-lg bg-white hover:bg-gray-200 text-sm font-medium text-black transition-colors" vid="161">
+                            Save
+                        </button>
+                    </div>
+                </div>
+
+                
+                <div class="glass-panel rounded-xl p-6 flex flex-col items-center text-center shadow-2xl" vid="162">
+                    <div class="w-12 h-12 rounded-full bg-green-500/10 flex items-center justify-center text-green-500 mb-4 border border-green-500/20" vid="163">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 256 256" vid="164"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z" vid="165"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-semibold text-white mb-2" vid="166">Export Complete</h3>
+                    <p class="text-sm text-gray-400 mb-6 leading-relaxed" vid="167">
+                        Your document has been exported successfully. It has been saved to your local downloads folder.
+                    </p>
+                    <div class="flex items-center gap-3 w-full" vid="168">
+                        <button class="flex-1 h-9 rounded-lg border border-[rgba(255,255,255,0.08)] bg-transparent hover:bg-white/5 text-sm font-medium text-gray-300 transition-colors" vid="169">
+                            Done
+                        </button>
+                        <button class="flex-1 h-9 rounded-lg bg-[#22c55e] hover:bg-green-500 text-sm font-medium text-black shadow-lg shadow-green-500/20 transition-colors" vid="170">
+                            Open File
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/34-component-primitives.html
+++ b/design/Variant/designs/34-component-primitives.html
@@ -1,0 +1,405 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">CreoNow Component Primitives</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="6">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="7">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&amp;display=swap" rel="stylesheet" vid="8">
+    <style vid="9">
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #080808;
+            color: #ffffff;
+        }
+        
+        .custom-scrollbar::-webkit-scrollbar {
+            width: 4px;
+            height: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 4px;
+        }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        
+        
+        input[type=range]::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            height: 16px;
+            width: 16px;
+            border-radius: 50%;
+            background: #ffffff;
+            cursor: pointer;
+            margin-top: -6px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+        }
+        input[type=range]::-webkit-slider-runnable-track {
+            width: 100%;
+            height: 4px;
+            cursor: pointer;
+            background: rgba(255,255,255,0.1);
+            border-radius: 2px;
+        }
+    </style>
+</head>
+<body class="flex h-screen w-full overflow-hidden bg-[#050505] p-8 box-border gap-10 items-start justify-center" vid="10">
+
+    
+    <div class="flex-1 h-full max-w-[800px] bg-[#0f0f0f] border border-[rgba(255,255,255,0.06)] rounded-xl shadow-2xl flex flex-col overflow-hidden relative" vid="11">
+        
+        <div class="h-16 border-b border-[rgba(255,255,255,0.06)] flex items-center px-6 justify-between shrink-0 bg-[#0f0f0f] z-10" vid="12">
+            <h2 class="text-lg font-semibold text-white" vid="13">Settings</h2>
+            <div class="flex items-center gap-4" vid="14">
+                <div class="relative group" vid="15">
+                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-gray-500 group-focus-within:text-white" vid="16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 256 256" vid="17"><path fill="currentColor" d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z" vid="18"></path></svg>
+                    </div>
+                    <input type="text" placeholder="Search settings..." class="h-9 w-64 bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded-md pl-9 pr-3 text-sm text-gray-300 placeholder-gray-600 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/50 transition-all" vid="19">
+                </div>
+                <button class="text-gray-400 hover:text-white transition-colors" vid="20">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256" vid="21"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="22"></path></svg>
+                </button>
+            </div>
+        </div>
+
+        <div class="flex flex-1 overflow-hidden" vid="23">
+            
+            <div class="w-48 border-r border-[rgba(255,255,255,0.06)] bg-[#0f0f0f] py-4 shrink-0 flex flex-col gap-1" vid="24">
+                <button class="px-6 py-2 text-sm font-medium text-left text-blue-400 bg-blue-500/10 border-r-2 border-blue-500" vid="25">General</button>
+                <button class="px-6 py-2 text-sm font-medium text-left text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors" vid="26">Editor</button>
+                <button class="px-6 py-2 text-sm font-medium text-left text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors" vid="27">AI &amp; Intelligence</button>
+                <button class="px-6 py-2 text-sm font-medium text-left text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors" vid="28">Appearance</button>
+                <button class="px-6 py-2 text-sm font-medium text-left text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors" vid="29">Keyboard</button>
+            </div>
+
+            
+            <div class="flex-1 overflow-y-auto custom-scrollbar p-8 bg-[#0f0f0f]" vid="30">
+                <div class="max-w-2xl mx-auto space-y-10" vid="31">
+                    
+                    
+                    <section class="space-y-6" vid="32">
+                        <div class="pb-2 border-b border-[rgba(255,255,255,0.06)]" vid="33">
+                            <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500" vid="34">Preferences</h3>
+                            <p class="text-sm text-gray-400 mt-1" vid="35">Manage your workspace basics and defaults.</p>
+                        </div>
+
+                        
+                        <div class="flex items-center justify-between group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="36">
+                            <div vid="37">
+                                <label class="text-sm font-medium text-gray-200 block" vid="38">Auto-Save</label>
+                                <p class="text-xs text-gray-500 mt-1" vid="39">Automatically save changes every few seconds</p>
+                            </div>
+                            <div class="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in" vid="40">
+                                <input type="checkbox" name="toggle" id="toggle" checked="" class="toggle-checkbox absolute block w-5 h-5 rounded-full bg-white border-4 appearance-none cursor-pointer transition-all duration-300 right-0 border-blue-600" vid="41">
+                                <label for="toggle" class="toggle-label block overflow-hidden h-5 rounded-full bg-blue-600 cursor-pointer" vid="42"></label>
+                            </div>
+                        </div>
+
+                        
+                        <div class="flex items-center justify-between group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="43">
+                            <div vid="44">
+                                <label class="text-sm font-medium text-gray-200 block" vid="45">Interface Language</label>
+                                <p class="text-xs text-gray-500 mt-1" vid="46">Select your preferred language</p>
+                            </div>
+                            <div class="relative" vid="47">
+                                <select class="appearance-none bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-white text-sm rounded px-3 py-1.5 pr-8 focus:outline-none focus:border-blue-500/50 cursor-pointer hover:border-[rgba(255,255,255,0.15)] transition-colors w-40" vid="48">
+                                    <option vid="49">English (US)</option>
+                                    <option vid="50">Spanish</option>
+                                    <option vid="51">French</option>
+                                </select>
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-400" vid="52">
+                                    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" vid="53"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" vid="54"></path></svg>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    
+                    <section class="space-y-6" vid="55">
+                        <div class="pb-2 border-b border-[rgba(255,255,255,0.06)]" vid="56">
+                            <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500" vid="57">Editor Configuration</h3>
+                            <p class="text-sm text-gray-400 mt-1" vid="58">Customize your writing environment.</p>
+                        </div>
+
+                        
+                        <div class="group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="59">
+                            <label class="text-sm font-medium text-gray-200 block mb-1" vid="60">Default Project Name</label>
+                            <p class="text-xs text-gray-500 mb-3" vid="61">Pattern used for new untitled documents</p>
+                            <input type="text" value="Untitled Project {{date}}" class="w-full bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all" vid="62">
+                        </div>
+
+                        
+                        <div class="group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="63">
+                            <div class="flex justify-between items-center mb-1" vid="64">
+                                <label class="text-sm font-medium text-gray-200" vid="65">Editor Font Size</label>
+                                <span class="text-xs font-mono text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded" vid="66">16px</span>
+                            </div>
+                            <div class="relative pt-4 pb-2" vid="67">
+                                <input type="range" min="12" max="24" value="16" class="w-full appearance-none bg-transparent focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed" vid="68">
+                                <div class="flex justify-between text-[10px] text-gray-500 mt-2 font-medium" vid="69">
+                                    <span vid="70">12px</span>
+                                    <span vid="71">24px</span>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    
+                    <section class="space-y-6" vid="72">
+                        <div class="pb-2 border-b border-[rgba(255,255,255,0.06)]" vid="73">
+                            <h3 class="text-[10px] font-bold uppercase tracking-wider text-gray-500" vid="74">Data &amp; Storage</h3>
+                        </div>
+
+                        
+                        <div class="group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="75">
+                            <label class="text-sm font-medium text-gray-200 block mb-3" vid="76">Export Quality</label>
+                            <div class="space-y-3" vid="77">
+                                <label class="flex items-start gap-3 cursor-pointer group/radio" vid="78">
+                                    <div class="relative flex items-center" vid="79">
+                                        <input type="radio" name="export" class="peer h-4 w-4 appearance-none rounded-full border border-gray-600 checked:border-blue-500 transition-colors" vid="80">
+                                        <div class="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 peer-checked:opacity-100" vid="81">
+                                            <div class="w-2 h-2 rounded-full bg-blue-500" vid="82"></div>
+                                        </div>
+                                    </div>
+                                    <div class="text-sm" vid="83">
+                                        <span class="block text-gray-300 group-hover/radio:text-white transition-colors" vid="84">Standard</span>
+                                        <span class="block text-xs text-gray-500 mt-0.5" vid="85">Optimized for web sharing (72dpi)</span>
+                                    </div>
+                                </label>
+                                <label class="flex items-start gap-3 cursor-pointer group/radio" vid="86">
+                                    <div class="relative flex items-center" vid="87">
+                                        <input type="radio" name="export" checked="" class="peer h-4 w-4 appearance-none rounded-full border border-gray-600 checked:border-blue-500 transition-colors" vid="88">
+                                        <div class="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 peer-checked:opacity-100" vid="89">
+                                            <div class="w-2 h-2 rounded-full bg-blue-500" vid="90"></div>
+                                        </div>
+                                    </div>
+                                    <div class="text-sm" vid="91">
+                                        <span class="block text-gray-300 group-hover/radio:text-white transition-colors" vid="92">High Quality</span>
+                                        <span class="block text-xs text-gray-500 mt-0.5" vid="93">Best for printing (300dpi)</span>
+                                    </div>
+                                </label>
+                            </div>
+                        </div>
+
+                        
+                         <div class="flex items-center justify-between group rounded-lg transition-colors hover:bg-white/[0.02] -mx-3 px-3 py-2" vid="94">
+                            <div vid="95">
+                                <label class="text-sm font-medium text-gray-200 block" vid="96">Reset Application Data</label>
+                                <p class="text-xs text-gray-500 mt-1" vid="97">Clears local cache and preferences</p>
+                            </div>
+                            <button class="px-3 py-1.5 text-xs font-medium text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded transition-colors" vid="98">
+                                Reset to Defaults
+                            </button>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+        
+        
+        <div class="px-6 py-3 border-t border-[rgba(255,255,255,0.06)] bg-[#0f0f0f] flex justify-between items-center shrink-0" vid="99">
+            <div class="flex items-center gap-2" vid="100">
+                <div class="w-1.5 h-1.5 rounded-full bg-green-500" vid="101"></div>
+                <span class="text-xs text-gray-500" vid="102">Changes saved automatically</span>
+            </div>
+            <div class="flex gap-3" vid="103">
+                 
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="w-[360px] h-full flex flex-col gap-10 overflow-y-auto custom-scrollbar pr-2" vid="104">
+        
+        
+        <div class="flex flex-col gap-4" vid="105">
+            <div class="flex items-center gap-2 mb-2 opacity-50" vid="106">
+                <h3 class="text-xs font-bold uppercase tracking-wider text-gray-400" vid="107">Toast Notifications</h3>
+                <div class="h-px bg-white/10 flex-1" vid="108"></div>
+            </div>
+
+            
+            <div class="flex flex-col gap-3" vid="109">
+                
+                
+                <div class="w-full bg-[#0f0f0f]/95 backdrop-blur-md border border-[rgba(255,255,255,0.06)] border-l-[3px] border-l-blue-500 rounded shadow-xl flex items-start p-3 gap-3 animate-slide-in" vid="110">
+                    <div class="text-blue-500 mt-0.5" vid="111">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="112"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm16-40a8,8,0,0,1-8,8,16,16,0,0,1-16-16V128a8,8,0,0,1,0-16,16,16,0,0,1,16,16v40A8,8,0,0,1,144,176ZM128,88a12,12,0,1,1-12,12A12,12,0,0,1,128,88Z" vid="113"></path></svg>
+                    </div>
+                    <div class="flex-1" vid="114">
+                        <p class="text-sm text-gray-200 font-medium leading-snug" vid="115">Document saved successfully</p>
+                    </div>
+                </div>
+
+                
+                <div class="w-full bg-[#0f0f0f]/95 backdrop-blur-md border border-[rgba(255,255,255,0.06)] border-l-[3px] border-l-green-500 rounded shadow-xl flex items-start p-3 gap-3" vid="116">
+                    <div class="text-green-500 mt-0.5" vid="117">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="118"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm45.66-106.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,160.69l50.34-50.35A8,8,0,0,1,173.66,109.66Z" vid="119"></path></svg>
+                    </div>
+                    <div class="flex-1" vid="120">
+                        <p class="text-sm text-gray-200 font-medium leading-snug" vid="121">Export complete</p>
+                        <button class="text-xs text-green-500 font-medium hover:text-green-400 mt-1 hover:underline" vid="122">View File</button>
+                    </div>
+                </div>
+
+                
+                <div class="w-full bg-[#0f0f0f]/95 backdrop-blur-md border border-[rgba(255,255,255,0.06)] border-l-[3px] border-l-yellow-500 rounded shadow-xl flex items-start p-3 gap-3" vid="123">
+                    <div class="text-yellow-500 mt-0.5" vid="124">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="125"><path d="M236.8,188.09,149.35,36.22a24.76,24.76,0,0,0-42.7,0L19.2,188.09a23.51,23.51,0,0,0,0,23.72A24.35,24.35,0,0,0,40.55,224h174.9a24.35,24.35,0,0,0,21.33-12.19A23.51,23.51,0,0,0,236.8,188.09Zm-20.17,11.14a8.18,8.18,0,0,1-7.18,4.77H40.55a8.18,8.18,0,0,1-7.18-4.77,7.57,7.57,0,0,1,0-7.85L120.87,40.13a8.74,8.74,0,0,1,14.26,0l87.52,151.25A7.57,7.57,0,0,1,216.63,199.23ZM120,144V104a8,8,0,0,1,16,0v40a8,8,0,0,1-16,0Zm20,36a12,12,0,1,1-12-12A12,12,0,0,1,140,180Z" vid="126"></path></svg>
+                    </div>
+                    <div class="flex-1" vid="127">
+                        <p class="text-sm text-gray-200 font-medium leading-snug" vid="128">Large document may slow performance</p>
+                    </div>
+                    <button class="text-gray-500 hover:text-white transition-colors" vid="129">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" vid="130"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="131"></path></svg>
+                    </button>
+                </div>
+
+                
+                <div class="w-full bg-[#0f0f0f]/95 backdrop-blur-md border border-[rgba(255,255,255,0.06)] border-l-[3px] border-l-red-500 rounded shadow-xl flex items-start p-3 gap-3" vid="132">
+                    <div class="text-red-500 mt-0.5" vid="133">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="134"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm37.66-130.34a8,8,0,0,1,0,11.32L139.31,128l26.35,26.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35A8,8,0,0,1,165.66,85.66Z" vid="135"></path></svg>
+                    </div>
+                    <div class="flex-1" vid="136">
+                        <p class="text-sm text-gray-200 font-medium leading-snug mb-1" vid="137">Failed to save document</p>
+                        <button class="text-xs bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/20 px-2 py-0.5 rounded transition-colors" vid="138">Retry</button>
+                    </div>
+                </div>
+
+                 
+                <div class="w-full bg-[#0f0f0f]/95 backdrop-blur-md border border-[rgba(255,255,255,0.06)] rounded shadow-xl flex flex-col p-3 gap-2" vid="139">
+                    <div class="flex justify-between items-center" vid="140">
+                        <p class="text-sm text-gray-200 font-medium" vid="141">Exporting...</p>
+                        <span class="text-xs text-gray-400 font-mono" vid="142">45%</span>
+                    </div>
+                    <div class="h-1 w-full bg-gray-800 rounded-full overflow-hidden" vid="143">
+                        <div class="h-full bg-blue-500 w-[45%] rounded-full" vid="144"></div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+        
+        <div class="flex flex-col gap-6" vid="145">
+            <div class="flex items-center gap-2 mb-2 opacity-50" vid="146">
+                <h3 class="text-xs font-bold uppercase tracking-wider text-gray-400" vid="147">Tooltips &amp; Popovers</h3>
+                <div class="h-px bg-white/10 flex-1" vid="148"></div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-x-4 gap-y-12" vid="149">
+                
+                
+                <div class="relative flex justify-center" vid="150">
+                    <button class="w-8 h-8 rounded bg-[#1a1a1a] border border-white/10 flex items-center justify-center text-gray-400 hover:text-white" vid="151">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 256 256" vid="152"><path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm16-40a8,8,0,0,1-8,8,16,16,0,0,1-16-16V128a8,8,0,0,1,0-16,16,16,0,0,1,16,16v40A8,8,0,0,1,144,176ZM128,88a12,12,0,1,1-12,12A12,12,0,0,1,128,88Z" vid="153"></path></svg>
+                    </button>
+                    
+                    <div class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded text-xs text-gray-200 whitespace-nowrap shadow-xl z-20" vid="154">
+                        View Details
+                        <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-[1px] border-4 border-transparent border-t-[#1a1a1a] pointer-events-none" vid="155"></div>
+                         <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-[rgba(255,255,255,0.08)] -z-10" vid="156"></div>
+                    </div>
+                </div>
+
+                
+                <div class="relative flex justify-center" vid="157">
+                    <button class="px-3 py-1.5 rounded bg-[#1a1a1a] border border-white/10 text-xs text-gray-300" vid="158">
+                        Save
+                    </button>
+                    
+                    <div class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded flex items-center gap-2 text-xs text-gray-200 shadow-xl z-20" vid="159">
+                        <span vid="160">Save Document</span>
+                        <span class="flex items-center justify-center bg-white/10 px-1 rounded text-[10px] font-mono text-gray-400 h-4 min-w-[20px] border border-white/5" vid="161">⌘S</span>
+                        <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-[1px] border-4 border-transparent border-t-[#1a1a1a] pointer-events-none" vid="162"></div>
+                    </div>
+                </div>
+
+                
+                <div class="col-span-2 relative flex justify-center mt-4" vid="163">
+                     <span class="text-sm text-gray-500 border-b border-dashed border-gray-600 cursor-help" vid="164">Memory Context</span>
+                     
+                     
+                     <div class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-64 bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] rounded-lg p-3 shadow-2xl z-20 text-left" vid="165">
+                        <p class="text-xs font-semibold text-white mb-1" vid="166">Context Memory</p>
+                        <p class="text-xs text-gray-400 leading-relaxed mb-2" vid="167">
+                            The AI uses this information to maintain continuity across your document sessions.
+                        </p>
+                        <a href="#" class="text-[10px] text-blue-500 hover:text-blue-400 font-medium" vid="168">Learn more →</a>
+                        
+                        <div class="absolute top-full left-1/2 -translate-x-1/2 -mt-[1px] border-4 border-transparent border-t-[#1a1a1a] pointer-events-none" vid="169"></div>
+                     </div>
+                </div>
+
+            </div>
+
+            
+            <div class="relative mt-8 ml-4" vid="170">
+                <div class="w-full bg-[#0f0f0f] border border-[rgba(255,255,255,0.08)] rounded-lg shadow-2xl overflow-hidden w-[280px]" vid="171">
+                    
+                    <div class="p-3 border-b border-[rgba(255,255,255,0.06)] flex items-center justify-between" vid="172">
+                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider" vid="173">Account</span>
+                        <button class="text-gray-500 hover:text-white" vid="174">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 256 256" vid="175"><path d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" vid="176"></path></svg>
+                        </button>
+                    </div>
+                    
+                    
+                    <div class="p-3" vid="177">
+                        <div class="flex items-center gap-3 mb-4" vid="178">
+                            <div class="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-blue-700 flex items-center justify-center text-white font-medium text-sm border border-white/10 shadow-inner" vid="179">
+                                JD
+                            </div>
+                            <div class="overflow-hidden" vid="180">
+                                <p class="text-sm font-medium text-white truncate" vid="181">John Doe</p>
+                                <p class="text-xs text-gray-500 truncate" vid="182">john.doe@example.com</p>
+                            </div>
+                        </div>
+                        
+                        <div class="space-y-1" vid="183">
+                            <button class="w-full text-left px-2 py-1.5 rounded text-sm text-gray-300 hover:bg-white/5 hover:text-white transition-colors flex items-center gap-2" vid="184">
+                                <svg class="w-4 h-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="185"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" vid="186"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" vid="187"></path></svg>
+                                Settings
+                            </button>
+                            <button class="w-full text-left px-2 py-1.5 rounded text-sm text-gray-300 hover:bg-white/5 hover:text-white transition-colors flex items-center gap-2" vid="188">
+                                <svg class="w-4 h-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="189"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" vid="190"></path></svg>
+                                Help &amp; Support
+                            </button>
+                        </div>
+                    </div>
+                    
+                    
+                    <div class="p-2 border-t border-[rgba(255,255,255,0.06)] bg-white/[0.02]" vid="191">
+                        <button class="w-full text-left px-3 py-1.5 rounded text-xs text-red-400 hover:bg-red-500/10 transition-colors flex items-center gap-2" vid="192">
+                            <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" vid="193"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" vid="194"></path></svg>
+                            Sign Out
+                        </button>
+                    </div>
+                </div>
+
+                
+                 <div class="absolute -top-2 left-8 border-8 border-transparent border-b-[#0f0f0f] transform -translate-x-1/2" vid="195"></div>
+                 <div class="absolute -top-[9px] left-8 border-8 border-transparent border-b-[rgba(255,255,255,0.08)] transform -translate-x-1/2 -z-10" vid="196"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+
+</body></html>

--- a/design/Variant/designs/35-constraints-panel.html
+++ b/design/Variant/designs/35-constraints-panel.html
@@ -1,0 +1,358 @@
+<html lang="en" vid="0"><head vid="1">
+    <meta charset="UTF-8" vid="2">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" vid="3">
+    <title vid="4">Quality Gates - CreoNow</title>
+    <script src="https://cdn.tailwindcss.com/3.4.17" vid="5"></script>
+    <script src="https://unpkg.com/@phosphor-icons/web" vid="6"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" vid="7">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" vid="8">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet" vid="9">
+    <script vid="10">
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    },
+                    colors: {
+                        base: '#080808',
+                        panel: '#0f0f0f',
+                        border: 'rgba(255, 255, 255, 0.06)',
+                        secondary: '#888888',
+                        tertiary: '#444444',
+                        accent: {
+                            blue: '#3b82f6',
+                            green: '#22c55e',
+                            red: '#ef4444',
+                            yellow: '#f59e0b'
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style vid="11">
+        body {
+            background-color: #080808;
+            color: #ffffff;
+            font-family: 'Inter', sans-serif;
+        }
+
+        
+        ::-webkit-scrollbar {
+            width: 6px;
+        }
+        ::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #222;
+            border-radius: 3px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #333;
+        }
+
+        
+        .custom-checkbox {
+            appearance: none;
+            background-color: transparent;
+            margin: 0;
+            font: inherit;
+            color: currentColor;
+            width: 1rem;
+            height: 1rem;
+            border: 1px solid #4b5563;
+            border-radius: 0.25rem;
+            display: grid;
+            place-content: center;
+            cursor: pointer;
+            transition: all 0.2s ease-in-out;
+        }
+
+        .custom-checkbox::before {
+            content: "";
+            width: 0.65em;
+            height: 0.65em;
+            transform: scale(0);
+            transition: 120ms transform ease-in-out;
+            box-shadow: inset 1em 1em white;
+            transform-origin: center;
+            clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+        }
+
+        .custom-checkbox:checked {
+            background-color: #3b82f6;
+            border-color: #3b82f6;
+        }
+
+        .custom-checkbox:checked::before {
+            transform: scale(1);
+        }
+
+        
+        .toggle-checkbox:checked {
+            right: 0;
+            border-color: #3b82f6;
+        }
+        .toggle-checkbox:checked + .toggle-label {
+            background-color: #3b82f6;
+        }
+        .toggle-checkbox {
+            right: 1.25rem; 
+            border-color: #4b5563;
+        }
+        .toggle-checkbox + .toggle-label {
+            background-color: #27272a;
+        }
+    </style>
+</head>
+<body class="h-screen w-full flex overflow-hidden bg-base relative" vid="12">
+
+    
+    <div class="flex-1 flex flex-col items-center justify-center opacity-30 pointer-events-none select-none p-20" vid="13">
+        <div class="max-w-2xl w-full text-left space-y-6 font-serif text-lg text-gray-500" vid="14">
+            <h1 class="text-4xl text-gray-700 font-bold mb-8" vid="15">The Architecture of Silence</h1>
+            <p vid="16">Design is not just about making things look good. It is about how things work. In the digital realm, this translates to the seamless integration of form and function. <span class="bg-yellow-900/30 text-yellow-600 px-1 rounded" vid="17">We build immersive environments</span> where typography leads the eye and imagery sets the mood.</p>
+            <p vid="18">Intrigued by beauty, fascinated by technology and fuelled with an everlasting devotion to digital craftsmanship.</p>
+        </div>
+    </div>
+
+    
+    <div class="w-[320px] bg-panel border-l border-border flex flex-col h-full shadow-2xl z-10" vid="19">
+        
+        
+        <div class="flex items-center justify-between px-5 py-4 border-b border-border bg-panel" vid="20">
+            <div class="flex flex-col gap-1" vid="21">
+                <h2 class="text-sm font-semibold text-white tracking-wide" vid="22">Quality Gates</h2>
+                <div class="flex items-center gap-2" vid="23">
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent-red/10 text-accent-red border border-accent-red/20 uppercase tracking-wide" vid="24">
+                        2 Issues
+                    </span>
+                    <span class="text-[10px] text-tertiary" vid="25">Checked just now</span>
+                </div>
+            </div>
+            <button class="text-secondary hover:text-white transition-colors p-2 rounded-md hover:bg-white/5" vid="26">
+                <i class="ph ph-arrows-clockwise text-lg" vid="27"></i>
+            </button>
+        </div>
+
+        
+        <div class="flex-1 overflow-y-auto custom-scrollbar" vid="28">
+            
+            
+            <div class="border-b border-border" vid="29">
+                <button class="w-full flex items-center justify-between px-5 py-3 bg-base/50 hover:bg-white/5 transition-colors group" vid="30">
+                    <div class="flex items-center gap-2" vid="31">
+                        <span class="text-xs font-semibold text-secondary uppercase tracking-wider group-hover:text-gray-300" vid="32">Style</span>
+                        <span class="px-1.5 py-0.5 rounded-full bg-white/5 text-[10px] text-tertiary font-mono group-hover:bg-white/10 group-hover:text-secondary" vid="33">3</span>
+                    </div>
+                    <i class="ph ph-caret-down text-tertiary group-hover:text-secondary text-sm" vid="34"></i>
+                </button>
+                
+                
+                <div class="bg-panel" vid="35">
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] border-b border-border/50 group cursor-pointer transition-colors" vid="36">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="37">
+                        <div class="flex-1 min-w-0" vid="38">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="39">AP Styleguide</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="40"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="41"></i>
+                    </div>
+
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] border-b border-border/50 group cursor-pointer transition-colors" vid="42">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="43">
+                        <div class="flex-1 min-w-0" vid="44">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="45">Tone Consistency</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="46"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="47"></i>
+                    </div>
+
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] border-border/50 group cursor-pointer transition-colors" vid="48">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="49">
+                        <div class="flex-1 min-w-0" vid="50">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="51">Readability Score</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="52"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="53"></i>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="border-b border-border" vid="54">
+                <button class="w-full flex items-center justify-between px-5 py-3 bg-base/50 hover:bg-white/5 transition-colors group" vid="55">
+                    <div class="flex items-center gap-2" vid="56">
+                        <span class="text-xs font-semibold text-secondary uppercase tracking-wider group-hover:text-gray-300" vid="57">Consistency</span>
+                        <span class="px-1.5 py-0.5 rounded-full bg-white/5 text-[10px] text-tertiary font-mono group-hover:bg-white/10 group-hover:text-secondary" vid="58">2</span>
+                    </div>
+                    <i class="ph ph-caret-down text-tertiary group-hover:text-secondary text-sm" vid="59"></i>
+                </button>
+
+                <div class="bg-panel" vid="60">
+                    
+                    <div class="bg-white/[0.02] border-b border-border border-l-2 border-l-accent-yellow" vid="61">
+                        <div class="flex items-center gap-3 px-5 py-3 cursor-pointer" vid="62">
+                            <input type="checkbox" checked="" class="custom-checkbox" vid="63">
+                            <div class="flex-1 min-w-0" vid="64">
+                                <span class="text-sm font-medium text-white truncate block" vid="65">Terminology</span>
+                            </div>
+                            <i class="ph-fill ph-warning text-accent-yellow text-lg" vid="66"></i>
+                            <i class="ph ph-caret-down text-secondary text-sm ml-1" vid="67"></i>
+                        </div>
+
+                        
+                        <div class="px-5 pb-5 pt-1 pl-12" vid="68">
+                            <p class="text-xs text-secondary leading-relaxed mb-3" vid="69">
+                                Checks for consistent use of domain-specific terms defined in the project glossary.
+                            </p>
+                            
+                            
+                            <div class="space-y-2 mb-4" vid="70">
+                                <div class="bg-accent-yellow/5 border border-accent-yellow/20 rounded p-2.5 flex flex-col gap-2" vid="71">
+                                    <div class="flex items-start gap-2" vid="72">
+                                        <i class="ph-fill ph-warning-circle text-accent-yellow text-sm mt-0.5" vid="73"></i>
+                                        <div class="text-xs text-gray-300" vid="74">
+                                            Found instance of <span class="text-white font-mono bg-white/10 px-1 rounded" vid="75">client</span> instead of <span class="text-white font-mono bg-white/10 px-1 rounded" vid="76">customer</span>.
+                                        </div>
+                                    </div>
+                                    <div class="flex items-center justify-between pl-6" vid="77">
+                                        <a href="#" class="text-[10px] text-accent-blue hover:underline font-medium" vid="78">section-2, paragraph 4</a>
+                                        <div class="flex gap-2" vid="79">
+                                            <button class="text-[10px] font-medium text-secondary hover:text-white px-2 py-1 rounded bg-white/5 border border-white/5 hover:bg-white/10 transition-colors" vid="80">Ignore</button>
+                                            <button class="text-[10px] font-medium text-black px-2 py-1 rounded bg-accent-yellow hover:bg-yellow-400 transition-colors" vid="81">Fix Issue</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="flex items-center justify-between pt-3 border-t border-white/5" vid="82">
+                                <span class="text-[10px] text-tertiary font-mono" vid="83">Last check: 2m ago</span>
+                                <button class="flex items-center gap-1.5 text-xs font-medium text-accent-blue hover:text-blue-400 transition-colors" vid="84">
+                                    <i class="ph ph-play" vid="85"></i>
+                                    Run Check
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] group cursor-pointer transition-colors" vid="86">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="87">
+                        <div class="flex-1 min-w-0" vid="88">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="89">Formatting Rules</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="90"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="91"></i>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="border-b border-border" vid="92">
+                <button class="w-full flex items-center justify-between px-5 py-3 bg-base/50 hover:bg-white/5 transition-colors group" vid="93">
+                    <div class="flex items-center gap-2" vid="94">
+                        <span class="text-xs font-semibold text-secondary uppercase tracking-wider group-hover:text-gray-300" vid="95">Completeness</span>
+                        <span class="px-1.5 py-0.5 rounded-full bg-white/5 text-[10px] text-tertiary font-mono group-hover:bg-white/10 group-hover:text-secondary" vid="96">4</span>
+                    </div>
+                    <i class="ph ph-caret-down text-tertiary group-hover:text-secondary text-sm" vid="97"></i>
+                </button>
+
+                <div class="bg-panel" vid="98">
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 bg-accent-red/5 border-l-2 border-l-accent-red group cursor-pointer" vid="99">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="100">
+                        <div class="flex-1 min-w-0" vid="101">
+                            <span class="text-sm text-white font-medium truncate block" vid="102">Meta Descriptions</span>
+                        </div>
+                        <i class="ph-fill ph-x-circle text-accent-red text-lg" vid="103"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="104"></i>
+                    </div>
+
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] border-b border-border/50 group cursor-pointer transition-colors" vid="105">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="106">
+                        <div class="flex-1 min-w-0" vid="107">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="108">Alt Text</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="109"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="110"></i>
+                    </div>
+                    
+                    
+                    <div class="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.02] group cursor-pointer transition-colors" vid="111">
+                        <input type="checkbox" checked="" class="custom-checkbox" vid="112">
+                        <div class="flex-1 min-w-0" vid="113">
+                            <span class="text-sm text-gray-300 group-hover:text-white truncate block" vid="114">Citation Links</span>
+                        </div>
+                        <i class="ph-fill ph-check-circle text-accent-green text-lg" vid="115"></i>
+                        <i class="ph ph-caret-right text-tertiary text-sm ml-1 group-hover:text-secondary" vid="116"></i>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        
+        <div class="bg-panel border-t border-border" vid="117">
+            
+            
+            <div class="p-5 border-b border-border space-y-4" vid="118">
+                <div class="flex items-center justify-between" vid="119">
+                    <div class="flex flex-col" vid="120">
+                        <span class="text-xs text-gray-300 font-medium" vid="121">Run checks on save</span>
+                        <span class="text-[10px] text-tertiary" vid="122">Automatically validate content</span>
+                    </div>
+                    <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="123">
+                        <input type="checkbox" name="toggle" id="toggle1" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-4 appearance-none cursor-pointer border-accent-blue" checked="" vid="124">
+                        <label for="toggle1" class="toggle-label block overflow-hidden h-3 rounded-full cursor-pointer bg-accent-blue" vid="125"></label>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-between" vid="126">
+                    <div class="flex flex-col" vid="127">
+                        <span class="text-xs text-gray-300 font-medium" vid="128">Block save on errors</span>
+                        <span class="text-[10px] text-tertiary" vid="129">Prevent saving invalid states</span>
+                    </div>
+                    <div class="relative inline-block w-8 h-4 align-middle select-none transition duration-200 ease-in" vid="130">
+                        <input type="checkbox" name="toggle" id="toggle2" class="toggle-checkbox absolute block w-3 h-3 rounded-full bg-white border-4 appearance-none cursor-pointer left-0 border-gray-600" vid="131">
+                        <label for="toggle2" class="toggle-label block overflow-hidden h-3 rounded-full cursor-pointer bg-[#27272a]" vid="132"></label>
+                    </div>
+                </div>
+
+                <div class="pt-2" vid="133">
+                    <div class="relative group" vid="134">
+                        <div class="absolute inset-y-0 left-2 flex items-center pointer-events-none" vid="135">
+                            <i class="ph ph-timer text-secondary text-sm" vid="136"></i>
+                        </div>
+                        <select class="w-full bg-[#1a1a1a] text-xs text-gray-300 border border-white/10 rounded px-2 pl-8 py-2 appearance-none focus:outline-none focus:border-accent-blue cursor-pointer hover:bg-[#202020] transition-colors" vid="137">
+                            <option vid="138">Every 5 minutes</option>
+                            <option vid="139">Every 15 minutes</option>
+                            <option vid="140">Manual only</option>
+                        </select>
+                        <div class="absolute inset-y-0 right-2 flex items-center pointer-events-none" vid="141">
+                            <i class="ph ph-caret-down text-tertiary text-xs" vid="142"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            
+            <div class="p-5 bg-[#0a0a0a]" vid="143">
+                <button class="w-full flex items-center justify-center gap-2 bg-accent-blue hover:bg-blue-600 text-white text-sm font-medium py-2.5 rounded shadow-lg shadow-blue-500/10 transition-all active:scale-[0.98]" vid="144">
+                    <i class="ph-bold ph-play" vid="145"></i>
+                    Run All Checks
+                </button>
+            </div>
+        </div>
+
+    </div>
+
+
+</body></html>

--- a/openspec/_ops/task_runs/ISSUE-79.md
+++ b/openspec/_ops/task_runs/ISSUE-79.md
@@ -1,0 +1,53 @@
+# ISSUE-79
+
+- Issue: #79
+- Branch: task/79-design-spec-update
+- PR: https://github.com/Leeky1017/CreoNow/pull/80
+
+## Plan
+
+- 更新 DESIGN_DECISIONS.md 强调色定义为纯白色系
+- 重命名 17 个 UUID 设计稿为规范命名格式
+- 添加 Agent 参考说明，明确设计稿与规范的关系
+
+## Runs
+
+### 2026-02-01 设计规范更新
+
+**1. 强调色更新**
+
+- Command: 修改 `design/DESIGN_DECISIONS.md`
+- 改动内容:
+  - §3.6 添加纯白强调色定义（`--color-accent: #ffffff`）
+  - 知识图谱节点色改名为 `--color-node-*`
+  - §7.3 拖拽指示线改用 `--color-accent`
+  - 附录 B 添加 Agent 参考说明
+
+**2. 设计稿重命名**
+
+- Command: `mv design-*.html XX-name.html`
+- 重命名映射:
+  | 原文件名 | 新文件名 |
+  |----------|----------|
+  | design-0a285476-...html | 20-memory-panel.html |
+  | design-7ccddead-...html | 20-memory-panel-alt.html |
+  | design-65900f89-...html | 21-skills-picker.html |
+  | design-7482d493-...html | 22-context-viewer.html |
+  | design-85557324-...html | 23-version-history.html |
+  | design-3a09f780-...html | 24-diff-view.html |
+  | design-96f8a239-...html | 25-search-panel.html |
+  | design-f3eae964-...html | 26-empty-states.html |
+  | design-ac1a7875-...html | 27-loading-states.html |
+  | design-66284919-...html | 28-template-picker.html |
+  | design-dcbba17f-...html | 29-export-dialog.html |
+  | design-32e1671e-...html | 30-zen-mode.html |
+  | design-f08fa496-...html | 31-interaction-patterns.html |
+  | design-8d50be7e-...html | 32-ai-streaming-states.html |
+  | design-54c0893d-...html | 33-ai-dialogs.html |
+  | design-7daed012-...html | 34-component-primitives.html |
+  | design-e556280e-...html | 35-constraints-panel.html |
+
+**3. 清理 Zone.Identifier 文件**
+
+- Command: `rm -f *:Zone.Identifier`
+- Key output: 删除 17 个 Windows Zone.Identifier 元数据文件


### PR DESCRIPTION
Closes #79

## Summary

- **强调色统一为纯白**：将 DESIGN_DECISIONS.md 中的强调色从蓝色/紫色改为纯白色系 (`--color-accent: #ffffff`)
- **设计稿规范命名**：将 17 个 UUID 命名的设计稿重命名为规范格式 (20-35)
- **Agent 参考说明**：添加附录 B，明确设计稿仅作布局参考，颜色等数值以规范为准

## 改动文件

| 类别 | 文件 |
|------|------|
| 规范更新 | `design/DESIGN_DECISIONS.md` |
| 新增提示词 | `design/Variant/MISSING_DESIGNS_PROMPTS.md` |
| 新增设计稿 | `design/Variant/designs/20-*.html` 至 `35-*.html` (17个) |
| 任务日志 | `openspec/_ops/task_runs/ISSUE-79.md` |

## 设计稿命名映射

- 20-memory-panel.html / 20-memory-panel-alt.html
- 21-skills-picker.html
- 22-context-viewer.html
- 23-version-history.html
- 24-diff-view.html
- 25-search-panel.html
- 26-empty-states.html
- 27-loading-states.html
- 28-template-picker.html
- 29-export-dialog.html
- 30-zen-mode.html
- 31-interaction-patterns.html
- 32-ai-streaming-states.html
- 33-ai-dialogs.html
- 34-component-primitives.html
- 35-constraints-panel.html

## Test Plan

- [x] DESIGN_DECISIONS.md 包含纯白强调色定义
- [x] DESIGN_DECISIONS.md 包含 Agent 参考说明（附录 B）
- [x] 所有设计稿使用规范命名（编号-用途.html）
- [x] Zone.Identifier 文件已清理