### PR TITLE
feat: Input 组件黄金标准 - Story + Test + 自检 (#87)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Input.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Input.stories.tsx
@@ -1,0 +1,586 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input } from "./Input";
+
+/**
+ * Input 组件 Story
+ *
+ * 设计规范 §6.2
+ * 单行文本输入框，支持 error、disabled、readonly 等状态。
+ *
+ * 状态矩阵（MUST 全部实现）：
+ * - default: 正常边框颜色
+ * - hover: 边框颜色变化（需要交互触发）
+ * - focus-visible: 边框颜色 + focus ring（聚焦触发）
+ * - error: 红色边框
+ * - disabled: opacity: 0.5，不可编辑
+ * - readonly: 轻微区分背景，可聚焦但不可编辑
+ */
+const meta = {
+  title: "Primitives/Input",
+  component: Input,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    error: {
+      control: "boolean",
+      description: "Show error state styling",
+    },
+    fullWidth: {
+      control: "boolean",
+      description: "Full width input",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable the input",
+    },
+    readOnly: {
+      control: "boolean",
+      description: "Make input read-only",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text",
+    },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态：标准输入框 */
+export const Default: Story = {
+  args: {
+    placeholder: "Enter text...",
+  },
+};
+
+/** 带默认值 */
+export const WithValue: Story = {
+  args: {
+    defaultValue: "Hello World",
+  },
+};
+
+/** 带 placeholder */
+export const WithPlaceholder: Story = {
+  args: {
+    placeholder: "Type something here...",
+  },
+};
+
+// ============================================================================
+// 状态 Stories
+// ============================================================================
+
+/** Error 状态：验证失败 */
+export const Error: Story = {
+  args: {
+    error: true,
+    defaultValue: "Invalid input",
+  },
+};
+
+/** Disabled 状态：禁用输入 */
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: "Disabled input",
+  },
+};
+
+/** ReadOnly 状态：只读输入 */
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+    defaultValue: "Read only input",
+  },
+};
+
+/** Full Width：全宽输入框 */
+export const FullWidth: Story = {
+  args: {
+    fullWidth: true,
+    placeholder: "Full width input",
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+// ============================================================================
+// 组合展示 Stories
+// ============================================================================
+
+/** 所有状态展示 */
+export const AllStates: Story = {
+  args: {
+    placeholder: "Input",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", width: "300px" }}>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Default
+        </label>
+        <Input placeholder="Enter text..." fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          With Value
+        </label>
+        <Input defaultValue="Hello World" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Error
+        </label>
+        <Input error defaultValue="Invalid input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Disabled
+        </label>
+        <Input disabled defaultValue="Disabled input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Read Only
+        </label>
+        <Input readOnly defaultValue="Read only input" fullWidth />
+      </div>
+    </div>
+  ),
+};
+
+// ============================================================================
+// 输入类型 Stories
+// ============================================================================
+
+/** Password 输入 */
+export const Password: Story = {
+  args: {
+    type: "password",
+    placeholder: "Enter password...",
+  },
+};
+
+/** Email 输入 */
+export const Email: Story = {
+  args: {
+    type: "email",
+    placeholder: "Enter email...",
+  },
+};
+
+/** Number 输入 */
+export const Number: Story = {
+  args: {
+    type: "number",
+    placeholder: "Enter number...",
+  },
+};
+
+/** Search 输入 */
+export const Search: Story = {
+  args: {
+    type: "search",
+    placeholder: "Search...",
+  },
+};
+
+/** 所有输入类型 */
+export const AllTypes: Story = {
+  args: {
+    placeholder: "Input",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", width: "300px" }}>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Text
+        </label>
+        <Input type="text" placeholder="Text input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Password
+        </label>
+        <Input type="password" placeholder="Password input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Email
+        </label>
+        <Input type="email" placeholder="Email input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Number
+        </label>
+        <Input type="number" placeholder="Number input" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Search
+        </label>
+        <Input type="search" placeholder="Search input" fullWidth />
+      </div>
+    </div>
+  ),
+};
+
+// ============================================================================
+// 边界情况 Stories
+// ============================================================================
+
+/**
+ * 超长文本
+ *
+ * 验证超长输入时的水平滚动行为
+ */
+export const LongText: Story = {
+  args: {
+    defaultValue:
+      "This is a very long text that should scroll horizontally when it exceeds the input width",
+  },
+};
+
+/**
+ * 超长文本（在有限宽度容器中）
+ *
+ * 验证文本过长时不会撑破布局
+ */
+export const LongTextConstrained: Story = {
+  args: {
+    defaultValue: "Input",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: () => (
+    <div style={{ width: "200px", border: "1px dashed var(--color-border-default)" }}>
+      <Input
+        fullWidth
+        defaultValue="Very long text that should handle overflow properly without breaking layout"
+      />
+    </div>
+  ),
+};
+
+/**
+ * 短文本
+ *
+ * 验证短文本时输入框仍保持正常宽度
+ */
+export const ShortText: Story = {
+  args: {
+    defaultValue: "Hi",
+  },
+};
+
+/**
+ * 带 Emoji 的输入
+ *
+ * 验证 emoji 正确显示
+ */
+export const WithEmoji: Story = {
+  args: {
+    defaultValue: "Hello 🌍 World 🚀",
+  },
+};
+
+// ============================================================================
+// 交互状态展示（用于 Focus 测试）
+// ============================================================================
+
+/**
+ * Focus 状态测试
+ *
+ * 使用 Tab 键导航到输入框，验证 focus-visible 样式
+ * - 应显示 focus ring（outline）
+ * - 边框颜色变化
+ */
+export const FocusTest: Story = {
+  args: {
+    placeholder: "Input",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "使用 Tab 键聚焦到输入框，验证 focus ring 是否正确显示",
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>Tab →</span>
+      <Input placeholder="Default Focus" />
+      <Input error placeholder="Error Focus" />
+    </div>
+  ),
+};
+
+/**
+ * 表单场景
+ *
+ * 模拟真实表单中的输入框使用
+ */
+export const FormScenario: Story = {
+  args: {
+    placeholder: "Input",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", width: "300px" }}>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "13px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          用户名
+        </label>
+        <Input placeholder="请输入用户名" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "13px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          密码
+        </label>
+        <Input type="password" placeholder="请输入密码" fullWidth />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.25rem",
+            fontSize: "13px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          邮箱 <span style={{ color: "var(--color-error)" }}>*</span>
+        </label>
+        <Input type="email" error placeholder="请输入有效邮箱" fullWidth />
+        <span
+          style={{
+            display: "block",
+            marginTop: "0.25rem",
+            fontSize: "12px",
+            color: "var(--color-error)",
+          }}
+        >
+          请输入有效的邮箱地址
+        </span>
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * 完整状态展示（用于 AI 自检）
+ *
+ * 包含所有状态的完整矩阵，便于一次性检查
+ */
+export const FullMatrix: Story = {
+  args: {
+    placeholder: "Input",
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => (
+    <div style={{ padding: "2rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
+      {/* States */}
+      <section>
+        <h3
+          style={{
+            margin: "0 0 1rem",
+            fontSize: "14px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          States
+        </h3>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "100px 1fr",
+            gap: "1rem",
+            alignItems: "center",
+            maxWidth: "400px",
+          }}
+        >
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>default</span>
+          <Input placeholder="Default input" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>with value</span>
+          <Input defaultValue="Hello World" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>error</span>
+          <Input error defaultValue="Invalid" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>disabled</span>
+          <Input disabled defaultValue="Disabled" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>readonly</span>
+          <Input readOnly defaultValue="Read only" fullWidth />
+        </div>
+      </section>
+
+      {/* Input Types */}
+      <section>
+        <h3
+          style={{
+            margin: "0 0 1rem",
+            fontSize: "14px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          Input Types
+        </h3>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "100px 1fr",
+            gap: "1rem",
+            alignItems: "center",
+            maxWidth: "400px",
+          }}
+        >
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>text</span>
+          <Input type="text" placeholder="Text" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>password</span>
+          <Input type="password" placeholder="Password" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>email</span>
+          <Input type="email" placeholder="Email" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>number</span>
+          <Input type="number" placeholder="Number" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>search</span>
+          <Input type="search" placeholder="Search" fullWidth />
+        </div>
+      </section>
+
+      {/* Edge Cases */}
+      <section>
+        <h3
+          style={{
+            margin: "0 0 1rem",
+            fontSize: "14px",
+            color: "var(--color-fg-default)",
+          }}
+        >
+          Edge Cases
+        </h3>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "100px 1fr",
+            gap: "1rem",
+            alignItems: "center",
+            maxWidth: "400px",
+          }}
+        >
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>long text</span>
+          <Input
+            defaultValue="This is a very long text that should scroll horizontally"
+            fullWidth
+          />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>short</span>
+          <Input defaultValue="Hi" fullWidth />
+
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>emoji</span>
+          <Input defaultValue="Hello 🌍 World 🚀" fullWidth />
+        </div>
+      </section>
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Input.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Input.test.tsx
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { Input } from "./Input";
+
+describe("Input", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染输入框", () => {
+      render(<Input placeholder="Enter text" />);
+
+      expect(screen.getByPlaceholderText("Enter text")).toBeInTheDocument();
+    });
+
+    it("应该渲染默认值", () => {
+      render(<Input defaultValue="Hello World" />);
+
+      expect(screen.getByRole("textbox")).toHaveValue("Hello World");
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Input className="custom-class" />);
+
+      expect(screen.getByRole("textbox")).toHaveClass("custom-class");
+    });
+
+    it("应该传递原生 input 属性", () => {
+      render(
+        <Input
+          data-testid="test-input"
+          aria-label="Test input"
+          name="test"
+        />,
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("data-testid", "test-input");
+      expect(input).toHaveAttribute("aria-label", "Test input");
+      expect(input).toHaveAttribute("name", "test");
+    });
+
+    it("应该支持 ref 转发", () => {
+      const ref = createRef<HTMLInputElement>();
+      render(<Input ref={ref} />);
+
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+  });
+
+  // ===========================================================================
+  // 状态测试
+  // ===========================================================================
+  describe("状态", () => {
+    it("应该处理 error 状态", () => {
+      render(<Input error />);
+
+      const input = screen.getByRole("textbox");
+      // Error 状态应该有红色边框类
+      expect(input).toHaveClass("border-[var(--color-error)]");
+    });
+
+    it("应该处理 disabled 状态", () => {
+      render(<Input disabled />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toBeDisabled();
+      expect(input).toHaveClass("disabled:opacity-50");
+    });
+
+    it("应该处理 readOnly 状态", () => {
+      render(<Input readOnly defaultValue="Read only" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("readonly");
+    });
+
+    it("应该渲染 fullWidth 样式", () => {
+      render(<Input fullWidth />);
+
+      expect(screen.getByRole("textbox")).toHaveClass("w-full");
+    });
+
+    it("应该同时支持 error 和 disabled", () => {
+      render(<Input error disabled defaultValue="Error + Disabled" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toBeDisabled();
+      expect(input).toHaveClass("border-[var(--color-error)]");
+    });
+  });
+
+  // ===========================================================================
+  // 交互测试
+  // ===========================================================================
+  describe("交互", () => {
+    it("应该能输入文本", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "Hello World");
+
+      expect(input).toHaveValue("Hello World");
+    });
+
+    it("应该调用 onChange", async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Input onChange={handleChange} />);
+
+      await user.type(screen.getByRole("textbox"), "a");
+
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it("disabled 状态下不应该可编辑", async () => {
+      const user = userEvent.setup();
+      render(<Input disabled defaultValue="test" />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "new text");
+
+      expect(input).toHaveValue("test");
+    });
+
+    it("readOnly 状态下不应该可编辑", async () => {
+      const user = userEvent.setup();
+      render(<Input readOnly defaultValue="test" />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "new text");
+
+      expect(input).toHaveValue("test");
+    });
+
+    it("应该可以通过 Tab 键聚焦", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      await user.tab();
+
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+
+    it("disabled 时不应该可以通过 Tab 键聚焦", async () => {
+      const user = userEvent.setup();
+      render(<Input disabled />);
+
+      await user.tab();
+
+      expect(screen.getByRole("textbox")).not.toHaveFocus();
+    });
+
+    it("readOnly 时应该可以通过 Tab 键聚焦", async () => {
+      const user = userEvent.setup();
+      render(<Input readOnly />);
+
+      await user.tab();
+
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+  });
+
+  // ===========================================================================
+  // Focus 样式测试
+  // ===========================================================================
+  describe("Focus 样式", () => {
+    it("应该有 focus-visible 相关类", () => {
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveClass("focus-visible:outline");
+      expect(input).toHaveClass("focus-visible:border-[var(--color-border-focus)]");
+    });
+  });
+
+  // ===========================================================================
+  // CSS Variables 检查（不使用硬编码颜色）
+  // ===========================================================================
+  describe("CSS Variables", () => {
+    it("class 中不应该包含硬编码的十六进制颜色", () => {
+      const { container } = render(<Input />);
+
+      const input = container.querySelector("input");
+      const classNames = input?.className ?? "";
+
+      // 检查 class 中不包含硬编码的颜色值
+      expect(classNames).not.toMatch(/#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])/);
+    });
+
+    it("应该使用 CSS Variables 定义颜色", () => {
+      const { container } = render(<Input />);
+
+      const input = container.querySelector("input");
+      const classNames = input?.className ?? "";
+
+      // 检查使用了 CSS Variables
+      expect(classNames).toContain("var(--");
+    });
+  });
+
+  // ===========================================================================
+  // 输入类型测试
+  // ===========================================================================
+  describe("输入类型", () => {
+    it("应该支持 password 类型", () => {
+      render(<Input type="password" />);
+
+      // password 类型不是 textbox role
+      const input = document.querySelector('input[type="password"]');
+      expect(input).toBeInTheDocument();
+    });
+
+    it("应该支持 email 类型", () => {
+      render(<Input type="email" />);
+
+      expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+    });
+
+    it("应该支持 number 类型", () => {
+      render(<Input type="number" />);
+
+      expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+    });
+
+    it("应该支持 search 类型", () => {
+      render(<Input type="search" />);
+
+      expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理空字符串值", () => {
+      render(<Input defaultValue="" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveValue("");
+    });
+
+    it("应该处理超长文本", async () => {
+      const longText =
+        "This is an extremely long input text that should still render correctly without breaking the layout and should scroll horizontally";
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, longText);
+
+      expect(input).toHaveValue(longText);
+    });
+
+    it("应该处理单字符", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "X");
+
+      expect(input).toHaveValue("X");
+    });
+
+    it("应该处理 emoji", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "Hello 🌍 World 🚀");
+
+      expect(input).toHaveValue("Hello 🌍 World 🚀");
+    });
+
+    it("应该处理中文输入", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "你好世界");
+
+      expect(input).toHaveValue("你好世界");
+    });
+
+    it("应该处理特殊字符", async () => {
+      const user = userEvent.setup();
+      render(<Input />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "<script>alert('xss')</script>");
+
+      expect(input).toHaveValue("<script>alert('xss')</script>");
+    });
+  });
+
+  // ===========================================================================
+  // Placeholder 测试
+  // ===========================================================================
+  describe("Placeholder", () => {
+    it("应该显示 placeholder", () => {
+      render(<Input placeholder="Enter text here" />);
+
+      expect(screen.getByPlaceholderText("Enter text here")).toBeInTheDocument();
+    });
+
+    it("有值时应该显示值而不是 placeholder", () => {
+      render(<Input placeholder="Enter text" defaultValue="Actual value" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveValue("Actual value");
+    });
+  });
+
+  // ===========================================================================
+  // 无障碍 (a11y) 测试
+  // ===========================================================================
+  describe("无障碍", () => {
+    it("应该支持 aria-label", () => {
+      render(<Input aria-label="Email address" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAccessibleName("Email address");
+    });
+
+    it("应该支持 aria-describedby", () => {
+      render(
+        <>
+          <span id="desc">Enter your email address</span>
+          <Input aria-describedby="desc" />
+        </>,
+      );
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-describedby", "desc");
+    });
+
+    it("应该支持 aria-invalid", () => {
+      render(<Input aria-invalid="true" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("应该支持 aria-required", () => {
+      render(<Input aria-required="true" />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("aria-required", "true");
+    });
+
+    it("disabled 输入框应该有正确的属性", () => {
+      render(<Input disabled />);
+
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveAttribute("disabled");
+    });
+  });
+
+  // ===========================================================================
+  // 受控组件测试
+  // ===========================================================================
+  describe("受控组件", () => {
+    it("应该支持受控 value", () => {
+      const { rerender } = render(<Input value="initial" onChange={() => {}} />);
+
+      expect(screen.getByRole("textbox")).toHaveValue("initial");
+
+      rerender(<Input value="updated" onChange={() => {}} />);
+
+      expect(screen.getByRole("textbox")).toHaveValue("updated");
+    });
+  });
+});

--- a/design/system/02-component-cards/Button.md
+++ b/design/system/02-component-cards/Button.md
@@ -91,13 +91,20 @@
 
 ```typescript
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 视觉样式变体 */
   variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+  /** 按钮尺寸 */
   size?: 'sm' | 'md' | 'lg';
+  /** 显示加载状态并禁用交互 */
   loading?: boolean;
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
+  /** 全宽按钮 */
+  fullWidth?: boolean;
+  /** 按钮内容 */
+  children: React.ReactNode;
 }
 ```
+
+> **注意**: leftIcon/rightIcon 功能通过 children 支持 React 节点实现，如 `<Button><Icon /> Text</Button>`
 
 ---
 

--- a/openspec/_ops/task_runs/ISSUE-87.md
+++ b/openspec/_ops/task_runs/ISSUE-87.md
@@ -1,0 +1,42 @@
+# ISSUE-87
+- Issue: #87
+- Branch: task/87-p1-input-golden-standard
+- PR: <fill-after-created>
+
+## Plan
+- 更新 Button.md 生成卡片，使 Props 接口与实际实现一致
+- 创建 Input.stories.tsx，包含所有状态和边界情况的 20 个 Story
+- 创建 Input.test.tsx，包含完整的 38 个测试用例
+- 通过浏览器 MCP 执行 AI 可视化自检
+
+## Runs
+
+### 2026-02-01 21:40 p1-btn-card
+- Command: 更新 `design/system/02-component-cards/Button.md`
+- Key output: Props 接口更新，添加 fullWidth 属性，移除未实现的 leftIcon/rightIcon
+- Evidence: `design/system/02-component-cards/Button.md`
+
+### 2026-02-01 21:41 p1-inp-story
+- Command: 创建 `apps/desktop/renderer/src/components/primitives/Input.stories.tsx`
+- Key output: 20 个 Story 创建完成，包含所有状态、输入类型、边界情况
+- Evidence: `apps/desktop/renderer/src/components/primitives/Input.stories.tsx`
+
+### 2026-02-01 21:42 p1-inp-test
+- Command: `pnpm test:run -- renderer/src/components/primitives/Input.test.tsx`
+- Key output:
+  ```
+  ✓ renderer/src/components/primitives/Input.test.tsx (38 tests) 1161ms
+  Test Files  2 passed (2)
+  Tests  84 passed (84)
+  ```
+- Evidence: `apps/desktop/renderer/src/components/primitives/Input.test.tsx`
+
+### 2026-02-01 21:45 p1-inp-selfcheck
+- Command: 使用 cursor-ide-browser MCP 进行可视化自检
+- Key output:
+  - 导航到 Storybook: http://172.18.248.30:6008/?path=/story/primitives-input--full-matrix
+  - 截图验证所有状态渲染正确
+  - ✅ States: default, with value, error, disabled, readonly 全部正确
+  - ✅ Input Types: text, password, email, number, search 全部正确
+  - ✅ Edge Cases: 长文本、短文本、emoji 正确处理
+- Evidence: Storybook 截图验证通过

--- a/openspec/_ops/task_runs/ISSUE-87.md
+++ b/openspec/_ops/task_runs/ISSUE-87.md
@@ -1,7 +1,7 @@
 # ISSUE-87
 - Issue: #87
 - Branch: task/87-p1-input-golden-standard
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/88
 
 ## Plan
 - 更新 Button.md 生成卡片，使 Props 接口与实际实现一致


### PR DESCRIPTION
Closes #87

## Summary
- 更新 Button.md Props 接口与实际实现一致（添加 fullWidth，移除未实现的 leftIcon/rightIcon）
- 创建 Input.stories.tsx，包含 20 个 Story 覆盖所有状态、输入类型、边界情况
- 创建 Input.test.tsx，包含 38 个测试用例，全部通过
- 通过浏览器 MCP 完成 AI 可视化自检

## Test Plan
- [x] `pnpm test:run` - 38 个 Input 测试全部通过
- [x] Storybook 启动并验证所有 Story 正确渲染
- [x] AI 浏览器自检通过：
  - States: default, with value, error, disabled, readonly ✅
  - Input Types: text, password, email, number, search ✅
  - Edge Cases: 长文本、短文本、emoji ✅

## Evidence
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-87.md`