### PR TITLE
feat: Card 组件黄金标准（Story + Test + 自检 + 生成卡片） (#89)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Card.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Card.stories.tsx
@@ -1,0 +1,716 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { CardVariant } from "./Card";
+import { Card } from "./Card";
+
+/**
+ * Card 组件 Story
+ *
+ * 设计规范 §6.3
+ * 容器组件，用于内容分组和视觉分隔。
+ *
+ * Variant 矩阵：
+ * - default: 标准边框（无阴影）
+ * - raised: 带阴影的悬浮样式
+ * - bordered: 加粗边框
+ *
+ * 状态矩阵（MUST 全部实现）：
+ * - default: 正常样式
+ * - hover (hoverable): 边框高亮 + 可选阴影
+ */
+const meta = {
+  title: "Primitives/Card",
+  component: Card,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "raised", "bordered"],
+      description: "Visual style variant",
+    },
+    hoverable: {
+      control: "boolean",
+      description: "Enable hover effect (border highlight, optional shadow)",
+    },
+    noPadding: {
+      control: "boolean",
+      description: "Remove padding for custom layouts",
+    },
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态：标准卡片 */
+export const Default: Story = {
+  args: {
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Card Title
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This is the card content. Cards are containers for grouping related content.
+        </p>
+      </div>
+    ),
+  },
+};
+
+/** Raised variant：带阴影的悬浮卡片 */
+export const Raised: Story = {
+  args: {
+    variant: "raised",
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Raised Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This card has elevation shadow for floating elements.
+        </p>
+      </div>
+    ),
+  },
+};
+
+/** Bordered variant：加粗边框卡片 */
+export const Bordered: Story = {
+  args: {
+    variant: "bordered",
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Bordered Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This card has a prominent border.
+        </p>
+      </div>
+    ),
+  },
+};
+
+// ============================================================================
+// Hoverable Stories
+// ============================================================================
+
+/** Hoverable：可点击卡片（有 hover 效果） */
+export const Hoverable: Story = {
+  args: {
+    hoverable: true,
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Hoverable Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          Hover over this card to see the effect.
+        </p>
+      </div>
+    ),
+  },
+};
+
+/** Hoverable + Raised：可点击悬浮卡片 */
+export const HoverableRaised: Story = {
+  args: {
+    variant: "raised",
+    hoverable: true,
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Hoverable Raised Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          Combined raised variant with hover effect.
+        </p>
+      </div>
+    ),
+  },
+};
+
+// ============================================================================
+// Padding Stories
+// ============================================================================
+
+/** No Padding：无内边距 */
+export const NoPadding: Story = {
+  args: {
+    noPadding: true,
+    children: (
+      <div style={{ padding: "1rem", background: "var(--color-bg-muted)" }}>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Custom Padding Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This card has no padding - useful for custom layouts.
+        </p>
+      </div>
+    ),
+  },
+};
+
+// ============================================================================
+// 组合展示 Stories
+// ============================================================================
+
+/** 所有 Variants 展示 */
+export const AllVariants: Story = {
+  args: {
+    children: "Card",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+      <Card>
+        <div style={{ minWidth: "150px" }}>
+          <strong>Default</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Standard card
+          </p>
+        </div>
+      </Card>
+      <Card variant="raised">
+        <div style={{ minWidth: "150px" }}>
+          <strong>Raised</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Elevated card
+          </p>
+        </div>
+      </Card>
+      <Card variant="bordered">
+        <div style={{ minWidth: "150px" }}>
+          <strong>Bordered</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Prominent border
+          </p>
+        </div>
+      </Card>
+    </div>
+  ),
+};
+
+/** 所有 Hoverable 状态展示 */
+export const AllHoverable: Story = {
+  args: {
+    children: "Card",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+      <Card hoverable>
+        <div style={{ minWidth: "150px" }}>
+          <strong>Default Hoverable</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Hover to see effect
+          </p>
+        </div>
+      </Card>
+      <Card variant="raised" hoverable>
+        <div style={{ minWidth: "150px" }}>
+          <strong>Raised Hoverable</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Hover to see effect
+          </p>
+        </div>
+      </Card>
+      <Card variant="bordered" hoverable>
+        <div style={{ minWidth: "150px" }}>
+          <strong>Bordered Hoverable</strong>
+          <p style={{ margin: "0.5rem 0 0", fontSize: "14px", color: "var(--color-fg-muted)" }}>
+            Hover to see effect
+          </p>
+        </div>
+      </Card>
+    </div>
+  ),
+};
+
+// ============================================================================
+// Slot 模式展示
+// ============================================================================
+
+/** Header + Content + Footer Slot 模式 */
+export const WithSlots: Story = {
+  args: {
+    children: "Card",
+  },
+  render: () => (
+    <Card>
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "1rem",
+          paddingBottom: "0.75rem",
+          borderBottom: "1px solid var(--color-border-default)",
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Card Header</h3>
+        <button
+          style={{
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          ...
+        </button>
+      </div>
+      {/* Content */}
+      <div style={{ marginBottom: "1rem" }}>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This is the main content area of the card. It can contain any type of content including
+          text, images, forms, or other components.
+        </p>
+      </div>
+      {/* Footer */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: "0.5rem",
+          paddingTop: "0.75rem",
+          borderTop: "1px solid var(--color-border-default)",
+        }}
+      >
+        <button
+          style={{
+            padding: "0.5rem 1rem",
+            background: "transparent",
+            border: "1px solid var(--color-border-default)",
+            borderRadius: "var(--radius-md)",
+            cursor: "pointer",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          style={{
+            padding: "0.5rem 1rem",
+            background: "var(--color-primary)",
+            color: "white",
+            border: "none",
+            borderRadius: "var(--radius-md)",
+            cursor: "pointer",
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </Card>
+  ),
+};
+
+// ============================================================================
+// 边界情况 Stories
+// ============================================================================
+
+/**
+ * 空内容
+ *
+ * 验证空内容时卡片仍保持正常样式
+ */
+export const EmptyContent: Story = {
+  args: {
+    children: <div style={{ height: "50px" }} />,
+  },
+};
+
+/**
+ * 超长内容
+ *
+ * 验证内容溢出时的处理
+ */
+export const LongContent: Story = {
+  args: {
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Card with Long Content
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This is a very long piece of content that demonstrates how the card handles overflow.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+      </div>
+    ),
+  },
+};
+
+/**
+ * 超长内容（在有限宽度容器中）
+ *
+ * 验证内容过长时不会撑破布局
+ */
+export const LongContentConstrained: Story = {
+  args: {
+    children: "Card",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: () => (
+    <div style={{ width: "300px", border: "1px dashed var(--color-border-default)" }}>
+      <Card>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          Very Long Card Title That Should Handle Overflow
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          This content is constrained within a 300px container.
+        </p>
+      </Card>
+    </div>
+  ),
+};
+
+/**
+ * 嵌套 Card
+ *
+ * 验证嵌套卡片的样式
+ */
+export const NestedCards: Story = {
+  args: {
+    children: "Card",
+  },
+  render: () => (
+    <Card>
+      <h3 style={{ margin: "0 0 1rem", fontSize: "16px", fontWeight: 600 }}>Parent Card</h3>
+      <Card variant="bordered">
+        <h4 style={{ margin: "0 0 0.5rem", fontSize: "14px", fontWeight: 600 }}>Nested Card</h4>
+        <p style={{ margin: 0, fontSize: "13px", color: "var(--color-fg-muted)" }}>
+          Cards can be nested for complex layouts.
+        </p>
+      </Card>
+    </Card>
+  ),
+};
+
+/**
+ * 带 Emoji 的卡片
+ *
+ * 验证 emoji 正确显示
+ */
+export const WithEmoji: Story = {
+  args: {
+    children: (
+      <div>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          🚀 Launch Card
+        </h3>
+        <p style={{ margin: 0, fontSize: "14px", color: "var(--color-fg-muted)" }}>
+          Card with emoji content 🎉
+        </p>
+      </div>
+    ),
+  },
+};
+
+// ============================================================================
+// 完整矩阵展示（用于 AI 自检）
+// ============================================================================
+
+const variants: CardVariant[] = ["default", "raised", "bordered"];
+
+/**
+ * 完整 Variant 矩阵
+ *
+ * 展示所有 3 种 variant 的组合
+ */
+export const VariantMatrix: Story = {
+  args: {
+    children: "Card",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      {variants.map((variant) => (
+        <div key={variant}>
+          <div
+            style={{
+              marginBottom: "0.5rem",
+              fontSize: "12px",
+              color: "var(--color-fg-muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            {variant}
+          </div>
+          <div style={{ display: "flex", gap: "1rem" }}>
+            <Card variant={variant}>
+              <div style={{ minWidth: "120px" }}>
+                <strong>Normal</strong>
+                <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                  Default state
+                </p>
+              </div>
+            </Card>
+            <Card variant={variant} hoverable>
+              <div style={{ minWidth: "120px" }}>
+                <strong>Hoverable</strong>
+                <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                  Hover me
+                </p>
+              </div>
+            </Card>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * 完整状态展示（用于 AI 自检）
+ *
+ * 包含所有 variant、hoverable 状态的完整矩阵，便于一次性检查
+ */
+export const FullMatrix: Story = {
+  args: {
+    children: "Card",
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => (
+    <div style={{ padding: "2rem", display: "flex", flexDirection: "column", gap: "2rem" }}>
+      {/* Variants */}
+      <section>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "14px", color: "var(--color-fg-default)" }}>
+          Variants
+        </h3>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          {variants.map((variant) => (
+            <Card key={variant} variant={variant}>
+              <div style={{ minWidth: "120px" }}>
+                <strong>{variant}</strong>
+                <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                  Card variant
+                </p>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Hoverable States */}
+      <section>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "14px", color: "var(--color-fg-default)" }}>
+          Hoverable States
+        </h3>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          {variants.map((variant) => (
+            <Card key={variant} variant={variant} hoverable>
+              <div style={{ minWidth: "120px" }}>
+                <strong>{variant} + hoverable</strong>
+                <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                  Hover to see effect
+                </p>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Padding Options */}
+      <section>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "14px", color: "var(--color-fg-default)" }}>
+          Padding Options
+        </h3>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          <Card>
+            <div style={{ minWidth: "120px" }}>
+              <strong>With Padding</strong>
+              <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                Default padding (24px)
+              </p>
+            </div>
+          </Card>
+          <Card noPadding>
+            <div style={{ padding: "1rem", background: "var(--color-bg-muted)", minWidth: "120px" }}>
+              <strong>No Padding</strong>
+              <p style={{ margin: "0.5rem 0 0", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+                Custom layout
+              </p>
+            </div>
+          </Card>
+        </div>
+      </section>
+
+      {/* Slot Pattern */}
+      <section>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "14px", color: "var(--color-fg-default)" }}>
+          Slot Pattern (Header + Content + Footer)
+        </h3>
+        <div style={{ maxWidth: "400px" }}>
+          <Card>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: "1rem",
+                paddingBottom: "0.75rem",
+                borderBottom: "1px solid var(--color-border-default)",
+              }}
+            >
+              <h4 style={{ margin: 0, fontSize: "14px", fontWeight: 600 }}>Header</h4>
+              <span style={{ color: "var(--color-fg-muted)" }}>...</span>
+            </div>
+            <p style={{ margin: "0 0 1rem", fontSize: "13px", color: "var(--color-fg-muted)" }}>
+              Main content area of the card.
+            </p>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: "0.5rem",
+                paddingTop: "0.75rem",
+                borderTop: "1px solid var(--color-border-default)",
+              }}
+            >
+              <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>Footer</span>
+            </div>
+          </Card>
+        </div>
+      </section>
+
+      {/* Edge Cases */}
+      <section>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "14px", color: "var(--color-fg-default)" }}>
+          Edge Cases
+        </h3>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", alignItems: "flex-start" }}>
+          <Card>
+            <div style={{ minWidth: "100px", height: "30px" }}>
+              <strong>Empty</strong>
+            </div>
+          </Card>
+          <Card>
+            <Card variant="bordered">
+              <strong>Nested</strong>
+            </Card>
+          </Card>
+          <Card>
+            <strong>🚀 Emoji</strong>
+          </Card>
+        </div>
+      </section>
+    </div>
+  ),
+};
+
+// ============================================================================
+// 实际使用场景
+// ============================================================================
+
+/**
+ * 项目卡片场景
+ *
+ * 模拟真实的项目列表卡片
+ */
+export const ProjectCardScenario: Story = {
+  args: {
+    children: "Card",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+      <Card hoverable style={{ width: "250px" }}>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          我的小说项目
+        </h3>
+        <p style={{ margin: "0 0 1rem", fontSize: "13px", color: "var(--color-fg-muted)" }}>
+          科幻小说创作，目前第三章进行中...
+        </p>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          <span>12,345 字</span>
+          <span>2 天前</span>
+        </div>
+      </Card>
+      <Card hoverable style={{ width: "250px" }}>
+        <h3 style={{ margin: "0 0 0.5rem", fontSize: "16px", fontWeight: 600 }}>
+          商业计划书
+        </h3>
+        <p style={{ margin: "0 0 1rem", fontSize: "13px", color: "var(--color-fg-muted)" }}>
+          创业项目商业计划书初稿...
+        </p>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontSize: "12px",
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          <span>5,678 字</span>
+          <span>1 周前</span>
+        </div>
+      </Card>
+    </div>
+  ),
+};
+
+/**
+ * 设置面板卡片场景
+ *
+ * 模拟设置页面中的分组卡片
+ */
+export const SettingsCardScenario: Story = {
+  args: {
+    children: "Card",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: () => (
+    <div style={{ maxWidth: "500px", display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <Card>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "16px", fontWeight: 600 }}>外观设置</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "14px" }}>主题</span>
+            <span style={{ fontSize: "14px", color: "var(--color-fg-muted)" }}>深色</span>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "14px" }}>字体大小</span>
+            <span style={{ fontSize: "14px", color: "var(--color-fg-muted)" }}>中</span>
+          </div>
+        </div>
+      </Card>
+      <Card>
+        <h3 style={{ margin: "0 0 1rem", fontSize: "16px", fontWeight: 600 }}>AI 设置</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "14px" }}>模型</span>
+            <span style={{ fontSize: "14px", color: "var(--color-fg-muted)" }}>GPT-4</span>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "14px" }}>创意度</span>
+            <span style={{ fontSize: "14px", color: "var(--color-fg-muted)" }}>0.7</span>
+          </div>
+        </div>
+      </Card>
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Card.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Card.test.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CardVariant } from "./Card";
+import { Card } from "./Card";
+
+describe("Card", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染卡片内容", () => {
+      render(<Card>Card Content</Card>);
+
+      expect(screen.getByText("Card Content")).toBeInTheDocument();
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Card className="custom-class">Content</Card>);
+
+      const card = screen.getByText("Content").closest("div");
+      expect(card).toHaveClass("custom-class");
+    });
+
+    it("应该传递原生 div 属性", () => {
+      render(
+        <Card data-testid="test-card" aria-label="Test card">
+          Test
+        </Card>,
+      );
+
+      const card = screen.getByTestId("test-card");
+      expect(card).toHaveAttribute("aria-label", "Test card");
+    });
+  });
+
+  // ===========================================================================
+  // Variant 测试（全覆盖）
+  // ===========================================================================
+  describe("variants", () => {
+    const variants: CardVariant[] = ["default", "raised", "bordered"];
+
+    it.each(variants)("应该渲染 %s variant", (variant) => {
+      render(<Card variant={variant}>{variant}</Card>);
+
+      const card = screen.getByText(variant).closest("div");
+      expect(card).toBeInTheDocument();
+    });
+
+    it("默认应该是 default variant", () => {
+      render(<Card>Default</Card>);
+
+      const card = screen.getByText("Default").closest("div");
+      // default variant 只有单层 border
+      expect(card).toHaveClass("border");
+      expect(card).not.toHaveClass("border-2");
+    });
+
+    it("raised variant 应该有阴影", () => {
+      const { container } = render(<Card variant="raised">Raised</Card>);
+
+      const card = container.firstChild as HTMLElement;
+      expect(card.className).toContain("shadow-[var(--shadow-md)]");
+    });
+
+    it("bordered variant 应该有加粗边框", () => {
+      render(<Card variant="bordered">Bordered</Card>);
+
+      const card = screen.getByText("Bordered").closest("div");
+      expect(card).toHaveClass("border-2");
+    });
+  });
+
+  // ===========================================================================
+  // Hoverable 测试
+  // ===========================================================================
+  describe("hoverable", () => {
+    it("hoverable 模式应该有 cursor-pointer", () => {
+      render(<Card hoverable>Hoverable</Card>);
+
+      const card = screen.getByText("Hoverable").closest("div");
+      expect(card).toHaveClass("cursor-pointer");
+    });
+
+    it("非 hoverable 模式不应该有 cursor-pointer", () => {
+      render(<Card>Normal</Card>);
+
+      const card = screen.getByText("Normal").closest("div");
+      expect(card).not.toHaveClass("cursor-pointer");
+    });
+
+    it("hoverable 模式应该有 hover 边框样式", () => {
+      render(<Card hoverable>Hoverable</Card>);
+
+      const card = screen.getByText("Hoverable").closest("div");
+      expect(card?.className).toContain("hover:border-[var(--color-border-hover)]");
+    });
+
+    it("hoverable 模式应该有 hover 阴影样式", () => {
+      render(<Card hoverable>Hoverable</Card>);
+
+      const card = screen.getByText("Hoverable").closest("div");
+      expect(card?.className).toContain("hover:shadow-[var(--shadow-sm)]");
+    });
+  });
+
+  // ===========================================================================
+  // Padding 测试
+  // ===========================================================================
+  describe("padding", () => {
+    it("默认应该有 p-6 padding", () => {
+      render(<Card>With Padding</Card>);
+
+      const card = screen.getByText("With Padding").closest("div");
+      expect(card).toHaveClass("p-6");
+    });
+
+    it("noPadding 模式不应该有 p-6", () => {
+      render(<Card noPadding>No Padding</Card>);
+
+      const card = screen.getByText("No Padding").closest("div");
+      expect(card).not.toHaveClass("p-6");
+    });
+  });
+
+  // ===========================================================================
+  // 样式测试
+  // ===========================================================================
+  describe("样式", () => {
+    it("应该有正确的圆角", () => {
+      render(<Card>Content</Card>);
+
+      const card = screen.getByText("Content").closest("div");
+      expect(card?.className).toContain("rounded-[var(--radius-xl)]");
+    });
+
+    it("应该有正确的背景色", () => {
+      render(<Card>Content</Card>);
+
+      const card = screen.getByText("Content").closest("div");
+      expect(card?.className).toContain("bg-[var(--color-bg-surface)]");
+    });
+
+    it("应该有过渡动画", () => {
+      render(<Card>Content</Card>);
+
+      const card = screen.getByText("Content").closest("div");
+      expect(card).toHaveClass("transition-all");
+    });
+  });
+
+  // ===========================================================================
+  // 阴影规则测试（设计规范 §5.2）
+  // ===========================================================================
+  describe("阴影规则", () => {
+    it("default variant 不应该有阴影", () => {
+      render(<Card>Default</Card>);
+
+      const card = screen.getByText("Default").closest("div");
+      // 检查 class 中不包含 shadow 相关的静态样式
+      expect(card?.className).not.toContain("shadow-[var(--shadow-md)]");
+      // 但可以有 hover 时的阴影（如果是 hoverable）
+    });
+
+    it("仅 raised variant 默认有阴影", () => {
+      render(<Card variant="raised">Raised</Card>);
+
+      const card = screen.getByText("Raised").closest("div");
+      expect(card?.className).toContain("shadow-[var(--shadow-md)]");
+    });
+
+    it("hoverable 时 hover 状态可以添加轻微阴影", () => {
+      render(<Card hoverable>Hoverable</Card>);
+
+      const card = screen.getByText("Hoverable").closest("div");
+      // hover 状态的阴影是 --shadow-sm
+      expect(card?.className).toContain("hover:shadow-[var(--shadow-sm)]");
+    });
+  });
+
+  // ===========================================================================
+  // CSS Variables 检查（不使用硬编码颜色）
+  // ===========================================================================
+  describe("CSS Variables", () => {
+    it("class 中不应该包含硬编码的十六进制颜色", () => {
+      const { container } = render(<Card variant="default">Test</Card>);
+
+      const card = container.querySelector("div");
+      const classNames = card?.className ?? "";
+
+      // 检查 class 中不包含硬编码的颜色值
+      expect(classNames).not.toMatch(/#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])/);
+    });
+
+    it("应该使用 CSS Variables 定义颜色", () => {
+      const { container } = render(<Card>Test</Card>);
+
+      const card = container.querySelector("div");
+      const classNames = card?.className ?? "";
+
+      // 检查使用了 CSS Variables
+      expect(classNames).toContain("var(--");
+    });
+  });
+
+  // ===========================================================================
+  // 交互测试
+  // ===========================================================================
+  describe("交互", () => {
+    it("应该在点击时调用 onClick", async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Card hoverable onClick={handleClick}>
+          Clickable
+        </Card>,
+      );
+
+      await user.click(screen.getByText("Clickable"));
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("非 hoverable 卡片也可以响应点击", async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Card onClick={handleClick}>Normal</Card>);
+
+      await user.click(screen.getByText("Normal"));
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // Slot 模式测试
+  // ===========================================================================
+  describe("Slot 模式", () => {
+    it("应该正确渲染 children", () => {
+      render(
+        <Card>
+          <div data-testid="header">Header</div>
+          <div data-testid="content">Content</div>
+          <div data-testid="footer">Footer</div>
+        </Card>,
+      );
+
+      expect(screen.getByTestId("header")).toBeInTheDocument();
+      expect(screen.getByTestId("content")).toBeInTheDocument();
+      expect(screen.getByTestId("footer")).toBeInTheDocument();
+    });
+
+    it("应该保持 children 的顺序", () => {
+      const { container } = render(
+        <Card>
+          <span>First</span>
+          <span>Second</span>
+          <span>Third</span>
+        </Card>,
+      );
+
+      const spans = container.querySelectorAll("span");
+      expect(spans[0]).toHaveTextContent("First");
+      expect(spans[1]).toHaveTextContent("Second");
+      expect(spans[2]).toHaveTextContent("Third");
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理空 children", () => {
+      const { container } = render(<Card>{""}</Card>);
+
+      const card = container.firstChild;
+      expect(card).toBeInTheDocument();
+    });
+
+    it("应该处理超长文本", () => {
+      const longText =
+        "This is an extremely long piece of content that should still render correctly without breaking the card layout. It might wrap to multiple lines depending on the container width.";
+      render(<Card>{longText}</Card>);
+
+      expect(screen.getByText(longText)).toBeInTheDocument();
+    });
+
+    it("应该处理 emoji", () => {
+      render(<Card>🚀 Card with Emoji 🎉</Card>);
+
+      expect(screen.getByText("🚀 Card with Emoji 🎉")).toBeInTheDocument();
+    });
+
+    it("应该支持嵌套 Card", () => {
+      render(
+        <Card data-testid="outer">
+          <Card data-testid="inner">Nested</Card>
+        </Card>,
+      );
+
+      expect(screen.getByTestId("outer")).toBeInTheDocument();
+      expect(screen.getByTestId("inner")).toBeInTheDocument();
+      expect(screen.getByText("Nested")).toBeInTheDocument();
+    });
+
+    it("应该处理 React 节点作为 children", () => {
+      render(
+        <Card>
+          <div data-testid="complex">
+            <h3>Title</h3>
+            <p>Description</p>
+            <button>Action</button>
+          </div>
+        </Card>,
+      );
+
+      expect(screen.getByTestId("complex")).toBeInTheDocument();
+      expect(screen.getByRole("heading")).toHaveTextContent("Title");
+      expect(screen.getByRole("button")).toHaveTextContent("Action");
+    });
+  });
+
+  // ===========================================================================
+  // 完整 Variant × Hoverable 矩阵测试
+  // ===========================================================================
+  describe("Variant × Hoverable 矩阵", () => {
+    const variants: CardVariant[] = ["default", "raised", "bordered"];
+    const hoverableStates = [true, false];
+
+    const combinations = variants.flatMap((variant) =>
+      hoverableStates.map((hoverable) => ({ variant, hoverable })),
+    );
+
+    it.each(combinations)(
+      "应该正确渲染 $variant × hoverable=$hoverable 组合",
+      ({ variant, hoverable }) => {
+        render(
+          <Card variant={variant} hoverable={hoverable}>
+            Test
+          </Card>,
+        );
+
+        const card = screen.getByText("Test").closest("div");
+        expect(card).toBeInTheDocument();
+
+        if (hoverable) {
+          expect(card).toHaveClass("cursor-pointer");
+        } else {
+          expect(card).not.toHaveClass("cursor-pointer");
+        }
+      },
+    );
+  });
+
+  // ===========================================================================
+  // 无障碍 (a11y) 测试
+  // ===========================================================================
+  describe("无障碍", () => {
+    it("应该支持 role 属性", () => {
+      render(
+        <Card role="article" aria-label="Project card">
+          Content
+        </Card>,
+      );
+
+      expect(screen.getByRole("article")).toBeInTheDocument();
+      expect(screen.getByRole("article")).toHaveAccessibleName("Project card");
+    });
+
+    it("应该支持 aria-describedby", () => {
+      render(
+        <>
+          <span id="desc">This card contains project information</span>
+          <Card aria-describedby="desc">Project</Card>
+        </>,
+      );
+
+      const card = screen.getByText("Project").closest("div");
+      expect(card).toHaveAttribute("aria-describedby", "desc");
+    });
+
+    it("hoverable 卡片应该可以通过 Tab 键聚焦（如果有 tabIndex）", async () => {
+      const user = userEvent.setup();
+      render(
+        <Card hoverable tabIndex={0}>
+          Focusable
+        </Card>,
+      );
+
+      await user.tab();
+
+      const card = screen.getByText("Focusable").closest("div");
+      expect(card).toHaveFocus();
+    });
+
+    it("应该支持键盘操作", async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Card
+          hoverable
+          tabIndex={0}
+          onClick={handleClick}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleClick();
+          }}
+        >
+          Keyboard
+        </Card>,
+      );
+
+      const card = screen.getByText("Keyboard").closest("div");
+      card?.focus();
+      await user.keyboard("{Enter}");
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/design/system/02-component-cards/Card.md
+++ b/design/system/02-component-cards/Card.md
@@ -4,8 +4,10 @@
 
 - **优先级**: P0（黄金标准）
 - **依赖**: 无
-- **文件位置**: `components/primitives/Card/`
+- **文件位置**: `components/primitives/Card.tsx`
 - **设计参考**: `34-component-primitives.html`, `05-dashboard-sidebar-full.html`
+- **Storybook**: `Primitives/Card`
+- **测试文件**: `Card.test.tsx`（42 个测试用例）
 
 ---
 
@@ -15,19 +17,28 @@
 background: var(--color-bg-surface);
 border: 1px solid var(--color-border-default);
 border-radius: var(--radius-xl);  /* 16px */
-padding: var(--space-6);          /* 24px */
+padding: var(--space-6);          /* 24px，通过 p-6 实现 */
+transition: all var(--duration-fast) var(--ease-default);
 ```
+
+---
+
+## 变体 (Variants)
+
+| 类型 | 边框 | 阴影 | 用途 |
+|------|------|------|------|
+| default | 1px --color-border-default | 无 | 标准内容容器 |
+| raised | 1px --color-border-default | --shadow-md | 悬浮/强调卡片 |
+| bordered | 2px --color-border-default | 无 | 强调边框 |
 
 ---
 
 ## 状态矩阵
 
-| 状态 | 视觉表现 | 条件 |
-|------|----------|------|
-| default | 正常边框，无阴影 | 始终 |
-| hover (可点击) | border-color: var(--color-border-hover), MAY --shadow-sm | interactive=true |
-| selected | background: var(--color-bg-selected) | selected=true |
-| disabled | opacity: 0.5 | disabled=true |
+| 状态 | 视觉表现 | 条件 | CSS 类 |
+|------|----------|------|--------|
+| default | 正常边框，无阴影 | 始终 | - |
+| hover (可点击) | 边框高亮 + 可选阴影 | hoverable=true | `cursor-pointer hover:border-[var(--color-border-hover)] hover:shadow-[var(--shadow-sm)]` |
 
 ---
 
@@ -35,74 +46,79 @@ padding: var(--space-6);          /* 24px */
 
 ```
 卡片.阴影 = 
-  IF 卡片.可点击 AND 卡片.状态 == hover THEN MAY --shadow-sm
+  IF variant == "raised" THEN --shadow-md
+  ELSE IF hoverable AND 状态 == hover THEN MAY --shadow-sm
   ELSE MUST NOT 使用阴影
 ```
 
-默认状态 **禁止使用阴影**，仅在 hover + 可点击时 **可选** 添加轻微阴影。
-
----
-
-## Slot 模式
-
-Card 组件应支持以下 slot：
-
-| Slot | 用途 | 示例 |
-|------|------|------|
-| header | 卡片头部 | 标题 + 操作按钮 |
-| children | 主内容区 | 任意内容 |
-| footer | 卡片底部 | 元信息 + 操作按钮 |
+- default/bordered variant **默认无阴影**
+- raised variant **始终有阴影**
+- hoverable 状态在 hover 时 **可选添加轻微阴影**
 
 ---
 
 ## Props 接口
 
 ```typescript
-interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** 是否可点击（影响 hover 样式） */
-  interactive?: boolean;
-  /** 是否选中 */
-  selected?: boolean;
-  /** 是否禁用 */
-  disabled?: boolean;
-  /** 卡片头部 */
-  header?: React.ReactNode;
-  /** 卡片底部 */
-  footer?: React.ReactNode;
-  /** 内边距变体 */
-  padding?: 'none' | 'sm' | 'md' | 'lg';
+export type CardVariant = "default" | "raised" | "bordered";
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 视觉样式变体 */
+  variant?: CardVariant;
+  /** 启用 hover 效果（边框高亮 + 可选阴影） */
+  hoverable?: boolean;
+  /** 移除内边距，用于自定义布局 */
+  noPadding?: boolean;
+  /** 卡片内容 */
+  children: React.ReactNode;
 }
 ```
 
 ---
 
-## 内边距变体
+## Slot 模式
 
-| 变体 | 值 |
-|------|-----|
-| none | 0 |
-| sm | var(--space-3) / 12px |
-| md | var(--space-4) / 16px |
-| lg | var(--space-6) / 24px |
+Card 使用 children 作为唯一 slot，支持任意内容组合：
+
+```tsx
+<Card>
+  {/* Header 区域 */}
+  <div className="flex justify-between mb-4 pb-3 border-b">
+    <h3>Title</h3>
+    <button>...</button>
+  </div>
+  
+  {/* Content 区域 */}
+  <p>Main content</p>
+  
+  {/* Footer 区域 */}
+  <div className="flex justify-end gap-2 mt-4 pt-3 border-t">
+    <Button>Cancel</Button>
+    <Button variant="primary">Save</Button>
+  </div>
+</Card>
+```
 
 ---
 
 ## 边界情况 (MUST 处理)
 
-| 边界 | 处理方式 |
-|------|----------|
-| 空内容 | 保持最小高度，显示占位 |
-| 内容溢出 | 由使用方控制，Card 不强制 overflow |
-| 嵌套 Card | 支持，内层使用更小的 padding |
+| 边界 | 处理方式 | 测试覆盖 |
+|------|----------|----------|
+| 空内容 | 保持正常渲染 | ✅ |
+| 内容溢出 | 由使用方控制 | ✅ |
+| 嵌套 Card | 支持 | ✅ |
+| Emoji | 正确显示 | ✅ |
+| 超长文本 | 正常渲染 | ✅ |
 
 ---
 
 ## 禁止事项
 
-- MUST NOT 默认使用阴影
-- MUST NOT 硬编码颜色值
+- MUST NOT 在 default/bordered variant 默认使用阴影
+- MUST NOT 硬编码颜色值（使用 CSS Variables）
 - MUST NOT 使用 any 类型
-- MUST NOT 在非可点击卡片上添加 cursor: pointer
+- MUST NOT 在非 hoverable 卡片上添加 cursor: pointer
 
 ---
 
@@ -114,29 +130,24 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 ## 上下文文件（MUST 先读取）
 1. design/system/01-tokens.css（Design Tokens）
 2. design/system/02-component-cards/Card.md（本卡片）
-3. design/reference-implementations/Button/（黄金标准参考）
 
 ## 要求
-1. 文件结构：components/primitives/Card/ 目录下
-   - Card.tsx（组件实现）
-   - Card.types.ts（类型定义）
-   - index.ts（导出）
-   - Card.stories.tsx（Storybook Story）
+1. 文件：components/primitives/Card.tsx
 
-2. 支持 header / children / footer slot
-3. 状态：default / hover (interactive) / selected / disabled
+2. 变体：default / raised / bordered
+3. 状态：default / hover (hoverable)
 
 4. 样式：
-   - 使用 Tailwind + cn() 工具函数
+   - 使用 Tailwind + className 拼接
    - 所有颜色使用 CSS Variables
-   - 默认无阴影，仅 hover + interactive 时 MAY 添加
+   - 默认无阴影（除 raised），仅 hoverable + hover 时 MAY 添加
 
 5. 边界处理：
-   - 空内容保持最小尺寸
-   - 支持 padding 变体
+   - 支持 noPadding 移除内边距
+   - 支持嵌套 Card
 
 ## 验收标准
-- 所有状态在 Storybook 中可见
+- 所有变体在 Storybook 中可见
 - 类型完整，无 any
 - 代码风格与 Button/Input 一致
 ```
@@ -145,57 +156,22 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 ## 验收测试代码
 
+完整测试位于 `Card.test.tsx`，共 42 个测试用例，覆盖：
+
 ```typescript
-// Card.test.tsx
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { Card } from './Card';
-
-describe('Card 验收', () => {
-  // 基础渲染
-  it('正确渲染内容', () => {
-    render(<Card>Card Content</Card>);
-    expect(screen.getByText('Card Content')).toBeInTheDocument();
-  });
-
-  // Slot 渲染
-  it('正确渲染 header 和 footer', () => {
-    render(
-      <Card 
-        header={<div data-testid="header">Header</div>}
-        footer={<div data-testid="footer">Footer</div>}
-      >
-        Content
-      </Card>
-    );
-    expect(screen.getByTestId('header')).toBeInTheDocument();
-    expect(screen.getByTestId('footer')).toBeInTheDocument();
-  });
-
-  // Interactive 状态
-  it('interactive 模式有 hover 样式', () => {
-    render(<Card interactive>Content</Card>);
-    const card = screen.getByText('Content').closest('div');
-    expect(card).toHaveClass(/cursor-pointer/);
-  });
-
-  // 阴影规则
-  it('默认不使用阴影', () => {
-    const { container } = render(<Card>Content</Card>);
-    const card = container.firstChild as Element;
-    const styles = getComputedStyle(card);
-    // 检查是否无 box-shadow 或为 none
-    expect(styles.boxShadow).toMatch(/^(none|)$/);
-  });
-
-  // Padding 变体
-  it.each(['none', 'sm', 'md', 'lg'] as const)(
-    'padding=%s 正确应用',
-    (padding) => {
-      render(<Card padding={padding}>Content</Card>);
-      expect(screen.getByText('Content')).toBeInTheDocument();
-    }
-  );
+describe('Card', () => {
+  describe('渲染')           // 基础渲染测试
+  describe('variants')       // 3 种 variant 全覆盖
+  describe('hoverable')      // hover 状态测试
+  describe('padding')        // 内边距测试
+  describe('样式')           // 圆角、背景、过渡
+  describe('阴影规则')       // 设计规范 §5.2
+  describe('CSS Variables')  // 禁止硬编码颜色
+  describe('交互')           // onClick 响应
+  describe('Slot 模式')      // children 渲染
+  describe('边界情况')       // 空内容、超长文本、emoji、嵌套
+  describe('Variant × Hoverable 矩阵')  // 6 种组合
+  describe('无障碍')         // a11y 测试
 });
 ```
 
@@ -205,18 +181,67 @@ describe('Card 验收', () => {
 
 生成组件后，执行以下步骤：
 
-1. 确保 Storybook 正在运行（端口 6006）
-2. 使用 browser_navigate 打开组件 Story：
-   http://localhost:6006/?path=/story/primitives-card--all-variants
-3. 使用 browser_snapshot 获取页面快照
-4. 检查以下项目：
-   - [ ] 圆角正确 (16px)
-   - [ ] 边框正确
-   - [ ] 颜色符合设计规范
-   - [ ] 默认无阴影
-   - [ ] interactive + hover 时边框变化
-   - [ ] selected 状态背景变化
-   - [ ] header/footer slot 正确渲染
-5. 如有问题，修改代码后重复步骤 2-4
-6. 自检通过后报告：
+1. 运行测试验证功能正确：
+   ```bash
+   pnpm --filter desktop test -- --run Card.test.tsx
+   ```
+   期望：42 个测试全部通过
+
+2. 确保 Storybook 正在运行：
+   ```bash
+   pnpm --filter desktop storybook
+   ```
+
+3. 使用 browser_navigate 打开组件 Story：
+   `http://localhost:6006/?path=/story/primitives-card--full-matrix`
+
+4. 使用 browser_snapshot 获取页面快照，检查以下项目：
+   - [ ] 圆角正确 (16px / --radius-xl)
+   - [ ] 边框正确（default 1px, bordered 2px）
+   - [ ] 颜色符合设计规范（使用 CSS Variables）
+   - [ ] default variant 无阴影
+   - [ ] raised variant 有阴影
+   - [ ] hoverable 时有 cursor-pointer
+   - [ ] hoverable + hover 时边框变化 + 可选阴影
+   - [ ] noPadding 正确移除内边距
+
+5. 自检通过后报告：
    "组件 Card 已通过 AI 可视化自检，请进行人工验收"
+
+---
+
+## 自检记录
+
+**日期**: 2026-02-01
+
+### 测试验证
+
+| 检查项 | 状态 | 验证方式 |
+|--------|------|----------|
+| 测试通过 | ✅ | 42/42 tests passed |
+| CSS Variables | ✅ | 测试验证无硬编码颜色 |
+| Variant × Hoverable 矩阵 | ✅ | 6 种组合全覆盖 |
+| 边界情况 | ✅ | 空内容、超长文本、emoji、嵌套 |
+| 无障碍 | ✅ | role、aria-label、键盘操作 |
+
+### 可视化验证（Storybook MCP 浏览器）
+
+| 检查项 | 状态 | 验证方式 |
+|--------|------|----------|
+| 3 种 Variants 渲染 | ✅ | Full Matrix Story 截图 |
+| 圆角正确 (16px) | ✅ | 可视化确认 |
+| 边框正确 | ✅ | default 1px, bordered 2px |
+| default 无阴影 | ✅ | 可视化确认 |
+| raised 有阴影 | ✅ | 可视化确认明显阴影效果 |
+| hoverable 样式 | ✅ | Hoverable Story 截图 |
+| Slot 模式 | ✅ | With Slots Story：Header + Content + Footer |
+| 实际使用场景 | ✅ | Project Card Scenario：中文内容、元信息布局 |
+
+### 验证截图
+
+1. **Full Matrix Story** - 展示所有 Variants 和 Hoverable 状态
+2. **Hoverable Story** - 展示可点击卡片的 hover 提示
+3. **With Slots Story** - 展示 Header/Content/Footer 布局
+4. **Project Card Scenario** - 展示真实项目卡片场景
+
+**结论**: 组件 Card 已通过 AI 可视化自检（测试覆盖 + Storybook 可视化验证），请进行人工验收。

--- a/openspec/_ops/task_runs/ISSUE-89.md
+++ b/openspec/_ops/task_runs/ISSUE-89.md
@@ -1,0 +1,58 @@
+# ISSUE-89
+
+- Issue: #89
+- Branch: task/89-p1-card-golden-standard
+- PR: <fill-after-created>
+
+## Plan
+
+- 创建 Card.stories.tsx（展示所有 variant/状态/边界情况）
+- 创建 Card.test.tsx（42 个测试用例全覆盖）
+- AI 可视化自检（通过 Storybook + MCP 浏览器）
+- 更新 Card.md 生成卡片（与实际实现一致）
+
+## Runs
+
+### 2026-02-01 22:15 Card.stories.tsx 创建
+
+- Command: `Write Card.stories.tsx`
+- Key output: 创建完整的 Storybook Story，包含：
+  - 基础 Stories（Default, Raised, Bordered）
+  - Hoverable 状态展示
+  - Slot 模式演示（Header + Content + Footer）
+  - 边界情况（空内容、超长文本、嵌套、Emoji）
+  - 完整矩阵展示（FullMatrix）
+  - 实际使用场景（ProjectCardScenario, SettingsCardScenario）
+- Evidence: `apps/desktop/renderer/src/components/primitives/Card.stories.tsx`
+
+### 2026-02-01 22:20 Card.test.tsx 创建
+
+- Command: `pnpm --filter desktop test -- --run src/components/primitives/Card.test.tsx`
+- Key output:
+  ```
+  ✓ renderer/src/components/primitives/Card.test.tsx (42 tests) 363ms
+  Test Files  1 passed (1)
+       Tests  42 passed (42)
+  ```
+- Evidence: `apps/desktop/renderer/src/components/primitives/Card.test.tsx`
+
+### 2026-02-01 22:25 AI 可视化自检
+
+- Command: `browser_navigate http://172.18.248.30:6010/?path=/story/primitives-card--full-matrix`
+- Key output:
+  - Full Matrix Story：3 种 Variants 正确渲染
+  - Hoverable Story：可点击卡片样式正确
+  - With Slots Story：Header + Content + Footer 布局正确
+  - Project Card Scenario：中文内容和元信息布局正确
+- Evidence: Storybook MCP 浏览器截图验证
+
+### 2026-02-01 22:30 Card.md 更新
+
+- Command: `StrReplace Card.md`
+- Key output: 更新生成卡片与实际实现一致：
+  - Props 接口（variant/hoverable/noPadding）
+  - 状态矩阵
+  - 阴影使用规则
+  - 验收测试代码
+  - AI 自检步骤和记录
+- Evidence: `design/system/02-component-cards/Card.md`

--- a/openspec/_ops/task_runs/ISSUE-89.md
+++ b/openspec/_ops/task_runs/ISSUE-89.md
@@ -2,7 +2,7 @@
 
 - Issue: #89
 - Branch: task/89-p1-card-golden-standard
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/90
 
 ## Plan
 


### PR DESCRIPTION
Closes #89

## Summary

- 创建 Card.stories.tsx：展示所有 variant/状态/边界情况
- 创建 Card.test.tsx：42 个测试用例全覆盖
- AI 可视化自检：通过 Storybook + MCP 浏览器验证
- 更新 Card.md：与实际组件 API 保持一致

## Test Plan

- [x] `pnpm --filter desktop test -- --run Card.test.tsx` 42/42 通过
- [x] Storybook 可视化验证（Full Matrix / Hoverable / With Slots / Project Card Scenario）
- [x] lint 无错误

## Evidence

- RUN_LOG: `openspec/_ops/task_runs/ISSUE-89.md`