### PR TITLE
fix(storybook): set data-theme on documentElement for CSS variable theming

### DIFF
--- a/apps/desktop/.storybook/preview.tsx
+++ b/apps/desktop/.storybook/preview.tsx
@@ -1,9 +1,25 @@
 import type { Preview } from "@storybook/react";
-import React from "react";
+import React, { useEffect } from "react";
 
 // Import global styles including design tokens
 import "../renderer/src/styles/tokens.css";
 import "../renderer/src/styles/main.css";
+
+/**
+ * Decorator that sets data-theme on documentElement to enable CSS variable theming.
+ * CSS tokens use :root[data-theme="dark"] selector, so data-theme must be on <html>.
+ */
+function ThemeDecorator({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Set theme on :root (html element) so CSS variables activate
+    document.documentElement.setAttribute("data-theme", "dark");
+    return () => {
+      document.documentElement.removeAttribute("data-theme");
+    };
+  }, []);
+
+  return <div style={{ padding: "1rem" }}>{children}</div>;
+}
 
 const preview: Preview = {
   parameters: {
@@ -23,9 +39,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <div data-theme="dark" style={{ padding: "1rem" }}>
+      <ThemeDecorator>
         <Story />
-      </div>
+      </ThemeDecorator>
     ),
   ],
 };

--- a/openspec/_ops/task_runs/ISSUE-95.md
+++ b/openspec/_ops/task_runs/ISSUE-95.md
@@ -1,0 +1,38 @@
+# ISSUE-95
+
+- Issue: #95
+- Branch: task/95-fix-storybook-theme-decorator
+- PR: https://github.com/Leeky1017/CreoNow/pull/96
+
+## Plan
+
+修复 Storybook decorator 中 data-theme 属性设置位置错误的问题：
+- CSS tokens 使用 `:root[data-theme="dark"]` 选择器
+- 但 decorator 把 data-theme 设置在 `<div>` 上而不是 `<html>` 上
+- 导致暗色模式下组件文字不可见
+
+## Runs
+
+### 2026-02-01 发现问题
+
+- 用户反馈浏览器验证时暗色背景下按钮文字不可见
+- 调查发现 CSS 变量没有正确激活
+
+### 2026-02-01 根因分析
+
+- `preview.tsx` 使用 `<div data-theme="dark">` 包裹 Story
+- CSS tokens 选择器是 `:root[data-theme="dark"]`
+- `:root` 只匹配 `<html>` 元素，不匹配普通 div
+- 因此 CSS 变量没有被激活
+
+### 2026-02-01 修复
+
+- 创建 `ThemeDecorator` 组件
+- 使用 `useEffect` 在 `document.documentElement` 上设置 `data-theme="dark"`
+- 确保 CSS 变量正确激活
+
+### 2026-02-01 验证
+
+- Command: `pnpm typecheck && pnpm lint`
+- Key output: 无错误
+- 浏览器验证：所有组件文字在暗色背景上清晰可见


### PR DESCRIPTION
## Summary

- Fixed Storybook decorator to set `data-theme` on `document.documentElement` instead of a `<div>`
- CSS tokens use `:root[data-theme="dark"]` selector which only matches `<html>`, not regular divs
- Created `ThemeDecorator` component using `useEffect` to properly set the theme attribute

## Problem

Components rendered with wrong colors in dark mode - button text (Basic, Confirm, Form) was nearly invisible because CSS variables weren't activated.

## Test plan

- [x] Verified in browser: all component text now visible on dark background
- [x] TypeScript check passes
- [x] ESLint passes

Closes #95