### PR TITLE
feat: add 8 new atomic components (Badge/Avatar/Spinner/Skeleton/Tooltip/Toast/Accordion/Radio)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,11 +20,15 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toast": "^1.2.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tiptap/react": "^2.26.0",
     "@tiptap/starter-kit": "^2.26.0",
     "better-sqlite3": "^12.6.2",

--- a/apps/desktop/renderer/src/components/primitives/Accordion.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Accordion.stories.tsx
@@ -1,0 +1,248 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Accordion } from "./Accordion";
+
+/**
+ * Accordion 组件 Story
+ *
+ * 用于显示可折叠的内容区域。
+ * 基于 Radix UI Accordion。
+ */
+const meta = {
+  title: "Primitives/Accordion",
+  component: Accordion,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["single", "multiple"],
+      description: "Single or multiple items can be open",
+    },
+    collapsible: {
+      control: "boolean",
+      description: "Whether items can be collapsed (single type only)",
+    },
+  },
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Sample items
+const sampleItems = [
+  {
+    value: "item-1",
+    title: "What is CreoNow?",
+    content:
+      "CreoNow is an AI-powered creative writing IDE designed for authors and content creators.",
+  },
+  {
+    value: "item-2",
+    title: "How does AI assistance work?",
+    content:
+      "The AI analyzes your writing context and provides suggestions, helps with brainstorming, and can generate draft content based on your specifications.",
+  },
+  {
+    value: "item-3",
+    title: "Is my data secure?",
+    content:
+      "Yes, all your writing is stored locally on your device. We do not store any of your content on our servers unless you explicitly choose to sync.",
+  },
+];
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 (single) */
+export const Default: Story = {
+  args: {
+    items: sampleItems,
+    type: "single",
+    collapsible: true,
+  },
+};
+
+/** 多选模式 */
+export const Multiple: Story = {
+  args: {
+    items: sampleItems,
+    type: "multiple",
+  },
+};
+
+/** 默认展开 */
+export const DefaultExpanded: Story = {
+  args: {
+    items: sampleItems,
+    type: "single",
+    defaultValue: "item-1",
+  },
+};
+
+/** 不可折叠 */
+export const NotCollapsible: Story = {
+  args: {
+    items: sampleItems,
+    type: "single",
+    collapsible: false,
+    defaultValue: "item-1",
+  },
+};
+
+/** 禁用项 */
+export const WithDisabled: Story = {
+  args: {
+    items: [
+      ...sampleItems,
+      {
+        value: "item-4",
+        title: "Disabled Section",
+        content: "This content is not accessible.",
+        disabled: true,
+      },
+    ],
+    type: "single",
+  },
+};
+
+// ============================================================================
+// 内容丰富的示例
+// ============================================================================
+
+/** 富文本内容 */
+export const RichContent: Story = {
+  args: {
+    items: [
+      {
+        value: "features",
+        title: "Features",
+        content: (
+          <ul style={{ margin: 0, paddingLeft: "1.5rem" }}>
+            <li>AI-powered writing assistance</li>
+            <li>Character and world management</li>
+            <li>Version history and branching</li>
+            <li>Export to multiple formats</li>
+          </ul>
+        ),
+      },
+      {
+        value: "pricing",
+        title: "Pricing",
+        content: (
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <div>
+              <strong>Free:</strong> Basic features, up to 3 projects
+            </div>
+            <div>
+              <strong>Pro:</strong> $9.99/month, unlimited projects + AI
+            </div>
+            <div>
+              <strong>Team:</strong> $29.99/month, collaboration features
+            </div>
+          </div>
+        ),
+      },
+      {
+        value: "support",
+        title: "Support",
+        content: (
+          <p style={{ margin: 0 }}>
+            For support, please email{" "}
+            <span style={{ color: "var(--color-accent)" }}>support@creonow.app</span> or
+            visit our Discord community.
+          </p>
+        ),
+      },
+    ],
+    type: "single",
+  },
+};
+
+/** 多选默认展开多项 */
+export const MultipleDefaultExpanded: Story = {
+  args: {
+    items: sampleItems,
+    type: "multiple",
+    defaultValue: ["item-1", "item-2"],
+  },
+};
+
+// ============================================================================
+// 受控模式
+// ============================================================================
+
+function ControlledDemo() {
+  const [value, setValue] = React.useState<string | undefined>("item-1");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Current: {value || "none"}
+      </div>
+      <Accordion
+        items={sampleItems}
+        type="single"
+        value={value}
+        onValueChange={(v) => setValue(v as string)}
+        collapsible
+      />
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  args: {
+    items: sampleItems,
+  },
+  render: () => <ControlledDemo />,
+};
+
+// ============================================================================
+// 边界情况
+// ============================================================================
+
+/** 长标题和内容 */
+export const LongContent: Story = {
+  args: {
+    items: [
+      {
+        value: "long",
+        title: "This is a very long title that might need to wrap to multiple lines in narrow containers",
+        content:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      },
+    ],
+    type: "single",
+    defaultValue: "long",
+  },
+};
+
+/** 单项 */
+export const SingleItem: Story = {
+  args: {
+    items: [
+      {
+        value: "only",
+        title: "Only Section",
+        content: "This accordion has only one item.",
+      },
+    ],
+    type: "single",
+  },
+};
+
+/** 多项 */
+export const ManyItems: Story = {
+  args: {
+    items: Array.from({ length: 10 }, (_, i) => ({
+      value: `item-${i + 1}`,
+      title: `Section ${i + 1}`,
+      content: `Content for section ${i + 1}. This is some placeholder text.`,
+    })),
+    type: "single",
+  },
+};

--- a/apps/desktop/renderer/src/components/primitives/Accordion.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Accordion.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Accordion } from "./Accordion";
+
+const sampleItems = [
+  { value: "item-1", title: "Section 1", content: "Content 1" },
+  { value: "item-2", title: "Section 2", content: "Content 2" },
+  { value: "item-3", title: "Section 3", content: "Content 3" },
+];
+
+describe("Accordion", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染所有 item 标题", () => {
+      render(<Accordion items={sampleItems} />);
+
+      expect(screen.getByText("Section 1")).toBeInTheDocument();
+      expect(screen.getByText("Section 2")).toBeInTheDocument();
+      expect(screen.getByText("Section 3")).toBeInTheDocument();
+    });
+
+    it("默认不应该显示内容", () => {
+      render(<Accordion items={sampleItems} />);
+
+      // Accordion content is hidden by default (data-state=closed)
+      const trigger1 = screen.getByText("Section 1").closest("button");
+      expect(trigger1).toHaveAttribute("data-state", "closed");
+    });
+
+    it("应该应用自定义 className", () => {
+      const { container } = render(
+        <Accordion items={sampleItems} className="custom-class" />,
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  // ===========================================================================
+  // Single 类型测试
+  // ===========================================================================
+  describe("single 类型", () => {
+    it("点击应该展开 item", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="single" />);
+
+      await user.click(screen.getByText("Section 1"));
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+    });
+
+    it("同时只能展开一个 item", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="single" />);
+
+      await user.click(screen.getByText("Section 1"));
+      const trigger1 = screen.getByText("Section 1").closest("button");
+      expect(trigger1).toHaveAttribute("data-state", "open");
+
+      await user.click(screen.getByText("Section 2"));
+      const trigger2 = screen.getByText("Section 2").closest("button");
+      expect(trigger2).toHaveAttribute("data-state", "open");
+      expect(trigger1).toHaveAttribute("data-state", "closed");
+    });
+
+    it("collapsible=true 时可以折叠", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="single" collapsible />);
+
+      const trigger1 = screen.getByText("Section 1").closest("button");
+      await user.click(screen.getByText("Section 1"));
+      expect(trigger1).toHaveAttribute("data-state", "open");
+
+      await user.click(screen.getByText("Section 1"));
+      expect(trigger1).toHaveAttribute("data-state", "closed");
+    });
+  });
+
+  // ===========================================================================
+  // Multiple 类型测试
+  // ===========================================================================
+  describe("multiple 类型", () => {
+    it("可以同时展开多个 item", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="multiple" />);
+
+      await user.click(screen.getByText("Section 1"));
+      await user.click(screen.getByText("Section 2"));
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+      expect(screen.getByText("Content 2")).toBeVisible();
+    });
+
+    it("点击已展开的 item 应该折叠", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="multiple" />);
+
+      const trigger1 = screen.getByText("Section 1").closest("button");
+      await user.click(screen.getByText("Section 1"));
+      expect(trigger1).toHaveAttribute("data-state", "open");
+
+      await user.click(screen.getByText("Section 1"));
+      expect(trigger1).toHaveAttribute("data-state", "closed");
+    });
+  });
+
+  // ===========================================================================
+  // 默认值测试
+  // ===========================================================================
+  describe("默认值", () => {
+    it("single 类型应该支持 defaultValue", () => {
+      render(
+        <Accordion items={sampleItems} type="single" defaultValue="item-2" />,
+      );
+
+      expect(screen.getByText("Content 2")).toBeVisible();
+    });
+
+    it("multiple 类型应该支持 defaultValue 数组", () => {
+      render(
+        <Accordion
+          items={sampleItems}
+          type="multiple"
+          defaultValue={["item-1", "item-3"]}
+        />,
+      );
+
+      const trigger1 = screen.getByText("Section 1").closest("button");
+      const trigger2 = screen.getByText("Section 2").closest("button");
+      const trigger3 = screen.getByText("Section 3").closest("button");
+      expect(trigger1).toHaveAttribute("data-state", "open");
+      expect(trigger3).toHaveAttribute("data-state", "open");
+      expect(trigger2).toHaveAttribute("data-state", "closed");
+    });
+  });
+
+  // ===========================================================================
+  // 受控模式测试
+  // ===========================================================================
+  describe("受控模式", () => {
+    it("应该调用 onValueChange", async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Accordion
+          items={sampleItems}
+          type="single"
+          onValueChange={onValueChange}
+        />,
+      );
+
+      await user.click(screen.getByText("Section 1"));
+
+      expect(onValueChange).toHaveBeenCalledWith("item-1");
+    });
+  });
+
+  // ===========================================================================
+  // 禁用项测试
+  // ===========================================================================
+  describe("禁用项", () => {
+    it("禁用的 item 不应该可点击", async () => {
+      const user = userEvent.setup();
+      render(
+        <Accordion
+          items={[
+            ...sampleItems,
+            { value: "disabled", title: "Disabled", content: "No access", disabled: true },
+          ]}
+        />,
+      );
+
+      const disabledTrigger = screen.getByText("Disabled").closest("button");
+      await user.click(disabledTrigger!);
+
+      expect(disabledTrigger).toHaveAttribute("data-state", "closed");
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理空数组", () => {
+      const { container } = render(<Accordion items={[]} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("应该处理单个 item", () => {
+      render(
+        <Accordion
+          items={[{ value: "only", title: "Only", content: "Single item" }]}
+        />,
+      );
+
+      expect(screen.getByText("Only")).toBeInTheDocument();
+    });
+
+    it("应该支持 React 节点作为 content", async () => {
+      const user = userEvent.setup();
+      render(
+        <Accordion
+          items={[
+            {
+              value: "rich",
+              title: "Rich Content",
+              content: (
+                <div data-testid="rich-content">
+                  <strong>Bold</strong> text
+                </div>
+              ),
+            },
+          ]}
+        />,
+      );
+
+      await user.click(screen.getByText("Rich Content"));
+
+      expect(screen.getByTestId("rich-content")).toBeVisible();
+    });
+  });
+
+  // ===========================================================================
+  // 键盘导航测试
+  // ===========================================================================
+  describe("键盘导航", () => {
+    it("应该支持 Tab 键聚焦", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} />);
+
+      await user.tab();
+
+      expect(screen.getByText("Section 1").closest("button")).toHaveFocus();
+    });
+
+    it("应该支持 Enter/Space 键展开", async () => {
+      const user = userEvent.setup();
+      render(<Accordion items={sampleItems} type="single" />);
+
+      await user.tab();
+      await user.keyboard("{Enter}");
+
+      expect(screen.getByText("Content 1")).toBeVisible();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Accordion.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Accordion.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+
+export interface AccordionItem {
+  /** Unique value for the item */
+  value: string;
+  /** Header/trigger text */
+  title: string;
+  /** Content to display when expanded */
+  content: React.ReactNode;
+  /** Whether the item is disabled */
+  disabled?: boolean;
+}
+
+export interface AccordionProps {
+  /** Array of accordion items */
+  items: AccordionItem[];
+  /** Type: single (one open at a time) or multiple */
+  type?: "single" | "multiple";
+  /** Default expanded items */
+  defaultValue?: string | string[];
+  /** Controlled value */
+  value?: string | string[];
+  /** Callback when value changes */
+  onValueChange?: (value: string | string[]) => void;
+  /** Whether items can be collapsed (only for single type) */
+  collapsible?: boolean;
+  /** Additional className for root */
+  className?: string;
+}
+
+/**
+ * Styles for accordion root
+ */
+const rootStyles = [
+  "w-full",
+  "rounded-[var(--radius-lg)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "overflow-hidden",
+].join(" ");
+
+/**
+ * Styles for accordion item
+ */
+const itemStyles = [
+  "border-b",
+  "border-[var(--color-separator)]",
+  "last:border-b-0",
+].join(" ");
+
+/**
+ * Styles for accordion trigger
+ */
+const triggerStyles = [
+  "flex",
+  "w-full",
+  "items-center",
+  "justify-between",
+  "px-4",
+  "py-3",
+  "text-sm",
+  "font-medium",
+  "text-[var(--color-fg-default)]",
+  "bg-transparent",
+  "border-0",
+  "cursor-pointer",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[-2px]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+  "disabled:opacity-50",
+  "disabled:cursor-not-allowed",
+  "[&[data-state=open]>svg]:rotate-180",
+].join(" ");
+
+/**
+ * Styles for accordion content
+ */
+const contentStyles = [
+  "overflow-hidden",
+  "text-sm",
+  "text-[var(--color-fg-muted)]",
+  "data-[state=open]:animate-accordion-down",
+  "data-[state=closed]:animate-accordion-up",
+].join(" ");
+
+/**
+ * Styles for content inner wrapper
+ */
+const contentInnerStyles = "px-4 pb-4 pt-0";
+
+/**
+ * Chevron icon component
+ */
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`transition-transform duration-[var(--duration-fast)] ${className ?? ""}`}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+/**
+ * Accordion component using Radix UI
+ *
+ * Displays collapsible content sections.
+ *
+ * @example
+ * ```tsx
+ * <Accordion
+ *   items={[
+ *     { value: "item-1", title: "Section 1", content: "Content 1" },
+ *     { value: "item-2", title: "Section 2", content: "Content 2" },
+ *   ]}
+ * />
+ * ```
+ */
+export function Accordion({
+  items,
+  type = "single",
+  defaultValue,
+  value,
+  onValueChange,
+  collapsible = true,
+  className = "",
+}: AccordionProps): JSX.Element {
+  const rootClasses = [rootStyles, className].filter(Boolean).join(" ");
+
+  // Type-safe props based on accordion type
+  if (type === "single") {
+    return (
+      <AccordionPrimitive.Root
+        type="single"
+        defaultValue={defaultValue as string | undefined}
+        value={value as string | undefined}
+        onValueChange={onValueChange as ((value: string) => void) | undefined}
+        collapsible={collapsible}
+        className={rootClasses}
+      >
+        {items.map((item) => (
+          <AccordionPrimitive.Item
+            key={item.value}
+            value={item.value}
+            disabled={item.disabled}
+            className={itemStyles}
+          >
+            <AccordionPrimitive.Header>
+              <AccordionPrimitive.Trigger className={triggerStyles}>
+                {item.title}
+                <ChevronIcon />
+              </AccordionPrimitive.Trigger>
+            </AccordionPrimitive.Header>
+            <AccordionPrimitive.Content className={contentStyles}>
+              <div className={contentInnerStyles}>{item.content}</div>
+            </AccordionPrimitive.Content>
+          </AccordionPrimitive.Item>
+        ))}
+      </AccordionPrimitive.Root>
+    );
+  }
+
+  return (
+    <AccordionPrimitive.Root
+      type="multiple"
+      defaultValue={defaultValue as string[] | undefined}
+      value={value as string[] | undefined}
+      onValueChange={onValueChange as ((value: string[]) => void) | undefined}
+      className={rootClasses}
+    >
+      {items.map((item) => (
+        <AccordionPrimitive.Item
+          key={item.value}
+          value={item.value}
+          disabled={item.disabled}
+          className={itemStyles}
+        >
+          <AccordionPrimitive.Header>
+            <AccordionPrimitive.Trigger className={triggerStyles}>
+              {item.title}
+              <ChevronIcon />
+            </AccordionPrimitive.Trigger>
+          </AccordionPrimitive.Header>
+          <AccordionPrimitive.Content className={contentStyles}>
+            <div className={contentInnerStyles}>{item.content}</div>
+          </AccordionPrimitive.Content>
+        </AccordionPrimitive.Item>
+      ))}
+    </AccordionPrimitive.Root>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Avatar.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Avatar.stories.tsx
@@ -1,0 +1,220 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { AvatarSize } from "./Avatar";
+import { Avatar } from "./Avatar";
+
+/**
+ * Avatar 组件 Story
+ *
+ * 用于显示用户头像或占位符。
+ * 支持图片、fallback 文本（自动提取首字母）。
+ */
+const meta = {
+  title: "Primitives/Avatar",
+  component: Avatar,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Size of the avatar",
+    },
+    src: {
+      control: "text",
+      description: "Image source URL",
+    },
+    alt: {
+      control: "text",
+      description: "Alt text for image",
+    },
+    fallback: {
+      control: "text",
+      description: "Fallback text (usually name, will extract initials)",
+    },
+  },
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态（无图片） */
+export const Default: Story = {
+  args: {
+    fallback: "John Doe",
+    size: "md",
+  },
+};
+
+/** 带图片 */
+export const WithImage: Story = {
+  args: {
+    src: "https://i.pravatar.cc/150?img=1",
+    alt: "John Doe",
+    size: "md",
+  },
+};
+
+/** 只有首字母 */
+export const WithInitials: Story = {
+  args: {
+    fallback: "AB",
+    size: "md",
+  },
+};
+
+/** 单字名字 */
+export const SingleName: Story = {
+  args: {
+    fallback: "Admin",
+    size: "md",
+  },
+};
+
+/** 图片加载失败时显示 fallback */
+export const ImageError: Story = {
+  args: {
+    src: "https://invalid-url.example.com/image.jpg",
+    fallback: "Error User",
+    size: "md",
+  },
+};
+
+// ============================================================================
+// Size Stories
+// ============================================================================
+
+const sizes: AvatarSize[] = ["xs", "sm", "md", "lg", "xl"];
+
+/** XS size (24px) */
+export const ExtraSmall: Story = {
+  args: {
+    fallback: "XS",
+    size: "xs",
+  },
+};
+
+/** SM size (32px) */
+export const Small: Story = {
+  args: {
+    fallback: "SM",
+    size: "sm",
+  },
+};
+
+/** MD size (40px) */
+export const Medium: Story = {
+  args: {
+    fallback: "MD",
+    size: "md",
+  },
+};
+
+/** LG size (56px) */
+export const Large: Story = {
+  args: {
+    fallback: "LG",
+    size: "lg",
+  },
+};
+
+/** XL size (80px) */
+export const ExtraLarge: Story = {
+  args: {
+    fallback: "XL",
+    size: "xl",
+  },
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+/** 所有 Sizes 展示 */
+export const AllSizes: Story = {
+  args: {
+    fallback: "JD",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      {sizes.map((size) => (
+        <Avatar key={size} fallback="John Doe" size={size} />
+      ))}
+    </div>
+  ),
+};
+
+/** 带图片的所有 Sizes */
+export const AllSizesWithImage: Story = {
+  args: {
+    fallback: "JD",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+      {sizes.map((size, i) => (
+        <Avatar
+          key={size}
+          src={`https://i.pravatar.cc/150?img=${i + 1}`}
+          alt={`User ${size}`}
+          size={size}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/** 用户列表示例 */
+export const UserList: Story = {
+  args: {
+    fallback: "JD",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      {[
+        { name: "Alice Chen", src: "https://i.pravatar.cc/150?img=5" },
+        { name: "Bob Smith", src: "https://i.pravatar.cc/150?img=8" },
+        { name: "Carol Williams" },
+        { name: "David" },
+      ].map((user) => (
+        <div key={user.name} style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <Avatar src={user.src} fallback={user.name} size="sm" />
+          <span style={{ color: "var(--color-fg-default)", fontSize: "13px" }}>
+            {user.name}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** 头像组（重叠） */
+export const AvatarGroup: Story = {
+  args: {
+    fallback: "JD",
+  },
+  render: () => (
+    <div style={{ display: "flex" }}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <div
+          key={i}
+          style={{
+            marginLeft: i === 1 ? 0 : "-8px",
+            border: "2px solid var(--color-bg-base)",
+            borderRadius: "9999px",
+          }}
+        >
+          <Avatar
+            src={`https://i.pravatar.cc/150?img=${i + 10}`}
+            alt={`User ${i}`}
+            size="sm"
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Avatar.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Avatar.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { AvatarSize } from "./Avatar";
+import { Avatar } from "./Avatar";
+
+describe("Avatar", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染 fallback 首字母", () => {
+      render(<Avatar fallback="John Doe" />);
+
+      expect(screen.getByText("JD")).toBeInTheDocument();
+    });
+
+    it("应该渲染单字名字的首字母", () => {
+      render(<Avatar fallback="Admin" />);
+
+      expect(screen.getByText("A")).toBeInTheDocument();
+    });
+
+    it("应该渲染图片", () => {
+      const { container } = render(<Avatar src="/test.jpg" alt="Test User" />);
+
+      const imgElement = container.querySelector("img");
+      expect(imgElement).toBeInTheDocument();
+      expect(imgElement).toHaveAttribute("src", "/test.jpg");
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Avatar fallback="JD" className="custom-class" />);
+
+      expect(screen.getByRole("img")).toHaveClass("custom-class");
+    });
+
+    it("应该有正确的 aria-label", () => {
+      render(<Avatar fallback="John Doe" />);
+
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "John Doe");
+    });
+
+    it("图片有 alt 时应该使用 alt 作为 aria-label", () => {
+      const { container } = render(<Avatar src="/test.jpg" alt="Test User" />);
+
+      // The outer div wrapper has role="img" and aria-label
+      const wrapper = container.querySelector('[role="img"][aria-label]');
+      expect(wrapper).toHaveAttribute("aria-label", "Test User");
+    });
+  });
+
+  // ===========================================================================
+  // Size 测试
+  // ===========================================================================
+  describe("sizes", () => {
+    const sizeClasses: Record<AvatarSize, string> = {
+      xs: "w-6",
+      sm: "w-8",
+      md: "w-10",
+      lg: "w-14",
+      xl: "w-20",
+    };
+
+    it.each(Object.entries(sizeClasses))(
+      "应该渲染 %s size 并有 %s 类",
+      (size, expectedClass) => {
+        render(<Avatar fallback="JD" size={size as AvatarSize} />);
+
+        expect(screen.getByRole("img")).toHaveClass(expectedClass);
+      },
+    );
+
+    it("默认应该是 md size", () => {
+      render(<Avatar fallback="JD" />);
+
+      expect(screen.getByRole("img")).toHaveClass("w-10");
+    });
+  });
+
+  // ===========================================================================
+  // 图片加载错误处理
+  // ===========================================================================
+  describe("图片加载错误", () => {
+    it("图片加载失败时应该显示 fallback", () => {
+      render(<Avatar src="/invalid.jpg" fallback="Error User" />);
+
+      const img = screen.getByRole("img");
+      const imgElement = img.querySelector("img");
+
+      // 触发图片加载错误
+      if (imgElement) {
+        fireEvent.error(imgElement);
+      }
+
+      // 应该显示 fallback
+      expect(screen.getByText("EU")).toBeInTheDocument();
+    });
+
+    it("无 fallback 时应该显示 ?", () => {
+      render(<Avatar />);
+
+      expect(screen.getByText("?")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 首字母提取测试
+  // ===========================================================================
+  describe("首字母提取", () => {
+    it("应该提取两个单词的首字母", () => {
+      render(<Avatar fallback="John Doe" />);
+      expect(screen.getByText("JD")).toBeInTheDocument();
+    });
+
+    it("应该提取三个单词的首尾首字母", () => {
+      render(<Avatar fallback="John Middle Doe" />);
+      expect(screen.getByText("JD")).toBeInTheDocument();
+    });
+
+    it("应该处理小写字母", () => {
+      render(<Avatar fallback="john doe" />);
+      expect(screen.getByText("JD")).toBeInTheDocument();
+    });
+
+    it("应该处理多余空格", () => {
+      render(<Avatar fallback="  John   Doe  " />);
+      expect(screen.getByText("JD")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // CSS Variables 检查
+  // ===========================================================================
+  describe("CSS Variables", () => {
+    it("应该使用 CSS Variables 定义颜色", () => {
+      render(<Avatar fallback="JD" />);
+
+      const avatar = screen.getByRole("img");
+      expect(avatar.className).toContain("var(--");
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理空 fallback", () => {
+      render(<Avatar fallback="" />);
+
+      expect(screen.getByText("?")).toBeInTheDocument();
+    });
+
+    it("应该处理单字符 fallback", () => {
+      render(<Avatar fallback="A" />);
+
+      expect(screen.getByText("A")).toBeInTheDocument();
+    });
+
+    it("应该处理 emoji 名字", () => {
+      render(<Avatar fallback="🎉 Party" />);
+
+      // emoji 作为首字符
+      expect(screen.getByRole("img")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Size 矩阵测试
+  // ===========================================================================
+  describe("Size 矩阵", () => {
+    const sizes: AvatarSize[] = ["xs", "sm", "md", "lg", "xl"];
+
+    it.each(sizes)("应该正确渲染 %s size", (size) => {
+      render(<Avatar fallback="Test" size={size} />);
+
+      expect(screen.getByRole("img")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Avatar.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Avatar.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+
+/**
+ * Avatar sizes
+ *
+ * | Size | Diameter |
+ * |------|----------|
+ * | xs   | 24px     |
+ * | sm   | 32px     |
+ * | md   | 40px     |
+ * | lg   | 56px     |
+ * | xl   | 80px     |
+ */
+export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Image source URL */
+  src?: string;
+  /** Alt text for image (required for accessibility when src is provided) */
+  alt?: string;
+  /** Fallback text (usually initials) when no image */
+  fallback?: string;
+  /** Size of the avatar */
+  size?: AvatarSize;
+}
+
+/**
+ * Size-specific styles
+ */
+const sizeStyles: Record<AvatarSize, { container: string; text: string }> = {
+  xs: { container: "w-6 h-6", text: "text-[10px]" },
+  sm: { container: "w-8 h-8", text: "text-xs" },
+  md: { container: "w-10 h-10", text: "text-sm" },
+  lg: { container: "w-14 h-14", text: "text-lg" },
+  xl: { container: "w-20 h-20", text: "text-2xl" },
+};
+
+/**
+ * Base styles for avatar container
+ */
+const baseStyles = [
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "rounded-[var(--radius-full)]",
+  "overflow-hidden",
+  "bg-[var(--color-bg-hover)]",
+  "text-[var(--color-fg-muted)]",
+  "font-medium",
+  "select-none",
+  "flex-shrink-0",
+].join(" ");
+
+/**
+ * Get initials from a name string
+ */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].charAt(0).toUpperCase();
+  }
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+/**
+ * Avatar component for displaying user profile images or initials
+ *
+ * @example
+ * ```tsx
+ * <Avatar src="/user.jpg" alt="John Doe" size="md" />
+ * <Avatar fallback="John Doe" size="lg" />
+ * <Avatar fallback="JD" size="sm" />
+ * ```
+ */
+export function Avatar({
+  src,
+  alt,
+  fallback,
+  size = "md",
+  className = "",
+  ...props
+}: AvatarProps): JSX.Element {
+  const [imageError, setImageError] = React.useState(false);
+
+  const showImage = src && !imageError;
+  const displayFallback = fallback ? getInitials(fallback) : "?";
+
+  const containerClasses = [
+    baseStyles,
+    sizeStyles[size].container,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={containerClasses}
+      role="img"
+      aria-label={alt || fallback || "Avatar"}
+      {...props}
+    >
+      {showImage ? (
+        <img
+          src={src}
+          alt={alt || ""}
+          className="w-full h-full object-cover"
+          onError={() => setImageError(true)}
+        />
+      ) : (
+        <span className={sizeStyles[size].text}>{displayFallback}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Badge.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { BadgeVariant, BadgeSize } from "./Badge";
+import { Badge } from "./Badge";
+
+/**
+ * Badge 组件 Story
+ *
+ * 用于显示状态标签、标签或计数。
+ * 支持多种 variant 和 size。
+ */
+const meta = {
+  title: "Primitives/Badge",
+  component: Badge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "success", "warning", "error", "info"],
+      description: "Visual style variant",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Size of the badge",
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    children: "Badge",
+    variant: "default",
+    size: "md",
+  },
+};
+
+/** Success variant */
+export const Success: Story = {
+  args: {
+    children: "Active",
+    variant: "success",
+  },
+};
+
+/** Warning variant */
+export const Warning: Story = {
+  args: {
+    children: "Pending",
+    variant: "warning",
+  },
+};
+
+/** Error variant */
+export const Error: Story = {
+  args: {
+    children: "Failed",
+    variant: "error",
+  },
+};
+
+/** Info variant */
+export const Info: Story = {
+  args: {
+    children: "New",
+    variant: "info",
+  },
+};
+
+// ============================================================================
+// Size Stories
+// ============================================================================
+
+/** Small size */
+export const Small: Story = {
+  args: {
+    children: "SM",
+    size: "sm",
+  },
+};
+
+/** Medium size */
+export const Medium: Story = {
+  args: {
+    children: "MD",
+    size: "md",
+  },
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+const variants: BadgeVariant[] = ["default", "success", "warning", "error", "info"];
+const sizes: BadgeSize[] = ["sm", "md"];
+
+/** 所有 Variants 展示 */
+export const AllVariants: Story = {
+  args: {
+    children: "Badge",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+      {variants.map((variant) => (
+        <Badge key={variant} variant={variant}>
+          {variant}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+/** 所有 Sizes 展示 */
+export const AllSizes: Story = {
+  args: {
+    children: "Badge",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+      {sizes.map((size) => (
+        <Badge key={size} size={size}>
+          {size}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+/** 完整矩阵 */
+export const FullMatrix: Story = {
+  args: {
+    children: "Badge",
+  },
+  parameters: {
+    layout: "padded",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      {variants.map((variant) => (
+        <div key={variant} style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <span style={{ width: "60px", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+            {variant}
+          </span>
+          {sizes.map((size) => (
+            <Badge key={`${variant}-${size}`} variant={variant} size={size}>
+              {size}
+            </Badge>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** 数字计数示例 */
+export const NumberBadges: Story = {
+  args: {
+    children: "Badge",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "0.5rem" }}>
+      <Badge variant="error" size="sm">3</Badge>
+      <Badge variant="info" size="sm">99+</Badge>
+      <Badge variant="success" size="sm">12</Badge>
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Badge.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { BadgeVariant, BadgeSize } from "./Badge";
+import { Badge } from "./Badge";
+
+describe("Badge", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染 badge 内容", () => {
+      render(<Badge>Test Badge</Badge>);
+
+      expect(screen.getByText("Test Badge")).toBeInTheDocument();
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Badge className="custom-class">Custom</Badge>);
+
+      expect(screen.getByText("Custom")).toHaveClass("custom-class");
+    });
+
+    it("应该传递原生属性", () => {
+      render(
+        <Badge data-testid="test-badge" aria-label="Status badge">
+          Test
+        </Badge>,
+      );
+
+      const badge = screen.getByTestId("test-badge");
+      expect(badge).toHaveAttribute("aria-label", "Status badge");
+    });
+  });
+
+  // ===========================================================================
+  // Variant 测试
+  // ===========================================================================
+  describe("variants", () => {
+    const variants: BadgeVariant[] = ["default", "success", "warning", "error", "info"];
+
+    it.each(variants)("应该渲染 %s variant", (variant) => {
+      render(<Badge variant={variant}>{variant}</Badge>);
+
+      expect(screen.getByText(variant)).toBeInTheDocument();
+    });
+
+    it("默认应该是 default variant", () => {
+      render(<Badge>Default</Badge>);
+
+      const badge = screen.getByText("Default");
+      expect(badge).toHaveClass("bg-[var(--color-bg-hover)]");
+    });
+  });
+
+  // ===========================================================================
+  // Size 测试
+  // ===========================================================================
+  describe("sizes", () => {
+    const sizeClasses: Record<BadgeSize, string> = {
+      sm: "h-[18px]",
+      md: "h-[22px]",
+    };
+
+    it.each(Object.entries(sizeClasses))(
+      "应该渲染 %s size 并有 %s 类",
+      (size, expectedClass) => {
+        render(<Badge size={size as BadgeSize}>{size}</Badge>);
+
+        expect(screen.getByText(size)).toHaveClass(expectedClass);
+      },
+    );
+
+    it("默认应该是 md size", () => {
+      render(<Badge>Default</Badge>);
+
+      expect(screen.getByText("Default")).toHaveClass("h-[22px]");
+    });
+  });
+
+  // ===========================================================================
+  // CSS Variables 检查
+  // ===========================================================================
+  describe("CSS Variables", () => {
+    it("应该使用 CSS Variables 定义颜色", () => {
+      render(<Badge variant="success">Test</Badge>);
+
+      const badge = screen.getByText("Test");
+      expect(badge.className).toContain("var(--");
+    });
+
+    it("class 中不应该包含硬编码的十六进制颜色", () => {
+      render(<Badge variant="error">Test</Badge>);
+
+      const badge = screen.getByText("Test");
+      expect(badge.className).not.toMatch(/#[0-9a-fA-F]{3,6}(?![0-9a-fA-F])/);
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理数字内容", () => {
+      render(<Badge>{99}</Badge>);
+
+      expect(screen.getByText("99")).toBeInTheDocument();
+    });
+
+    it("应该处理超长文本", () => {
+      const longText = "Very Long Badge Text";
+      render(<Badge>{longText}</Badge>);
+
+      expect(screen.getByText(longText)).toBeInTheDocument();
+    });
+
+    it("应该处理 emoji", () => {
+      render(<Badge>🎉 New</Badge>);
+
+      expect(screen.getByText("🎉 New")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Variant × Size 矩阵测试
+  // ===========================================================================
+  describe("Variant × Size 矩阵", () => {
+    const variants: BadgeVariant[] = ["default", "success", "warning", "error", "info"];
+    const sizes: BadgeSize[] = ["sm", "md"];
+
+    const combinations = variants.flatMap((variant) =>
+      sizes.map((size) => ({ variant, size })),
+    );
+
+    it.each(combinations)(
+      "应该正确渲染 $variant × $size 组合",
+      ({ variant, size }) => {
+        render(
+          <Badge variant={variant} size={size}>
+            Test
+          </Badge>,
+        );
+
+        expect(screen.getByText("Test")).toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Badge.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+
+/**
+ * Badge variants as defined in design spec
+ *
+ * - default: 默认灰色背景
+ * - success: 成功状态（绿色）
+ * - warning: 警告状态（橙色）
+ * - error: 错误状态（红色）
+ * - info: 信息状态（蓝色）
+ */
+export type BadgeVariant = "default" | "success" | "warning" | "error" | "info";
+
+/**
+ * Badge sizes
+ *
+ * | Size | Height | Font Size | Padding |
+ * |------|--------|-----------|---------|
+ * | sm   | 18px   | 10px      | 4px 6px |
+ * | md   | 22px   | 12px      | 4px 8px |
+ */
+export type BadgeSize = "sm" | "md";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Visual style variant */
+  variant?: BadgeVariant;
+  /** Size of the badge */
+  size?: BadgeSize;
+  /** Badge content */
+  children: React.ReactNode;
+}
+
+/**
+ * Base styles shared by all badge variants
+ */
+const baseStyles = [
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "font-medium",
+  "select-none",
+  "rounded-[var(--radius-full)]",
+  "whitespace-nowrap",
+].join(" ");
+
+/**
+ * Variant-specific styles
+ */
+const variantStyles: Record<BadgeVariant, string> = {
+  default: [
+    "bg-[var(--color-bg-hover)]",
+    "text-[var(--color-fg-muted)]",
+  ].join(" "),
+  success: [
+    "bg-[var(--color-success-subtle)]",
+    "text-[var(--color-success)]",
+  ].join(" "),
+  warning: [
+    "bg-[var(--color-warning-subtle)]",
+    "text-[var(--color-warning)]",
+  ].join(" "),
+  error: [
+    "bg-[var(--color-error-subtle)]",
+    "text-[var(--color-error)]",
+  ].join(" "),
+  info: [
+    "bg-[var(--color-info-subtle)]",
+    "text-[var(--color-info)]",
+  ].join(" "),
+};
+
+/**
+ * Size-specific styles
+ */
+const sizeStyles: Record<BadgeSize, string> = {
+  sm: "h-[18px] px-1.5 text-[10px]",
+  md: "h-[22px] px-2 text-xs",
+};
+
+/**
+ * Badge component for displaying status indicators, labels, or counts
+ *
+ * @example
+ * ```tsx
+ * <Badge variant="success">Active</Badge>
+ * <Badge variant="error" size="sm">3</Badge>
+ * ```
+ */
+export function Badge({
+  variant = "default",
+  size = "md",
+  className = "",
+  children,
+  ...props
+}: BadgeProps): JSX.Element {
+  const classes = [
+    baseStyles,
+    variantStyles[variant],
+    sizeStyles[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span className={classes} {...props}>
+      {children}
+    </span>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Radio.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Radio.stories.tsx
@@ -1,0 +1,280 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { RadioGroup, Radio, RadioGroupRoot } from "./Radio";
+
+/**
+ * Radio 组件 Story
+ *
+ * 用于单选选择。
+ * 基于 Radix UI RadioGroup。
+ */
+const meta = {
+  title: "Primitives/Radio",
+  component: RadioGroup,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["vertical", "horizontal"],
+      description: "Orientation of the radio group",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Size of the radio buttons",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the group is disabled",
+    },
+  },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Sample options
+const themeOptions = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+const planOptions = [
+  { value: "free", label: "Free", description: "Basic features, up to 3 projects" },
+  { value: "pro", label: "Pro", description: "$9.99/month, unlimited projects" },
+  { value: "team", label: "Team", description: "$29.99/month, collaboration features" },
+];
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    options: themeOptions,
+    defaultValue: "dark",
+  },
+};
+
+/** 水平布局 */
+export const Horizontal: Story = {
+  args: {
+    options: themeOptions,
+    orientation: "horizontal",
+    defaultValue: "dark",
+  },
+};
+
+/** 带描述 */
+export const WithDescriptions: Story = {
+  args: {
+    options: planOptions,
+    defaultValue: "pro",
+  },
+};
+
+/** 小尺寸 */
+export const Small: Story = {
+  args: {
+    options: themeOptions,
+    size: "sm",
+    defaultValue: "dark",
+  },
+};
+
+/** 禁用整个组 */
+export const DisabledGroup: Story = {
+  args: {
+    options: themeOptions,
+    disabled: true,
+    defaultValue: "dark",
+  },
+};
+
+/** 禁用单个选项 */
+export const DisabledOption: Story = {
+  args: {
+    options: [
+      { value: "light", label: "Light" },
+      { value: "dark", label: "Dark" },
+      { value: "system", label: "System", disabled: true },
+    ],
+    defaultValue: "dark",
+  },
+};
+
+// ============================================================================
+// 受控模式
+// ============================================================================
+
+function ControlledDemo() {
+  const [value, setValue] = React.useState("dark");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Selected: {value}
+      </div>
+      <RadioGroup
+        options={themeOptions}
+        value={value}
+        onValueChange={setValue}
+      />
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  args: {
+    options: themeOptions,
+  },
+  render: () => <ControlledDemo />,
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+/** 所有 Sizes */
+export const AllSizes: Story = {
+  args: {
+    options: themeOptions,
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "3rem" }}>
+      <div>
+        <div style={{ marginBottom: "0.5rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+          Small
+        </div>
+        <RadioGroup options={themeOptions} size="sm" defaultValue="dark" />
+      </div>
+      <div>
+        <div style={{ marginBottom: "0.5rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+          Medium
+        </div>
+        <RadioGroup options={themeOptions} size="md" defaultValue="dark" />
+      </div>
+    </div>
+  ),
+};
+
+/** 表单中使用 */
+export const InForm: Story = {
+  args: {
+    options: themeOptions,
+  },
+  render: () => (
+    <form
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.5rem",
+        maxWidth: "300px",
+        padding: "1.5rem",
+        backgroundColor: "var(--color-bg-surface)",
+        borderRadius: "var(--radius-lg)",
+      }}
+    >
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.75rem",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "var(--color-fg-default)",
+          }}
+        >
+          Theme
+        </label>
+        <RadioGroup
+          options={themeOptions}
+          name="theme"
+          defaultValue="dark"
+        />
+      </div>
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.75rem",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "var(--color-fg-default)",
+          }}
+        >
+          Plan
+        </label>
+        <RadioGroup
+          options={planOptions}
+          name="plan"
+          defaultValue="pro"
+        />
+      </div>
+    </form>
+  ),
+};
+
+// ============================================================================
+// 自定义布局
+// ============================================================================
+
+export const CustomLayout: Story = {
+  args: {
+    options: themeOptions,
+  },
+  render: () => (
+    <RadioGroupRoot defaultValue="dark" className="grid grid-cols-3 gap-3">
+      {["light", "dark", "system"].map((theme) => (
+        <label
+          key={theme}
+          className="flex items-center gap-3 p-3 border border-[var(--color-border-default)] rounded-[var(--radius-md)] cursor-pointer hover:bg-[var(--color-bg-hover)] has-[[data-state=checked]]:border-[var(--color-fg-default)] has-[[data-state=checked]]:bg-[var(--color-bg-hover)]"
+        >
+          <Radio value={theme} />
+          <span className="text-sm text-[var(--color-fg-default)] capitalize">
+            {theme}
+          </span>
+        </label>
+      ))}
+    </RadioGroupRoot>
+  ),
+};
+
+// ============================================================================
+// 边界情况
+// ============================================================================
+
+/** 长标签 */
+export const LongLabels: Story = {
+  args: {
+    options: [
+      { value: "option1", label: "This is a very long option label that might wrap" },
+      { value: "option2", label: "Another long option with detailed description", description: "This description provides additional context about what this option does and when you might want to select it." },
+    ],
+  },
+};
+
+/** 单个选项 */
+export const SingleOption: Story = {
+  args: {
+    options: [
+      { value: "only", label: "Only option" },
+    ],
+    defaultValue: "only",
+  },
+};
+
+/** 多个选项 */
+export const ManyOptions: Story = {
+  args: {
+    options: Array.from({ length: 8 }, (_, i) => ({
+      value: `option-${i + 1}`,
+      label: `Option ${i + 1}`,
+    })),
+  },
+};

--- a/apps/desktop/renderer/src/components/primitives/Radio.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Radio.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RadioGroup } from "./Radio";
+
+const sampleOptions = [
+  { value: "option1", label: "Option 1" },
+  { value: "option2", label: "Option 2" },
+  { value: "option3", label: "Option 3" },
+];
+
+describe("RadioGroup", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染所有选项", () => {
+      render(<RadioGroup options={sampleOptions} />);
+
+      expect(screen.getByText("Option 1")).toBeInTheDocument();
+      expect(screen.getByText("Option 2")).toBeInTheDocument();
+      expect(screen.getByText("Option 3")).toBeInTheDocument();
+    });
+
+    it("应该渲染 radio 按钮", () => {
+      render(<RadioGroup options={sampleOptions} />);
+
+      expect(screen.getAllByRole("radio")).toHaveLength(3);
+    });
+
+    it("应该渲染描述文本", () => {
+      render(
+        <RadioGroup
+          options={[
+            { value: "test", label: "Test", description: "Test description" },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Test description")).toBeInTheDocument();
+    });
+
+    it("应该应用自定义 className", () => {
+      const { container } = render(
+        <RadioGroup options={sampleOptions} className="custom-class" />,
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  // ===========================================================================
+  // 交互测试
+  // ===========================================================================
+  describe("交互", () => {
+    it("点击应该选中选项", async () => {
+      const user = userEvent.setup();
+      render(<RadioGroup options={sampleOptions} />);
+
+      const option1 = screen.getByRole("radio", { name: /Option 1/i });
+      await user.click(option1);
+
+      expect(option1).toBeChecked();
+    });
+
+    it("只能选中一个选项", async () => {
+      const user = userEvent.setup();
+      render(<RadioGroup options={sampleOptions} />);
+
+      const option1 = screen.getByRole("radio", { name: /Option 1/i });
+      const option2 = screen.getByRole("radio", { name: /Option 2/i });
+
+      await user.click(option1);
+      expect(option1).toBeChecked();
+
+      await user.click(option2);
+      expect(option2).toBeChecked();
+      expect(option1).not.toBeChecked();
+    });
+
+    it("应该调用 onValueChange", async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <RadioGroup options={sampleOptions} onValueChange={onValueChange} />,
+      );
+
+      await user.click(screen.getByRole("radio", { name: /Option 2/i }));
+
+      expect(onValueChange).toHaveBeenCalledWith("option2");
+    });
+  });
+
+  // ===========================================================================
+  // 默认值测试
+  // ===========================================================================
+  describe("默认值", () => {
+    it("应该支持 defaultValue", () => {
+      render(<RadioGroup options={sampleOptions} defaultValue="option2" />);
+
+      expect(screen.getByRole("radio", { name: /Option 2/i })).toBeChecked();
+    });
+
+    it("应该支持受控 value", () => {
+      render(<RadioGroup options={sampleOptions} value="option3" />);
+
+      expect(screen.getByRole("radio", { name: /Option 3/i })).toBeChecked();
+    });
+  });
+
+  // ===========================================================================
+  // 禁用测试
+  // ===========================================================================
+  describe("禁用", () => {
+    it("禁用整个组时所有选项不可点击", async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <RadioGroup
+          options={sampleOptions}
+          disabled
+          onValueChange={onValueChange}
+        />,
+      );
+
+      await user.click(screen.getByRole("radio", { name: /Option 1/i }));
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it("禁用单个选项时该选项不可点击", async () => {
+      const onValueChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <RadioGroup
+          options={[
+            ...sampleOptions,
+            { value: "disabled", label: "Disabled Option", disabled: true },
+          ]}
+          onValueChange={onValueChange}
+        />,
+      );
+
+      await user.click(screen.getByRole("radio", { name: /Disabled Option/i }));
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // 方向测试
+  // ===========================================================================
+  describe("方向", () => {
+    it("默认应该是垂直布局", () => {
+      const { container } = render(<RadioGroup options={sampleOptions} />);
+
+      expect(container.firstChild).toHaveClass("flex-col");
+    });
+
+    it("应该支持水平布局", () => {
+      const { container } = render(
+        <RadioGroup options={sampleOptions} orientation="horizontal" />,
+      );
+
+      expect(container.firstChild).toHaveClass("flex-row");
+    });
+  });
+
+  // ===========================================================================
+  // 尺寸测试
+  // ===========================================================================
+  describe("尺寸", () => {
+    it("默认应该是 md 尺寸", () => {
+      render(<RadioGroup options={sampleOptions} />);
+
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveClass("w-5");
+    });
+
+    it("应该支持 sm 尺寸", () => {
+      render(<RadioGroup options={sampleOptions} size="sm" />);
+
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveClass("w-4");
+    });
+  });
+
+  // ===========================================================================
+  // 键盘导航测试
+  // ===========================================================================
+  describe("键盘导航", () => {
+    it("应该支持 Tab 键聚焦", async () => {
+      const user = userEvent.setup();
+      render(<RadioGroup options={sampleOptions} defaultValue="option1" />);
+
+      await user.tab();
+
+      expect(screen.getByRole("radio", { name: /Option 1/i })).toHaveFocus();
+    });
+
+    it("应该支持 Tab 键聚焦到选中项", async () => {
+      const user = userEvent.setup();
+      render(<RadioGroup options={sampleOptions} defaultValue="option1" />);
+
+      // Tab should focus the checked radio
+      await user.tab();
+
+      const option1 = screen.getByRole("radio", { name: /Option 1/i });
+      expect(option1).toHaveFocus();
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该处理空数组", () => {
+      const { container } = render(<RadioGroup options={[]} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it("应该处理单个选项", () => {
+      render(
+        <RadioGroup
+          options={[{ value: "only", label: "Only Option" }]}
+        />,
+      );
+
+      expect(screen.getByText("Only Option")).toBeInTheDocument();
+    });
+
+    it("应该支持 name 属性", () => {
+      const { container } = render(<RadioGroup options={sampleOptions} name="test-group" />);
+
+      // The RadioGroup root has the name attribute
+      const radioGroup = container.querySelector('[role="radiogroup"]');
+      expect(radioGroup).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Radio.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Radio.tsx
@@ -1,0 +1,226 @@
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+
+export interface RadioOption {
+  /** Unique value for the option */
+  value: string;
+  /** Display label */
+  label: string;
+  /** Optional description */
+  description?: string;
+  /** Whether the option is disabled */
+  disabled?: boolean;
+}
+
+export interface RadioGroupProps {
+  /** Array of radio options */
+  options: RadioOption[];
+  /** Current selected value */
+  value?: string;
+  /** Default selected value */
+  defaultValue?: string;
+  /** Callback when value changes */
+  onValueChange?: (value: string) => void;
+  /** Name attribute for form submission */
+  name?: string;
+  /** Whether the group is disabled */
+  disabled?: boolean;
+  /** Orientation of the radio group */
+  orientation?: "horizontal" | "vertical";
+  /** Additional className for root */
+  className?: string;
+  /** Size of the radio buttons */
+  size?: "sm" | "md";
+}
+
+/**
+ * Radio indicator icon
+ */
+function RadioIndicator({ size }: { size: "sm" | "md" }) {
+  const indicatorSize = size === "sm" ? "w-1.5 h-1.5" : "w-2 h-2";
+  return (
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <span className={`${indicatorSize} rounded-[var(--radius-full)] bg-[var(--color-fg-default)]`} />
+    </RadioGroupPrimitive.Indicator>
+  );
+}
+
+/**
+ * Size-specific styles
+ */
+const sizeStyles = {
+  sm: {
+    radio: "w-4 h-4",
+    label: "text-xs",
+    description: "text-[10px]",
+    gap: "gap-2",
+  },
+  md: {
+    radio: "w-5 h-5",
+    label: "text-sm",
+    description: "text-xs",
+    gap: "gap-3",
+  },
+};
+
+/**
+ * RadioGroup component using Radix UI
+ *
+ * Displays a group of radio buttons for single selection.
+ *
+ * @example
+ * ```tsx
+ * <RadioGroup
+ *   options={[
+ *     { value: "light", label: "Light" },
+ *     { value: "dark", label: "Dark" },
+ *     { value: "system", label: "System" },
+ *   ]}
+ *   value={theme}
+ *   onValueChange={setTheme}
+ * />
+ * ```
+ */
+export function RadioGroup({
+  options,
+  value,
+  defaultValue,
+  onValueChange,
+  name,
+  disabled,
+  orientation = "vertical",
+  className = "",
+  size = "md",
+}: RadioGroupProps): JSX.Element {
+  const styles = sizeStyles[size];
+
+  const rootClasses = [
+    "flex",
+    orientation === "horizontal" ? "flex-row gap-6" : "flex-col gap-3",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const radioStyles = [
+    styles.radio,
+    "rounded-[var(--radius-full)]",
+    "border",
+    "border-[var(--color-border-default)]",
+    "bg-transparent",
+    "flex",
+    "items-center",
+    "justify-center",
+    "transition-colors",
+    "duration-[var(--duration-fast)]",
+    "hover:border-[var(--color-border-hover)]",
+    "focus-visible:outline",
+    "focus-visible:outline-[length:var(--ring-focus-width)]",
+    "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+    "focus-visible:outline-[var(--color-ring-focus)]",
+    "data-[state=checked]:border-[var(--color-fg-default)]",
+    "disabled:opacity-50",
+    "disabled:cursor-not-allowed",
+  ].join(" ");
+
+  return (
+    <RadioGroupPrimitive.Root
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange}
+      name={name}
+      disabled={disabled}
+      orientation={orientation}
+      className={rootClasses}
+    >
+      {options.map((option) => (
+        <div key={option.value} className={`flex items-start ${styles.gap}`}>
+          <RadioGroupPrimitive.Item
+            value={option.value}
+            disabled={option.disabled}
+            id={`radio-${name || "group"}-${option.value}`}
+            className={radioStyles}
+          >
+            <RadioIndicator size={size} />
+          </RadioGroupPrimitive.Item>
+          <div className="flex flex-col">
+            <label
+              htmlFor={`radio-${name || "group"}-${option.value}`}
+              className={`${styles.label} text-[var(--color-fg-default)] cursor-pointer ${
+                option.disabled ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+            >
+              {option.label}
+            </label>
+            {option.description && (
+              <span className={`${styles.description} text-[var(--color-fg-muted)] mt-0.5`}>
+                {option.description}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </RadioGroupPrimitive.Root>
+  );
+}
+
+/**
+ * Single Radio component for custom layouts
+ */
+export interface RadioProps {
+  /** Value of the radio */
+  value: string;
+  /** Whether the radio is disabled */
+  disabled?: boolean;
+  /** Additional className */
+  className?: string;
+  /** Size of the radio */
+  size?: "sm" | "md";
+}
+
+export function Radio({
+  value,
+  disabled,
+  className = "",
+  size = "md",
+}: RadioProps): JSX.Element {
+  const styles = sizeStyles[size];
+
+  const radioStyles = [
+    styles.radio,
+    "rounded-[var(--radius-full)]",
+    "border",
+    "border-[var(--color-border-default)]",
+    "bg-transparent",
+    "flex",
+    "items-center",
+    "justify-center",
+    "transition-colors",
+    "duration-[var(--duration-fast)]",
+    "hover:border-[var(--color-border-hover)]",
+    "focus-visible:outline",
+    "focus-visible:outline-[length:var(--ring-focus-width)]",
+    "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+    "focus-visible:outline-[var(--color-ring-focus)]",
+    "data-[state=checked]:border-[var(--color-fg-default)]",
+    "disabled:opacity-50",
+    "disabled:cursor-not-allowed",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <RadioGroupPrimitive.Item
+      value={value}
+      disabled={disabled}
+      className={radioStyles}
+    >
+      <RadioIndicator size={size} />
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+/**
+ * Re-export RadioGroup Root for custom layouts
+ */
+export const RadioGroupRoot = RadioGroupPrimitive.Root;

--- a/apps/desktop/renderer/src/components/primitives/Skeleton.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Skeleton.stories.tsx
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Skeleton } from "./Skeleton";
+
+/**
+ * Skeleton 组件 Story
+ *
+ * 用于显示内容加载占位符。
+ * 支持文本、圆形、矩形三种形态。
+ */
+const meta = {
+  title: "Primitives/Skeleton",
+  component: Skeleton,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["text", "circular", "rectangular"],
+      description: "Shape variant",
+    },
+    width: {
+      control: "text",
+      description: "Width (CSS value)",
+    },
+    height: {
+      control: "text",
+      description: "Height (CSS value)",
+    },
+    animate: {
+      control: "boolean",
+      description: "Enable shimmer animation",
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态（文本） */
+export const Default: Story = {
+  args: {
+    variant: "text",
+    width: "200px",
+  },
+};
+
+/** 文本占位 */
+export const Text: Story = {
+  args: {
+    variant: "text",
+    width: "80%",
+  },
+};
+
+/** 圆形占位（头像） */
+export const Circular: Story = {
+  args: {
+    variant: "circular",
+    width: 48,
+    height: 48,
+  },
+};
+
+/** 矩形占位（图片/卡片） */
+export const Rectangular: Story = {
+  args: {
+    variant: "rectangular",
+    width: "100%",
+    height: 120,
+  },
+};
+
+/** 无动画 */
+export const NoAnimation: Story = {
+  args: {
+    variant: "rectangular",
+    width: 200,
+    height: 100,
+    animate: false,
+  },
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+/** 所有 Variants 展示 */
+export const AllVariants: Story = {
+  args: {
+    variant: "text",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem", maxWidth: "400px" }}>
+      <div>
+        <div style={{ marginBottom: "0.5rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+          text
+        </div>
+        <Skeleton variant="text" width="80%" />
+      </div>
+      <div>
+        <div style={{ marginBottom: "0.5rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+          circular
+        </div>
+        <Skeleton variant="circular" width={48} height={48} />
+      </div>
+      <div>
+        <div style={{ marginBottom: "0.5rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+          rectangular
+        </div>
+        <Skeleton variant="rectangular" height={100} />
+      </div>
+    </div>
+  ),
+};
+
+/** 用户卡片骨架 */
+export const UserCardSkeleton: Story = {
+  args: {
+    variant: "text",
+  },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "1rem",
+        padding: "1rem",
+        backgroundColor: "var(--color-bg-surface)",
+        borderRadius: "var(--radius-lg)",
+        maxWidth: "320px",
+      }}
+    >
+      <Skeleton variant="circular" width={48} height={48} />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        <Skeleton variant="text" width="60%" height={16} />
+        <Skeleton variant="text" width="80%" height={14} />
+        <Skeleton variant="text" width="40%" height={14} />
+      </div>
+    </div>
+  ),
+};
+
+/** 文章列表骨架 */
+export const ArticleListSkeleton: Story = {
+  args: {
+    variant: "text",
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem", maxWidth: "500px" }}>
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            gap: "1rem",
+            padding: "1rem",
+            backgroundColor: "var(--color-bg-surface)",
+            borderRadius: "var(--radius-lg)",
+          }}
+        >
+          <Skeleton variant="rectangular" width={120} height={80} />
+          <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <Skeleton variant="text" width="90%" height={18} />
+            <Skeleton variant="text" width="70%" height={14} />
+            <Skeleton variant="text" width="50%" height={14} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** 表单骨架 */
+export const FormSkeleton: Story = {
+  args: {
+    variant: "text",
+  },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+        maxWidth: "300px",
+        padding: "1.5rem",
+        backgroundColor: "var(--color-bg-surface)",
+        borderRadius: "var(--radius-lg)",
+      }}
+    >
+      <Skeleton variant="text" width="30%" height={12} />
+      <Skeleton variant="rectangular" height={36} />
+      <Skeleton variant="text" width="30%" height={12} />
+      <Skeleton variant="rectangular" height={36} />
+      <Skeleton variant="text" width="30%" height={12} />
+      <Skeleton variant="rectangular" height={80} />
+      <Skeleton variant="rectangular" width="100%" height={36} />
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Skeleton.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Skeleton.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { SkeletonVariant } from "./Skeleton";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染 skeleton 元素", () => {
+      render(<Skeleton />);
+
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    it("应该有正确的 aria 属性", () => {
+      render(<Skeleton />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton).toHaveAttribute("aria-busy", "true");
+      expect(skeleton).toHaveAttribute("aria-label", "Loading...");
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Skeleton className="custom-class" />);
+
+      expect(screen.getByRole("progressbar")).toHaveClass("custom-class");
+    });
+  });
+
+  // ===========================================================================
+  // Variant 测试
+  // ===========================================================================
+  describe("variants", () => {
+    const variants: SkeletonVariant[] = ["text", "circular", "rectangular"];
+
+    it.each(variants)("应该渲染 %s variant", (variant) => {
+      render(<Skeleton variant={variant} />);
+
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    it("text variant 应该有 rounded-sm", () => {
+      render(<Skeleton variant="text" />);
+
+      expect(screen.getByRole("progressbar")).toHaveClass("rounded-[var(--radius-sm)]");
+    });
+
+    it("circular variant 应该有 rounded-full", () => {
+      render(<Skeleton variant="circular" />);
+
+      expect(screen.getByRole("progressbar")).toHaveClass("rounded-[var(--radius-full)]");
+    });
+
+    it("rectangular variant 应该有 rounded-md", () => {
+      render(<Skeleton variant="rectangular" />);
+
+      expect(screen.getByRole("progressbar")).toHaveClass("rounded-[var(--radius-md)]");
+    });
+  });
+
+  // ===========================================================================
+  // 尺寸测试
+  // ===========================================================================
+  describe("尺寸", () => {
+    it("应该接受数字 width/height", () => {
+      render(<Skeleton width={100} height={50} />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton).toHaveStyle({ width: "100px", height: "50px" });
+    });
+
+    it("应该接受字符串 width/height", () => {
+      render(<Skeleton width="80%" height="2rem" />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton).toHaveStyle({ width: "80%", height: "2rem" });
+    });
+
+    it("text variant 默认宽度 100%，高度 1em", () => {
+      render(<Skeleton variant="text" />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton).toHaveStyle({ width: "100%", height: "1em" });
+    });
+
+    it("circular variant 默认 40x40", () => {
+      render(<Skeleton variant="circular" />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton).toHaveStyle({ width: "40px", height: "40px" });
+    });
+  });
+
+  // ===========================================================================
+  // 动画测试
+  // ===========================================================================
+  describe("动画", () => {
+    it("默认应该启用动画", () => {
+      render(<Skeleton />);
+
+      expect(screen.getByRole("progressbar")).toHaveClass("before:animate-shimmer");
+    });
+
+    it("animate=false 时不应该有动画类", () => {
+      render(<Skeleton animate={false} />);
+
+      expect(screen.getByRole("progressbar")).not.toHaveClass("before:animate-shimmer");
+    });
+  });
+
+  // ===========================================================================
+  // CSS Variables 检查
+  // ===========================================================================
+  describe("CSS Variables", () => {
+    it("应该使用 CSS Variables 定义颜色", () => {
+      render(<Skeleton />);
+
+      const skeleton = screen.getByRole("progressbar");
+      expect(skeleton.className).toContain("var(--");
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该支持自定义 style", () => {
+      render(<Skeleton style={{ marginTop: "10px" }} />);
+
+      expect(screen.getByRole("progressbar")).toHaveStyle({ marginTop: "10px" });
+    });
+
+    it("应该传递原生属性", () => {
+      render(<Skeleton data-testid="test-skeleton" />);
+
+      expect(screen.getByTestId("test-skeleton")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Variant 矩阵测试
+  // ===========================================================================
+  describe("Variant 矩阵", () => {
+    const variants: SkeletonVariant[] = ["text", "circular", "rectangular"];
+    const animateStates = [true, false];
+
+    const combinations = variants.flatMap((variant) =>
+      animateStates.map((animate) => ({ variant, animate })),
+    );
+
+    it.each(combinations)(
+      "应该正确渲染 $variant + animate=$animate 组合",
+      ({ variant, animate }) => {
+        render(<Skeleton variant={variant} animate={animate} />);
+
+        expect(screen.getByRole("progressbar")).toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Skeleton.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Skeleton.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+
+/**
+ * Skeleton variants
+ *
+ * - text: 单行文本占位
+ * - circular: 圆形占位（头像等）
+ * - rectangular: 矩形占位（图片、卡片等）
+ */
+export type SkeletonVariant = "text" | "circular" | "rectangular";
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Shape variant */
+  variant?: SkeletonVariant;
+  /** Width (CSS value, e.g., "100%", "200px") */
+  width?: string | number;
+  /** Height (CSS value, e.g., "20px", "100%") */
+  height?: string | number;
+  /** Enable animation */
+  animate?: boolean;
+}
+
+/**
+ * Base styles for skeleton
+ */
+const baseStyles = [
+  "bg-[var(--color-bg-hover)]",
+  "overflow-hidden",
+  "relative",
+].join(" ");
+
+/**
+ * Animation styles using a shimmer effect
+ */
+const animationStyles = [
+  "before:absolute",
+  "before:inset-0",
+  "before:bg-gradient-to-r",
+  "before:from-transparent",
+  "before:via-[var(--color-bg-active)]",
+  "before:to-transparent",
+  "before:animate-shimmer",
+].join(" ");
+
+/**
+ * Variant-specific styles
+ */
+const variantStyles: Record<SkeletonVariant, string> = {
+  text: "rounded-[var(--radius-sm)]",
+  circular: "rounded-[var(--radius-full)]",
+  rectangular: "rounded-[var(--radius-md)]",
+};
+
+/**
+ * Default dimensions for each variant
+ */
+const defaultDimensions: Record<SkeletonVariant, { width: string; height: string }> = {
+  text: { width: "100%", height: "1em" },
+  circular: { width: "40px", height: "40px" },
+  rectangular: { width: "100%", height: "100px" },
+};
+
+/**
+ * Skeleton component for loading placeholder
+ *
+ * Displays a placeholder with optional shimmer animation
+ * while content is loading.
+ *
+ * @example
+ * ```tsx
+ * <Skeleton variant="text" width="80%" />
+ * <Skeleton variant="circular" width={40} height={40} />
+ * <Skeleton variant="rectangular" height={200} />
+ * ```
+ */
+export function Skeleton({
+  variant = "text",
+  width,
+  height,
+  animate = true,
+  className = "",
+  style,
+  ...props
+}: SkeletonProps): JSX.Element {
+  const defaults = defaultDimensions[variant];
+
+  const computedWidth = width !== undefined
+    ? typeof width === "number" ? `${width}px` : width
+    : defaults.width;
+
+  const computedHeight = height !== undefined
+    ? typeof height === "number" ? `${height}px` : height
+    : defaults.height;
+
+  const classes = [
+    baseStyles,
+    variantStyles[variant],
+    animate ? animationStyles : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={classes}
+      style={{
+        width: computedWidth,
+        height: computedHeight,
+        ...style,
+      }}
+      role="progressbar"
+      aria-busy="true"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Loading..."
+      {...props}
+    />
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Spinner.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Spinner.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { SpinnerSize } from "./Spinner";
+import { Spinner } from "./Spinner";
+
+/**
+ * Spinner 组件 Story
+ *
+ * 用于显示加载状态的旋转指示器。
+ * 支持多种尺寸。
+ */
+const meta = {
+  title: "Primitives/Spinner",
+  component: Spinner,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Size of the spinner",
+    },
+    label: {
+      control: "text",
+      description: "Accessibility label",
+    },
+  },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    size: "md",
+  },
+};
+
+// ============================================================================
+// Size Stories
+// ============================================================================
+
+const sizes: SpinnerSize[] = ["xs", "sm", "md", "lg", "xl"];
+
+/** XS size (12px) */
+export const ExtraSmall: Story = {
+  args: {
+    size: "xs",
+  },
+};
+
+/** SM size (16px) */
+export const Small: Story = {
+  args: {
+    size: "sm",
+  },
+};
+
+/** MD size (24px) */
+export const Medium: Story = {
+  args: {
+    size: "md",
+  },
+};
+
+/** LG size (32px) */
+export const Large: Story = {
+  args: {
+    size: "lg",
+  },
+};
+
+/** XL size (48px) */
+export const ExtraLarge: Story = {
+  args: {
+    size: "xl",
+  },
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+/** 所有 Sizes 展示 */
+export const AllSizes: Story = {
+  args: {
+    size: "md",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1.5rem", alignItems: "center" }}>
+      {sizes.map((size) => (
+        <div
+          key={size}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "0.5rem",
+          }}
+        >
+          <Spinner size={size} />
+          <span style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+            {size}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** 不同颜色（继承父元素 color） */
+export const Colors: Story = {
+  args: {
+    size: "md",
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1.5rem", alignItems: "center" }}>
+      <div style={{ color: "var(--color-fg-default)" }}>
+        <Spinner size="md" />
+      </div>
+      <div style={{ color: "var(--color-fg-muted)" }}>
+        <Spinner size="md" />
+      </div>
+      <div style={{ color: "var(--color-success)" }}>
+        <Spinner size="md" />
+      </div>
+      <div style={{ color: "var(--color-error)" }}>
+        <Spinner size="md" />
+      </div>
+      <div style={{ color: "var(--color-info)" }}>
+        <Spinner size="md" />
+      </div>
+    </div>
+  ),
+};
+
+/** 加载按钮示例 */
+export const InButton: Story = {
+  args: {
+    size: "sm",
+  },
+  render: () => (
+    <button
+      type="button"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        padding: "0.5rem 1rem",
+        backgroundColor: "var(--color-fg-default)",
+        color: "var(--color-fg-inverse)",
+        border: "none",
+        borderRadius: "var(--radius-md)",
+        fontSize: "13px",
+        cursor: "not-allowed",
+        opacity: 0.7,
+      }}
+      disabled
+    >
+      <Spinner size="sm" />
+      <span>Loading...</span>
+    </button>
+  ),
+};
+
+/** 全屏加载示例 */
+export const FullScreen: Story = {
+  args: {
+    size: "xl",
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100vh",
+        gap: "1rem",
+        color: "var(--color-fg-muted)",
+      }}
+    >
+      <Spinner size="xl" />
+      <span style={{ fontSize: "14px" }}>Loading content...</span>
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Spinner.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Spinner.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { SpinnerSize } from "./Spinner";
+import { Spinner } from "./Spinner";
+
+describe("Spinner", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染 SVG 元素", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("应该有 animate-spin 类", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toHaveClass("animate-spin");
+    });
+
+    it("应该有默认的 aria-label", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toHaveAttribute("aria-label", "Loading");
+    });
+
+    it("应该支持自定义 label", () => {
+      render(<Spinner label="Please wait..." />);
+
+      expect(screen.getByRole("status")).toHaveAttribute("aria-label", "Please wait...");
+    });
+
+    it("应该应用自定义 className", () => {
+      render(<Spinner className="custom-class" />);
+
+      expect(screen.getByRole("status")).toHaveClass("custom-class");
+    });
+  });
+
+  // ===========================================================================
+  // Size 测试
+  // ===========================================================================
+  describe("sizes", () => {
+    const sizeMap: Record<SpinnerSize, number> = {
+      xs: 12,
+      sm: 16,
+      md: 24,
+      lg: 32,
+      xl: 48,
+    };
+
+    it.each(Object.entries(sizeMap))(
+      "应该渲染 %s size 并有 %s 像素尺寸",
+      (size, expectedDimension) => {
+        render(<Spinner size={size as SpinnerSize} />);
+
+        const spinner = screen.getByRole("status");
+        expect(spinner).toHaveAttribute("width", String(expectedDimension));
+        expect(spinner).toHaveAttribute("height", String(expectedDimension));
+      },
+    );
+
+    it("默认应该是 md size (24px)", () => {
+      render(<Spinner />);
+
+      const spinner = screen.getByRole("status");
+      expect(spinner).toHaveAttribute("width", "24");
+      expect(spinner).toHaveAttribute("height", "24");
+    });
+  });
+
+  // ===========================================================================
+  // SVG 结构测试
+  // ===========================================================================
+  describe("SVG 结构", () => {
+    it("应该有 circle 和 path 元素", () => {
+      const { container } = render(<Spinner />);
+
+      expect(container.querySelector("circle")).toBeInTheDocument();
+      expect(container.querySelector("path")).toBeInTheDocument();
+    });
+
+    it("应该有正确的 viewBox", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toHaveAttribute("viewBox", "0 0 24 24");
+    });
+  });
+
+  // ===========================================================================
+  // 无障碍测试
+  // ===========================================================================
+  describe("无障碍", () => {
+    it("应该有 role=status", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("应该有 aria-label", () => {
+      render(<Spinner label="Loading data" />);
+
+      expect(screen.getByRole("status")).toHaveAccessibleName("Loading data");
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该支持传递原生 SVG 属性", () => {
+      render(<Spinner data-testid="test-spinner" />);
+
+      expect(screen.getByTestId("test-spinner")).toBeInTheDocument();
+    });
+
+    it("应该继承 text-current 类", () => {
+      render(<Spinner />);
+
+      expect(screen.getByRole("status")).toHaveClass("text-current");
+    });
+  });
+
+  // ===========================================================================
+  // Size 矩阵测试
+  // ===========================================================================
+  describe("Size 矩阵", () => {
+    const sizes: SpinnerSize[] = ["xs", "sm", "md", "lg", "xl"];
+
+    it.each(sizes)("应该正确渲染 %s size", (size) => {
+      render(<Spinner size={size} />);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Spinner.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Spinner.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+/**
+ * Spinner sizes
+ *
+ * | Size | Diameter |
+ * |------|----------|
+ * | xs   | 12px     |
+ * | sm   | 16px     |
+ * | md   | 24px     |
+ * | lg   | 32px     |
+ * | xl   | 48px     |
+ */
+export type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export interface SpinnerProps extends React.SVGAttributes<SVGSVGElement> {
+  /** Size of the spinner */
+  size?: SpinnerSize;
+  /** Custom label for accessibility */
+  label?: string;
+}
+
+/**
+ * Size-specific styles (width/height in pixels)
+ */
+const sizeMap: Record<SpinnerSize, number> = {
+  xs: 12,
+  sm: 16,
+  md: 24,
+  lg: 32,
+  xl: 48,
+};
+
+/**
+ * Spinner component for loading states
+ *
+ * Uses a circular animation with CSS animate-spin.
+ * Accessible with proper aria-label.
+ *
+ * @example
+ * ```tsx
+ * <Spinner size="md" />
+ * <Spinner size="lg" label="Loading content..." />
+ * ```
+ */
+export function Spinner({
+  size = "md",
+  label = "Loading",
+  className = "",
+  ...props
+}: SpinnerProps): JSX.Element {
+  const dimension = sizeMap[size];
+
+  const classes = [
+    "animate-spin",
+    "text-current",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <svg
+      className={classes}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      width={dimension}
+      height={dimension}
+      role="status"
+      aria-label={label}
+      {...props}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Toast.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toast.stories.tsx
@@ -113,50 +113,52 @@ export const WithAction: Story = {
 
 const variants: ToastVariant[] = ["default", "success", "error", "warning"];
 
+function AllVariantsDemo() {
+  const [openStates, setOpenStates] = React.useState<Record<ToastVariant, boolean>>({
+    default: true,
+    success: true,
+    error: true,
+    warning: true,
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        {variants.map((variant) => (
+          <Button
+            key={variant}
+            size="sm"
+            onClick={() =>
+              setOpenStates((prev) => ({ ...prev, [variant]: true }))
+            }
+          >
+            Show {variant}
+          </Button>
+        ))}
+      </div>
+      {variants.map((variant) => (
+        <Toast
+          key={variant}
+          title={`${variant.charAt(0).toUpperCase() + variant.slice(1)} Toast`}
+          description={`This is a ${variant} toast message.`}
+          variant={variant}
+          open={openStates[variant]}
+          onOpenChange={(open) =>
+            setOpenStates((prev) => ({ ...prev, [variant]: open }))
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
 /** 所有 Variants 展示 */
 export const AllVariants: Story = {
   args: {
     title: "Toast",
     open: true,
   },
-  render: () => {
-    const [openStates, setOpenStates] = React.useState<Record<ToastVariant, boolean>>({
-      default: true,
-      success: true,
-      error: true,
-      warning: true,
-    });
-
-    return (
-      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <div style={{ display: "flex", gap: "0.5rem" }}>
-          {variants.map((variant) => (
-            <Button
-              key={variant}
-              size="sm"
-              onClick={() =>
-                setOpenStates((prev) => ({ ...prev, [variant]: true }))
-              }
-            >
-              Show {variant}
-            </Button>
-          ))}
-        </div>
-        {variants.map((variant) => (
-          <Toast
-            key={variant}
-            title={`${variant.charAt(0).toUpperCase() + variant.slice(1)} Toast`}
-            description={`This is a ${variant} toast message.`}
-            variant={variant}
-            open={openStates[variant]}
-            onOpenChange={(open) =>
-              setOpenStates((prev) => ({ ...prev, [variant]: open }))
-            }
-          />
-        ))}
-      </div>
-    );
-  },
+  render: () => <AllVariantsDemo />,
 };
 
 /** 使用 Hook 触发 */

--- a/apps/desktop/renderer/src/components/primitives/Toast.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toast.stories.tsx
@@ -1,0 +1,226 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ToastVariant } from "./Toast";
+import { Toast, ToastProvider, ToastViewport, useToast } from "./Toast";
+import { Button } from "./Button";
+
+/**
+ * Toast 组件 Story
+ *
+ * 用于显示临时通知消息。
+ * 基于 Radix UI Toast。
+ */
+const meta: Meta<typeof Toast> = {
+  title: "Primitives/Toast",
+  component: Toast,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <div style={{ padding: "2rem", minHeight: "300px" }}>
+          <Story />
+          <ToastViewport />
+        </div>
+      </ToastProvider>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "success", "error", "warning"],
+      description: "Visual variant",
+    },
+    duration: {
+      control: "number",
+      description: "Duration in ms before auto-close",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    title: "Notification",
+    description: "This is a toast notification.",
+    open: true,
+  },
+};
+
+/** 成功状态 */
+export const Success: Story = {
+  args: {
+    title: "Success!",
+    description: "Your changes have been saved successfully.",
+    variant: "success",
+    open: true,
+  },
+};
+
+/** 错误状态 */
+export const Error: Story = {
+  args: {
+    title: "Error",
+    description: "Something went wrong. Please try again.",
+    variant: "error",
+    open: true,
+  },
+};
+
+/** 警告状态 */
+export const Warning: Story = {
+  args: {
+    title: "Warning",
+    description: "This action cannot be undone.",
+    variant: "warning",
+    open: true,
+  },
+};
+
+/** 只有标题 */
+export const TitleOnly: Story = {
+  args: {
+    title: "File uploaded",
+    open: true,
+  },
+};
+
+/** 带操作按钮 */
+export const WithAction: Story = {
+  args: {
+    title: "File deleted",
+    description: "The file has been moved to trash.",
+    action: {
+      label: "Undo",
+      onClick: () => console.log("Undo clicked"),
+    },
+    open: true,
+  },
+};
+
+// ============================================================================
+// 交互式 Stories
+// ============================================================================
+
+const variants: ToastVariant[] = ["default", "success", "error", "warning"];
+
+/** 所有 Variants 展示 */
+export const AllVariants: Story = {
+  args: {
+    title: "Toast",
+    open: true,
+  },
+  render: () => {
+    const [openStates, setOpenStates] = React.useState<Record<ToastVariant, boolean>>({
+      default: true,
+      success: true,
+      error: true,
+      warning: true,
+    });
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          {variants.map((variant) => (
+            <Button
+              key={variant}
+              size="sm"
+              onClick={() =>
+                setOpenStates((prev) => ({ ...prev, [variant]: true }))
+              }
+            >
+              Show {variant}
+            </Button>
+          ))}
+        </div>
+        {variants.map((variant) => (
+          <Toast
+            key={variant}
+            title={`${variant.charAt(0).toUpperCase() + variant.slice(1)} Toast`}
+            description={`This is a ${variant} toast message.`}
+            variant={variant}
+            open={openStates[variant]}
+            onOpenChange={(open) =>
+              setOpenStates((prev) => ({ ...prev, [variant]: open }))
+            }
+          />
+        ))}
+      </div>
+    );
+  },
+};
+
+/** 使用 Hook 触发 */
+function ToastDemo() {
+  const { toast, showToast, setOpen } = useToast();
+
+  return (
+    <div style={{ display: "flex", gap: "0.5rem" }}>
+      <Button
+        variant="primary"
+        onClick={() =>
+          showToast({
+            title: "Success!",
+            description: "Action completed successfully.",
+            variant: "success",
+          })
+        }
+      >
+        Show Success
+      </Button>
+      <Button
+        variant="danger"
+        onClick={() =>
+          showToast({
+            title: "Error",
+            description: "Something went wrong.",
+            variant: "error",
+          })
+        }
+      >
+        Show Error
+      </Button>
+      <Toast
+        {...toast}
+        onOpenChange={setOpen}
+      />
+    </div>
+  );
+}
+
+export const WithHook: Story = {
+  args: {
+    title: "Toast",
+    open: false,
+  },
+  render: () => <ToastDemo />,
+};
+
+/** 不自动关闭 */
+export const Persistent: Story = {
+  args: {
+    title: "Persistent Toast",
+    description: "This toast won't auto-close. Click the X to dismiss.",
+    duration: 0,
+    open: true,
+  },
+};
+
+/** 快速自动关闭 */
+export const QuickDismiss: Story = {
+  args: {
+    title: "Quick Toast",
+    description: "This will disappear in 2 seconds.",
+    duration: 2000,
+    open: true,
+  },
+};

--- a/apps/desktop/renderer/src/components/primitives/Toast.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toast.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ToastVariant } from "./Toast";
+import { Toast, ToastProvider, ToastViewport } from "./Toast";
+
+// Wrapper component for tests
+function ToastWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ToastProvider>
+      {children}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}
+
+describe("Toast", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("open=true 时应该渲染 toast", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Test Toast" open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Test Toast")).toBeInTheDocument();
+    });
+
+    it("open=false 时不应该渲染 toast", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Test Toast" open={false} />
+        </ToastWrapper>,
+      );
+
+      expect(screen.queryByText("Test Toast")).not.toBeInTheDocument();
+    });
+
+    it("应该渲染 title 和 description", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Toast Title" description="Toast description" open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Toast Title")).toBeInTheDocument();
+      expect(screen.getByText("Toast description")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Variant 测试
+  // ===========================================================================
+  describe("variants", () => {
+    const variants: ToastVariant[] = ["default", "success", "error", "warning"];
+
+    it.each(variants)("应该渲染 %s variant", (variant) => {
+      render(
+        <ToastWrapper>
+          <Toast title="Test" variant={variant} open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Test")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 交互测试
+  // ===========================================================================
+  describe("交互", () => {
+    it("点击关闭按钮应该调用 onOpenChange(false)", async () => {
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ToastWrapper>
+          <Toast title="Test" open onOpenChange={onOpenChange} />
+        </ToastWrapper>,
+      );
+
+      const closeButton = screen.getByRole("button", { name: "Close" });
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("应该渲染 action 按钮", () => {
+      const onClick = vi.fn();
+
+      render(
+        <ToastWrapper>
+          <Toast
+            title="Test"
+            action={{ label: "Undo", onClick }}
+            open
+          />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Undo")).toBeInTheDocument();
+    });
+
+    it("点击 action 按钮应该调用 onClick", async () => {
+      const onClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ToastWrapper>
+          <Toast
+            title="Test"
+            action={{ label: "Undo", onClick }}
+            open
+          />
+        </ToastWrapper>,
+      );
+
+      await user.click(screen.getByText("Undo"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // Props 测试
+  // ===========================================================================
+  describe("props", () => {
+    it("应该接受 duration prop", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Test" duration={3000} open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Test")).toBeInTheDocument();
+    });
+
+    it("duration=0 应该不自动关闭", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Test" duration={0} open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Test")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("只有 title 时应该正常渲染", () => {
+      render(
+        <ToastWrapper>
+          <Toast title="Only Title" open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText("Only Title")).toBeInTheDocument();
+    });
+
+    it("应该处理长文本", () => {
+      const longTitle = "This is a very long toast title that might overflow";
+      const longDescription =
+        "This is an even longer description that contains a lot of text and might need to wrap to multiple lines.";
+
+      render(
+        <ToastWrapper>
+          <Toast title={longTitle} description={longDescription} open />
+        </ToastWrapper>,
+      );
+
+      expect(screen.getByText(longTitle)).toBeInTheDocument();
+      expect(screen.getByText(longDescription)).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Variant × Props 矩阵测试
+  // ===========================================================================
+  describe("Variant × Props 矩阵", () => {
+    const variants: ToastVariant[] = ["default", "success", "error", "warning"];
+    const hasAction = [true, false];
+
+    const combinations = variants.flatMap((variant) =>
+      hasAction.map((withAction) => ({ variant, withAction })),
+    );
+
+    it.each(combinations)(
+      "应该正确渲染 $variant + action=$withAction 组合",
+      ({ variant, withAction }) => {
+        render(
+          <ToastWrapper>
+            <Toast
+              title="Test"
+              variant={variant}
+              action={
+                withAction
+                  ? { label: "Action", onClick: () => {} }
+                  : undefined
+              }
+              open
+            />
+          </ToastWrapper>,
+        );
+
+        expect(screen.getByText("Test")).toBeInTheDocument();
+        if (withAction) {
+          expect(screen.getByText("Action")).toBeInTheDocument();
+        }
+      },
+    );
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Toast.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toast.tsx
@@ -1,0 +1,226 @@
+import React from "react";
+import * as ToastPrimitive from "@radix-ui/react-toast";
+
+/**
+ * Toast variants
+ *
+ * - default: 默认样式
+ * - success: 成功状态
+ * - error: 错误状态
+ * - warning: 警告状态
+ */
+export type ToastVariant = "default" | "success" | "error" | "warning";
+
+export interface ToastProps {
+  /** Toast title */
+  title: string;
+  /** Toast description (optional) */
+  description?: string;
+  /** Visual variant */
+  variant?: ToastVariant;
+  /** Whether the toast is open (controlled) */
+  open?: boolean;
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /** Duration in ms before auto-close (0 to disable) */
+  duration?: number;
+  /** Action button (optional) */
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+/**
+ * Variant-specific styles
+ */
+const variantStyles: Record<ToastVariant, { border: string; icon: string }> = {
+  default: {
+    border: "border-[var(--color-border-default)]",
+    icon: "text-[var(--color-fg-muted)]",
+  },
+  success: {
+    border: "border-[var(--color-success)]",
+    icon: "text-[var(--color-success)]",
+  },
+  error: {
+    border: "border-[var(--color-error)]",
+    icon: "text-[var(--color-error)]",
+  },
+  warning: {
+    border: "border-[var(--color-warning)]",
+    icon: "text-[var(--color-warning)]",
+  },
+};
+
+/**
+ * Toast viewport styles
+ */
+const viewportStyles = [
+  "fixed",
+  "bottom-4",
+  "right-4",
+  "z-[var(--z-toast)]",
+  "flex",
+  "flex-col",
+  "gap-2",
+  "w-[360px]",
+  "max-w-[calc(100vw-32px)]",
+  "outline-none",
+].join(" ");
+
+/**
+ * Toast root styles
+ */
+const toastStyles = [
+  "bg-[var(--color-bg-raised)]",
+  "rounded-[var(--radius-lg)]",
+  "shadow-[var(--shadow-lg)]",
+  "border",
+  "p-4",
+  "flex",
+  "gap-3",
+  "items-start",
+  // Animation
+  "data-[state=open]:animate-in",
+  "data-[state=open]:slide-in-from-right-full",
+  "data-[state=open]:fade-in-0",
+  "data-[state=closed]:animate-out",
+  "data-[state=closed]:slide-out-to-right-full",
+  "data-[state=closed]:fade-out-0",
+  "data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)]",
+  "data-[swipe=cancel]:translate-x-0",
+  "data-[swipe=cancel]:transition-transform",
+  "data-[swipe=end]:animate-out",
+  "data-[swipe=end]:slide-out-to-right-full",
+].join(" ");
+
+/**
+ * Toast Provider - wrap your app with this
+ */
+export const ToastProvider = ToastPrimitive.Provider;
+
+/**
+ * Toast Viewport - place this at the root of your app
+ */
+export function ToastViewport(): JSX.Element {
+  return <ToastPrimitive.Viewport className={viewportStyles} />;
+}
+
+/**
+ * Toast component using Radix UI
+ *
+ * Displays a temporary notification message.
+ *
+ * @example
+ * ```tsx
+ * <ToastProvider>
+ *   <Toast
+ *     title="File saved"
+ *     description="Your changes have been saved."
+ *     variant="success"
+ *     open={open}
+ *     onOpenChange={setOpen}
+ *   />
+ *   <ToastViewport />
+ * </ToastProvider>
+ * ```
+ */
+export function Toast({
+  title,
+  description,
+  variant = "default",
+  open,
+  onOpenChange,
+  duration = 5000,
+  action,
+}: ToastProps): JSX.Element {
+  const variantStyle = variantStyles[variant];
+
+  return (
+    <ToastPrimitive.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      duration={duration}
+      className={`${toastStyles} ${variantStyle.border}`}
+    >
+      <div className="flex-1 min-w-0">
+        <ToastPrimitive.Title className="text-sm font-medium text-[var(--color-fg-default)]">
+          {title}
+        </ToastPrimitive.Title>
+        {description && (
+          <ToastPrimitive.Description className="mt-1 text-xs text-[var(--color-fg-muted)]">
+            {description}
+          </ToastPrimitive.Description>
+        )}
+        {action && (
+          <ToastPrimitive.Action
+            altText={action.label}
+            onClick={action.onClick}
+            className="mt-2 text-xs font-medium text-[var(--color-accent)] hover:underline cursor-pointer"
+          >
+            {action.label}
+          </ToastPrimitive.Action>
+        )}
+      </div>
+      <ToastPrimitive.Close
+        className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-default)] transition-colors cursor-pointer"
+        aria-label="Close"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </ToastPrimitive.Close>
+    </ToastPrimitive.Root>
+  );
+}
+
+/**
+ * Hook to create toasts imperatively
+ *
+ * Note: This is a simplified implementation.
+ * For production, consider using a context-based approach.
+ */
+export interface ToastState {
+  open: boolean;
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  action?: ToastProps["action"];
+}
+
+export function useToast() {
+  const [toast, setToast] = React.useState<ToastState>({
+    open: false,
+    title: "",
+  });
+
+  const showToast = React.useCallback(
+    (props: Omit<ToastState, "open">) => {
+      setToast({ ...props, open: true });
+    },
+    [],
+  );
+
+  const hideToast = React.useCallback(() => {
+    setToast((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return {
+    toast,
+    showToast,
+    hideToast,
+    setOpen: (open: boolean) => setToast((prev) => ({ ...prev, open })),
+  };
+}

--- a/apps/desktop/renderer/src/components/primitives/Tooltip.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Tooltip.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tooltip } from "./Tooltip";
+import { Button } from "./Button";
+
+/**
+ * Tooltip 组件 Story
+ *
+ * 用于在悬停时显示额外信息。
+ * 基于 Radix UI Tooltip。
+ */
+const meta = {
+  title: "Primitives/Tooltip",
+  component: Tooltip,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    side: {
+      control: "select",
+      options: ["top", "right", "bottom", "left"],
+      description: "Side where tooltip appears",
+    },
+    align: {
+      control: "select",
+      options: ["start", "center", "end"],
+      description: "Alignment of tooltip",
+    },
+    delayDuration: {
+      control: "number",
+      description: "Delay in ms before showing tooltip",
+    },
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    content: "This is a tooltip",
+    children: <Button>Hover me</Button>,
+  },
+};
+
+/** 长文本内容 */
+export const LongContent: Story = {
+  args: {
+    content: "This is a longer tooltip that contains more information about the element you're hovering over.",
+    children: <Button>Hover for details</Button>,
+  },
+};
+
+// ============================================================================
+// Side Stories
+// ============================================================================
+
+/** Top side */
+export const Top: Story = {
+  args: {
+    content: "Top tooltip",
+    side: "top",
+    children: <Button>Top</Button>,
+  },
+};
+
+/** Right side */
+export const Right: Story = {
+  args: {
+    content: "Right tooltip",
+    side: "right",
+    children: <Button>Right</Button>,
+  },
+};
+
+/** Bottom side */
+export const Bottom: Story = {
+  args: {
+    content: "Bottom tooltip",
+    side: "bottom",
+    children: <Button>Bottom</Button>,
+  },
+};
+
+/** Left side */
+export const Left: Story = {
+  args: {
+    content: "Left tooltip",
+    side: "left",
+    children: <Button>Left</Button>,
+  },
+};
+
+// ============================================================================
+// 组合展示
+// ============================================================================
+
+/** 所有方向展示 */
+export const AllSides: Story = {
+  args: {
+    content: "Tooltip",
+    children: <Button>Hover</Button>,
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "2rem", padding: "4rem" }}>
+      <Tooltip content="Top tooltip" side="top">
+        <Button>Top</Button>
+      </Tooltip>
+      <Tooltip content="Right tooltip" side="right">
+        <Button>Right</Button>
+      </Tooltip>
+      <Tooltip content="Bottom tooltip" side="bottom">
+        <Button>Bottom</Button>
+      </Tooltip>
+      <Tooltip content="Left tooltip" side="left">
+        <Button>Left</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+/** 不同触发元素 */
+export const DifferentTriggers: Story = {
+  args: {
+    content: "Tooltip",
+    children: <Button>Hover</Button>,
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1.5rem", alignItems: "center" }}>
+      <Tooltip content="Button tooltip">
+        <Button variant="primary">Button</Button>
+      </Tooltip>
+      <Tooltip content="Text tooltip">
+        <span style={{ cursor: "help", textDecoration: "underline dotted", color: "var(--color-fg-default)" }}>
+          Hover text
+        </span>
+      </Tooltip>
+      <Tooltip content="Icon tooltip">
+        <button
+          type="button"
+          style={{
+            width: "32px",
+            height: "32px",
+            borderRadius: "var(--radius-full)",
+            border: "1px solid var(--color-border-default)",
+            background: "transparent",
+            color: "var(--color-fg-muted)",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          ?
+        </button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+/** 即时显示 */
+export const InstantDelay: Story = {
+  args: {
+    content: "Instant tooltip",
+    delayDuration: 0,
+    children: <Button>No delay</Button>,
+  },
+};
+
+/** 长延迟 */
+export const LongDelay: Story = {
+  args: {
+    content: "Delayed tooltip",
+    delayDuration: 1000,
+    children: <Button>1s delay</Button>,
+  },
+};
+
+/** 对齐方式 */
+export const Alignments: Story = {
+  args: {
+    content: "Tooltip",
+    children: <Button>Hover</Button>,
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "2rem", padding: "4rem" }}>
+      <Tooltip content="Start aligned" side="bottom" align="start">
+        <Button style={{ width: "120px" }}>Start</Button>
+      </Tooltip>
+      <Tooltip content="Center aligned" side="bottom" align="center">
+        <Button style={{ width: "120px" }}>Center</Button>
+      </Tooltip>
+      <Tooltip content="End aligned" side="bottom" align="end">
+        <Button style={{ width: "120px" }}>End</Button>
+      </Tooltip>
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/Tooltip.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Tooltip.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Tooltip } from "./Tooltip";
+
+describe("Tooltip", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染触发元素", () => {
+      render(
+        <Tooltip content="Tooltip content">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button", { name: "Trigger" })).toBeInTheDocument();
+    });
+
+    it("默认不应该显示 tooltip 内容", () => {
+      render(
+        <Tooltip content="Tooltip content">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.queryByText("Tooltip content")).not.toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Props 测试
+  // ===========================================================================
+  describe("props", () => {
+    it("应该接受 delayDuration prop", () => {
+      render(
+        <Tooltip content="Tooltip content" delayDuration={100}>
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("应该接受 side prop", () => {
+      render(
+        <Tooltip content="Tooltip content" side="bottom">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("应该接受 align prop", () => {
+      render(
+        <Tooltip content="Tooltip content" align="start">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("应该接受 onOpenChange prop", () => {
+      const onOpenChange = vi.fn();
+
+      render(
+        <Tooltip content="Tooltip content" onOpenChange={onOpenChange}>
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 边界情况测试
+  // ===========================================================================
+  describe("边界情况", () => {
+    it("应该支持字符串 content", () => {
+      render(
+        <Tooltip content="Simple text">
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("应该支持 React 节点作为 children", () => {
+      render(
+        <Tooltip content="Tooltip">
+          <span>
+            <button>Nested Button</button>
+          </span>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole("button", { name: "Nested Button" })).toBeInTheDocument();
+    });
+  });
+
+  // Note: Tooltip hover/open tests are skipped because Radix Tooltip
+  // requires a real browser environment for proper Portal rendering.
+  // These behaviors are tested in Storybook via browser MCP.
+});

--- a/apps/desktop/renderer/src/components/primitives/Tooltip.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Tooltip.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+export interface TooltipProps {
+  /** The element that triggers the tooltip */
+  children: React.ReactNode;
+  /** The content to display in the tooltip */
+  content: React.ReactNode;
+  /** Side where tooltip appears */
+  side?: "top" | "right" | "bottom" | "left";
+  /** Alignment of tooltip */
+  align?: "start" | "center" | "end";
+  /** Delay in ms before showing tooltip */
+  delayDuration?: number;
+  /** Whether the tooltip is open (controlled) */
+  open?: boolean;
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /** Skip delay when moving between tooltips */
+  skipDelayDuration?: number;
+}
+
+/**
+ * Tooltip content styles
+ */
+const contentStyles = [
+  "z-[var(--z-tooltip)]",
+  "px-3",
+  "py-2",
+  "text-xs",
+  "font-normal",
+  "leading-tight",
+  "max-w-[200px]",
+  "rounded-[var(--radius-md)]",
+  "bg-[var(--color-fg-default)]",
+  "text-[var(--color-fg-inverse)]",
+  "shadow-[var(--shadow-md)]",
+  // Animation
+  "animate-in",
+  "fade-in-0",
+  "zoom-in-95",
+  "data-[state=closed]:animate-out",
+  "data-[state=closed]:fade-out-0",
+  "data-[state=closed]:zoom-out-95",
+  "data-[side=bottom]:slide-in-from-top-2",
+  "data-[side=left]:slide-in-from-right-2",
+  "data-[side=right]:slide-in-from-left-2",
+  "data-[side=top]:slide-in-from-bottom-2",
+].join(" ");
+
+/**
+ * Arrow styles
+ */
+const arrowStyles = "fill-[var(--color-fg-default)]";
+
+/**
+ * Tooltip Provider - wrap your app with this
+ */
+export const TooltipProvider = TooltipPrimitive.Provider;
+
+/**
+ * Tooltip component using Radix UI
+ *
+ * Displays additional information when hovering over an element.
+ *
+ * @example
+ * ```tsx
+ * <TooltipProvider>
+ *   <Tooltip content="This is a tooltip">
+ *     <button>Hover me</button>
+ *   </Tooltip>
+ * </TooltipProvider>
+ * ```
+ */
+export function Tooltip({
+  children,
+  content,
+  side = "top",
+  align = "center",
+  delayDuration = 400,
+  open,
+  onOpenChange,
+  skipDelayDuration = 300,
+}: TooltipProps): JSX.Element {
+  return (
+    <TooltipPrimitive.Provider
+      delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+    >
+      <TooltipPrimitive.Root open={open} onOpenChange={onOpenChange}>
+        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side={side}
+            align={align}
+            sideOffset={5}
+            className={contentStyles}
+          >
+            {content}
+            <TooltipPrimitive.Arrow className={arrowStyles} />
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/index.ts
+++ b/apps/desktop/renderer/src/components/primitives/index.ts
@@ -60,3 +60,28 @@ export type { CheckboxProps } from "./Checkbox";
 
 export { Tabs, TabsRoot, TabsList, TabsTrigger, TabsContent } from "./Tabs";
 export type { TabsProps, TabItem } from "./Tabs";
+
+// Feedback & Status
+export { Badge } from "./Badge";
+export type { BadgeProps, BadgeVariant, BadgeSize } from "./Badge";
+
+export { Avatar } from "./Avatar";
+export type { AvatarProps, AvatarSize } from "./Avatar";
+
+export { Spinner } from "./Spinner";
+export type { SpinnerProps, SpinnerSize } from "./Spinner";
+
+export { Skeleton } from "./Skeleton";
+export type { SkeletonProps, SkeletonVariant } from "./Skeleton";
+
+export { Tooltip, TooltipProvider } from "./Tooltip";
+export type { TooltipProps } from "./Tooltip";
+
+export { Toast, ToastProvider, ToastViewport, useToast } from "./Toast";
+export type { ToastProps, ToastVariant, ToastState } from "./Toast";
+
+export { Accordion } from "./Accordion";
+export type { AccordionProps, AccordionItem } from "./Accordion";
+
+export { RadioGroup, Radio, RadioGroupRoot } from "./Radio";
+export type { RadioGroupProps, RadioOption, RadioProps } from "./Radio";

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -141,3 +141,45 @@ textarea:focus-visible {
     transform: translateX(-100%);
   }
 }
+
+/* Skeleton shimmer 动画 */
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* 自定义动画类 */
+@utility animate-shimmer {
+  animation: shimmer 1.5s infinite;
+}
+
+/* Accordion 展开/折叠动画 */
+@keyframes accordion-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-accordion-content-height);
+  }
+}
+
+@keyframes accordion-up {
+  from {
+    height: var(--radix-accordion-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+
+@utility animate-accordion-down {
+  animation: accordion-down 200ms ease-out;
+}
+
+@utility animate-accordion-up {
+  animation: accordion-up 200ms ease-out;
+}

--- a/openspec/_ops/task_runs/ISSUE-97.md
+++ b/openspec/_ops/task_runs/ISSUE-97.md
@@ -1,0 +1,37 @@
+# ISSUE-97
+- Issue: #97
+- Branch: task/97-p2-atomic-components
+- PR: https://github.com/Leeky1017/CreoNow/pull/98
+
+## Plan
+- 创建 8 个新增原子组件：Badge/Avatar/Spinner/Skeleton/Tooltip/Toast/Accordion/Radio
+- 每个组件包含：组件实现 + Story + 测试
+- 更新 index.ts 导出，通过 Storybook 浏览器验证
+
+## Runs
+### 2026-02-02 00:18 创建 worktree
+- Command: `scripts/agent_worktree_setup.sh 97 p2-atomic-components`
+- Key output: Worktree created: .worktrees/issue-97-p2-atomic-components
+- Evidence: Branch task/97-p2-atomic-components created
+
+### 2026-02-02 00:20 创建组件和测试
+- 创建文件：
+  - Badge.tsx, Badge.stories.tsx, Badge.test.tsx
+  - Avatar.tsx, Avatar.stories.tsx, Avatar.test.tsx
+  - Spinner.tsx, Spinner.stories.tsx, Spinner.test.tsx
+  - Skeleton.tsx, Skeleton.stories.tsx, Skeleton.test.tsx
+  - Tooltip.tsx, Tooltip.stories.tsx, Tooltip.test.tsx
+  - Toast.tsx, Toast.stories.tsx, Toast.test.tsx
+  - Accordion.tsx, Accordion.stories.tsx, Accordion.test.tsx
+  - Radio.tsx, Radio.stories.tsx, Radio.test.tsx
+- 更新 main.css 添加 shimmer 和 accordion 动画
+- 更新 index.ts 导出所有新组件
+- 安装 Radix UI 依赖：@radix-ui/react-tooltip, @radix-ui/react-toast, @radix-ui/react-accordion, @radix-ui/react-radio-group
+
+### 2026-02-02 00:26 测试和验证
+- Command: `pnpm test:run`
+- Key output: `Test Files 20 passed (20), Tests 593 passed (593)`
+- Command: `pnpm typecheck`
+- Key output: 通过
+- Command: `pnpm storybook:build`
+- Key output: 构建成功，输出目录 storybook-static

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-checkbox':
         specifier: ^1.1.4
         version: 1.3.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
@@ -50,12 +53,21 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.15
+        version: 1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@tiptap/react':
         specifier: ^2.26.0
         version: 2.27.2(@tiptap/core@2.27.2)(@tiptap/pm@2.27.2)(react-dom@18.3.1)(react@18.3.1)
@@ -1323,6 +1335,34 @@ packages:
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
     dev: false
 
+  /@radix-ui/react-accordion@1.2.12(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -1364,6 +1404,33 @@ packages:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.27)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-collapsible@1.1.12(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
       react: 18.3.1
@@ -1663,6 +1730,35 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-radio-group@1.3.8(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1766,6 +1862,68 @@ packages:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-toast@1.2.15(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7)(@types/react@18.3.27)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
       react: 18.3.1


### PR DESCRIPTION
Closes #97

## Summary
- 新增 8 个 Phase 2 原子组件：Badge、Avatar、Spinner、Skeleton、Tooltip、Toast、Accordion、Radio
- 每个组件包含完整的 Story 和测试覆盖
- 安装必要的 Radix UI 依赖包
- 更新 CSS 动画（shimmer 和 accordion）

## 组件详情
| 组件 | 描述 | Radix UI |
|------|------|----------|
| Badge | 状态标签，5 种 variant | 否 |
| Avatar | 用户头像，支持图片/fallback | 否 |
| Spinner | 加载旋转器，5 种 size | 否 |
| Skeleton | 骨架屏，3 种 variant | 否 |
| Tooltip | 悬浮提示 | 是 |
| Toast | 通知消息，4 种 variant | 是 |
| Accordion | 折叠面板，single/multiple | 是 |
| Radio | 单选框组 | 是 |

## Test plan
- [x] `pnpm test:run` - 593 tests passed
- [x] `pnpm typecheck` - 通过
- [x] `pnpm storybook:build` - 构建成功