### PR TITLE
fix(ai): SKILL uppercase + rename static demo stories (#106)

### DIFF
--- a/apps/desktop/renderer/src/features/ai/AiPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.stories.tsx
@@ -39,14 +39,16 @@ export const Default: Story = {
 };
 
 /**
- * 带对话内容
+ * 对话内容（静态展示）
  *
- * 展示用户输入和 AI 回复的完整交互
+ * 静态 UI 演示，展示用户输入和 AI 回复的样式
  * - 用户输入（有框）
  * - AI 回复（无框，纯文本流）
  * - 代码块带 Copy/Apply 按钮
+ *
+ * 注意：这是静态展示，不可交互。完整交互请使用 Default story。
  */
-export const WithConversation: Story = {
+export const ConversationStatic: Story = {
   render: () => <ConversationDemo />,
 };
 
@@ -164,11 +166,13 @@ function ConversationDemo(): JSX.Element {
 }
 
 /**
- * 流式输出状态
+ * 流式输出状态（静态展示）
  *
- * 展示 AI 正在生成回复时的状态（带光标动画）
+ * 静态 UI 演示，展示 AI 正在生成回复时的状态（带光标动画）
+ *
+ * 注意：这是静态展示，不可交互。完整交互请使用 Default story。
  */
-export const Streaming: Story = {
+export const StreamingStatic: Story = {
   render: () => <StreamingDemo />,
 };
 
@@ -237,7 +241,7 @@ function StreamingDemo(): JSX.Element {
               <div className="flex items-center gap-1.5">
                 <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">Ask</span>
                 <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">GPT-5.2</span>
-                <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">Skill</span>
+                <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">SKILL</span>
               </div>
               {/* Stop button */}
               <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]">
@@ -293,11 +297,13 @@ export const MediumHeight: Story = {
 };
 
 /**
- * 历史记录下拉
+ * 历史记录下拉（静态展示）
  *
- * 展示历史记录下拉菜单的样式
+ * 静态 UI 演示，展示历史记录下拉菜单的样式
+ *
+ * 注意：这是静态展示，不可交互。完整交互请使用 Default story。
  */
-export const WithHistoryDropdown: Story = {
+export const HistoryDropdownStatic: Story = {
   render: () => <HistoryDropdownDemo />,
 };
 
@@ -404,7 +410,7 @@ function HistoryDropdownDemo(): JSX.Element {
               <div className="flex items-center gap-1.5">
                 <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">Ask</span>
                 <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">GPT-5.2</span>
-                <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">Skill</span>
+                <span className="px-1.5 py-0.5 text-[11px] text-[var(--color-fg-muted)]">SKILL</span>
               </div>
               <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)]">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -644,7 +644,7 @@ export function AiPanel(): JSX.Element {
                           setModelOpen(false);
                         }}
                       >
-                        {skillsStatus === "loading" ? "Loading" : "Skill"}
+                        {skillsStatus === "loading" ? "Loading" : "SKILL"}
                         <svg
                           className="inline-block ml-0.5 w-3 h-3"
                           viewBox="0 0 24 24"

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
@@ -26,7 +26,7 @@ export function SkillPicker(props: {
       {/* Popup - positioned above the button */}
       <div
         role="dialog"
-        aria-label="Skill"
+        aria-label="SKILL"
         onClick={(e) => e.stopPropagation()}
         className="absolute bottom-full left-0 mb-1 w-56 p-2.5 z-30 bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[0_18px_48px_rgba(0,0,0,0.45)]"
       >

--- a/openspec/_ops/task_runs/ISSUE-106.md
+++ b/openspec/_ops/task_runs/ISSUE-106.md
@@ -1,0 +1,22 @@
+# ISSUE-106
+- Issue: #106
+- Branch: task/106-skill-uppercase-storybook
+- PR: <fill-after-created>
+
+## Plan
+- SKILL 统一改为全大写
+- 静态 Demo Story 重命名并添加注释说明
+
+## Runs
+### 2026-02-02 18:15 SKILL 大写 + Storybook 改进
+- Command: `pnpm typecheck`
+- Key output: 编译通过
+- Changes:
+  - `AiPanel.tsx`: "Skill" → "SKILL"
+  - `SkillPicker.tsx`: aria-label "Skill" → "SKILL"
+  - `AiPanel.stories.tsx`: 
+    - "Skill" → "SKILL" (2 处)
+    - `WithConversation` → `ConversationStatic`
+    - `Streaming` → `StreamingStatic`
+    - `WithHistoryDropdown` → `HistoryDropdownStatic`
+    - 添加注释说明静态展示

--- a/openspec/_ops/task_runs/ISSUE-106.md
+++ b/openspec/_ops/task_runs/ISSUE-106.md
@@ -1,7 +1,7 @@
 # ISSUE-106
 - Issue: #106
 - Branch: task/106-skill-uppercase-storybook
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/107
 
 ## Plan
 - SKILL 统一改为全大写


### PR DESCRIPTION
Closes #106

## Summary
- SKILL 统一改为全大写
- 静态 Demo Story 重命名为 `*Static` 后缀
- 添加注释说明静态展示与可交互组件的区别

## Test Plan
- [x] `pnpm typecheck` 通过
- [ ] CI checks 通过