### PR TITLE
feat(commandPalette): 完整实现设计稿规格 (#113)

### DIFF
--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.stories.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.stories.tsx
@@ -1,14 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
-import { CommandPalette } from "./CommandPalette";
+import React from "react";
+
+import { CommandPalette, type CommandItem } from "./CommandPalette";
 
 /**
  * CommandPalette 组件 Story
  *
+ * 设计稿参考：design/Variant/designs/17-command-palette.html
+ *
  * 功能：
- * - 命令面板弹窗（Cmd/Ctrl+P 触发）
- * - 命令列表
- * - 导出 Markdown 等操作
+ * - 三段式布局：Header（搜索框）+ Body（分组列表）+ Footer（键盘提示）
+ * - 搜索过滤：实时过滤命令/文件
+ * - 键盘导航：↑↓ 移动，Enter 确认，Esc 关闭
+ * - 搜索高亮：匹配文字高亮显示
  */
 const meta: Meta<typeof CommandPalette> = {
   title: "Features/CommandPalette",
@@ -31,17 +36,329 @@ const meta: Meta<typeof CommandPalette> = {
 export default meta;
 type Story = StoryObj<typeof CommandPalette>;
 
+// =============================================================================
+// Icons for stories
+// =============================================================================
+
+function FileIcon({
+  className,
+  color,
+}: {
+  className?: string;
+  color?: string;
+}): JSX.Element {
+  return (
+    <svg
+      className={className}
+      style={{ color }}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+    </svg>
+  );
+}
+
+function EditIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34" />
+      <polygon points="18 2 22 6 12 16 8 16 8 12 18 2" />
+    </svg>
+  );
+}
+
+function SidebarIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <line x1="9" y1="3" x2="9" y2="21" />
+    </svg>
+  );
+}
+
+function MoonIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function SettingsIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+function TerminalIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>
+  );
+}
+
+function DownloadIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+// =============================================================================
+// Mock commands for stories
+// =============================================================================
+
+const recentFiles: CommandItem[] = [
+  {
+    id: "file-app",
+    label: "App.tsx",
+    icon: <FileIcon color="#3b82f6" />,
+    subtext: "src/components",
+    group: "Recent Files",
+    onSelect: fn(),
+  },
+  {
+    id: "file-package",
+    label: "package.json",
+    icon: <FileIcon color="#eab308" />,
+    group: "Recent Files",
+    onSelect: fn(),
+  },
+  {
+    id: "file-logo",
+    label: "logo-brand.svg",
+    icon: <FileIcon color="#c084fc" />,
+    group: "Recent Files",
+    onSelect: fn(),
+  },
+];
+
+const suggestions: CommandItem[] = [
+  {
+    id: "create-new-file",
+    label: "Create New File",
+    icon: <EditIcon className="text-[var(--color-fg-muted)]" />,
+    shortcut: "⌘N",
+    group: "Suggestions",
+    onSelect: fn(),
+  },
+  {
+    id: "toggle-sidebar",
+    label: "Toggle Sidebar",
+    icon: <SidebarIcon className="text-[var(--color-fg-muted)]" />,
+    shortcut: "⌘B",
+    group: "Suggestions",
+    onSelect: fn(),
+  },
+  {
+    id: "switch-dark-mode",
+    label: "Switch to Dark Mode",
+    icon: <MoonIcon className="text-[var(--color-fg-muted)]" />,
+    shortcut: "⇧D",
+    group: "Suggestions",
+    onSelect: fn(),
+  },
+];
+
+const searchCommands: CommandItem[] = [
+  {
+    id: "open-settings",
+    label: "Open Settings",
+    icon: <SettingsIcon className="text-[var(--color-fg-muted)]" />,
+    shortcut: "⌘,",
+    group: "Settings & Commands",
+    onSelect: fn(),
+  },
+  {
+    id: "reset-layout",
+    label: "Reset Window Layout",
+    icon: <TerminalIcon className="text-[var(--color-fg-muted)]" />,
+    group: "Settings & Commands",
+    onSelect: fn(),
+  },
+  {
+    id: "download-assets",
+    label: "Download Assets",
+    icon: <DownloadIcon className="text-[var(--color-fg-muted)]" />,
+    group: "Settings & Commands",
+    onSelect: fn(),
+  },
+  {
+    id: "file-use-settings",
+    label: "useSettings.ts",
+    icon: <FileIcon color="#3b82f6" />,
+    subtext: "src/hooks",
+    group: "Files",
+    onSelect: fn(),
+  },
+  {
+    id: "file-settings-modal",
+    label: "SettingsModal.tsx",
+    icon: <FileIcon color="#3b82f6" />,
+    subtext: "src/components",
+    group: "Files",
+    onSelect: fn(),
+  },
+  {
+    id: "file-reset-css",
+    label: "reset.css",
+    icon: <FileIcon color="#4ade80" />,
+    subtext: "public/styles",
+    group: "Files",
+    onSelect: fn(),
+  },
+];
+
+const defaultCommands = [...recentFiles, ...suggestions];
+
+// =============================================================================
+// Stories
+// =============================================================================
+
 /**
- * 打开状态
+ * 默认状态
  *
- * 命令面板打开
+ * 显示 Recent Files 和 Suggestions 分组
  */
-export const Open: Story = {
+export const Default: Story = {
   args: {
     open: true,
+    commands: defaultCommands,
   },
   render: (args) => (
-    <div style={{ width: "600px", height: "300px", position: "relative" }}>
+    <div
+      style={{
+        width: "800px",
+        height: "500px",
+        position: "relative",
+        backgroundColor: "var(--color-bg-base)",
+      }}
+    >
+      <CommandPalette {...args} />
+    </div>
+  ),
+};
+
+/**
+ * 搜索状态
+ *
+ * 搜索 "set" 时的过滤结果，显示匹配高亮
+ */
+export const Searching: Story = {
+  args: {
+    open: true,
+    commands: searchCommands,
+  },
+  render: function SearchingStory(args) {
+    const [open, setOpen] = React.useState(true);
+
+    return (
+      <div
+        style={{
+          width: "800px",
+          height: "500px",
+          position: "relative",
+          backgroundColor: "var(--color-bg-base)",
+        }}
+      >
+        <CommandPalette {...args} open={open} onOpenChange={setOpen} />
+        <div
+          style={{
+            position: "absolute",
+            bottom: "20px",
+            left: "20px",
+            color: "var(--color-fg-muted)",
+            fontSize: "12px",
+          }}
+        >
+          Try typing &quot;set&quot; in the search box to see filtering
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * 空结果状态
+ *
+ * 搜索无匹配时的空状态
+ */
+export const EmptyResults: Story = {
+  args: {
+    open: true,
+    commands: [], // 空命令列表模拟无结果
+  },
+  render: (args) => (
+    <div
+      style={{
+        width: "800px",
+        height: "500px",
+        position: "relative",
+        backgroundColor: "var(--color-bg-base)",
+      }}
+    >
       <CommandPalette {...args} />
     </div>
   ),
@@ -55,36 +372,148 @@ export const Open: Story = {
 export const Closed: Story = {
   args: {
     open: false,
+    commands: defaultCommands,
   },
   render: (args) => (
-    <div style={{ width: "600px", height: "300px", position: "relative" }}>
+    <div
+      style={{
+        width: "800px",
+        height: "300px",
+        position: "relative",
+        backgroundColor: "var(--color-bg-base)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
       <CommandPalette {...args} />
-      <div style={{ padding: "20px", color: "var(--color-fg-muted)", textAlign: "center" }}>
+      <div style={{ color: "var(--color-fg-muted)", textAlign: "center" }}>
         Command palette is closed (nothing rendered)
+        <br />
+        <span style={{ fontSize: "12px", color: "var(--color-fg-placeholder)" }}>
+          Press Cmd/Ctrl+P to open
+        </span>
       </div>
     </div>
   ),
 };
 
 /**
- * 暗色背景
+ * 交互演示
  *
- * 在暗色背景下的显示效果
+ * 可交互的完整演示（点击按钮打开）
  */
-export const DarkBackground: Story = {
+export const Interactive: Story = {
+  args: {
+    commands: defaultCommands,
+  },
+  render: function InteractiveStory(args) {
+    const [open, setOpen] = React.useState(false);
+
+    React.useEffect(() => {
+      function handleKeyDown(e: KeyboardEvent): void {
+        if ((e.metaKey || e.ctrlKey) && e.key === "p") {
+          e.preventDefault();
+          setOpen(true);
+        }
+      }
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, []);
+
+    return (
+      <div
+        style={{
+          width: "800px",
+          height: "500px",
+          position: "relative",
+          backgroundColor: "var(--color-bg-base)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "16px",
+        }}
+      >
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "var(--color-bg-raised)",
+            border: "1px solid var(--color-border-default)",
+            borderRadius: "var(--radius-sm)",
+            color: "var(--color-fg-default)",
+            cursor: "pointer",
+            fontSize: "13px",
+          }}
+        >
+          Open Command Palette
+        </button>
+        <div style={{ color: "var(--color-fg-placeholder)", fontSize: "12px" }}>
+          or press Cmd/Ctrl+P
+        </div>
+        <CommandPalette {...args} open={open} onOpenChange={setOpen} />
+      </div>
+    );
+  },
+};
+
+/**
+ * 多分组
+ *
+ * 显示多个分组的场景
+ */
+export const MultipleGroups: Story = {
   args: {
     open: true,
+    commands: [
+      ...recentFiles,
+      ...suggestions,
+      {
+        id: "cmd-undo",
+        label: "Undo",
+        shortcut: "⌘Z",
+        group: "Edit",
+        onSelect: fn(),
+      },
+      {
+        id: "cmd-redo",
+        label: "Redo",
+        shortcut: "⌘⇧Z",
+        group: "Edit",
+        onSelect: fn(),
+      },
+      {
+        id: "cmd-cut",
+        label: "Cut",
+        shortcut: "⌘X",
+        group: "Edit",
+        onSelect: fn(),
+      },
+      {
+        id: "cmd-copy",
+        label: "Copy",
+        shortcut: "⌘C",
+        group: "Edit",
+        onSelect: fn(),
+      },
+      {
+        id: "cmd-paste",
+        label: "Paste",
+        shortcut: "⌘V",
+        group: "Edit",
+        onSelect: fn(),
+      },
+    ],
   },
   render: (args) => (
     <div
       style={{
         width: "800px",
-        height: "400px",
+        height: "600px",
         position: "relative",
         backgroundColor: "var(--color-bg-base)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
       }}
     >
       <CommandPalette {...args} />

--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.test.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { CommandPalette } from "./CommandPalette";
-import type { ProjectStore } from "../../stores/projectStore";
+import userEvent from "@testing-library/user-event";
+
+import { CommandPalette, type CommandItem } from "./CommandPalette";
 
 // Mock stores
 vi.mock("../../stores/projectStore", () => ({
@@ -26,6 +27,53 @@ vi.mock("../../lib/ipcClient", () => ({
   invoke: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+function createMockCommands(): CommandItem[] {
+  return [
+    {
+      id: "open-settings",
+      label: "Open Settings",
+      shortcut: "⌘,",
+      group: "Commands",
+      onSelect: vi.fn(),
+    },
+    {
+      id: "toggle-sidebar",
+      label: "Toggle Sidebar",
+      shortcut: "⌘B",
+      group: "Commands",
+      onSelect: vi.fn(),
+    },
+    {
+      id: "create-file",
+      label: "Create New File",
+      shortcut: "⌘N",
+      group: "Commands",
+      onSelect: vi.fn(),
+    },
+    {
+      id: "file-app",
+      label: "App.tsx",
+      subtext: "src/components",
+      group: "Recent Files",
+      onSelect: vi.fn(),
+    },
+    {
+      id: "file-package",
+      label: "package.json",
+      group: "Recent Files",
+      onSelect: vi.fn(),
+    },
+  ];
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
 describe("CommandPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,34 +84,85 @@ describe("CommandPalette", () => {
   // ===========================================================================
   describe("渲染", () => {
     it("open 为 true 时应该渲染", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
       expect(screen.getByTestId("command-palette")).toBeInTheDocument();
     });
 
     it("open 为 false 时不应该渲染", () => {
-      render(<CommandPalette open={false} onOpenChange={vi.fn()} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette
+          open={false}
+          onOpenChange={vi.fn()}
+          commands={commands}
+        />,
+      );
 
       expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
     });
 
-    it("应该显示 Command Palette 标题", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+    it("应该显示搜索输入框", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
-      expect(screen.getByText("Command Palette")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("搜索命令或文件...")).toBeInTheDocument();
     });
 
-    it("应该显示快捷键提示", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+    it("应该显示键盘提示", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
-      expect(screen.getByText("Ctrl/Cmd+P")).toBeInTheDocument();
+      expect(screen.getByText("导航")).toBeInTheDocument();
+      expect(screen.getByText("选择")).toBeInTheDocument();
+      expect(screen.getByText("关闭")).toBeInTheDocument();
     });
 
-    it("应该显示 Export Markdown 命令", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+    it("应该显示分组标题", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
-      expect(screen.getByTestId("command-item-export-markdown")).toBeInTheDocument();
-      expect(screen.getByText("Export Markdown")).toBeInTheDocument();
+      expect(screen.getByText("Commands")).toBeInTheDocument();
+      expect(screen.getByText("Recent Files")).toBeInTheDocument();
+    });
+
+    it("应该显示命令项", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      expect(screen.getByText("Open Settings")).toBeInTheDocument();
+      expect(screen.getByText("Toggle Sidebar")).toBeInTheDocument();
+      expect(screen.getByText("App.tsx")).toBeInTheDocument();
+    });
+
+    it("应该显示快捷键", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      expect(screen.getByText("⌘,")).toBeInTheDocument();
+      expect(screen.getByText("⌘B")).toBeInTheDocument();
+    });
+
+    it("应该显示子文本（文件路径）", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      expect(screen.getByText("src/components")).toBeInTheDocument();
     });
   });
 
@@ -72,16 +171,219 @@ describe("CommandPalette", () => {
   // ===========================================================================
   describe("无障碍", () => {
     it("应该有 dialog role", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
     it("应该有 aria-modal", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
       const dialog = screen.getByRole("dialog");
       expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("应该有 listbox role", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("命令项应该有 option role", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const options = screen.getAllByRole("option");
+      expect(options.length).toBe(commands.length);
+    });
+  });
+
+  // ===========================================================================
+  // 搜索过滤测试
+  // ===========================================================================
+  describe("搜索过滤", () => {
+    it("输入搜索词应该过滤命令", async () => {
+      const user = userEvent.setup();
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const input = screen.getByPlaceholderText("搜索命令或文件...");
+      await user.type(input, "setting");
+
+      // 应该只显示包含 "setting" 的命令（使用 testid 因为高亮会分割文本）
+      expect(screen.getByTestId("command-item-open-settings")).toBeInTheDocument();
+      expect(screen.queryByTestId("command-item-toggle-sidebar")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("command-item-file-app")).not.toBeInTheDocument();
+    });
+
+    it("搜索应该不区分大小写", async () => {
+      const user = userEvent.setup();
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const input = screen.getByPlaceholderText("搜索命令或文件...");
+      await user.type(input, "SETTING");
+
+      // 使用 testid 因为高亮会分割文本
+      expect(screen.getByTestId("command-item-open-settings")).toBeInTheDocument();
+    });
+
+    it("搜索子文本（文件路径）", async () => {
+      const user = userEvent.setup();
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const input = screen.getByPlaceholderText("搜索命令或文件...");
+      await user.type(input, "src/components");
+
+      expect(screen.getByTestId("command-item-file-app")).toBeInTheDocument();
+      expect(screen.queryByTestId("command-item-file-package")).not.toBeInTheDocument();
+    });
+
+    it("无匹配时显示空状态", async () => {
+      const user = userEvent.setup();
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const input = screen.getByPlaceholderText("搜索命令或文件...");
+      await user.type(input, "xyznonexistent");
+
+      expect(screen.getByText("未找到匹配的命令")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 键盘导航测试
+  // ===========================================================================
+  describe("键盘导航", () => {
+    it("按 ↓ 应该移动到下一项", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      // 第一项应该是 active
+      const firstItem = screen.getByTestId("command-item-open-settings");
+      expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+      // 在 overlay 上触发 ↓
+      const overlay = document.querySelector(".cn-overlay")!;
+      fireEvent.keyDown(overlay, { key: "ArrowDown" });
+
+      // 第二项应该是 active
+      const secondItem = screen.getByTestId("command-item-toggle-sidebar");
+      expect(secondItem).toHaveAttribute("aria-selected", "true");
+      expect(firstItem).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("按 ↑ 应该移动到上一项", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const overlay = document.querySelector(".cn-overlay")!;
+
+      // 先移动到第二项
+      fireEvent.keyDown(overlay, { key: "ArrowDown" });
+
+      const secondItem = screen.getByTestId("command-item-toggle-sidebar");
+      expect(secondItem).toHaveAttribute("aria-selected", "true");
+
+      // 按 ↑ 回到第一项
+      fireEvent.keyDown(overlay, { key: "ArrowUp" });
+
+      const firstItem = screen.getByTestId("command-item-open-settings");
+      expect(firstItem).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("在第一项按 ↑ 不应该移动", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const firstItem = screen.getByTestId("command-item-open-settings");
+      expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+      // 按 ↑
+      const overlay = document.querySelector(".cn-overlay")!;
+      fireEvent.keyDown(overlay, { key: "ArrowUp" });
+
+      // 仍然是第一项
+      expect(firstItem).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("在最后一项按 ↓ 不应该移动", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      const overlay = document.querySelector(".cn-overlay")!;
+
+      // 移动到最后一项
+      for (let i = 0; i < commands.length - 1; i++) {
+        fireEvent.keyDown(overlay, { key: "ArrowDown" });
+      }
+
+      const lastItem = screen.getByTestId("command-item-file-package");
+      expect(lastItem).toHaveAttribute("aria-selected", "true");
+
+      // 按 ↓
+      fireEvent.keyDown(overlay, { key: "ArrowDown" });
+
+      // 仍然是最后一项
+      expect(lastItem).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("按 Enter 应该执行选中的命令", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      // 按 Enter 执行第一项
+      const overlay = document.querySelector(".cn-overlay")!;
+      fireEvent.keyDown(overlay, { key: "Enter" });
+
+      expect(commands[0].onSelect).toHaveBeenCalled();
+    });
+
+    it("按 Escape 应该关闭面板", () => {
+      const onOpenChange = vi.fn();
+      const commands = createMockCommands();
+      render(
+        <CommandPalette
+          open={true}
+          onOpenChange={onOpenChange}
+          commands={commands}
+        />,
+      );
+
+      const overlay = document.querySelector(".cn-overlay")!;
+      fireEvent.keyDown(overlay, { key: "Escape" });
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
 
@@ -91,7 +393,14 @@ describe("CommandPalette", () => {
   describe("交互", () => {
     it("点击背景应调用 onOpenChange(false)", () => {
       const onOpenChange = vi.fn();
-      render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette
+          open={true}
+          onOpenChange={onOpenChange}
+          commands={commands}
+        />,
+      );
 
       const overlay = document.querySelector(".cn-overlay");
       if (overlay) {
@@ -102,51 +411,81 @@ describe("CommandPalette", () => {
 
     it("点击弹窗内部不应关闭", () => {
       const onOpenChange = vi.fn();
-      render(<CommandPalette open={true} onOpenChange={onOpenChange} />);
+      const commands = createMockCommands();
+      render(
+        <CommandPalette
+          open={true}
+          onOpenChange={onOpenChange}
+          commands={commands}
+        />,
+      );
 
       const dialog = screen.getByRole("dialog");
       fireEvent.click(dialog);
 
       expect(onOpenChange).not.toHaveBeenCalled();
     });
-  });
 
-  // ===========================================================================
-  // 错误状态测试
-  // ===========================================================================
-  describe("错误状态", () => {
-    it("无项目时应显示错误", async () => {
-      const { useProjectStore } = await import("../../stores/projectStore");
-      vi.mocked(useProjectStore).mockImplementation((selector) => {
-        const state = {
-          current: null,
-        };
-        return selector(state as unknown as ProjectStore);
-      });
+    it("点击命令项应该执行命令", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+      const item = screen.getByTestId("command-item-toggle-sidebar");
+      fireEvent.click(item);
 
-      const exportButton = screen.getByTestId("command-item-export-markdown");
-      fireEvent.click(exportButton);
+      expect(commands[1].onSelect).toHaveBeenCalled();
+    });
 
-      // Wait for error to appear
-      await vi.waitFor(() => {
-        expect(screen.getByTestId("command-palette-error")).toBeInTheDocument();
-        expect(screen.getByText("No current project")).toBeInTheDocument();
-      });
+    it("鼠标悬停应该更新 active 状态", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
+
+      // 初始第一项是 active
+      const firstItem = screen.getByTestId("command-item-open-settings");
+      expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+      // 悬停第三项
+      const thirdItem = screen.getByTestId("command-item-create-file");
+      fireEvent.mouseEnter(thirdItem);
+
+      expect(thirdItem).toHaveAttribute("aria-selected", "true");
+      expect(firstItem).toHaveAttribute("aria-selected", "false");
     });
   });
 
   // ===========================================================================
-  // 样式测试
+  // Active 指示器测试
   // ===========================================================================
-  describe("样式", () => {
-    it("应该有 Card 样式", () => {
-      render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+  describe("Active 指示器", () => {
+    it("active 项应该有左侧蓝色指示器", () => {
+      const commands = createMockCommands();
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={commands} />,
+      );
 
-      const dialog = screen.getByRole("dialog");
-      // Card 组件使用 shadow 样式来表示 raised 变体
-      expect(dialog.className).toContain("shadow");
+      const firstItem = screen.getByTestId("command-item-open-settings");
+      // 检查 active 项内部有指示器元素
+      const indicator = firstItem.querySelector(
+        ".bg-\\[var\\(--color-accent-blue\\)\\]",
+      );
+      expect(indicator).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 空列表测试
+  // ===========================================================================
+  describe("空列表", () => {
+    it("空命令列表应该显示空状态", () => {
+      render(
+        <CommandPalette open={true} onOpenChange={vi.fn()} commands={[]} />,
+      );
+
+      expect(screen.getByText("未找到匹配的命令")).toBeInTheDocument();
     });
   });
 });

--- a/openspec/_ops/task_runs/ISSUE-113.md
+++ b/openspec/_ops/task_runs/ISSUE-113.md
@@ -1,0 +1,28 @@
+# ISSUE-113
+- Issue: #113
+- Branch: task/113-p4-command-palette
+- PR: https://github.com/Leeky1017/CreoNow/pull/114
+
+## Plan
+- 完整复刻设计稿 `17-command-palette.html` 的 CommandPalette 组件
+- 使用项目现有 primitives 和 design tokens 保持风格统一
+- 补充 Storybook Story 和测试用例
+
+## Runs
+### 2026-02-02 初始化
+- Command: `gh issue create`, `scripts/agent_worktree_setup.sh`
+- Key output: Issue #113 created, worktree at `.worktrees/issue-113-p4-command-palette`
+- Evidence: https://github.com/Leeky1017/CreoNow/issues/113
+
+### 2026-02-02 实现
+- 重写 `CommandPalette.tsx`：三段式布局（Header/Body/Footer）、搜索过滤、键盘导航、搜索高亮、Active 指示器
+- 更新 `CommandPalette.stories.tsx`：Default/Searching/EmptyResults/Interactive/MultipleGroups
+- 更新 `CommandPalette.test.tsx`：28 个测试用例全部通过
+
+### 2026-02-02 验证
+- Command: `pnpm typecheck && pnpm lint && pnpm vitest run CommandPalette.test.tsx && pnpm storybook:build`
+- Key output:
+  - typecheck: ✓ passed
+  - lint: ✓ passed
+  - test: ✓ 28 passed
+  - storybook:build: ✓ built in 10s

--- a/rulebook/tasks/issue-113-p4-command-palette/.metadata.json
+++ b/rulebook/tasks/issue-113-p4-command-palette/.metadata.json
@@ -1,0 +1,7 @@
+{
+  "id": "issue-113-p4-command-palette",
+  "title": "[P4-OVERLAY] CommandPalette: 完整实现设计稿规格",
+  "status": "in_progress",
+  "created": "2026-02-02",
+  "issue": 113
+}

--- a/rulebook/tasks/issue-113-p4-command-palette/proposal.md
+++ b/rulebook/tasks/issue-113-p4-command-palette/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: issue-113-p4-command-palette
+
+## Why
+当前 CommandPalette 是极简占位版本（仅一个 Card + 一个 ListItem），与设计稿 `17-command-palette.html` 差距较大：
+- 无搜索输入框
+- 无分组显示
+- 无键盘导航
+- 无 Active 状态指示器
+- 无底部键盘提示
+
+需要完整复刻设计稿规格，提供专业级的命令面板体验。
+
+## What Changes
+- **组件重写**：`CommandPalette.tsx` 按设计稿三段式布局重写（Header/Body/Footer）
+- **新增功能**：
+  - 搜索输入框（带图标，实时过滤）
+  - 分组显示（Recent Files / Suggestions）
+  - 键盘导航（↑↓ 移动，Enter 确认，Esc 关闭）
+  - Active 状态指示器（左侧蓝色竖条）
+  - 搜索高亮
+  - 底部键盘提示
+- **Story 补充**：覆盖默认状态、搜索状态、空结果状态
+- **测试补充**：键盘导航、搜索过滤、命令执行
+
+## Impact
+- Affected specs:
+  - `rulebook/tasks/issue-113-p4-command-palette/specs/creonow-v1-workbench/spec.md`
+- Affected code:
+  - `apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx`
+  - `apps/desktop/renderer/src/features/commandPalette/CommandPalette.stories.tsx`
+  - `apps/desktop/renderer/src/features/commandPalette/CommandPalette.test.tsx`
+- Breaking change: NO（API 保持兼容：`open`, `onOpenChange`）
+- User benefit:
+  - 专业级命令面板体验
+  - 键盘优先的快速操作
+  - 可发现的命令入口

--- a/rulebook/tasks/issue-113-p4-command-palette/specs/creonow-v1-workbench/spec.md
+++ b/rulebook/tasks/issue-113-p4-command-palette/specs/creonow-v1-workbench/spec.md
@@ -1,0 +1,107 @@
+# CommandPalette Spec
+
+## Overview
+CommandPalette 是一个快速命令/文件访问面板，通过 `Cmd/Ctrl+P` 打开。
+
+## Visual Structure
+```
+┌──────────────────────────────────────────┐
+│ 🔍  搜索命令或文件...                      │ ← Header (56px)
+├──────────────────────────────────────────┤
+│ RECENT FILES                             │
+│ ●│ App.tsx               src/components  │ ← Active 项有左侧蓝条
+│   package.json                           │
+│ SUGGESTIONS                              │
+│   Create New File                   ⌘N  │ ← 快捷键
+│   Toggle Sidebar                    ⌘B  │
+├──────────────────────────────────────────┤
+│           ↑↓ 导航   ↵ 选择   esc 关闭     │ ← Footer (36px)
+└──────────────────────────────────────────┘
+```
+
+## Design Tokens (from design reference)
+- Width: `600px`
+- Background: `--bg-modal` (#0f0f0f)
+- Border: `1px solid #222222`
+- Border radius: `12px`
+- Shadow: `0 16px 32px rgba(0,0,0,0.6)`
+- Header height: `56px`
+- Footer height: `36px`
+- Body max-height: `424px`
+- Item height: `40px`
+- Active indicator: `2px` blue bar on left (`#3b82f6`)
+
+## Functional Requirements
+
+### FR-1: Search Input
+- Input field with search icon
+- Placeholder: "搜索命令或文件..."
+- Real-time filtering as user types
+- Clear button (optional)
+
+### FR-2: Grouped List
+- Support multiple groups (e.g., "Recent Files", "Suggestions")
+- Group title styling: uppercase, small text, muted color
+- Items sorted by relevance within group
+
+### FR-3: List Item
+- Icon (colored by file type)
+- Label text
+- Optional subtext (file path)
+- Optional shortcut badge
+
+### FR-4: Active State
+- One item active at a time
+- Left border indicator (2px blue)
+- Background highlight
+
+### FR-5: Keyboard Navigation
+- `↑` / `↓`: Move selection
+- `Enter`: Execute selected command
+- `Escape`: Close palette
+- Focus trap within palette
+
+### FR-6: Search Highlighting
+- Highlight matched characters in item label
+- Use `<mark>` or span with highlight class
+
+## API
+```typescript
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface CommandItem {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  shortcut?: string;
+  subtext?: string;
+  group?: string;
+  onSelect: () => void;
+}
+```
+
+## Scenarios
+
+### S1: Default State
+Given: User opens CommandPalette
+Then: Shows Recent Files and Suggestions
+And: First item is active
+
+### S2: Search Filtering
+Given: User types "set"
+Then: List filters to matching items
+And: Matched text is highlighted
+
+### S3: Keyboard Navigation
+Given: User presses ↓
+Then: Selection moves to next item
+Given: User presses Enter
+Then: Selected command executes
+And: Palette closes
+
+### S4: Empty Results
+Given: Search has no matches
+Then: Shows empty state message

--- a/rulebook/tasks/issue-113-p4-command-palette/tasks.md
+++ b/rulebook/tasks/issue-113-p4-command-palette/tasks.md
@@ -1,0 +1,29 @@
+## 1. Implementation
+- [ ] 1.1 重写 `CommandPalette.tsx`：
+  - [ ] 1.1.1 Header：搜索图标 + 输入框（56px 高度，底部边框）
+  - [ ] 1.1.2 Body：分组列表（可滚动，max-height 424px）
+  - [ ] 1.1.3 Footer：键盘提示（↑↓ 导航 / ↵ 选择 / esc 关闭）
+  - [ ] 1.1.4 列表项：图标 + 文本 + 路径 + 快捷键
+  - [ ] 1.1.5 Active 状态：左侧 2px 蓝色竖条
+  - [ ] 1.1.6 搜索过滤：实时过滤命令/文件
+  - [ ] 1.1.7 搜索高亮：匹配文字高亮
+  - [ ] 1.1.8 键盘导航：↑↓ 移动，Enter 确认，Esc 关闭
+- [ ] 1.2 创建 `CommandPalette.stories.tsx`：
+  - [ ] 1.2.1 Default Story：默认状态（Recent Files + Suggestions）
+  - [ ] 1.2.2 Searching Story：搜索状态（带过滤结果）
+  - [ ] 1.2.3 Empty Story：空结果状态
+- [ ] 1.3 更新 `CommandPalette.test.tsx`：
+  - [ ] 1.3.1 测试键盘导航（↑↓ 移动选中项）
+  - [ ] 1.3.2 测试搜索过滤（输入关键词过滤列表）
+  - [ ] 1.3.3 测试命令执行（Enter 确认执行）
+  - [ ] 1.3.4 测试关闭（Esc 关闭面板）
+
+## 2. Testing
+- [ ] 2.1 `pnpm typecheck`
+- [ ] 2.2 `pnpm lint`
+- [ ] 2.3 `pnpm test:run`
+- [ ] 2.4 `pnpm storybook:build`
+- [ ] 2.5 Browser：验证 Storybook 中 CommandPalette Stories 符合设计稿
+
+## 3. Documentation
+- [ ] 3.1 更新 `openspec/_ops/task_runs/ISSUE-113.md` Runs（仅追加不回写）


### PR DESCRIPTION
Closes #113

## Summary
- 完整复刻设计稿 `17-command-palette.html` 的 CommandPalette 组件
- 三段式布局：Header（搜索框）+ Body（分组列表）+ Footer（键盘提示）
- 搜索功能：带放大镜图标的输入框，实时过滤
- 键盘导航：↑↓ 移动，Enter 确认，Esc 关闭
- Active 状态：左侧 2px 蓝色竖条指示器

## Test Plan
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm vitest run CommandPalette.test.tsx` - 28 个测试全部通过
- [x] `pnpm storybook:build` 通过
- [ ] Browser 验证 Storybook 中 CommandPalette Stories

## RUN_LOG
- `openspec/_ops/task_runs/ISSUE-113.md`