### PR TITLE
feat(ui): CreateProjectDialog 重构 + 模板系统 (#118)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/ImageUpload.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/ImageUpload.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ImageUpload } from "./ImageUpload";
 

--- a/apps/desktop/renderer/src/components/primitives/ImageUpload.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/ImageUpload.stories.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ImageUpload } from "./ImageUpload";
+
+/**
+ * ImageUpload 组件 Story
+ *
+ * 用于上传图片，支持：
+ * - 拖拽上传
+ * - 点击选择文件
+ * - 图片预览
+ * - 移除已选图片
+ * - 文件大小/类型校验
+ */
+const meta: Meta<typeof ImageUpload> = {
+  title: "Primitives/ImageUpload",
+  component: ImageUpload,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    disabled: {
+      control: "boolean",
+      description: "Whether the upload is disabled",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text",
+    },
+    hint: {
+      control: "text",
+      description: "Hint text",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageUpload>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认状态 */
+export const Default: Story = {
+  args: {
+    placeholder: "Click or drag image to upload",
+    hint: "PNG, JPG up to 5MB",
+  },
+};
+
+/** 禁用状态 */
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    placeholder: "Click or drag image to upload",
+    hint: "PNG, JPG up to 5MB",
+  },
+};
+
+/** 自定义文案 */
+export const CustomText: Story = {
+  args: {
+    placeholder: "Drop your cover image here",
+    hint: "Recommended: 800x600 PNG or JPG",
+  },
+};
+
+// ============================================================================
+// 受控模式
+// ============================================================================
+
+function ControlledDemo() {
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        File: {file ? file.name : "None"}
+      </div>
+      {error && (
+        <div
+          style={{ fontSize: "12px", color: "var(--color-error)" }}
+        >
+          Error: {error}
+        </div>
+      )}
+      <div style={{ maxWidth: "400px" }}>
+        <ImageUpload
+          value={file}
+          onChange={setFile}
+          onError={setError}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledDemo />,
+};
+
+// ============================================================================
+// 带预览图
+// ============================================================================
+
+function WithPreviewDemo() {
+  const [file, setFile] = useState<File | null>(null);
+
+  // 使用一个静态图片 URL 作为初始值演示
+  const previewUrl = file
+    ? undefined
+    : "https://images.unsplash.com/photo-1544716278-ca5e3f4abd8c?w=400&h=300&fit=crop";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Hover over the image to see the remove button
+      </div>
+      <div style={{ maxWidth: "400px" }}>
+        <ImageUpload
+          value={file || previewUrl}
+          onChange={setFile}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const WithPreview: Story = {
+  render: () => <WithPreviewDemo />,
+};
+
+// ============================================================================
+// 在表单中使用
+// ============================================================================
+
+export const InForm: Story = {
+  render: () => (
+    <form
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.5rem",
+        maxWidth: "480px",
+        padding: "1.5rem",
+        backgroundColor: "var(--color-bg-surface)",
+        borderRadius: "var(--radius-lg)",
+      }}
+    >
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.75rem",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Cover Image
+          <span
+            style={{
+              fontSize: "12px",
+              fontWeight: 400,
+              opacity: 0.5,
+              marginLeft: "4px",
+            }}
+          >
+            (Optional)
+          </span>
+        </label>
+        <ImageUpload
+          placeholder="Click or drag image to upload"
+          hint="PNG, JPG up to 5MB"
+        />
+      </div>
+    </form>
+  ),
+};
+
+// ============================================================================
+// 不同尺寸
+// ============================================================================
+
+export const Compact: Story = {
+  render: () => (
+    <div style={{ maxWidth: "300px" }}>
+      <ImageUpload
+        placeholder="Upload"
+        hint="Max 2MB"
+        maxSize={2 * 1024 * 1024}
+        className="min-h-[100px]"
+      />
+    </div>
+  ),
+};
+
+export const Large: Story = {
+  render: () => (
+    <div style={{ maxWidth: "600px" }}>
+      <ImageUpload
+        placeholder="Drop your high-resolution cover image here"
+        hint="Recommended: 1920x1080 PNG or JPG, up to 10MB"
+        maxSize={10 * 1024 * 1024}
+        className="min-h-[200px]"
+      />
+    </div>
+  ),
+};

--- a/apps/desktop/renderer/src/components/primitives/ImageUpload.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/ImageUpload.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImageUpload } from "./ImageUpload";
+
+describe("ImageUpload", () => {
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("应该渲染上传区域", () => {
+      render(<ImageUpload />);
+
+      expect(screen.getByTestId("image-upload")).toBeInTheDocument();
+    });
+
+    it("应该显示 placeholder 文案", () => {
+      render(<ImageUpload placeholder="Click to upload" />);
+
+      expect(screen.getByText("Click to upload")).toBeInTheDocument();
+    });
+
+    it("应该显示 hint 文案", () => {
+      render(<ImageUpload hint="PNG, JPG up to 5MB" />);
+
+      expect(screen.getByText("PNG, JPG up to 5MB")).toBeInTheDocument();
+    });
+
+    it("应该渲染隐藏的 file input", () => {
+      render(<ImageUpload />);
+
+      const input = screen.getByTestId("image-upload-input");
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveClass("hidden");
+    });
+  });
+
+  // ===========================================================================
+  // 预览测试
+  // ===========================================================================
+  describe("预览", () => {
+    it("传入 URL 时应该显示预览图", () => {
+      render(<ImageUpload value="https://example.com/image.jpg" />);
+
+      const img = screen.getByAltText("Preview");
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute("src", "https://example.com/image.jpg");
+    });
+
+    it("预览状态应该显示移除按钮", () => {
+      render(<ImageUpload value="https://example.com/image.jpg" />);
+
+      expect(screen.getByTestId("image-upload-remove")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 交互测试
+  // ===========================================================================
+  describe("交互", () => {
+    it("点击应该触发 file input", async () => {
+      const user = userEvent.setup();
+      render(<ImageUpload />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      const input = screen.getByTestId("image-upload-input");
+
+      const clickSpy = vi.spyOn(input, "click");
+
+      await user.click(uploadArea);
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it("选择文件应该调用 onChange", async () => {
+      const onChange = vi.fn();
+      render(<ImageUpload onChange={onChange} />);
+
+      const input = screen.getByTestId("image-upload-input");
+      const file = new File(["test"], "test.png", { type: "image/png" });
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      expect(onChange).toHaveBeenCalledWith(file);
+    });
+
+    it("点击移除按钮应该调用 onChange(null)", async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ImageUpload
+          value="https://example.com/image.jpg"
+          onChange={onChange}
+        />,
+      );
+
+      await user.click(screen.getByTestId("image-upload-remove"));
+
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  // ===========================================================================
+  // 验证测试
+  // ===========================================================================
+  describe("验证", () => {
+    it("非图片文件应该调用 onError", () => {
+      const onError = vi.fn();
+      render(<ImageUpload onError={onError} />);
+
+      const input = screen.getByTestId("image-upload-input");
+      const file = new File(["test"], "test.txt", { type: "text/plain" });
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      expect(onError).toHaveBeenCalledWith("Please select an image file");
+    });
+
+    it("超过大小限制应该调用 onError", () => {
+      const onError = vi.fn();
+      render(<ImageUpload maxSize={1024} onError={onError} />); // 1KB limit
+
+      const input = screen.getByTestId("image-upload-input");
+      // Create a file larger than 1KB
+      const largeContent = new Array(2000).fill("a").join("");
+      const file = new File([largeContent], "large.png", { type: "image/png" });
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // 禁用测试
+  // ===========================================================================
+  describe("禁用", () => {
+    it("禁用时应该有 disabled 样式", () => {
+      render(<ImageUpload disabled />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      expect(uploadArea).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("禁用时点击不应该触发 file input", async () => {
+      const user = userEvent.setup();
+      render(<ImageUpload disabled />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      const input = screen.getByTestId("image-upload-input");
+
+      const clickSpy = vi.spyOn(input, "click");
+
+      await user.click(uploadArea);
+
+      expect(clickSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // 拖拽测试
+  // ===========================================================================
+  describe("拖拽", () => {
+    it("拖拽文件进入应该改变样式", () => {
+      render(<ImageUpload />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+
+      fireEvent.dragEnter(uploadArea, {
+        dataTransfer: { files: [] },
+      });
+
+      // 拖拽状态样式变化 - 检查是否包含 accent 边框色
+      expect(uploadArea).toHaveClass("border-[var(--color-accent)]");
+    });
+
+    it("拖拽离开应该恢复样式", () => {
+      render(<ImageUpload />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+
+      fireEvent.dragEnter(uploadArea, {
+        dataTransfer: { files: [] },
+      });
+
+      fireEvent.dragLeave(uploadArea, {
+        dataTransfer: { files: [] },
+      });
+
+      expect(uploadArea).not.toHaveClass("border-[var(--color-accent)]");
+    });
+
+    it("放下文件应该调用 onChange", () => {
+      const onChange = vi.fn();
+      render(<ImageUpload onChange={onChange} />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      const file = new File(["test"], "test.png", { type: "image/png" });
+
+      fireEvent.drop(uploadArea, {
+        dataTransfer: { files: [file] },
+      });
+
+      expect(onChange).toHaveBeenCalledWith(file);
+    });
+  });
+
+  // ===========================================================================
+  // 键盘导航测试
+  // ===========================================================================
+  describe("键盘导航", () => {
+    it("应该可以通过 Tab 聚焦", async () => {
+      const user = userEvent.setup();
+      render(<ImageUpload />);
+
+      await user.tab();
+
+      expect(screen.getByTestId("image-upload")).toHaveFocus();
+    });
+
+    it("按 Enter 应该触发 file input", async () => {
+      const user = userEvent.setup();
+      render(<ImageUpload />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      const input = screen.getByTestId("image-upload-input");
+
+      const clickSpy = vi.spyOn(input, "click");
+
+      uploadArea.focus();
+      await user.keyboard("{Enter}");
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it("按 Space 应该触发 file input", async () => {
+      const user = userEvent.setup();
+      render(<ImageUpload />);
+
+      const uploadArea = screen.getByTestId("image-upload");
+      const input = screen.getByTestId("image-upload-input");
+
+      const clickSpy = vi.spyOn(input, "click");
+
+      uploadArea.focus();
+      await user.keyboard(" ");
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/ImageUpload.tsx
+++ b/apps/desktop/renderer/src/components/primitives/ImageUpload.tsx
@@ -1,0 +1,330 @@
+import React, { useCallback, useState, useRef } from "react";
+
+export interface ImageUploadProps {
+  /** Current value (File object or URL string) */
+  value?: File | string | null;
+  /** Callback when file changes */
+  onChange?: (file: File | null) => void;
+  /** Accepted file types (default: "image/*") */
+  accept?: string;
+  /** Maximum file size in bytes (default: 5MB) */
+  maxSize?: number;
+  /** Error callback for validation failures */
+  onError?: (error: string) => void;
+  /** Whether the upload is disabled */
+  disabled?: boolean;
+  /** Additional className */
+  className?: string;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Hint text (e.g., "PNG, JPG up to 5MB") */
+  hint?: string;
+}
+
+/**
+ * Default max file size: 5MB
+ */
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024;
+
+/**
+ * ImageUpload component
+ *
+ * A drop zone for uploading images with preview and remove functionality.
+ * Follows design spec for dashed border, drag states, and preview overlay.
+ *
+ * @example
+ * ```tsx
+ * const [cover, setCover] = useState<File | null>(null);
+ *
+ * <ImageUpload
+ *   value={cover}
+ *   onChange={setCover}
+ *   placeholder="Click or drag image to upload"
+ *   hint="PNG, JPG up to 5MB"
+ * />
+ * ```
+ */
+export function ImageUpload({
+  value,
+  onChange,
+  accept = "image/*",
+  maxSize = DEFAULT_MAX_SIZE,
+  onError,
+  disabled = false,
+  className = "",
+  placeholder = "Click or drag image to upload",
+  hint = "PNG, JPG up to 5MB",
+}: ImageUploadProps): JSX.Element {
+  const [isDragging, setIsDragging] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Track the last created object URL for cleanup
+  const lastObjectUrlRef = useRef<string | null>(null);
+
+  // Derive preview URL from value - using a layout effect to avoid flicker
+  React.useLayoutEffect(() => {
+    // Cleanup previous object URL
+    if (lastObjectUrlRef.current) {
+      URL.revokeObjectURL(lastObjectUrlRef.current);
+      lastObjectUrlRef.current = null;
+    }
+
+    if (!value) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    if (typeof value === "string") {
+      setPreviewUrl(value);
+      return;
+    }
+
+    // Create object URL for File
+    const url = URL.createObjectURL(value);
+    lastObjectUrlRef.current = url;
+    setPreviewUrl(url);
+
+    return () => {
+      if (lastObjectUrlRef.current) {
+        URL.revokeObjectURL(lastObjectUrlRef.current);
+        lastObjectUrlRef.current = null;
+      }
+    };
+  }, [value]);
+
+  const validateFile = useCallback(
+    (file: File): boolean => {
+      // Check file type
+      if (!file.type.startsWith("image/")) {
+        onError?.("Please select an image file");
+        return false;
+      }
+
+      // Check file size
+      if (file.size > maxSize) {
+        const maxMB = Math.round(maxSize / (1024 * 1024));
+        onError?.(`File size must be less than ${maxMB}MB`);
+        return false;
+      }
+
+      return true;
+    },
+    [maxSize, onError],
+  );
+
+  const handleFile = useCallback(
+    (file: File | null) => {
+      if (!file) {
+        onChange?.(null);
+        return;
+      }
+
+      if (validateFile(file)) {
+        onChange?.(file);
+      }
+    },
+    [onChange, validateFile],
+  );
+
+  const handleDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!disabled) {
+        setIsDragging(true);
+      }
+    },
+    [disabled],
+  );
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!disabled) {
+        setIsDragging(true);
+      }
+    },
+    [disabled],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+
+      if (disabled) return;
+
+      const files = e.dataTransfer.files;
+      if (files && files[0]) {
+        handleFile(files[0]);
+      }
+    },
+    [disabled, handleFile],
+  );
+
+  const handleClick = useCallback(() => {
+    if (!disabled && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  }, [disabled]);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (files && files[0]) {
+        handleFile(files[0]);
+      }
+      // Reset input so same file can be selected again
+      e.target.value = "";
+    },
+    [handleFile],
+  );
+
+  const handleRemove = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      handleFile(null);
+    },
+    [handleFile],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
+  const baseStyles = [
+    "relative",
+    "group",
+    "cursor-pointer",
+    "border-2",
+    "border-dashed",
+    "rounded-[var(--radius-sm)]",
+    "min-h-[140px]",
+    "flex",
+    "flex-col",
+    "items-center",
+    "justify-center",
+    "transition-all",
+    "duration-[var(--duration-fast)]",
+    // Focus visible
+    "focus-visible:outline",
+    "focus-visible:outline-[length:var(--ring-focus-width)]",
+    "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+    "focus-visible:outline-[var(--color-ring-focus)]",
+  ];
+
+  const stateStyles = disabled
+    ? [
+        "border-[var(--color-border-default)]",
+        "bg-[var(--color-bg-disabled)]",
+        "cursor-not-allowed",
+        "opacity-50",
+      ]
+    : isDragging
+      ? [
+          "border-[var(--color-accent)]",
+          "bg-[var(--color-accent-subtle)]",
+        ]
+      : [
+          "border-[var(--color-border-default)]",
+          "hover:border-[var(--color-border-hover)]",
+          "hover:bg-[var(--color-bg-hover)]",
+        ];
+
+  const containerStyles = [...baseStyles, ...stateStyles, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      className={containerStyles}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-disabled={disabled}
+      data-testid="image-upload"
+    >
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        onChange={handleFileChange}
+        disabled={disabled}
+        className="hidden"
+        data-testid="image-upload-input"
+      />
+
+      {/* Preview or Placeholder */}
+      {previewUrl ? (
+        <div className="absolute inset-0 w-full h-full rounded-[var(--radius-sm)] overflow-hidden">
+          <img
+            src={previewUrl}
+            alt="Preview"
+            className="w-full h-full object-cover opacity-80 group-hover:opacity-40 transition-opacity"
+          />
+          {/* Remove button overlay */}
+          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+              type="button"
+              onClick={handleRemove}
+              disabled={disabled}
+              className="bg-[var(--color-error)]/20 hover:bg-[var(--color-error)]/40 text-[var(--color-error)] px-3 py-1.5 rounded-[var(--radius-sm)] text-xs font-medium border border-[var(--color-error)]/30 transition-colors backdrop-blur-sm"
+              data-testid="image-upload-remove"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)] transition-colors p-6">
+          {/* Icon */}
+          <div className="w-10 h-10 rounded-[var(--radius-full)] bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] flex items-center justify-center group-hover:border-[var(--color-border-hover)] transition-colors">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+              <circle cx="8.5" cy="8.5" r="1.5" />
+              <polyline points="21 15 16 10 5 21" />
+            </svg>
+          </div>
+          {/* Text */}
+          <div className="text-center">
+            <p className="text-xs font-medium">{placeholder}</p>
+            <p className="text-[10px] text-[var(--color-fg-subtle)] mt-1">
+              {hint}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Radio.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Radio.stories.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { RadioGroup, Radio, RadioGroupRoot } from "./Radio";
+import {
+  RadioGroup,
+  Radio,
+  RadioGroupRoot,
+  RadioCardGroup,
+  RadioCardItem,
+} from "./Radio";
 
 /**
  * Radio 组件 Story
@@ -299,4 +305,175 @@ export const ManyOptions: Story = {
       label: `Option ${i + 1}`,
     })),
   },
+};
+
+// ============================================================================
+// RadioCardGroup Stories
+// ============================================================================
+
+// Template options for project types
+const templateOptions = [
+  { value: "novel", label: "Novel" },
+  { value: "short", label: "Short Story" },
+  { value: "script", label: "Screenplay" },
+  { value: "other", label: "Other" },
+];
+
+/** Card Group 默认 2x2 网格 */
+export const CardGroup: StoryObj<typeof RadioCardGroup> = {
+  render: () => (
+    <div style={{ maxWidth: "400px" }}>
+      <RadioCardGroup
+        options={templateOptions}
+        defaultValue="novel"
+        columns={2}
+      />
+    </div>
+  ),
+};
+
+/** Card Group 3 列 */
+export const CardGroup3Columns: StoryObj<typeof RadioCardGroup> = {
+  render: () => (
+    <div style={{ maxWidth: "500px" }}>
+      <RadioCardGroup
+        options={[...templateOptions, { value: "essay", label: "Essay" }]}
+        defaultValue="novel"
+        columns={3}
+      />
+    </div>
+  ),
+};
+
+/** Card Group 受控模式 */
+function CardGroupControlledDemo() {
+  const [value, setValue] = React.useState("novel");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Selected: {value}
+      </div>
+      <div style={{ maxWidth: "400px" }}>
+        <RadioCardGroup
+          options={templateOptions}
+          value={value}
+          onValueChange={setValue}
+          columns={2}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const CardGroupControlled: StoryObj<typeof RadioCardGroup> = {
+  render: () => <CardGroupControlledDemo />,
+};
+
+/** Card Group 禁用状态 */
+export const CardGroupDisabled: StoryObj<typeof RadioCardGroup> = {
+  render: () => (
+    <div style={{ maxWidth: "400px" }}>
+      <RadioCardGroup
+        options={templateOptions}
+        defaultValue="novel"
+        disabled
+        columns={2}
+      />
+    </div>
+  ),
+};
+
+/** Card Group 部分禁用 */
+export const CardGroupPartialDisabled: StoryObj<typeof RadioCardGroup> = {
+  render: () => (
+    <div style={{ maxWidth: "400px" }}>
+      <RadioCardGroup
+        options={[
+          { value: "novel", label: "Novel" },
+          { value: "short", label: "Short Story" },
+          { value: "script", label: "Screenplay", disabled: true },
+          { value: "other", label: "Other" },
+        ]}
+        defaultValue="novel"
+        columns={2}
+      />
+    </div>
+  ),
+};
+
+/** Card Group 带 Action 入口 */
+function CardGroupWithActionDemo() {
+  const [value, setValue] = React.useState("novel");
+  const [templates] = React.useState(templateOptions);
+
+  const handleCreateTemplate = () => {
+    alert("Open Create Template Dialog");
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Selected: {value}
+      </div>
+      <div style={{ maxWidth: "400px" }}>
+        <RadioGroupRoot
+          value={value}
+          onValueChange={setValue}
+          className="grid grid-cols-2 gap-3"
+        >
+          {templates.map((opt) => (
+            <RadioCardItem key={opt.value} value={opt.value} label={opt.label} />
+          ))}
+          <RadioCardItem
+            value=""
+            label="+ Create Template"
+            isAction
+            onAction={handleCreateTemplate}
+          />
+        </RadioGroupRoot>
+      </div>
+    </div>
+  );
+}
+
+export const CardGroupWithAction: StoryObj<typeof RadioCardGroup> = {
+  render: () => <CardGroupWithActionDemo />,
+};
+
+/** Card Group 在表单中 */
+export const CardGroupInForm: StoryObj<typeof RadioCardGroup> = {
+  render: () => (
+    <form
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.5rem",
+        maxWidth: "480px",
+        padding: "1.5rem",
+        backgroundColor: "var(--color-bg-surface)",
+        borderRadius: "var(--radius-lg)",
+      }}
+    >
+      <div>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "0.75rem",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "var(--color-fg-muted)",
+          }}
+        >
+          Project Type
+        </label>
+        <RadioCardGroup
+          options={templateOptions}
+          name="projectType"
+          defaultValue="novel"
+          columns={2}
+        />
+      </div>
+    </form>
+  ),
 };

--- a/apps/desktop/renderer/src/components/primitives/Radio.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Radio.tsx
@@ -228,3 +228,264 @@ export function Radio({
  * Re-export RadioGroup Root for custom layouts
  */
 export const RadioGroupRoot = RadioGroupPrimitive.Root;
+
+// =============================================================================
+// RadioCardGroup - Card-style radio selection
+// =============================================================================
+
+export interface RadioCardOption {
+  /** Unique value for the option */
+  value: string;
+  /** Display label */
+  label: string;
+  /** Optional icon */
+  icon?: React.ReactNode;
+  /** Whether the option is disabled */
+  disabled?: boolean;
+}
+
+export interface RadioCardGroupProps {
+  /** Array of card options */
+  options: RadioCardOption[];
+  /** Current selected value */
+  value?: string;
+  /** Default selected value */
+  defaultValue?: string;
+  /** Callback when value changes */
+  onValueChange?: (value: string) => void;
+  /** Name attribute for form submission */
+  name?: string;
+  /** Whether the group is disabled */
+  disabled?: boolean;
+  /** Number of columns in grid */
+  columns?: 2 | 3 | 4;
+  /** Additional className for root */
+  className?: string;
+}
+
+/**
+ * Check icon for selected state
+ */
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-[var(--color-accent)]"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+/**
+ * RadioCardGroup component
+ *
+ * Displays a grid of card-style radio buttons for single selection.
+ * Used for template/type selection in dialogs.
+ *
+ * @example
+ * ```tsx
+ * <RadioCardGroup
+ *   options={[
+ *     { value: "novel", label: "Novel" },
+ *     { value: "short", label: "Short Story" },
+ *     { value: "script", label: "Screenplay" },
+ *     { value: "other", label: "Other" },
+ *   ]}
+ *   value={type}
+ *   onValueChange={setType}
+ *   columns={2}
+ * />
+ * ```
+ */
+export function RadioCardGroup({
+  options,
+  value,
+  defaultValue,
+  onValueChange,
+  name,
+  disabled,
+  columns = 2,
+  className = "",
+}: RadioCardGroupProps): JSX.Element {
+  const gridCols = {
+    2: "grid-cols-2",
+    3: "grid-cols-3",
+    4: "grid-cols-4",
+  };
+
+  const rootClasses = ["grid", "gap-3", gridCols[columns], className]
+    .filter(Boolean)
+    .join(" ");
+
+  const cardBaseStyles = [
+    "relative",
+    "h-10",
+    "px-3",
+    "flex",
+    "items-center",
+    "justify-center",
+    "border",
+    "rounded-[var(--radius-sm)]",
+    "text-sm",
+    "cursor-pointer",
+    "transition-all",
+    "duration-[var(--duration-fast)]",
+    // Default state
+    "border-[var(--color-border-default)]",
+    "text-[var(--color-fg-muted)]",
+    "bg-transparent",
+    // Hover state
+    "hover:border-[var(--color-border-hover)]",
+    // Focus visible
+    "focus-visible:outline",
+    "focus-visible:outline-[length:var(--ring-focus-width)]",
+    "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+    "focus-visible:outline-[var(--color-ring-focus)]",
+    // Checked state
+    "data-[state=checked]:border-[var(--color-accent)]",
+    "data-[state=checked]:bg-[var(--color-accent-subtle)]",
+    "data-[state=checked]:text-[var(--color-fg-default)]",
+    // Disabled state
+    "disabled:opacity-50",
+    "disabled:cursor-not-allowed",
+  ].join(" ");
+
+  return (
+    <RadioGroupPrimitive.Root
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange}
+      name={name}
+      disabled={disabled}
+      className={rootClasses}
+    >
+      {options.map((option) => (
+        <RadioGroupPrimitive.Item
+          key={option.value}
+          value={option.value}
+          disabled={option.disabled}
+          id={`radio-card-${name || "group"}-${option.value}`}
+          className={cardBaseStyles}
+        >
+          {option.icon && <span className="mr-2">{option.icon}</span>}
+          <span>{option.label}</span>
+          <RadioGroupPrimitive.Indicator className="absolute right-2">
+            <CheckIcon />
+          </RadioGroupPrimitive.Indicator>
+        </RadioGroupPrimitive.Item>
+      ))}
+    </RadioGroupPrimitive.Root>
+  );
+}
+
+// =============================================================================
+// RadioCardItem - Single card for custom layouts (e.g., "+ Create Template")
+// =============================================================================
+
+export interface RadioCardItemProps {
+  /** Value of the card */
+  value: string;
+  /** Display label */
+  label: string;
+  /** Optional icon */
+  icon?: React.ReactNode;
+  /** Whether the card is disabled */
+  disabled?: boolean;
+  /** Additional className */
+  className?: string;
+  /** Whether this is a special action card (e.g., "+ Create") */
+  isAction?: boolean;
+  /** Click handler for action cards */
+  onAction?: () => void;
+}
+
+/**
+ * Single RadioCard component for custom layouts
+ *
+ * Can be used as a regular radio option or as an action button.
+ */
+export function RadioCardItem({
+  value,
+  label,
+  icon,
+  disabled,
+  className = "",
+  isAction = false,
+  onAction,
+}: RadioCardItemProps): JSX.Element {
+  const cardStyles = [
+    "relative",
+    "h-10",
+    "px-3",
+    "flex",
+    "items-center",
+    "justify-center",
+    "border",
+    "rounded-[var(--radius-sm)]",
+    "text-sm",
+    "cursor-pointer",
+    "transition-all",
+    "duration-[var(--duration-fast)]",
+    isAction
+      ? [
+          "border-dashed",
+          "border-[var(--color-border-default)]",
+          "text-[var(--color-fg-muted)]",
+          "hover:border-[var(--color-border-hover)]",
+          "hover:text-[var(--color-fg-default)]",
+        ].join(" ")
+      : [
+          "border-[var(--color-border-default)]",
+          "text-[var(--color-fg-muted)]",
+          "hover:border-[var(--color-border-hover)]",
+          "data-[state=checked]:border-[var(--color-accent)]",
+          "data-[state=checked]:bg-[var(--color-accent-subtle)]",
+          "data-[state=checked]:text-[var(--color-fg-default)]",
+        ].join(" "),
+    "focus-visible:outline",
+    "focus-visible:outline-[length:var(--ring-focus-width)]",
+    "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+    "focus-visible:outline-[var(--color-ring-focus)]",
+    "disabled:opacity-50",
+    "disabled:cursor-not-allowed",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (isAction && onAction) {
+    return (
+      <button
+        type="button"
+        onClick={onAction}
+        disabled={disabled}
+        className={cardStyles}
+      >
+        {icon && <span className="mr-2">{icon}</span>}
+        <span>{label}</span>
+      </button>
+    );
+  }
+
+  return (
+    <RadioGroupPrimitive.Item
+      value={value}
+      disabled={disabled}
+      className={cardStyles}
+    >
+      {icon && <span className="mr-2">{icon}</span>}
+      <span>{label}</span>
+      <RadioGroupPrimitive.Indicator className="absolute right-2">
+        <CheckIcon />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/index.ts
+++ b/apps/desktop/renderer/src/components/primitives/index.ts
@@ -83,8 +83,24 @@ export type { ToastProps, ToastVariant, ToastState } from "./Toast";
 export { Accordion } from "./Accordion";
 export type { AccordionProps, AccordionItem } from "./Accordion";
 
-export { RadioGroup, Radio, RadioGroupRoot } from "./Radio";
-export type { RadioGroupProps, RadioOption, RadioProps } from "./Radio";
+export {
+  RadioGroup,
+  Radio,
+  RadioGroupRoot,
+  RadioCardGroup,
+  RadioCardItem,
+} from "./Radio";
+export type {
+  RadioGroupProps,
+  RadioOption,
+  RadioProps,
+  RadioCardGroupProps,
+  RadioCardOption,
+  RadioCardItemProps,
+} from "./Radio";
 
 export { ContextMenu } from "./ContextMenu";
 export type { ContextMenuProps, ContextMenuItem } from "./ContextMenu";
+
+export { ImageUpload } from "./ImageUpload";
+export type { ImageUploadProps } from "./ImageUpload";

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
@@ -1,8 +1,40 @@
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
+import { create } from "zustand";
 import { CreateProjectDialog } from "./CreateProjectDialog";
 import { Button } from "../../components/primitives/Button";
+import {
+  ProjectStoreProvider,
+  type ProjectStore,
+} from "../../stores/projectStore";
+
+/**
+ * Create a mock project store for Storybook
+ */
+function createMockProjectStore() {
+  return create<ProjectStore>(() => ({
+    current: null,
+    items: [],
+    bootstrapStatus: "ready",
+    lastError: null,
+    clearError: () => {},
+    bootstrap: async () => {},
+    createAndSetCurrent: async () => {
+      // Simulate delay
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return { ok: true, data: { projectId: "mock-id", rootPath: "/mock/path" } };
+    },
+  }));
+}
+
+/**
+ * Wrapper component that provides mock store
+ */
+function MockStoreWrapper({ children }: { children: React.ReactNode }) {
+  const [store] = useState(() => createMockProjectStore());
+  return <ProjectStoreProvider store={store}>{children}</ProjectStoreProvider>;
+}
 
 /**
  * CreateProjectDialog 组件 Story
@@ -18,6 +50,13 @@ import { Button } from "../../components/primitives/Button";
 const meta: Meta<typeof CreateProjectDialog> = {
   title: "Features/CreateProjectDialog",
   component: CreateProjectDialog,
+  decorators: [
+    (Story) => (
+      <MockStoreWrapper>
+        <Story />
+      </MockStoreWrapper>
+    ),
+  ],
   parameters: {
     layout: "centered",
   },

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
@@ -1,14 +1,19 @@
+import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import { CreateProjectDialog } from "./CreateProjectDialog";
+import { Button } from "../../components/primitives/Button";
 
 /**
  * CreateProjectDialog 组件 Story
  *
  * 功能：
  * - 创建项目对话框
- * - 名称输入
- * - 表单验证
+ * - 项目名称输入（必填）
+ * - 模板选择（预设 + 自定义）
+ * - 描述输入（可选）
+ * - 封面图片上传（可选）
+ * - 创建模板入口
  */
 const meta: Meta<typeof CreateProjectDialog> = {
   title: "Features/CreateProjectDialog",
@@ -34,7 +39,11 @@ type Story = StoryObj<typeof CreateProjectDialog>;
 /**
  * 打开状态
  *
- * 创建项目对话框打开
+ * 完整的创建项目对话框，包含：
+ * - 项目名称输入
+ * - 模板选择（2x2 卡片网格）
+ * - 描述输入
+ * - 封面图片上传
  */
 export const Open: Story = {
   args: {
@@ -66,6 +75,26 @@ export const Closed: Story = {
 };
 
 /**
+ * 交互演示
+ *
+ * 可以交互的完整流程演示
+ */
+function InteractiveDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "center" }}>
+      <Button onClick={() => setOpen(true)}>Create New Project</Button>
+      <CreateProjectDialog open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
+};
+
+/**
  * 暗色背景
  *
  * 在暗色背景下的显示效果
@@ -77,8 +106,8 @@ export const DarkBackground: Story = {
   render: (args) => (
     <div
       style={{
-        width: "600px",
-        height: "400px",
+        width: "700px",
+        height: "600px",
         backgroundColor: "var(--color-bg-base)",
         display: "flex",
         alignItems: "center",

--- a/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { CreateTemplateDialog } from "./CreateTemplateDialog";
 import { Button } from "../../components/primitives/Button";

--- a/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.stories.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { CreateTemplateDialog } from "./CreateTemplateDialog";
+import { Button } from "../../components/primitives/Button";
+
+/**
+ * CreateTemplateDialog 组件 Story
+ *
+ * 用于创建自定义项目模板的对话框。
+ * 支持定义模板名称、描述、初始文件夹和文件。
+ */
+const meta: Meta<typeof CreateTemplateDialog> = {
+  title: "Features/CreateTemplateDialog",
+  component: CreateTemplateDialog,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CreateTemplateDialog>;
+
+// ============================================================================
+// 基础 Stories
+// ============================================================================
+
+/** 默认打开状态 */
+export const Open: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+  },
+};
+
+/** 关闭状态 */
+export const Closed: Story = {
+  args: {
+    open: false,
+    onOpenChange: () => {},
+  },
+};
+
+// ============================================================================
+// 交互演示
+// ============================================================================
+
+function InteractiveDemo() {
+  const [open, setOpen] = useState(false);
+  const [createdId, setCreatedId] = useState<string | null>(null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "center" }}>
+      <Button onClick={() => setOpen(true)}>Create Template</Button>
+
+      {createdId && (
+        <div
+          style={{
+            padding: "0.5rem 1rem",
+            backgroundColor: "var(--color-success-subtle)",
+            color: "var(--color-success)",
+            borderRadius: "var(--radius-sm)",
+            fontSize: "12px",
+          }}
+        >
+          Template created: {createdId}
+        </div>
+      )}
+
+      <CreateTemplateDialog
+        open={open}
+        onOpenChange={setOpen}
+        onCreated={(id) => setCreatedId(id)}
+      />
+    </div>
+  );
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
+};
+
+// ============================================================================
+// 完整流程演示
+// ============================================================================
+
+function FullFlowDemo() {
+  const [open, setOpen] = useState(true);
+  const [result, setResult] = useState<{ success: boolean; id?: string } | null>(null);
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <div style={{ marginBottom: "1rem", fontSize: "12px", color: "var(--color-fg-muted)" }}>
+        Fill in the form and click &quot;Create Template&quot; to test the flow.
+      </div>
+
+      {result && (
+        <div
+          style={{
+            marginBottom: "1rem",
+            padding: "0.5rem 1rem",
+            backgroundColor: result.success
+              ? "var(--color-success-subtle)"
+              : "var(--color-error-subtle)",
+            color: result.success ? "var(--color-success)" : "var(--color-error)",
+            borderRadius: "var(--radius-sm)",
+            fontSize: "12px",
+          }}
+        >
+          {result.success
+            ? `Template created successfully: ${result.id}`
+            : "Failed to create template"}
+        </div>
+      )}
+
+      {!open && (
+        <Button onClick={() => setOpen(true)}>Open Dialog Again</Button>
+      )}
+
+      <CreateTemplateDialog
+        open={open}
+        onOpenChange={setOpen}
+        onCreated={(id) => {
+          setResult({ success: true, id });
+        }}
+      />
+    </div>
+  );
+}
+
+export const FullFlow: Story = {
+  render: () => <FullFlowDemo />,
+};

--- a/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateTemplateDialog } from "./CreateTemplateDialog";
+import { useTemplateStore } from "../../stores/templateStore";
+
+// Mock the template store
+vi.mock("../../stores/templateStore", () => ({
+  useTemplateStore: vi.fn(),
+}));
+
+describe("CreateTemplateDialog", () => {
+  const mockCreateTemplate = vi.fn();
+  const mockOnOpenChange = vi.fn();
+  const mockOnCreated = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock useTemplateStore to return our mock function
+    (useTemplateStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (selector: (state: { createTemplate: typeof mockCreateTemplate }) => typeof mockCreateTemplate) => {
+        return selector({ createTemplate: mockCreateTemplate });
+      },
+    );
+
+    mockCreateTemplate.mockResolvedValue({ id: "custom-123" });
+  });
+
+  // ===========================================================================
+  // 基础渲染测试
+  // ===========================================================================
+  describe("渲染", () => {
+    it("打开时应该渲染对话框", () => {
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      expect(screen.getByTestId("create-template-dialog")).toBeInTheDocument();
+    });
+
+    it("关闭时不应该渲染对话框内容", () => {
+      render(
+        <CreateTemplateDialog
+          open={false}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      expect(screen.queryByTestId("create-template-dialog")).not.toBeInTheDocument();
+    });
+
+    it("应该渲染模板名称输入框", () => {
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      expect(screen.getByTestId("create-template-name")).toBeInTheDocument();
+    });
+
+    it("应该渲染描述输入框", () => {
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      expect(screen.getByTestId("create-template-description")).toBeInTheDocument();
+    });
+
+    it("应该渲染创建按钮", () => {
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      expect(screen.getByTestId("create-template-submit")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 表单提交测试
+  // ===========================================================================
+  describe("表单提交", () => {
+    it("没有名称时不应该提交", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      await user.click(screen.getByTestId("create-template-submit"));
+
+      expect(mockCreateTemplate).not.toHaveBeenCalled();
+    });
+
+    it("输入名称后应该能提交", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          onCreated={mockOnCreated}
+        />,
+      );
+
+      await user.type(screen.getByTestId("create-template-name"), "My Template");
+      await user.click(screen.getByTestId("create-template-submit"));
+
+      await waitFor(() => {
+        expect(mockCreateTemplate).toHaveBeenCalledWith({
+          name: "My Template",
+          description: undefined,
+          structure: { folders: [], files: [] },
+        });
+      });
+    });
+
+    it("提交成功后应该调用 onCreated", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          onCreated={mockOnCreated}
+        />,
+      );
+
+      await user.type(screen.getByTestId("create-template-name"), "My Template");
+      await user.click(screen.getByTestId("create-template-submit"));
+
+      await waitFor(() => {
+        expect(mockOnCreated).toHaveBeenCalledWith("custom-123");
+      });
+    });
+
+    it("提交成功后应该关闭对话框", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      await user.type(screen.getByTestId("create-template-name"), "My Template");
+      await user.click(screen.getByTestId("create-template-submit"));
+
+      await waitFor(() => {
+        expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // 文件夹/文件管理测试
+  // ===========================================================================
+  describe("文件夹管理", () => {
+    it("应该能添加文件夹", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          onCreated={mockOnCreated}
+        />,
+      );
+
+      // Find folder input (placeholder: "e.g., chapters")
+      const folderInputs = screen.getAllByPlaceholderText("e.g., chapters");
+      await user.type(folderInputs[0], "my-folder");
+
+      // Click add button
+      const addButtons = screen.getAllByText("Add");
+      await user.click(addButtons[0]);
+
+      // Should show the folder in the list
+      expect(screen.getByText("my-folder")).toBeInTheDocument();
+    });
+
+    it("应该能移除文件夹", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      // Add a folder first
+      const folderInputs = screen.getAllByPlaceholderText("e.g., chapters");
+      await user.type(folderInputs[0], "my-folder");
+      const addButtons = screen.getAllByText("Add");
+      await user.click(addButtons[0]);
+
+      // Now remove it
+      const removeButton = screen.getByLabelText("Remove my-folder");
+      await user.click(removeButton);
+
+      // Should not be in the document anymore
+      expect(screen.queryByText("my-folder")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("文件管理", () => {
+    it("应该能添加文件", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      // Find file input (placeholder: "e.g., outline.md")
+      const fileInputs = screen.getAllByPlaceholderText("e.g., outline.md");
+      await user.type(fileInputs[0], "readme.md");
+
+      // Click add button (second one)
+      const addButtons = screen.getAllByText("Add");
+      await user.click(addButtons[1]);
+
+      // Should show the file in the list
+      expect(screen.getByText("readme.md")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // 取消测试
+  // ===========================================================================
+  describe("取消", () => {
+    it("点击 Cancel 应该关闭对话框", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      await user.click(screen.getByText("Cancel"));
+
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ===========================================================================
+  // 错误处理测试
+  // ===========================================================================
+  describe("错误处理", () => {
+    it("创建失败时应该显示错误", async () => {
+      const user = userEvent.setup();
+      mockCreateTemplate.mockRejectedValueOnce(new Error("Network error"));
+
+      render(
+        <CreateTemplateDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+        />,
+      );
+
+      await user.type(screen.getByTestId("create-template-name"), "My Template");
+      await user.click(screen.getByTestId("create-template-submit"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateTemplateDialog.tsx
@@ -1,0 +1,346 @@
+import React, { useState, useCallback } from "react";
+
+import { Button } from "../../components/primitives/Button";
+import { Dialog } from "../../components/primitives/Dialog";
+import { Input } from "../../components/primitives/Input";
+import { Textarea } from "../../components/primitives/Textarea";
+import { Text } from "../../components/primitives/Text";
+import { useTemplateStore, type TemplateStructure } from "../../stores/templateStore";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface CreateTemplateDialogProps {
+  /** Whether the dialog is open */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Callback when template is created successfully */
+  onCreated?: (templateId: string) => void;
+}
+
+// =============================================================================
+// Folder/File List Item
+// =============================================================================
+
+interface ListItemProps {
+  value: string;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+function ListItem({ value, onRemove, disabled }: ListItemProps): JSX.Element {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded-[var(--radius-sm)]">
+      <span className="flex-1 text-sm text-[var(--color-fg-default)] truncate">
+        {value}
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        className="text-[var(--color-fg-muted)] hover:text-[var(--color-error)] transition-colors disabled:opacity-50"
+        aria-label={`Remove ${value}`}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// =============================================================================
+// Add Item Input
+// =============================================================================
+
+interface AddItemInputProps {
+  placeholder: string;
+  onAdd: (value: string) => void;
+  disabled?: boolean;
+}
+
+function AddItemInput({ placeholder, onAdd, disabled }: AddItemInputProps): JSX.Element {
+  const [value, setValue] = useState("");
+
+  const handleAdd = useCallback(() => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      onAdd(trimmed);
+      setValue("");
+    }
+  }, [value, onAdd]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleAdd();
+      }
+    },
+    [handleAdd],
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        fullWidth
+        className="flex-1"
+      />
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={handleAdd}
+        disabled={disabled || !value.trim()}
+      >
+        Add
+      </Button>
+    </div>
+  );
+}
+
+// =============================================================================
+// CreateTemplateDialog Component
+// =============================================================================
+
+/**
+ * Dialog for creating custom project templates
+ *
+ * Allows users to define:
+ * - Template name (required)
+ * - Description (optional)
+ * - Initial folders
+ * - Initial files
+ */
+export function CreateTemplateDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: CreateTemplateDialogProps): JSX.Element {
+  const createTemplate = useTemplateStore((s) => s.createTemplate);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [folders, setFolders] = useState<string[]>([]);
+  const [files, setFiles] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const formId = "create-template-form";
+
+  // Reset form when dialog closes
+  React.useEffect(() => {
+    if (!open) {
+      setName("");
+      setDescription("");
+      setFolders([]);
+      setFiles([]);
+      setSubmitting(false);
+      setError(null);
+    }
+  }, [open]);
+
+  const handleAddFolder = useCallback((folder: string) => {
+    setFolders((prev) => {
+      if (prev.includes(folder)) return prev;
+      return [...prev, folder];
+    });
+  }, []);
+
+  const handleRemoveFolder = useCallback((folder: string) => {
+    setFolders((prev) => prev.filter((f) => f !== folder));
+  }, []);
+
+  const handleAddFile = useCallback((file: string) => {
+    setFiles((prev) => {
+      if (prev.includes(file)) return prev;
+      return [...prev, file];
+    });
+  }, []);
+
+  const handleRemoveFile = useCallback((file: string) => {
+    setFiles((prev) => prev.filter((f) => f !== file));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        setError("Template name is required");
+        return;
+      }
+
+      setSubmitting(true);
+      setError(null);
+
+      try {
+        const structure: TemplateStructure = {
+          folders,
+          files: files.map((path) => ({ path })),
+        };
+
+        const template = await createTemplate({
+          name: trimmedName,
+          description: description.trim() || undefined,
+          structure,
+        });
+
+        onCreated?.(template.id);
+        onOpenChange(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create template");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [name, description, folders, files, createTemplate, onCreated, onOpenChange],
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Create Template"
+      description="Create a reusable template for new projects."
+      footer={
+        <>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            data-testid="create-template-submit"
+            variant="primary"
+            size="sm"
+            loading={submitting}
+            type="submit"
+            form={formId}
+          >
+            {submitting ? "Creating..." : "Create Template"}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id={formId}
+        data-testid="create-template-dialog"
+        onSubmit={handleSubmit}
+        className="space-y-6"
+      >
+        {/* Template Name */}
+        <div>
+          <label className="block mb-2">
+            <Text size="small" color="muted">
+              Template Name <span className="text-[var(--color-error)]">*</span>
+            </Text>
+          </label>
+          <Input
+            data-testid="create-template-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            placeholder="e.g., Sci-Fi Novel"
+            fullWidth
+            error={!!error && !name.trim()}
+          />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block mb-2">
+            <Text size="small" color="muted">
+              Description{" "}
+              <span className="opacity-50 text-xs">(Optional)</span>
+            </Text>
+          </label>
+          <Textarea
+            data-testid="create-template-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief description of this template..."
+            fullWidth
+            rows={2}
+          />
+        </div>
+
+        {/* Initial Folders */}
+        <div>
+          <label className="block mb-2">
+            <Text size="small" color="muted">
+              Initial Folders{" "}
+              <span className="opacity-50 text-xs">(Optional)</span>
+            </Text>
+          </label>
+          <div className="space-y-2">
+            {folders.map((folder) => (
+              <ListItem
+                key={folder}
+                value={folder}
+                onRemove={() => handleRemoveFolder(folder)}
+                disabled={submitting}
+              />
+            ))}
+            <AddItemInput
+              placeholder="e.g., chapters"
+              onAdd={handleAddFolder}
+              disabled={submitting}
+            />
+          </div>
+        </div>
+
+        {/* Initial Files */}
+        <div>
+          <label className="block mb-2">
+            <Text size="small" color="muted">
+              Initial Files{" "}
+              <span className="opacity-50 text-xs">(Optional)</span>
+            </Text>
+          </label>
+          <div className="space-y-2">
+            {files.map((file) => (
+              <ListItem
+                key={file}
+                value={file}
+                onRemove={() => handleRemoveFile(file)}
+                disabled={submitting}
+              />
+            ))}
+            <AddItemInput
+              placeholder="e.g., outline.md"
+              onAdd={handleAddFile}
+              disabled={submitting}
+            />
+          </div>
+        </div>
+
+        {/* Error Message */}
+        {error && (
+          <Text size="small" color="muted" as="div" className="text-[var(--color-error)]">
+            {error}
+          </Text>
+        )}
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/desktop/renderer/src/stores/templateStore.ts
+++ b/apps/desktop/renderer/src/stores/templateStore.ts
@@ -1,0 +1,246 @@
+import { create } from "zustand";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Template structure defines initial folders and files
+ */
+export interface TemplateStructure {
+  /** Initial folders to create */
+  folders: string[];
+  /** Initial files to create */
+  files: { path: string; content?: string }[];
+}
+
+/**
+ * Project template definition
+ */
+export interface ProjectTemplate {
+  /** Unique identifier */
+  id: string;
+  /** Template name */
+  name: string;
+  /** Template type: preset (built-in) or custom (user-created) */
+  type: "preset" | "custom";
+  /** Optional icon identifier */
+  icon?: string;
+  /** Template description */
+  description?: string;
+  /** Initial folder/file structure */
+  structure: TemplateStructure;
+  /** Creation timestamp (for custom templates) */
+  createdAt?: number;
+}
+
+// =============================================================================
+// Preset Templates
+// =============================================================================
+
+const PRESET_TEMPLATES: ProjectTemplate[] = [
+  {
+    id: "preset-novel",
+    name: "Novel",
+    type: "preset",
+    description: "Long-form fiction with chapter structure",
+    structure: {
+      folders: ["chapters", "characters", "worldbuilding"],
+      files: [
+        { path: "chapters/chapter-01.md", content: "# Chapter 1\n\n" },
+        { path: "outline.md", content: "# Story Outline\n\n## Act 1\n\n## Act 2\n\n## Act 3\n" },
+      ],
+    },
+  },
+  {
+    id: "preset-short",
+    name: "Short Story",
+    type: "preset",
+    description: "Single document for short fiction",
+    structure: {
+      folders: [],
+      files: [{ path: "story.md", content: "# Untitled Story\n\n" }],
+    },
+  },
+  {
+    id: "preset-script",
+    name: "Screenplay",
+    type: "preset",
+    description: "Script format with scenes and dialogue",
+    structure: {
+      folders: ["scenes"],
+      files: [
+        { path: "scenes/scene-01.md", content: "# Scene 1\n\nINT. LOCATION - DAY\n\n" },
+        { path: "characters.md", content: "# Characters\n\n" },
+      ],
+    },
+  },
+  {
+    id: "preset-other",
+    name: "Other",
+    type: "preset",
+    description: "Blank project with no predefined structure",
+    structure: {
+      folders: [],
+      files: [],
+    },
+  },
+];
+
+// =============================================================================
+// Store Interface
+// =============================================================================
+
+interface TemplateState {
+  /** System preset templates (read-only) */
+  presets: ProjectTemplate[];
+  /** User custom templates */
+  customs: ProjectTemplate[];
+  /** Loading state */
+  loading: boolean;
+  /** Last error */
+  error: string | null;
+}
+
+interface TemplateActions {
+  /** Load all templates */
+  loadTemplates: () => Promise<void>;
+  /** Create a new custom template */
+  createTemplate: (
+    template: Omit<ProjectTemplate, "id" | "type" | "createdAt">,
+  ) => Promise<ProjectTemplate>;
+  /** Update an existing custom template */
+  updateTemplate: (
+    id: string,
+    updates: Partial<Omit<ProjectTemplate, "id" | "type">>,
+  ) => Promise<void>;
+  /** Delete a custom template */
+  deleteTemplate: (id: string) => Promise<void>;
+  /** Get all templates (presets + customs) */
+  getAllTemplates: () => ProjectTemplate[];
+  /** Get a template by ID */
+  getTemplateById: (id: string) => ProjectTemplate | undefined;
+  /** Clear error */
+  clearError: () => void;
+}
+
+type TemplateStore = TemplateState & TemplateActions;
+
+// =============================================================================
+// Store Implementation
+// =============================================================================
+
+/**
+ * Generate a unique ID for custom templates
+ */
+function generateTemplateId(): string {
+  return `custom-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Storage key for persisting custom templates
+ */
+const STORAGE_KEY = "creonow.templates.customs";
+
+/**
+ * Load custom templates from localStorage
+ */
+function loadCustomTemplatesFromStorage(): ProjectTemplate[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored) as ProjectTemplate[];
+  } catch {
+    console.error("Failed to load custom templates from storage");
+    return [];
+  }
+}
+
+/**
+ * Save custom templates to localStorage
+ */
+function saveCustomTemplatesToStorage(templates: ProjectTemplate[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  } catch {
+    console.error("Failed to save custom templates to storage");
+  }
+}
+
+/**
+ * Template store for managing project templates
+ */
+export const useTemplateStore = create<TemplateStore>((set, get) => ({
+  // State
+  presets: PRESET_TEMPLATES,
+  customs: [],
+  loading: false,
+  error: null,
+
+  // Actions
+  loadTemplates: async () => {
+    set({ loading: true, error: null });
+    try {
+      const customs = loadCustomTemplatesFromStorage();
+      set({ customs, loading: false });
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : "Failed to load templates",
+        loading: false,
+      });
+    }
+  },
+
+  createTemplate: async (template) => {
+    const { customs } = get();
+    const newTemplate: ProjectTemplate = {
+      ...template,
+      id: generateTemplateId(),
+      type: "custom",
+      createdAt: Date.now(),
+    };
+
+    const updated = [...customs, newTemplate];
+    saveCustomTemplatesToStorage(updated);
+    set({ customs: updated });
+
+    return newTemplate;
+  },
+
+  updateTemplate: async (id, updates) => {
+    const { customs } = get();
+    const index = customs.findIndex((t) => t.id === id);
+
+    if (index === -1) {
+      throw new Error(`Template not found: ${id}`);
+    }
+
+    const updated = [...customs];
+    updated[index] = { ...updated[index], ...updates };
+
+    saveCustomTemplatesToStorage(updated);
+    set({ customs: updated });
+  },
+
+  deleteTemplate: async (id) => {
+    const { customs } = get();
+    const updated = customs.filter((t) => t.id !== id);
+
+    saveCustomTemplatesToStorage(updated);
+    set({ customs: updated });
+  },
+
+  getAllTemplates: () => {
+    const { presets, customs } = get();
+    return [...presets, ...customs];
+  },
+
+  getTemplateById: (id) => {
+    const { presets, customs } = get();
+    return presets.find((t) => t.id === id) || customs.find((t) => t.id === id);
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+}));

--- a/openspec/_ops/task_runs/ISSUE-118.md
+++ b/openspec/_ops/task_runs/ISSUE-118.md
@@ -55,3 +55,21 @@
 **总测试**
 - Command: `pnpm vitest run` (相关测试文件)
 - Key output: 85 tests passed (4 files)
+
+### 2026-02-03 Browser Storybook 验收
+
+**RadioCardGroup**
+- URL: `http://172.18.248.30:6008/?path=/story/primitives-radio--card-group`
+- 验证: 2x2 网格布局正确，点击切换选中状态，选中时边框/背景/check icon 显示正确
+- Evidence: MCP browser screenshot
+
+**ImageUpload**
+- URL: `http://172.18.248.30:6008/?path=/story/primitives-imageupload--default`
+- 验证: 虚线边框样式正确，placeholder/hint 文案显示正确
+- Evidence: MCP browser screenshot
+
+**CreateProjectDialog**
+- URL: `http://172.18.248.30:6008/?path=/story/features-createprojectdialog--open`
+- 验证: 对话框打开正常，预设模板 4 个卡片显示正确，Create Template 入口可见
+- Evidence: MCP browser screenshot
+- Fix: 添加 mock ProjectStoreProvider decorator 解决 context missing 问题

--- a/openspec/_ops/task_runs/ISSUE-118.md
+++ b/openspec/_ops/task_runs/ISSUE-118.md
@@ -2,7 +2,7 @@
 
 - Issue: #118
 - Branch: task/118-create-project-dialog
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/119
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-118.md
+++ b/openspec/_ops/task_runs/ISSUE-118.md
@@ -1,0 +1,57 @@
+# ISSUE-118
+
+- Issue: #118
+- Branch: task/118-create-project-dialog
+- PR: <fill-after-created>
+
+## Plan
+
+- 扩展 Radio 组件，新增 RadioCardGroup 卡片式选择变体
+- 新建 ImageUpload 组件，支持拖拽上传/预览/移除
+- 实现模板系统（预设 + 自定义模板 CRUD）
+- 重构 CreateProjectDialog，集成表单 + 模板选择 + 创建模板入口
+- 完善 Storybook Story + 测试用例
+- 通过浏览器 Storybook 完整验收所有组件
+
+## Runs
+
+### 2026-02-03 Setup
+
+- Command: `gh issue create`, `scripts/agent_worktree_setup.sh 118 create-project-dialog`
+- Key output: Issue #118 created, worktree at `.worktrees/issue-118-create-project-dialog`
+- Evidence: Branch `task/118-create-project-dialog`
+
+### 2026-02-03 Implementation
+
+**RadioCardGroup 组件**
+- Command: `pnpm vitest run renderer/src/components/primitives/Radio.test.tsx`
+- Key output: 33 tests passed
+- Evidence: `apps/desktop/renderer/src/components/primitives/Radio.tsx`
+
+**ImageUpload 组件**
+- Command: `pnpm vitest run renderer/src/components/primitives/ImageUpload.test.tsx`
+- Key output: 19 tests passed
+- Evidence: `apps/desktop/renderer/src/components/primitives/ImageUpload.tsx`
+
+**Template System**
+- Command: `pnpm vitest run renderer/src/features/projects/CreateTemplateDialog.test.tsx`
+- Key output: 14 tests passed
+- Evidence: `apps/desktop/renderer/src/stores/templateStore.ts`, `apps/desktop/renderer/src/features/projects/CreateTemplateDialog.tsx`
+
+**CreateProjectDialog 重构**
+- Command: `pnpm vitest run renderer/src/features/projects/CreateProjectDialog.test.tsx`
+- Key output: 19 tests passed
+- Evidence: `apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx`
+
+**Lint 验证**
+- Command: `pnpm lint`
+- Key output: No errors
+
+**Storybook 构建验证**
+- Command: `pnpm storybook:build`
+- Key output: All stories built successfully (7.74s)
+- Evidence: `storybook-static/` directory created
+
+**总测试**
+- Command: `pnpm vitest run` (相关测试文件)
+- Key output: 85 tests passed (4 files)


### PR DESCRIPTION
Closes #118

## Summary

- 新增 `RadioCardGroup` 组件：卡片式单选按钮组，用于模板选择
- 新增 `ImageUpload` 组件：拖拽上传/预览/移除封面图片
- 新增 `templateStore`：管理预设模板（Novel/Short/Screenplay/Other）+ 自定义模板 CRUD
- 新增 `CreateTemplateDialog`：创建自定义模板对话框
- 重构 `CreateProjectDialog`：
  - 项目名称（必填验证 + shake 动画）
  - 模板选择（预设 + 自定义 + 创建入口）
  - 描述字段（可选）
  - 封面图片上传（可选）

## Test Plan

- [x] RadioCardGroup: 33 tests passed
- [x] ImageUpload: 19 tests passed  
- [x] CreateTemplateDialog: 14 tests passed
- [x] CreateProjectDialog: 19 tests passed
- [x] Lint: No errors
- [x] Storybook build: Success

## Design Notes

- 使用 `--color-accent` (白色) 而非设计稿中的紫色，遵循 DESIGN_DECISIONS.md 规范
- 所有颜色使用 CSS Variables
- 对话框使用 `--radius-lg`、`--shadow-xl`、`--z-modal`