### PR TITLE
fix(e2e): click memory button before checking panel visibility (#120)

### DIFF
--- a/apps/desktop/tests/e2e/memory-preference-learning.spec.ts
+++ b/apps/desktop/tests/e2e/memory-preference-learning.spec.ts
@@ -85,6 +85,8 @@ test("memory: injection preview + preference learning loop", async () => {
   const userDataDir = await createIsolatedUserDataDir();
   const { electronApp, page } = await launchApp({ userDataDir });
 
+  // Switch to memory panel first (default is sidebar/files panel)
+  await page.getByTestId("icon-bar-memory").click();
   await expect(page.getByTestId("memory-panel")).toBeVisible();
 
   const settingsRes = await ipcInvoke(page, "memory:settings:update", {

--- a/openspec/_ops/task_runs/ISSUE-120.md
+++ b/openspec/_ops/task_runs/ISSUE-120.md
@@ -1,7 +1,7 @@
 # ISSUE-120
 - Issue: #120
 - Branch: task/120-memory-e2e-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/121
 
 ## Plan
 - 修复 memory-preference-learning E2E 测试：在检查 memory-panel 前先切换到 memory 面板

--- a/openspec/_ops/task_runs/ISSUE-120.md
+++ b/openspec/_ops/task_runs/ISSUE-120.md
@@ -1,0 +1,19 @@
+# ISSUE-120
+- Issue: #120
+- Branch: task/120-memory-e2e-fix
+- PR: <fill-after-created>
+
+## Plan
+- 修复 memory-preference-learning E2E 测试：在检查 memory-panel 前先切换到 memory 面板
+- 验证 windows-e2e 全部通过 (27/27)
+
+## Runs
+### 2026-02-03 12:45 Analysis
+- Root cause: `activeLeftPanel` defaults to `"sidebar"`, but test expects `memory-panel` visible
+- Solution: Click `icon-bar-memory` button before asserting `memory-panel` visibility
+
+### 2026-02-03 12:50 Implementation
+- Command: Edit `memory-preference-learning.spec.ts` line 88
+- Change: Add `await page.getByTestId("icon-bar-memory").click();` before visibility check
+- Command: `pnpm typecheck`
+- Key output: No errors


### PR DESCRIPTION
Closes #120

## Summary
Fix the flaky `memory-preference-learning.spec.ts` E2E test by clicking the memory button before asserting panel visibility.

**Root cause**: `activeLeftPanel` defaults to `"sidebar"` (Files/Search/KG), but the test expected `memory-panel` to be visible immediately.

**Fix**: Add `await page.getByTestId("icon-bar-memory").click()` before the visibility assertion.

## Test plan
- [ ] windows-e2e passes (27/27 tests)
- [ ] All CI checks green