### PR TITLE
feat: add SettingsDialog system settings modal (#122)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Slider.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Slider.stories.tsx
@@ -67,62 +67,72 @@ export const WithLabels: Story = {
 };
 
 /**
+ * Interface scale slider wrapper component
+ */
+function InterfaceScaleSlider(): JSX.Element {
+  const [scale, setScale] = React.useState(100);
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] text-[var(--color-fg-muted)]">
+          Interface Scale
+        </span>
+        <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
+          {scale}%
+        </span>
+      </div>
+      <Slider
+        min={80}
+        max={120}
+        step={10}
+        value={scale}
+        onValueChange={setScale}
+        showLabels
+      />
+    </div>
+  );
+}
+
+/**
  * Interface scale slider (as used in settings)
  */
 export const InterfaceScale: Story = {
-  render: () => {
-    const [scale, setScale] = React.useState(100);
-    return (
-      <div className="flex flex-col gap-2 w-full">
-        <div className="flex items-center justify-between">
-          <span className="text-[13px] text-[var(--color-fg-muted)]">
-            Interface Scale
-          </span>
-          <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
-            {scale}%
-          </span>
-        </div>
-        <Slider
-          min={80}
-          max={120}
-          step={10}
-          value={scale}
-          onValueChange={setScale}
-          showLabels
-        />
-      </div>
-    );
-  },
+  render: () => <InterfaceScaleSlider />,
 };
+
+/**
+ * Font size slider wrapper component
+ */
+function FontSizeSlider(): JSX.Element {
+  const [fontSize, setFontSize] = React.useState(16);
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] text-[var(--color-fg-muted)]">
+          Font Size
+        </span>
+        <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
+          {fontSize}px
+        </span>
+      </div>
+      <Slider
+        min={12}
+        max={24}
+        step={1}
+        value={fontSize}
+        onValueChange={setFontSize}
+        showLabels
+        formatLabel={(v) => `${v}px`}
+      />
+    </div>
+  );
+}
 
 /**
  * Font size slider
  */
 export const FontSize: Story = {
-  render: () => {
-    const [fontSize, setFontSize] = React.useState(16);
-    return (
-      <div className="flex flex-col gap-2 w-full">
-        <div className="flex items-center justify-between">
-          <span className="text-[13px] text-[var(--color-fg-muted)]">
-            Font Size
-          </span>
-          <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
-            {fontSize}px
-          </span>
-        </div>
-        <Slider
-          min={12}
-          max={24}
-          step={1}
-          value={fontSize}
-          onValueChange={setFontSize}
-          showLabels
-          formatLabel={(v) => `${v}px`}
-        />
-      </div>
-    );
-  },
+  render: () => <FontSizeSlider />,
 };
 
 /**
@@ -139,37 +149,42 @@ export const Disabled: Story = {
 };
 
 /**
+ * Volume slider wrapper component
+ */
+function VolumeSlider(): JSX.Element {
+  const [volume, setVolume] = React.useState(75);
+  return (
+    <div className="flex items-center gap-3 w-full">
+      <svg
+        className="w-5 h-5 text-[var(--color-fg-muted)]"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728M5 9v6h4l5 5V4L9 9H5z"
+        />
+      </svg>
+      <Slider
+        min={0}
+        max={100}
+        step={1}
+        value={volume}
+        onValueChange={setVolume}
+      />
+      <span className="text-[12px] text-[var(--color-fg-muted)] w-8 text-right">
+        {volume}
+      </span>
+    </div>
+  );
+}
+
+/**
  * Volume slider (0-100)
  */
 export const Volume: Story = {
-  render: () => {
-    const [volume, setVolume] = React.useState(75);
-    return (
-      <div className="flex items-center gap-3 w-full">
-        <svg
-          className="w-5 h-5 text-[var(--color-fg-muted)]"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728M5 9v6h4l5 5V4L9 9H5z"
-          />
-        </svg>
-        <Slider
-          min={0}
-          max={100}
-          step={1}
-          value={volume}
-          onValueChange={setVolume}
-        />
-        <span className="text-[12px] text-[var(--color-fg-muted)] w-8 text-right">
-          {volume}
-        </span>
-      </div>
-    );
-  },
+  render: () => <VolumeSlider />,
 };

--- a/apps/desktop/renderer/src/components/primitives/Slider.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Slider.stories.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Slider } from "./Slider";
+
+/**
+ * Slider component stories
+ *
+ * A range slider component for numeric values.
+ * Based on design spec style from 10-settings.html.
+ */
+const meta: Meta<typeof Slider> = {
+  title: "Primitives/Slider",
+  component: Slider,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+    },
+  },
+  argTypes: {
+    value: { control: { type: "number", min: 0, max: 100 } },
+    min: { control: "number" },
+    max: { control: "number" },
+    step: { control: "number" },
+    disabled: { control: "boolean" },
+    showLabels: { control: "boolean" },
+    onValueChange: { action: "valueChange" },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className="p-8 bg-[var(--color-bg-surface)] w-[300px]"
+        data-theme="dark"
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Slider>;
+
+/**
+ * Default slider (0-100)
+ */
+export const Default: Story = {
+  args: {
+    defaultValue: 50,
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+};
+
+/**
+ * Slider with labels
+ */
+export const WithLabels: Story = {
+  args: {
+    defaultValue: 100,
+    min: 80,
+    max: 120,
+    step: 10,
+    showLabels: true,
+  },
+};
+
+/**
+ * Interface scale slider (as used in settings)
+ */
+export const InterfaceScale: Story = {
+  render: () => {
+    const [scale, setScale] = React.useState(100);
+    return (
+      <div className="flex flex-col gap-2 w-full">
+        <div className="flex items-center justify-between">
+          <span className="text-[13px] text-[var(--color-fg-muted)]">
+            Interface Scale
+          </span>
+          <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
+            {scale}%
+          </span>
+        </div>
+        <Slider
+          min={80}
+          max={120}
+          step={10}
+          value={scale}
+          onValueChange={setScale}
+          showLabels
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Font size slider
+ */
+export const FontSize: Story = {
+  render: () => {
+    const [fontSize, setFontSize] = React.useState(16);
+    return (
+      <div className="flex flex-col gap-2 w-full">
+        <div className="flex items-center justify-between">
+          <span className="text-[13px] text-[var(--color-fg-muted)]">
+            Font Size
+          </span>
+          <span className="text-[13px] text-[var(--color-fg-default)] font-medium">
+            {fontSize}px
+          </span>
+        </div>
+        <Slider
+          min={12}
+          max={24}
+          step={1}
+          value={fontSize}
+          onValueChange={setFontSize}
+          showLabels
+          formatLabel={(v) => `${v}px`}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Disabled slider
+ */
+export const Disabled: Story = {
+  args: {
+    defaultValue: 50,
+    min: 0,
+    max: 100,
+    disabled: true,
+    showLabels: true,
+  },
+};
+
+/**
+ * Volume slider (0-100)
+ */
+export const Volume: Story = {
+  render: () => {
+    const [volume, setVolume] = React.useState(75);
+    return (
+      <div className="flex items-center gap-3 w-full">
+        <svg
+          className="w-5 h-5 text-[var(--color-fg-muted)]"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15.536 8.464a5 5 0 010 7.072M18.364 5.636a9 9 0 010 12.728M5 9v6h4l5 5V4L9 9H5z"
+          />
+        </svg>
+        <Slider
+          min={0}
+          max={100}
+          step={1}
+          value={volume}
+          onValueChange={setVolume}
+        />
+        <span className="text-[12px] text-[var(--color-fg-muted)] w-8 text-right">
+          {volume}
+        </span>
+      </div>
+    );
+  },
+};

--- a/apps/desktop/renderer/src/components/primitives/Slider.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Slider.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Slider } from "./Slider";
+
+describe("Slider", () => {
+  it("renders with default value", () => {
+    render(<Slider defaultValue={50} min={0} max={100} />);
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("aria-valuenow", "50");
+    expect(slider).toHaveAttribute("aria-valuemin", "0");
+    expect(slider).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  it("renders with controlled value", () => {
+    render(<Slider value={75} min={0} max={100} />);
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("aria-valuenow", "75");
+  });
+
+  it("calls onValueChange when value changes", () => {
+    const onValueChange = vi.fn();
+    render(
+      <Slider
+        defaultValue={50}
+        min={0}
+        max={100}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "75" } });
+
+    expect(onValueChange).toHaveBeenCalledWith(75);
+  });
+
+  it("shows labels when showLabels is true", () => {
+    render(
+      <Slider
+        defaultValue={100}
+        min={80}
+        max={120}
+        showLabels
+        formatLabel={(v) => `${v}%`}
+      />,
+    );
+
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("120%")).toBeInTheDocument();
+  });
+
+  it("uses default format label (percentage)", () => {
+    render(
+      <Slider
+        defaultValue={50}
+        min={0}
+        max={100}
+        showLabels
+      />,
+    );
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("respects step value", () => {
+    const onValueChange = vi.fn();
+    render(
+      <Slider
+        defaultValue={100}
+        min={80}
+        max={120}
+        step={10}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveAttribute("step", "10");
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    const onValueChange = vi.fn();
+    render(
+      <Slider
+        defaultValue={50}
+        disabled
+        onValueChange={onValueChange}
+      />,
+    );
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeDisabled();
+  });
+
+  it("updates internal state when uncontrolled", () => {
+    render(<Slider defaultValue={50} min={0} max={100} />);
+
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "75" } });
+
+    expect(slider).toHaveAttribute("aria-valuenow", "75");
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Slider.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Slider.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { Slider } from "./Slider";

--- a/apps/desktop/renderer/src/components/primitives/Slider.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Slider.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+
+/**
+ * Slider component props
+ *
+ * A range slider component for numeric values.
+ * Based on design spec style from 10-settings.html
+ */
+export interface SliderProps {
+  /** Current value (controlled) */
+  value?: number;
+  /** Callback when value changes */
+  onValueChange?: (value: number) => void;
+  /** Default value (uncontrolled) */
+  defaultValue?: number;
+  /** Minimum value */
+  min?: number;
+  /** Maximum value */
+  max?: number;
+  /** Step increment */
+  step?: number;
+  /** Disabled state */
+  disabled?: boolean;
+  /** Show min/max labels */
+  showLabels?: boolean;
+  /** Format function for labels */
+  formatLabel?: (value: number) => string;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Track styles
+ */
+const trackStyles = [
+  "relative",
+  "flex-1",
+  "h-[2px]",
+  "bg-[var(--color-border-default)]",
+  "rounded-full",
+].join(" ");
+
+/**
+ * Thumb styles (design spec: 12px round white thumb with black border)
+ */
+const thumbStyles = [
+  "absolute",
+  "top-1/2",
+  "-translate-y-1/2",
+  "w-3",
+  "h-3",
+  "rounded-full",
+  "bg-[var(--color-fg-default)]",
+  "border",
+  "border-[var(--color-fg-inverse)]",
+  "cursor-pointer",
+  "transition-shadow",
+  "duration-[var(--duration-fast)]",
+  // Hover and focus
+  "hover:shadow-[0_0_0_4px_var(--color-bg-surface)]",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+/**
+ * Label styles
+ */
+const labelStyles = ["text-[11px]", "text-[var(--color-fg-placeholder)]"].join(
+  " ",
+);
+
+/**
+ * Default format function for percentage
+ */
+const defaultFormatLabel = (value: number) => `${value}%`;
+
+/**
+ * Slider component for numeric range values
+ *
+ * A styled range slider based on the settings dialog design.
+ *
+ * @example
+ * ```tsx
+ * <Slider
+ *   min={80}
+ *   max={120}
+ *   step={10}
+ *   value={scale}
+ *   onValueChange={setScale}
+ *   showLabels
+ * />
+ * ```
+ */
+export function Slider({
+  value,
+  onValueChange,
+  defaultValue,
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled = false,
+  showLabels = false,
+  formatLabel = defaultFormatLabel,
+  className = "",
+}: SliderProps): JSX.Element {
+  // Internal state for uncontrolled usage
+  const [internalValue, setInternalValue] = React.useState(
+    defaultValue ?? min,
+  );
+
+  // Use controlled value if provided, otherwise use internal state
+  const currentValue = value !== undefined ? value : internalValue;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
+    const newValue = Number(e.target.value);
+
+    // Update internal state for uncontrolled usage
+    if (value === undefined) {
+      setInternalValue(newValue);
+    }
+
+    // Call callback if provided
+    onValueChange?.(newValue);
+  };
+
+  // Calculate thumb position percentage
+  const percentage = ((currentValue - min) / (max - min)) * 100;
+
+  const containerClasses = [
+    "flex",
+    "items-center",
+    "gap-3",
+    disabled ? "opacity-50 cursor-not-allowed" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={containerClasses}>
+      {showLabels && <span className={labelStyles}>{formatLabel(min)}</span>}
+
+      <div className="relative flex-1 h-5 flex items-center">
+        {/* Track background */}
+        <div className={trackStyles}>
+          {/* Filled portion */}
+          <div
+            className="absolute inset-y-0 left-0 bg-[var(--color-fg-subtle)] rounded-full"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+
+        {/* Native range input for accessibility */}
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={currentValue}
+          onChange={handleChange}
+          disabled={disabled}
+          className="absolute inset-0 w-full h-full opacity-0 cursor-pointer disabled:cursor-not-allowed"
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={currentValue}
+        />
+
+        {/* Custom thumb */}
+        <div
+          className={thumbStyles}
+          style={{
+            left: `calc(${percentage}% - 6px)`,
+            pointerEvents: "none",
+          }}
+        />
+      </div>
+
+      {showLabels && <span className={labelStyles}>{formatLabel(max)}</span>}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/components/primitives/Toggle.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toggle.stories.tsx
@@ -99,35 +99,40 @@ export const DisabledChecked: Story = {
 };
 
 /**
+ * Toggle group wrapper component
+ */
+function ToggleGroupDemo(): JSX.Element {
+  const [focusMode, setFocusMode] = React.useState(true);
+  const [typewriter, setTypewriter] = React.useState(false);
+  const [smartPunctuation, setSmartPunctuation] = React.useState(true);
+
+  return (
+    <div className="flex flex-col gap-6 w-[400px]">
+      <Toggle
+        label="Focus Mode"
+        description="Dims all interface elements except the editor."
+        checked={focusMode}
+        onCheckedChange={setFocusMode}
+      />
+      <Toggle
+        label="Typewriter Scroll"
+        description="Keeps your active line vertically centered."
+        checked={typewriter}
+        onCheckedChange={setTypewriter}
+      />
+      <Toggle
+        label="Smart Punctuation"
+        description="Convert straight quotes to curly quotes."
+        checked={smartPunctuation}
+        onCheckedChange={setSmartPunctuation}
+      />
+    </div>
+  );
+}
+
+/**
  * Multiple toggles in a group
  */
 export const ToggleGroup: Story = {
-  render: () => {
-    const [focusMode, setFocusMode] = React.useState(true);
-    const [typewriter, setTypewriter] = React.useState(false);
-    const [smartPunctuation, setSmartPunctuation] = React.useState(true);
-
-    return (
-      <div className="flex flex-col gap-6 w-[400px]">
-        <Toggle
-          label="Focus Mode"
-          description="Dims all interface elements except the editor."
-          checked={focusMode}
-          onCheckedChange={setFocusMode}
-        />
-        <Toggle
-          label="Typewriter Scroll"
-          description="Keeps your active line vertically centered."
-          checked={typewriter}
-          onCheckedChange={setTypewriter}
-        />
-        <Toggle
-          label="Smart Punctuation"
-          description="Convert straight quotes to curly quotes."
-          checked={smartPunctuation}
-          onCheckedChange={setSmartPunctuation}
-        />
-      </div>
-    );
-  },
+  render: () => <ToggleGroupDemo />,
 };

--- a/apps/desktop/renderer/src/components/primitives/Toggle.stories.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toggle.stories.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Toggle } from "./Toggle";
+
+/**
+ * Toggle component stories
+ *
+ * A toggle switch component for boolean settings.
+ * Based on design spec toggle style from 10-settings.html.
+ */
+const meta: Meta<typeof Toggle> = {
+  title: "Primitives/Toggle",
+  component: Toggle,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+    },
+  },
+  argTypes: {
+    checked: { control: "boolean" },
+    disabled: { control: "boolean" },
+    onCheckedChange: { action: "checkedChange" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8 bg-[var(--color-bg-surface)]" data-theme="dark">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toggle>;
+
+/**
+ * Default toggle in unchecked state
+ */
+export const Default: Story = {
+  args: {
+    defaultChecked: false,
+  },
+};
+
+/**
+ * Checked toggle
+ */
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+/**
+ * Toggle with label
+ */
+export const WithLabel: Story = {
+  args: {
+    label: "Enable notifications",
+    defaultChecked: true,
+  },
+};
+
+/**
+ * Toggle with label and description
+ */
+export const WithLabelAndDescription: Story = {
+  args: {
+    label: "Focus Mode",
+    description:
+      "Dims all interface elements except the editor when you start typing to reduce distractions.",
+    defaultChecked: true,
+  },
+};
+
+/**
+ * Disabled toggle
+ */
+export const Disabled: Story = {
+  args: {
+    label: "Disabled option",
+    description: "This option is currently unavailable.",
+    disabled: true,
+    defaultChecked: false,
+  },
+};
+
+/**
+ * Disabled and checked toggle
+ */
+export const DisabledChecked: Story = {
+  args: {
+    label: "Disabled option (on)",
+    description: "This option is enabled but cannot be changed.",
+    disabled: true,
+    checked: true,
+  },
+};
+
+/**
+ * Multiple toggles in a group
+ */
+export const ToggleGroup: Story = {
+  render: () => {
+    const [focusMode, setFocusMode] = React.useState(true);
+    const [typewriter, setTypewriter] = React.useState(false);
+    const [smartPunctuation, setSmartPunctuation] = React.useState(true);
+
+    return (
+      <div className="flex flex-col gap-6 w-[400px]">
+        <Toggle
+          label="Focus Mode"
+          description="Dims all interface elements except the editor."
+          checked={focusMode}
+          onCheckedChange={setFocusMode}
+        />
+        <Toggle
+          label="Typewriter Scroll"
+          description="Keeps your active line vertically centered."
+          checked={typewriter}
+          onCheckedChange={setTypewriter}
+        />
+        <Toggle
+          label="Smart Punctuation"
+          description="Convert straight quotes to curly quotes."
+          checked={smartPunctuation}
+          onCheckedChange={setSmartPunctuation}
+        />
+      </div>
+    );
+  },
+};

--- a/apps/desktop/renderer/src/components/primitives/Toggle.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toggle.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Toggle } from "./Toggle";
+
+describe("Toggle", () => {
+  it("renders in unchecked state by default", () => {
+    render(<Toggle />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders in checked state when checked prop is true", () => {
+    render(<Toggle checked={true} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders with defaultChecked", () => {
+    render(<Toggle defaultChecked={true} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles state when clicked (uncontrolled)", async () => {
+    const user = userEvent.setup();
+    render(<Toggle defaultChecked={false} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls onCheckedChange when toggled", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    render(<Toggle checked={false} onCheckedChange={onCheckedChange} />);
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("renders label when provided", () => {
+    render(<Toggle label="Enable feature" />);
+
+    expect(screen.getByText("Enable feature")).toBeInTheDocument();
+    expect(screen.getByLabelText("Enable feature")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(
+      <Toggle
+        label="Focus Mode"
+        description="Dims interface elements"
+      />,
+    );
+
+    expect(screen.getByText("Dims interface elements")).toBeInTheDocument();
+  });
+
+  it("is disabled when disabled prop is true", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    render(
+      <Toggle disabled={true} onCheckedChange={onCheckedChange} />,
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toBeDisabled();
+
+    await user.click(toggle);
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it("can be toggled with keyboard", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    render(<Toggle checked={false} onCheckedChange={onCheckedChange} />);
+
+    const toggle = screen.getByRole("switch");
+    toggle.focus();
+
+    await user.keyboard(" ");
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/desktop/renderer/src/components/primitives/Toggle.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toggle.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/desktop/renderer/src/components/primitives/Toggle.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Toggle.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+
+/**
+ * Toggle component props
+ *
+ * A toggle switch component for boolean settings.
+ * Based on design spec toggle style from 10-settings.html
+ */
+export interface ToggleProps {
+  /** Controlled checked state */
+  checked?: boolean;
+  /** Callback when checked state changes */
+  onCheckedChange?: (checked: boolean) => void;
+  /** Default checked state (uncontrolled) */
+  defaultChecked?: boolean;
+  /** Disabled state */
+  disabled?: boolean;
+  /** Unique ID for label association */
+  id?: string;
+  /** Optional label text */
+  label?: string;
+  /** Optional description text */
+  description?: string;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Toggle track styles
+ *
+ * Uses design spec style:
+ * - Off: bg-[#1a1a1a] border-[#333]
+ * - On: bg-white border-white
+ */
+const trackStyles = [
+  "relative",
+  "inline-flex",
+  "items-center",
+  "w-11",
+  "h-6",
+  "rounded-full",
+  "border",
+  "cursor-pointer",
+  "transition-all",
+  "duration-[var(--duration-slow)]",
+  "ease-[var(--ease-default)]",
+  "shrink-0",
+  // Focus visible
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+/**
+ * Toggle thumb styles
+ *
+ * Uses design spec style:
+ * - Off: bg-[#666]
+ * - On: bg-black, translate-x-[20px]
+ */
+const thumbStyles = [
+  "absolute",
+  "left-[3px]",
+  "w-[18px]",
+  "h-[18px]",
+  "rounded-full",
+  "transition-all",
+  "duration-[var(--duration-slow)]",
+  "pointer-events-none",
+].join(" ");
+
+/**
+ * Label styles
+ */
+const labelStyles = [
+  "text-[14px]",
+  "text-[var(--color-fg-default)]",
+  "font-medium",
+  "select-none",
+].join(" ");
+
+/**
+ * Description styles
+ */
+const descriptionStyles = [
+  "text-[13px]",
+  "text-[var(--color-fg-subtle)]",
+  "leading-relaxed",
+].join(" ");
+
+/**
+ * Toggle component for boolean settings
+ *
+ * A styled toggle switch based on the settings dialog design.
+ * Supports controlled and uncontrolled usage.
+ *
+ * @example
+ * ```tsx
+ * // Simple toggle
+ * <Toggle checked={enabled} onCheckedChange={setEnabled} />
+ *
+ * // With label and description
+ * <Toggle
+ *   label="Focus Mode"
+ *   description="Dims all interface elements except the editor"
+ *   checked={focusMode}
+ *   onCheckedChange={setFocusMode}
+ * />
+ * ```
+ */
+export function Toggle({
+  checked,
+  onCheckedChange,
+  defaultChecked = false,
+  disabled = false,
+  id,
+  label,
+  description,
+  className = "",
+}: ToggleProps): JSX.Element {
+  const generatedId = React.useId();
+  const toggleId = id ?? generatedId;
+
+  // Internal state for uncontrolled usage
+  const [internalChecked, setInternalChecked] = React.useState(defaultChecked);
+
+  // Use controlled value if provided, otherwise use internal state
+  const isChecked = checked !== undefined ? checked : internalChecked;
+
+  const handleToggle = () => {
+    if (disabled) return;
+
+    const newChecked = !isChecked;
+
+    // Update internal state for uncontrolled usage
+    if (checked === undefined) {
+      setInternalChecked(newChecked);
+    }
+
+    // Call callback if provided
+    onCheckedChange?.(newChecked);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      handleToggle();
+    }
+  };
+
+  const trackClasses = [
+    trackStyles,
+    isChecked
+      ? "bg-[var(--color-fg-default)] border-[var(--color-fg-default)]"
+      : "bg-[var(--color-bg-hover)] border-[var(--color-border-default)]",
+    disabled ? "opacity-50 cursor-not-allowed" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const thumbClasses = [
+    thumbStyles,
+    isChecked
+      ? "translate-x-[20px] bg-[var(--color-fg-inverse)]"
+      : "translate-x-0 bg-[var(--color-fg-subtle)]",
+  ].join(" ");
+
+  const toggleElement = (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isChecked}
+      id={toggleId}
+      disabled={disabled}
+      className={trackClasses}
+      onClick={handleToggle}
+      onKeyDown={handleKeyDown}
+    >
+      <span className={thumbClasses} />
+    </button>
+  );
+
+  if (label || description) {
+    return (
+      <div className="flex items-start justify-between gap-4 group">
+        <div className="flex flex-col gap-1">
+          {label && (
+            <label
+              htmlFor={toggleId}
+              className={`${labelStyles} ${disabled ? "opacity-50" : ""} cursor-pointer`}
+            >
+              {label}
+            </label>
+          )}
+          {description && (
+            <p className={`${descriptionStyles} ${disabled ? "opacity-50" : ""}`}>
+              {description}
+            </p>
+          )}
+        </div>
+        {toggleElement}
+      </div>
+    );
+  }
+
+  return toggleElement;
+}

--- a/apps/desktop/renderer/src/components/primitives/index.ts
+++ b/apps/desktop/renderer/src/components/primitives/index.ts
@@ -104,3 +104,9 @@ export type { ContextMenuProps, ContextMenuItem } from "./ContextMenu";
 
 export { ImageUpload } from "./ImageUpload";
 export type { ImageUploadProps } from "./ImageUpload";
+
+export { Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
+
+export { Slider } from "./Slider";
+export type { SliderProps } from "./Slider";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Avatar, Button, Text } from "../../components/primitives";
 
 /**
@@ -104,9 +103,10 @@ function PlanBadge({ plan }: { plan: SubscriptionPlan }): JSX.Element {
 export function SettingsAccount({
   account,
   onUpgrade,
-  onLogout,
+  onLogout: _onLogout,
   onDeleteAccount,
 }: SettingsAccountProps): JSX.Element {
+  void _onLogout; // Reserved for future use
   return (
     <div className="max-w-[560px]">
       {/* Header */}

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import { Avatar, Button, Text } from "../../components/primitives";
+
+/**
+ * Subscription plan types
+ */
+export type SubscriptionPlan = "free" | "pro" | "team";
+
+/**
+ * Account settings state
+ */
+export interface AccountSettings {
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  plan: SubscriptionPlan;
+}
+
+/**
+ * SettingsAccount page props
+ */
+export interface SettingsAccountProps {
+  /** Current account info */
+  account: AccountSettings;
+  /** Callback when upgrade is requested */
+  onUpgrade?: () => void;
+  /** Callback when logout is requested */
+  onLogout?: () => void;
+  /** Callback when delete account is requested */
+  onDeleteAccount?: () => void;
+}
+
+/**
+ * Section label styles
+ */
+const sectionLabelStyles = [
+  "text-[10px]",
+  "uppercase",
+  "tracking-[0.15em]",
+  "text-[var(--color-fg-placeholder)]",
+  "font-semibold",
+  "mb-6",
+].join(" ");
+
+/**
+ * Divider styles
+ */
+const dividerStyles = [
+  "w-full",
+  "h-px",
+  "bg-[var(--color-border-default)]",
+  "my-12",
+].join(" ");
+
+/**
+ * Card styles
+ */
+const cardStyles = [
+  "p-4",
+  "rounded-[var(--radius-md)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "bg-[var(--color-bg-raised)]",
+].join(" ");
+
+/**
+ * Plan badge component
+ */
+function PlanBadge({ plan }: { plan: SubscriptionPlan }): JSX.Element {
+  const planConfig: Record<
+    SubscriptionPlan,
+    { label: string; className: string }
+  > = {
+    free: {
+      label: "Free",
+      className: "bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]",
+    },
+    pro: {
+      label: "Pro",
+      className: "bg-[var(--color-info-subtle)] text-[var(--color-info)]",
+    },
+    team: {
+      label: "Team",
+      className: "bg-[var(--color-success-subtle)] text-[var(--color-success)]",
+    },
+  };
+
+  const { label, className } = planConfig[plan];
+
+  return (
+    <span
+      className={`px-2 py-0.5 rounded text-xs font-medium ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
+ * SettingsAccount page component
+ *
+ * Account settings page with profile, subscription, and danger zone sections.
+ */
+export function SettingsAccount({
+  account,
+  onUpgrade,
+  onLogout,
+  onDeleteAccount,
+}: SettingsAccountProps): JSX.Element {
+  return (
+    <div className="max-w-[560px]">
+      {/* Header */}
+      <h1 className="text-2xl font-normal text-[var(--color-fg-default)] mb-2 tracking-tight">
+        Account
+      </h1>
+      <p className="text-[var(--color-fg-subtle)] text-sm mb-12 font-light">
+        Manage your account settings and subscription.
+      </p>
+
+      {/* Profile Section */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Profile</h4>
+
+        <div className={`${cardStyles} flex items-center gap-4`}>
+          <Avatar
+            src={account.avatarUrl}
+            fallback={account.name}
+            size="lg"
+          />
+          <div className="flex flex-col gap-1">
+            <Text size="body" weight="medium" color="default">
+              {account.name}
+            </Text>
+            <Text size="small" color="muted">
+              {account.email}
+            </Text>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="ml-auto"
+          >
+            Edit Profile
+          </Button>
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Subscription Section */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Subscription</h4>
+
+        <div className={cardStyles}>
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-3">
+              <Text size="body" weight="medium" color="default">
+                Current Plan
+              </Text>
+              <PlanBadge plan={account.plan} />
+            </div>
+          </div>
+
+          <Text size="small" color="muted" className="mb-4" as="p">
+            {account.plan === "free"
+              ? "Upgrade to Pro for unlimited AI assistance, priority support, and advanced export options."
+              : account.plan === "pro"
+                ? "You have access to all Pro features including unlimited AI assistance and priority support."
+                : "Team plan includes collaboration features, shared workspaces, and admin controls."}
+          </Text>
+
+          <div className="flex gap-3">
+            {account.plan === "free" && (
+              <Button variant="primary" size="sm" onClick={onUpgrade}>
+                Upgrade to Pro
+              </Button>
+            )}
+            {account.plan !== "free" && (
+              <Button variant="secondary" size="sm">
+                Manage Subscription
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Danger Zone */}
+      <div className="mb-6">
+        <h4 className={sectionLabelStyles}>Danger Zone</h4>
+
+        <div className={cardStyles}>
+          <div className="flex items-center justify-between">
+            <div>
+              <Text size="body" weight="medium" color="default">
+                Delete Account
+              </Text>
+              <Text size="small" color="muted" as="p" className="mt-1">
+                Permanently delete your account and all associated data.
+              </Text>
+            </div>
+            <Button variant="danger" size="sm" onClick={onDeleteAccount}>
+              Delete Account
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Default account settings (example data)
+ */
+export const defaultAccountSettings: AccountSettings = {
+  name: "Sarah Mitchell",
+  email: "sarah@example.com",
+  avatarUrl: undefined,
+  plan: "pro",
+};

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Text } from "../../components/primitives";
 import { Slider } from "../../components/primitives/Slider";
 

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
@@ -1,0 +1,242 @@
+import React from "react";
+import { Text } from "../../components/primitives";
+import { Slider } from "../../components/primitives/Slider";
+
+/**
+ * Theme mode types
+ */
+export type ThemeMode = "light" | "dark" | "system";
+
+/**
+ * Appearance settings state
+ */
+export interface AppearanceSettings {
+  themeMode: ThemeMode;
+  accentColor: string;
+  fontSize: number;
+}
+
+/**
+ * SettingsAppearancePage props
+ */
+export interface SettingsAppearancePageProps {
+  /** Current settings values */
+  settings: AppearanceSettings;
+  /** Callback when settings change */
+  onSettingsChange: (settings: AppearanceSettings) => void;
+}
+
+/**
+ * Section label styles
+ */
+const sectionLabelStyles = [
+  "text-[10px]",
+  "uppercase",
+  "tracking-[0.15em]",
+  "text-[var(--color-fg-placeholder)]",
+  "font-semibold",
+  "mb-6",
+].join(" ");
+
+/**
+ * Divider styles
+ */
+const dividerStyles = [
+  "w-full",
+  "h-px",
+  "bg-[var(--color-border-default)]",
+  "my-12",
+].join(" ");
+
+/**
+ * Theme button styles
+ */
+const themeButtonBaseStyles = [
+  "flex",
+  "flex-col",
+  "items-center",
+  "gap-2",
+  "px-6",
+  "py-4",
+  "rounded-[var(--radius-md)]",
+  "border",
+  "cursor-pointer",
+  "transition-all",
+  "duration-[var(--duration-fast)]",
+].join(" ");
+
+/**
+ * Accent color options
+ */
+const accentColors = [
+  { value: "#ffffff", label: "White" },
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#22c55e", label: "Green" },
+  { value: "#f97316", label: "Orange" },
+  { value: "#8b5cf6", label: "Purple" },
+  { value: "#ec4899", label: "Pink" },
+];
+
+/**
+ * Theme preview component
+ */
+function ThemePreview({ mode }: { mode: ThemeMode }): JSX.Element {
+  const isDark = mode === "dark" || mode === "system";
+  const bgColor = isDark ? "#0f0f0f" : "#ffffff";
+  const fgColor = isDark ? "#ffffff" : "#1a1a1a";
+  const mutedColor = isDark ? "#666666" : "#888888";
+
+  return (
+    <div
+      className="w-16 h-12 rounded border border-[var(--color-border-default)] overflow-hidden"
+      style={{ backgroundColor: bgColor }}
+    >
+      {/* Mini preview content */}
+      <div className="p-1.5">
+        <div
+          className="h-1 w-8 rounded-sm mb-1"
+          style={{ backgroundColor: fgColor }}
+        />
+        <div
+          className="h-0.5 w-12 rounded-sm mb-0.5"
+          style={{ backgroundColor: mutedColor }}
+        />
+        <div
+          className="h-0.5 w-10 rounded-sm"
+          style={{ backgroundColor: mutedColor }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SettingsAppearancePage component
+ *
+ * Appearance settings page with theme selection, accent color, and font size controls.
+ */
+export function SettingsAppearancePage({
+  settings,
+  onSettingsChange,
+}: SettingsAppearancePageProps): JSX.Element {
+  const updateSetting = <K extends keyof AppearanceSettings>(
+    key: K,
+    value: AppearanceSettings[K],
+  ) => {
+    onSettingsChange({ ...settings, [key]: value });
+  };
+
+  const themes: { mode: ThemeMode; label: string }[] = [
+    { mode: "light", label: "Light" },
+    { mode: "dark", label: "Dark" },
+    { mode: "system", label: "System" },
+  ];
+
+  return (
+    <div className="max-w-[560px]">
+      {/* Header */}
+      <h1 className="text-2xl font-normal text-[var(--color-fg-default)] mb-2 tracking-tight">
+        Appearance
+      </h1>
+      <p className="text-[var(--color-fg-subtle)] text-sm mb-12 font-light">
+        Personalize the look and feel of your workspace.
+      </p>
+
+      {/* Theme Selection */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Theme</h4>
+
+        <div className="flex gap-4">
+          {themes.map(({ mode, label }) => {
+            const isSelected = settings.themeMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => updateSetting("themeMode", mode)}
+                className={`${themeButtonBaseStyles} ${
+                  isSelected
+                    ? "border-[var(--color-fg-default)] bg-[var(--color-bg-selected)]"
+                    : "border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)]"
+                }`}
+              >
+                <ThemePreview mode={mode} />
+                <Text
+                  size="small"
+                  color={isSelected ? "default" : "muted"}
+                  weight={isSelected ? "medium" : "normal"}
+                >
+                  {label}
+                </Text>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Accent Color */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Accent Color</h4>
+
+        <div className="flex gap-3">
+          {accentColors.map(({ value, label }) => {
+            const isSelected = settings.accentColor === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => updateSetting("accentColor", value)}
+                className={`w-8 h-8 rounded-full border-2 transition-all duration-[var(--duration-fast)] ${
+                  isSelected
+                    ? "ring-2 ring-offset-2 ring-offset-[var(--color-bg-surface)] ring-[var(--color-ring-focus)]"
+                    : "hover:scale-110"
+                }`}
+                style={{ backgroundColor: value }}
+                title={label}
+                aria-label={`Select ${label} accent color`}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Font Size */}
+      <div className="mb-6">
+        <h4 className={sectionLabelStyles}>Font Size</h4>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <Text size="small" color="muted">
+              Editor font size
+            </Text>
+            <Text size="small" color="default" weight="medium">
+              {settings.fontSize}px
+            </Text>
+          </div>
+          <Slider
+            min={12}
+            max={24}
+            step={1}
+            value={settings.fontSize}
+            onValueChange={(value) => updateSetting("fontSize", value)}
+            showLabels
+            formatLabel={(v) => `${v}px`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Default appearance settings
+ */
+export const defaultAppearanceSettings: AppearanceSettings = {
+  themeMode: "dark",
+  accentColor: "#ffffff",
+  fontSize: 16,
+};

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
@@ -306,8 +306,10 @@ export const NavigationTransition: Story = {
  * - Cancel returns to previous state
  */
 export const UnsavedChangesWarning: Story = {
-  render: (args) => {
-    const [settings, setSettings] = React.useState({
+  args: {
+    open: true,
+    defaultTab: "general",
+    initialSettings: {
       general: {
         ...defaultGeneralSettings,
         focusMode: false, // Changed from default
@@ -315,22 +317,7 @@ export const UnsavedChangesWarning: Story = {
       },
       appearance: defaultAppearanceSettings,
       export: defaultExportSettings,
-    });
-
-    return (
-      <SettingsDialog
-        {...args}
-        initialSettings={settings}
-        onSave={(newSettings) => {
-          setSettings(newSettings);
-          console.log("Settings saved:", newSettings);
-        }}
-      />
-    );
-  },
-  args: {
-    open: true,
-    defaultTab: "general",
+    },
     account: {
       name: "Sarah Mitchell",
       email: "sarah@example.com",

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
@@ -1,0 +1,382 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SettingsDialog } from "./SettingsDialog";
+import { defaultGeneralSettings } from "./SettingsGeneral";
+import { defaultAppearanceSettings } from "./SettingsAppearancePage";
+import { defaultExportSettings } from "./SettingsExport";
+
+/**
+ * SettingsDialog component stories
+ *
+ * Comprehensive settings dialog with 4 tabbed pages:
+ * - General: Writing experience, data storage, editor defaults
+ * - Appearance: Theme, accent color, font size
+ * - Export & Share: Default format, export options
+ * - Account: Profile, subscription, danger zone
+ *
+ * Based on design spec: 10-settings.html
+ */
+const meta: Meta<typeof SettingsDialog> = {
+  title: "Features/SettingsDialog",
+  component: SettingsDialog,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: {
+      default: "dark",
+    },
+  },
+  argTypes: {
+    open: { control: "boolean" },
+    onOpenChange: { action: "openChange" },
+    onSave: { action: "save" },
+    onUpgrade: { action: "upgrade" },
+    onLogout: { action: "logout" },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className="w-full h-screen bg-[var(--color-bg-base)]"
+        data-theme="dark"
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingsDialog>;
+
+/**
+ * Story 1: GeneralWritingExperience
+ *
+ * General page with Writing Experience section focused.
+ * Validates:
+ * - Focus Mode toggle state (default: on)
+ * - Typewriter Scroll toggle state (default: off)
+ * - Smart Punctuation toggle state (default: on)
+ * - Description text styling (13px, muted color)
+ */
+export const GeneralWritingExperience: Story = {
+  args: {
+    open: true,
+    defaultTab: "general",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "General page with Writing Experience section. Focus Mode and Smart Punctuation are ON by default, Typewriter Scroll is OFF.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 2: GeneralDataStorage
+ *
+ * General page with Data & Storage section focused.
+ * Validates:
+ * - Backup Interval dropdown options
+ * - Dropdown selection interaction
+ * - "Last backup: 2 minutes ago" text
+ */
+export const GeneralDataStorage: Story = {
+  args: {
+    open: true,
+    defaultTab: "general",
+    initialSettings: {
+      general: {
+        ...defaultGeneralSettings,
+        backupInterval: "15min",
+      },
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "General page focused on Data & Storage section. Backup Interval is set to 'Every 15 minutes'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 3: GeneralEditorDefaults
+ *
+ * General page with Editor Defaults section focused.
+ * Validates:
+ * - Interface Scale slider (80% - 120%)
+ * - Slider thumb movement
+ * - Default Typography dropdown
+ */
+export const GeneralEditorDefaults: Story = {
+  args: {
+    open: true,
+    defaultTab: "general",
+    initialSettings: {
+      general: {
+        ...defaultGeneralSettings,
+        interfaceScale: 110,
+        defaultTypography: "merriweather",
+      },
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "General page with Editor Defaults modified. Interface Scale at 110%, Typography set to Merriweather.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 4: AppearanceThemeSelection
+ *
+ * Appearance page with theme selection.
+ * Validates:
+ * - Light/Dark/System three-way selection
+ * - Selected state styling
+ * - Theme preview areas
+ */
+export const AppearanceThemeSelection: Story = {
+  args: {
+    open: true,
+    defaultTab: "appearance",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: {
+        ...defaultAppearanceSettings,
+        themeMode: "dark",
+      },
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Appearance page with theme selection. Dark theme is selected by default.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 5: ExportDefaultSettings
+ *
+ * Export & Share page with default settings.
+ * Validates:
+ * - Default export format selection (2x2 grid)
+ * - Include Metadata toggle
+ * - Auto-generate filename toggle
+ */
+export const ExportDefaultSettings: Story = {
+  args: {
+    open: true,
+    defaultTab: "export",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export & Share page with default settings. PDF is selected, both metadata and auto-filename are enabled.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 6: AccountProfileEdit
+ *
+ * Account page showing user profile.
+ * Validates:
+ * - Avatar display (initials fallback)
+ * - Subscription status "Pro"
+ * - Upgrade button styling
+ */
+export const AccountProfileEdit: Story = {
+  args: {
+    open: true,
+    defaultTab: "account",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Account page showing user profile with Pro subscription. Avatar shows initials 'SM'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 7: NavigationTransition
+ *
+ * Testing rapid navigation between tabs.
+ * Validates:
+ * - Page switching without flicker
+ * - Current selection indicator (right border)
+ * - State preservation between tabs
+ */
+export const NavigationTransition: Story = {
+  args: {
+    open: true,
+    defaultTab: "general",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Test navigation between tabs. Click General → Appearance → Export → Account rapidly to verify smooth transitions.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 8: UnsavedChangesWarning (Modified State)
+ *
+ * Settings with modifications (dirty state).
+ * Validates:
+ * - Modified settings are tracked
+ * - Save Changes button is functional
+ * - Cancel returns to previous state
+ */
+export const UnsavedChangesWarning: Story = {
+  render: (args) => {
+    const [settings, setSettings] = React.useState({
+      general: {
+        ...defaultGeneralSettings,
+        focusMode: false, // Changed from default
+        typewriterScroll: true, // Changed from default
+      },
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    });
+
+    return (
+      <SettingsDialog
+        {...args}
+        initialSettings={settings}
+        onSave={(newSettings) => {
+          setSettings(newSettings);
+          console.log("Settings saved:", newSettings);
+        }}
+      />
+    );
+  },
+  args: {
+    open: true,
+    defaultTab: "general",
+    account: {
+      name: "Sarah Mitchell",
+      email: "sarah@example.com",
+      plan: "pro",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Settings with modifications. Focus Mode is OFF (changed) and Typewriter Scroll is ON (changed). Test Save and Cancel behavior.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 9: FreeUserAccount
+ *
+ * Account page for a free tier user.
+ * Validates:
+ * - Free plan badge
+ * - Upgrade to Pro button visible
+ * - Different subscription messaging
+ */
+export const FreeUserAccount: Story = {
+  args: {
+    open: true,
+    defaultTab: "account",
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "John Doe",
+      email: "john@example.com",
+      plan: "free",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Account page for a free tier user. Shows 'Free' badge and 'Upgrade to Pro' button.",
+      },
+    },
+  },
+};

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { SettingsDialog } from "./SettingsDialog";
 import { defaultGeneralSettings } from "./SettingsGeneral";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
@@ -1,0 +1,289 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsDialog } from "./SettingsDialog";
+import { defaultGeneralSettings } from "./SettingsGeneral";
+import { defaultAppearanceSettings } from "./SettingsAppearancePage";
+import { defaultExportSettings } from "./SettingsExport";
+
+/**
+ * SettingsDialog component tests
+ *
+ * Tests cover:
+ * - Dialog open/close behavior
+ * - Tab navigation
+ * - Settings state management
+ * - Save/Cancel actions
+ */
+describe("SettingsDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+    account: {
+      name: "Test User",
+      email: "test@example.com",
+      plan: "pro" as const,
+    },
+  };
+
+  it("renders when open is true", () => {
+    render(<SettingsDialog {...defaultProps} />);
+
+    // Check for dialog presence
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Check for navigation items
+    expect(screen.getByRole("button", { name: "General" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Appearance" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Export & Share" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Account" })).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    render(<SettingsDialog {...defaultProps} open={false} />);
+
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
+  it("shows General page by default", () => {
+    render(<SettingsDialog {...defaultProps} />);
+
+    // Check for General page heading
+    expect(
+      screen.getByRole("heading", { name: "General", level: 1 }),
+    ).toBeInTheDocument();
+
+    // Check for Writing Experience section
+    expect(screen.getByText("Writing Experience")).toBeInTheDocument();
+    expect(screen.getByText("Focus Mode")).toBeInTheDocument();
+  });
+
+  it("navigates to Appearance page when tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Appearance", level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+  });
+
+  it("navigates to Export & Share page when tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Export & Share" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Export & Share", level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Default Export Format")).toBeInTheDocument();
+  });
+
+  it("navigates to Account page when tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Account", level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+  });
+
+  it("calls onOpenChange when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<SettingsDialog {...defaultProps} onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onSave with settings when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <SettingsDialog
+        {...defaultProps}
+        onSave={onSave}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("toggles Focus Mode when clicked", async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog {...defaultProps} />);
+
+    // Find the Focus Mode toggle (it's a switch button)
+    const focusModeToggle = screen.getByRole("switch", { name: /focus mode/i });
+
+    // Initially should be checked (defaultGeneralSettings.focusMode = true)
+    expect(focusModeToggle).toHaveAttribute("aria-checked", "true");
+
+    // Click to toggle off
+    await user.click(focusModeToggle);
+
+    // Should now be unchecked
+    expect(focusModeToggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("starts on specified defaultTab", () => {
+    render(<SettingsDialog {...defaultProps} defaultTab="appearance" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Appearance", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onLogout when Log Out is clicked", async () => {
+    const user = userEvent.setup();
+    const onLogout = vi.fn();
+    render(<SettingsDialog {...defaultProps} onLogout={onLogout} />);
+
+    await user.click(screen.getByRole("button", { name: "Log Out" }));
+
+    expect(onLogout).toHaveBeenCalled();
+  });
+
+  it("shows close button and closes on click", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<SettingsDialog {...defaultProps} onOpenChange={onOpenChange} />);
+
+    // Find the close button (has sr-only "Close" text)
+    const closeButton = screen.getByRole("button", { name: "Close" });
+
+    await user.click(closeButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("SettingsDialog - General Page", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    defaultTab: "general" as const,
+    initialSettings: {
+      general: defaultGeneralSettings,
+      appearance: defaultAppearanceSettings,
+      export: defaultExportSettings,
+    },
+  };
+
+  it("displays all Writing Experience toggles", () => {
+    render(<SettingsDialog {...defaultProps} />);
+
+    expect(screen.getByText("Focus Mode")).toBeInTheDocument();
+    expect(screen.getByText("Typewriter Scroll")).toBeInTheDocument();
+    expect(screen.getByText("Smart Punctuation")).toBeInTheDocument();
+  });
+
+  it("displays Data & Storage section", () => {
+    render(<SettingsDialog {...defaultProps} />);
+
+    expect(screen.getByText("Data & Storage")).toBeInTheDocument();
+    expect(screen.getByText("Local Auto-Save")).toBeInTheDocument();
+    expect(screen.getByText("Backup Interval")).toBeInTheDocument();
+    expect(screen.getByText("Last backup: 2 minutes ago")).toBeInTheDocument();
+  });
+
+  it("displays Editor Defaults section", () => {
+    render(<SettingsDialog {...defaultProps} />);
+
+    expect(screen.getByText("Editor Defaults")).toBeInTheDocument();
+    expect(screen.getByText("Default Typography")).toBeInTheDocument();
+    expect(screen.getByText("Interface Scale")).toBeInTheDocument();
+  });
+});
+
+describe("SettingsDialog - Account Page", () => {
+  it("shows Upgrade button for free users", async () => {
+    const user = userEvent.setup();
+    const onUpgrade = vi.fn();
+    render(
+      <SettingsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        defaultTab="account"
+        account={{
+          name: "Free User",
+          email: "free@example.com",
+          plan: "free",
+        }}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    const upgradeButton = screen.getByRole("button", { name: "Upgrade to Pro" });
+    expect(upgradeButton).toBeInTheDocument();
+
+    await user.click(upgradeButton);
+    expect(onUpgrade).toHaveBeenCalled();
+  });
+
+  it("shows Manage Subscription button for pro users", () => {
+    render(
+      <SettingsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        defaultTab="account"
+        account={{
+          name: "Pro User",
+          email: "pro@example.com",
+          plan: "pro",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Manage Subscription" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Delete Account button in danger zone", () => {
+    render(
+      <SettingsDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        defaultTab="account"
+        account={{
+          name: "Test User",
+          email: "test@example.com",
+          plan: "pro",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Delete Account" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SettingsDialog } from "./SettingsDialog";
 import { defaultGeneralSettings } from "./SettingsGeneral";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -1,0 +1,366 @@
+import React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Button, Text } from "../../components/primitives";
+import { SettingsGeneral, GeneralSettings, defaultGeneralSettings } from "./SettingsGeneral";
+import {
+  SettingsAppearancePage,
+  AppearanceSettings,
+  defaultAppearanceSettings,
+} from "./SettingsAppearancePage";
+import { SettingsExport, ExportSettings, defaultExportSettings } from "./SettingsExport";
+import { SettingsAccount, AccountSettings, defaultAccountSettings } from "./SettingsAccount";
+
+/**
+ * Settings tab values
+ */
+export type SettingsTab = "general" | "appearance" | "export" | "account";
+
+/**
+ * Complete settings state
+ */
+export interface AllSettings {
+  general: GeneralSettings;
+  appearance: AppearanceSettings;
+  export: ExportSettings;
+}
+
+/**
+ * SettingsDialog props
+ */
+export interface SettingsDialogProps {
+  /** Controlled open state */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Initial settings values */
+  initialSettings?: AllSettings;
+  /** Callback when settings are saved */
+  onSave?: (settings: AllSettings) => void;
+  /** Account information */
+  account?: AccountSettings;
+  /** Callback when upgrade is requested */
+  onUpgrade?: () => void;
+  /** Callback when logout is requested */
+  onLogout?: () => void;
+  /** Initial active tab */
+  defaultTab?: SettingsTab;
+}
+
+/**
+ * Nav item configuration
+ */
+const navItems: { value: SettingsTab; label: string }[] = [
+  { value: "general", label: "General" },
+  { value: "appearance", label: "Appearance" },
+  { value: "export", label: "Export & Share" },
+  { value: "account", label: "Account" },
+];
+
+/**
+ * Overlay styles
+ */
+const overlayStyles = [
+  "fixed",
+  "inset-0",
+  "z-[var(--z-modal)]",
+  "bg-[rgba(0,0,0,0.75)]",
+  "backdrop-blur-sm",
+  "transition-opacity",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=closed]:opacity-0",
+].join(" ");
+
+/**
+ * Content styles
+ */
+const contentStyles = [
+  "fixed",
+  "left-1/2",
+  "top-1/2",
+  "-translate-x-1/2",
+  "-translate-y-1/2",
+  "z-[var(--z-modal)]",
+  "w-[1000px]",
+  "h-[700px]",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-lg)]",
+  "shadow-2xl",
+  "flex",
+  "overflow-hidden",
+  // Animation
+  "transition-[opacity,transform]",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=open]:scale-100",
+  "data-[state=closed]:opacity-0",
+  "data-[state=closed]:scale-95",
+  "focus:outline-none",
+].join(" ");
+
+/**
+ * Sidebar styles
+ */
+const sidebarStyles = [
+  "w-[260px]",
+  "bg-[var(--color-bg-base)]",
+  "border-r",
+  "border-[var(--color-border-default)]",
+  "flex",
+  "flex-col",
+  "py-8",
+  "shrink-0",
+].join(" ");
+
+/**
+ * Nav button styles
+ */
+const navButtonBaseStyles = [
+  "w-full",
+  "text-left",
+  "px-8",
+  "py-3",
+  "text-[13px]",
+  "border-r-2",
+  "transition-all",
+  "duration-[var(--duration-fast)]",
+].join(" ");
+
+/**
+ * Close button styles
+ */
+const closeButtonStyles = [
+  "absolute",
+  "top-6",
+  "right-8",
+  "p-2",
+  "text-[var(--color-fg-placeholder)]",
+  "hover:text-[var(--color-fg-default)]",
+  "transition-colors",
+  "z-10",
+  "hover:bg-[var(--color-bg-hover)]",
+  "rounded-full",
+].join(" ");
+
+/**
+ * SettingsDialog component
+ *
+ * A full-featured settings dialog with tabbed navigation.
+ * Supports General, Appearance, Export & Share, and Account pages.
+ *
+ * @example
+ * ```tsx
+ * <SettingsDialog
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   onSave={handleSave}
+ * />
+ * ```
+ */
+export function SettingsDialog({
+  open,
+  onOpenChange,
+  initialSettings,
+  onSave,
+  account = defaultAccountSettings,
+  onUpgrade,
+  onLogout,
+  defaultTab = "general",
+}: SettingsDialogProps): JSX.Element {
+  // Active tab state
+  const [activeTab, setActiveTab] = React.useState<SettingsTab>(defaultTab);
+
+  // Settings state (local copy for editing)
+  const [settings, setSettings] = React.useState<AllSettings>({
+    general: initialSettings?.general ?? defaultGeneralSettings,
+    appearance: initialSettings?.appearance ?? defaultAppearanceSettings,
+    export: initialSettings?.export ?? defaultExportSettings,
+  });
+
+  // Track if settings have been modified
+  const [isDirty, setIsDirty] = React.useState(false);
+
+  // Reset state when dialog opens
+  React.useEffect(() => {
+    if (open) {
+      setActiveTab(defaultTab);
+      setSettings({
+        general: initialSettings?.general ?? defaultGeneralSettings,
+        appearance: initialSettings?.appearance ?? defaultAppearanceSettings,
+        export: initialSettings?.export ?? defaultExportSettings,
+      });
+      setIsDirty(false);
+    }
+  }, [open, initialSettings, defaultTab]);
+
+  const handleSettingsChange = <K extends keyof AllSettings>(
+    key: K,
+    value: AllSettings[K],
+  ) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+    setIsDirty(true);
+  };
+
+  const handleSave = () => {
+    onSave?.(settings);
+    setIsDirty(false);
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case "general":
+        return (
+          <SettingsGeneral
+            settings={settings.general}
+            onSettingsChange={(value) => handleSettingsChange("general", value)}
+          />
+        );
+      case "appearance":
+        return (
+          <SettingsAppearancePage
+            settings={settings.appearance}
+            onSettingsChange={(value) =>
+              handleSettingsChange("appearance", value)
+            }
+          />
+        );
+      case "export":
+        return (
+          <SettingsExport
+            settings={settings.export}
+            onSettingsChange={(value) => handleSettingsChange("export", value)}
+          />
+        );
+      case "account":
+        return (
+          <SettingsAccount
+            account={account}
+            onUpgrade={onUpgrade}
+            onLogout={onLogout}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className={overlayStyles} />
+        <DialogPrimitive.Content className={contentStyles}>
+          {/* Sidebar Navigation */}
+          <div className={sidebarStyles}>
+            <div className="px-8 mb-8">
+              <Text
+                size="label"
+                color="placeholder"
+                weight="semibold"
+                className="tracking-[0.15em]"
+              >
+                Settings
+              </Text>
+            </div>
+
+            <nav className="flex flex-col w-full">
+              {navItems.map(({ value, label }) => {
+                const isActive = activeTab === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setActiveTab(value)}
+                    className={`${navButtonBaseStyles} ${
+                      isActive
+                        ? "text-[var(--color-fg-default)] bg-[var(--color-bg-hover)] border-[var(--color-fg-default)]"
+                        : "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-surface)] border-transparent"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </nav>
+
+            {/* Logout button at bottom */}
+            <div className="mt-auto px-8">
+              <div className="pt-6 border-t border-[var(--color-border-default)]">
+                <button
+                  type="button"
+                  onClick={onLogout}
+                  className="flex items-center gap-2 text-[12px] text-[var(--color-fg-subtle)] hover:text-[var(--color-fg-default)] transition-colors"
+                >
+                  Log Out
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Main Content Area */}
+          <div className="flex-1 bg-[var(--color-bg-surface)] flex flex-col relative min-w-0">
+            {/* Close button */}
+            <DialogPrimitive.Close className={closeButtonStyles}>
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+
+            {/* Scrollable content */}
+            <div className="flex-1 overflow-y-auto px-12 py-10">
+              {renderContent()}
+            </div>
+
+            {/* Footer with Save/Cancel */}
+            <div className="p-8 border-t border-[var(--color-border-default)] flex justify-end gap-3 bg-[var(--color-bg-surface)]">
+              <Button variant="ghost" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={handleSave}>
+                Save Changes
+              </Button>
+            </div>
+          </div>
+
+          {/* Hidden title for accessibility */}
+          <DialogPrimitive.Title className="sr-only">
+            Settings
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Configure your application settings including general preferences,
+            appearance, export options, and account settings.
+          </DialogPrimitive.Description>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+// Re-export types and defaults
+export { defaultGeneralSettings } from "./SettingsGeneral";
+export { defaultAppearanceSettings } from "./SettingsAppearancePage";
+export { defaultExportSettings } from "./SettingsExport";
+export { defaultAccountSettings } from "./SettingsAccount";
+export type { GeneralSettings } from "./SettingsGeneral";
+export type { AppearanceSettings, ThemeMode } from "./SettingsAppearancePage";
+export type { ExportSettings, ExportFormat } from "./SettingsExport";
+export type { AccountSettings, SubscriptionPlan } from "./SettingsAccount";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -181,8 +181,9 @@ export function SettingsDialog({
     export: initialSettings?.export ?? defaultExportSettings,
   });
 
-  // Track if settings have been modified
-  const [isDirty, setIsDirty] = React.useState(false);
+  // Track if settings have been modified (reserved for unsaved changes warning)
+  const [_isDirty, setIsDirty] = React.useState(false);
+  void _isDirty; // Will be used for unsaved changes warning dialog
 
   // Reset state when dialog opens
   React.useEffect(() => {

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Button, Text } from "../../components/primitives";
-import { SettingsGeneral, GeneralSettings, defaultGeneralSettings } from "./SettingsGeneral";
-import {
-  SettingsAppearancePage,
-  AppearanceSettings,
-  defaultAppearanceSettings,
-} from "./SettingsAppearancePage";
-import { SettingsExport, ExportSettings, defaultExportSettings } from "./SettingsExport";
-import { SettingsAccount, AccountSettings, defaultAccountSettings } from "./SettingsAccount";
+import { SettingsGeneral, defaultGeneralSettings } from "./SettingsGeneral";
+import type { GeneralSettings } from "./SettingsGeneral";
+import { SettingsAppearancePage, defaultAppearanceSettings } from "./SettingsAppearancePage";
+import type { AppearanceSettings } from "./SettingsAppearancePage";
+import { SettingsExport, defaultExportSettings } from "./SettingsExport";
+import type { ExportSettings } from "./SettingsExport";
+import { SettingsAccount, defaultAccountSettings } from "./SettingsAccount";
+import type { AccountSettings } from "./SettingsAccount";
 
 /**
  * Settings tab values

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { Toggle } from "../../components/primitives/Toggle";
+import { Select, Text } from "../../components/primitives";
+
+/**
+ * Export format types
+ */
+export type ExportFormat = "pdf" | "markdown" | "word" | "txt";
+
+/**
+ * Export settings state
+ */
+export interface ExportSettings {
+  defaultFormat: ExportFormat;
+  includeMetadata: boolean;
+  autoGenerateFilename: boolean;
+}
+
+/**
+ * SettingsExport page props
+ */
+export interface SettingsExportProps {
+  /** Current settings values */
+  settings: ExportSettings;
+  /** Callback when settings change */
+  onSettingsChange: (settings: ExportSettings) => void;
+}
+
+/**
+ * Section label styles
+ */
+const sectionLabelStyles = [
+  "text-[10px]",
+  "uppercase",
+  "tracking-[0.15em]",
+  "text-[var(--color-fg-placeholder)]",
+  "font-semibold",
+  "mb-6",
+].join(" ");
+
+/**
+ * Divider styles
+ */
+const dividerStyles = [
+  "w-full",
+  "h-px",
+  "bg-[var(--color-border-default)]",
+  "my-12",
+].join(" ");
+
+/**
+ * Export format options
+ */
+const formatOptions = [
+  { value: "pdf", label: "PDF" },
+  { value: "markdown", label: "Markdown (.md)" },
+  { value: "word", label: "Word (.docx)" },
+  { value: "txt", label: "Plain Text (.txt)" },
+];
+
+/**
+ * Format icon component
+ */
+function FormatIcon({ format }: { format: ExportFormat }): JSX.Element {
+  const iconMap: Record<ExportFormat, JSX.Element> = {
+    pdf: (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+        <path d="M14 2v6h6" />
+        <path d="M10 12h4" />
+        <path d="M10 16h4" />
+      </svg>
+    ),
+    markdown: (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M4 4h16a2 2 0 012 2v12a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2z" />
+        <path d="M7 15V9l3 3 3-3v6" />
+        <path d="M17 12l-2 3m2-3l2 3m-2-3V9" />
+      </svg>
+    ),
+    word: (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+        <path d="M14 2v6h6" />
+        <path d="M8 13l2 4 2-4 2 4" />
+      </svg>
+    ),
+    txt: (
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+        <path d="M14 2v6h6" />
+        <path d="M8 12h8" />
+        <path d="M8 16h8" />
+      </svg>
+    ),
+  };
+
+  return iconMap[format];
+}
+
+/**
+ * Format card button styles
+ */
+const formatCardBaseStyles = [
+  "flex",
+  "flex-col",
+  "items-center",
+  "gap-2",
+  "p-4",
+  "rounded-[var(--radius-md)]",
+  "border",
+  "cursor-pointer",
+  "transition-all",
+  "duration-[var(--duration-fast)]",
+  "text-[var(--color-fg-muted)]",
+].join(" ");
+
+/**
+ * SettingsExport page component
+ *
+ * Export & Share settings page with format selection and export options.
+ */
+export function SettingsExport({
+  settings,
+  onSettingsChange,
+}: SettingsExportProps): JSX.Element {
+  const updateSetting = <K extends keyof ExportSettings>(
+    key: K,
+    value: ExportSettings[K],
+  ) => {
+    onSettingsChange({ ...settings, [key]: value });
+  };
+
+  const formats: { value: ExportFormat; label: string; sublabel: string }[] = [
+    { value: "pdf", label: "PDF", sublabel: "Portable Document" },
+    { value: "markdown", label: "Markdown", sublabel: ".md" },
+    { value: "word", label: "Word", sublabel: ".docx" },
+    { value: "txt", label: "Plain Text", sublabel: ".txt" },
+  ];
+
+  return (
+    <div className="max-w-[560px]">
+      {/* Header */}
+      <h1 className="text-2xl font-normal text-[var(--color-fg-default)] mb-2 tracking-tight">
+        Export & Share
+      </h1>
+      <p className="text-[var(--color-fg-subtle)] text-sm mb-12 font-light">
+        Configure default export format and sharing options.
+      </p>
+
+      {/* Default Export Format */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Default Export Format</h4>
+
+        <div className="grid grid-cols-2 gap-4">
+          {formats.map(({ value, label, sublabel }) => {
+            const isSelected = settings.defaultFormat === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => updateSetting("defaultFormat", value)}
+                className={`${formatCardBaseStyles} ${
+                  isSelected
+                    ? "border-[var(--color-fg-default)] bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]"
+                    : "border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)]"
+                }`}
+              >
+                <FormatIcon format={value} />
+                <div className="flex flex-col items-center">
+                  <Text
+                    size="small"
+                    color={isSelected ? "default" : "muted"}
+                    weight="medium"
+                  >
+                    {label}
+                  </Text>
+                  <Text size="tiny" color="subtle">
+                    {sublabel}
+                  </Text>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Export Options */}
+      <div className="mb-6">
+        <h4 className={sectionLabelStyles}>Export Options</h4>
+
+        <div className="flex flex-col gap-8">
+          <Toggle
+            label="Include Metadata"
+            description="Include document title, author, creation date, and word count in exported files."
+            checked={settings.includeMetadata}
+            onCheckedChange={(checked) =>
+              updateSetting("includeMetadata", checked)
+            }
+          />
+
+          <Toggle
+            label="Auto-generate Filename"
+            description="Automatically create filenames based on document title and export date."
+            checked={settings.autoGenerateFilename}
+            onCheckedChange={(checked) =>
+              updateSetting("autoGenerateFilename", checked)
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Default export settings
+ */
+export const defaultExportSettings: ExportSettings = {
+  defaultFormat: "pdf",
+  includeMetadata: true,
+  autoGenerateFilename: true,
+};

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 import { Toggle } from "../../components/primitives/Toggle";
-import { Select, Text } from "../../components/primitives";
+import { Text } from "../../components/primitives";
 
 /**
  * Export format types
@@ -48,15 +47,6 @@ const dividerStyles = [
   "my-12",
 ].join(" ");
 
-/**
- * Export format options
- */
-const formatOptions = [
-  { value: "pdf", label: "PDF" },
-  { value: "markdown", label: "Markdown (.md)" },
-  { value: "word", label: "Word (.docx)" },
-  { value: "txt", label: "Plain Text (.txt)" },
-];
 
 /**
  * Format icon component

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Toggle } from "../../components/primitives/Toggle";
 import { Slider } from "../../components/primitives/Slider";
 import { Select } from "../../components/primitives";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -1,0 +1,217 @@
+import React from "react";
+import { Toggle } from "../../components/primitives/Toggle";
+import { Slider } from "../../components/primitives/Slider";
+import { Select } from "../../components/primitives";
+import { Text } from "../../components/primitives";
+
+/**
+ * Settings state for General page
+ */
+export interface GeneralSettings {
+  focusMode: boolean;
+  typewriterScroll: boolean;
+  smartPunctuation: boolean;
+  localAutoSave: boolean;
+  backupInterval: string;
+  defaultTypography: string;
+  interfaceScale: number;
+}
+
+/**
+ * SettingsGeneral page props
+ */
+export interface SettingsGeneralProps {
+  /** Current settings values */
+  settings: GeneralSettings;
+  /** Callback when settings change */
+  onSettingsChange: (settings: GeneralSettings) => void;
+}
+
+/**
+ * Section label styles (uppercase label from design spec)
+ */
+const sectionLabelStyles = [
+  "text-[10px]",
+  "uppercase",
+  "tracking-[0.15em]",
+  "text-[var(--color-fg-placeholder)]",
+  "font-semibold",
+  "mb-6",
+].join(" ");
+
+/**
+ * Divider styles
+ */
+const dividerStyles = [
+  "w-full",
+  "h-px",
+  "bg-[var(--color-border-default)]",
+  "my-12",
+].join(" ");
+
+/**
+ * Field label styles
+ */
+const fieldLabelStyles = [
+  "text-[13px]",
+  "text-[var(--color-fg-muted)]",
+].join(" ");
+
+/**
+ * Backup interval options
+ */
+const backupIntervalOptions = [
+  { value: "5min", label: "Every 5 minutes" },
+  { value: "15min", label: "Every 15 minutes" },
+  { value: "1hour", label: "Every hour" },
+];
+
+/**
+ * Typography options
+ */
+const typographyOptions = [
+  { value: "inter", label: "Inter (Sans-Serif)" },
+  { value: "merriweather", label: "Merriweather (Serif)" },
+  { value: "jetbrains", label: "JetBrains Mono (Monospace)" },
+];
+
+/**
+ * SettingsGeneral page component
+ *
+ * General settings page with Writing Experience, Data & Storage, and Editor Defaults sections.
+ * Uses real content from the design spec.
+ */
+export function SettingsGeneral({
+  settings,
+  onSettingsChange,
+}: SettingsGeneralProps): JSX.Element {
+  const updateSetting = <K extends keyof GeneralSettings>(
+    key: K,
+    value: GeneralSettings[K],
+  ) => {
+    onSettingsChange({ ...settings, [key]: value });
+  };
+
+  return (
+    <div className="max-w-[560px]">
+      {/* Header */}
+      <h1 className="text-2xl font-normal text-[var(--color-fg-default)] mb-2 tracking-tight">
+        General
+      </h1>
+      <p className="text-[var(--color-fg-subtle)] text-sm mb-12 font-light">
+        Customize your writing environment and workflow preferences.
+      </p>
+
+      {/* Writing Experience Section */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Writing Experience</h4>
+
+        <div className="flex flex-col gap-8">
+          <Toggle
+            label="Focus Mode"
+            description="Dims all interface elements except the editor when you start typing to reduce distractions."
+            checked={settings.focusMode}
+            onCheckedChange={(checked) => updateSetting("focusMode", checked)}
+          />
+
+          <Toggle
+            label="Typewriter Scroll"
+            description="Keeps your active line of text vertically centered on the screen as you write."
+            checked={settings.typewriterScroll}
+            onCheckedChange={(checked) =>
+              updateSetting("typewriterScroll", checked)
+            }
+          />
+
+          <Toggle
+            label="Smart Punctuation"
+            description="Automatically convert straight quotes to curly quotes and double hyphens to em-dashes."
+            checked={settings.smartPunctuation}
+            onCheckedChange={(checked) =>
+              updateSetting("smartPunctuation", checked)
+            }
+          />
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Data & Storage Section */}
+      <div className="mb-14">
+        <h4 className={sectionLabelStyles}>Data & Storage</h4>
+
+        <div className="flex flex-col gap-6">
+          <Toggle
+            label="Local Auto-Save"
+            description="Automatically save changes to your browser's local storage."
+            checked={settings.localAutoSave}
+            onCheckedChange={(checked) =>
+              updateSetting("localAutoSave", checked)
+            }
+          />
+
+          <div className="flex flex-col gap-3 mt-2">
+            <h3 className="text-[14px] text-[var(--color-fg-default)] font-medium">
+              Backup Interval
+            </h3>
+            <Select
+              options={backupIntervalOptions}
+              value={settings.backupInterval}
+              onValueChange={(value) => updateSetting("backupInterval", value)}
+              fullWidth
+            />
+            <Text size="small" color="placeholder" className="mt-1">
+              Last backup: 2 minutes ago
+            </Text>
+          </div>
+        </div>
+      </div>
+
+      <div className={dividerStyles} />
+
+      {/* Editor Defaults Section */}
+      <div className="mb-6">
+        <h4 className={sectionLabelStyles}>Editor Defaults</h4>
+
+        <div className="grid grid-cols-2 gap-8">
+          <div className="flex flex-col gap-3">
+            <label className={fieldLabelStyles}>Default Typography</label>
+            <Select
+              options={typographyOptions}
+              value={settings.defaultTypography}
+              onValueChange={(value) =>
+                updateSetting("defaultTypography", value)
+              }
+              fullWidth
+            />
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <label className={fieldLabelStyles}>Interface Scale</label>
+            <Slider
+              min={80}
+              max={120}
+              step={10}
+              value={settings.interfaceScale}
+              onValueChange={(value) => updateSetting("interfaceScale", value)}
+              showLabels
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Default settings values
+ */
+export const defaultGeneralSettings: GeneralSettings = {
+  focusMode: true,
+  typewriterScroll: false,
+  smartPunctuation: true,
+  localAutoSave: true,
+  backupInterval: "5min",
+  defaultTypography: "inter",
+  interfaceScale: 100,
+};

--- a/apps/desktop/renderer/src/features/settings-dialog/index.ts
+++ b/apps/desktop/renderer/src/features/settings-dialog/index.ts
@@ -1,0 +1,41 @@
+/**
+ * SettingsDialog feature module
+ *
+ * Full-featured settings dialog with tabbed navigation.
+ * Includes General, Appearance, Export & Share, and Account pages.
+ */
+
+export { SettingsDialog } from "./SettingsDialog";
+export type {
+  SettingsDialogProps,
+  SettingsTab,
+  AllSettings,
+} from "./SettingsDialog";
+
+// Re-export page components for standalone use
+export { SettingsGeneral, defaultGeneralSettings } from "./SettingsGeneral";
+export type { GeneralSettings, SettingsGeneralProps } from "./SettingsGeneral";
+
+export {
+  SettingsAppearancePage,
+  defaultAppearanceSettings,
+} from "./SettingsAppearancePage";
+export type {
+  AppearanceSettings,
+  ThemeMode,
+  SettingsAppearancePageProps,
+} from "./SettingsAppearancePage";
+
+export { SettingsExport, defaultExportSettings } from "./SettingsExport";
+export type {
+  ExportSettings,
+  ExportFormat,
+  SettingsExportProps,
+} from "./SettingsExport";
+
+export { SettingsAccount, defaultAccountSettings } from "./SettingsAccount";
+export type {
+  AccountSettings,
+  SubscriptionPlan,
+  SettingsAccountProps,
+} from "./SettingsAccount";

--- a/openspec/_ops/task_runs/ISSUE-122.md
+++ b/openspec/_ops/task_runs/ISSUE-122.md
@@ -41,3 +41,11 @@
   - 修复未使用的 `isDirty` 变量（重命名为 `_isDirty`）
   - 移除未使用的 `Select` import 和 `formatOptions` 变量
 - Key output: typecheck 通过，35 个测试全部通过
+
+### 2026-02-03 13:46 修复 ESLint 错误
+- Command: `pnpm lint`
+- Issues fixed:
+  - 修复 type imports（使用 `import type`）
+  - 将 story render 函数中的 React hooks 提取为独立组件（`InterfaceScaleSlider`、`FontSizeSlider`、`VolumeSlider`、`ToggleGroupDemo`）
+  - 简化 `UnsavedChangesWarning` story（移除不必要的 render 函数）
+- Key output: lint 通过，35 个测试全部通过

--- a/openspec/_ops/task_runs/ISSUE-122.md
+++ b/openspec/_ops/task_runs/ISSUE-122.md
@@ -1,7 +1,7 @@
 # ISSUE-122
 - Issue: #122
 - Branch: task/122-settings-dialog
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/123
 
 ## Plan
 - 实现 SettingsDialog 系统级设置弹窗（4 个页面：General/Appearance/Export/Account）

--- a/openspec/_ops/task_runs/ISSUE-122.md
+++ b/openspec/_ops/task_runs/ISSUE-122.md
@@ -31,3 +31,13 @@
   Tests  35 passed (35)
   Duration  3.30s
   ```
+
+### 2026-02-03 13:40 修复 TypeScript 未使用变量错误
+- Command: `pnpm typecheck`
+- Issues fixed:
+  - 移除未使用的 `React` imports
+  - 修复未使用的 `onLogout` 参数（重命名为 `_onLogout`）
+  - 移除未使用的 `fireEvent` import
+  - 修复未使用的 `isDirty` 变量（重命名为 `_isDirty`）
+  - 移除未使用的 `Select` import 和 `formatOptions` 变量
+- Key output: typecheck 通过，35 个测试全部通过

--- a/openspec/_ops/task_runs/ISSUE-122.md
+++ b/openspec/_ops/task_runs/ISSUE-122.md
@@ -1,0 +1,33 @@
+# ISSUE-122
+- Issue: #122
+- Branch: task/122-settings-dialog
+- PR: <fill-after-created>
+
+## Plan
+- 实现 SettingsDialog 系统级设置弹窗（4 个页面：General/Appearance/Export/Account）
+- 新增 Toggle、Slider primitives 组件
+- 创建 Storybook stories 和单元测试
+
+## Runs
+### 2026-02-03 13:19 实现 SettingsDialog
+- Command: `npm run test -- --run src/features/settings-dialog/ src/components/primitives/Toggle.test.tsx src/components/primitives/Slider.test.tsx`
+- Key output:
+  ```
+  Test Files  3 passed (3)
+  Tests  35 passed (35)
+  ```
+- Evidence: Storybook 验证截图确认 4 个页面（General/Appearance/Export/Account）渲染正确
+
+### 2026-02-03 13:30 修复 Danger Zone 样式
+- Command: 移除 Danger Zone 卡片的红色边框，只保留 Delete Account 按钮红色
+- Key output: 修改 SettingsAccount.tsx，移除 `border-[var(--color-error)]` 和 `text-[var(--color-error)]`
+- Evidence: 测试仍然全部通过
+
+### 2026-02-03 13:33 Worktree 测试验证
+- Command: `npm run test -- --run src/features/settings-dialog/ src/components/primitives/Toggle.test.tsx src/components/primitives/Slider.test.tsx`
+- Key output:
+  ```
+  Test Files  3 passed (3)
+  Tests  35 passed (35)
+  Duration  3.30s
+  ```


### PR DESCRIPTION
Closes #122

## Summary
- Add Toggle and Slider primitive components
- Implement SettingsDialog with 4 pages (General/Appearance/Export/Account)
- Add 9 Storybook stories for all scenarios
- Add 35 unit tests (all passing)

## Test Plan
- [x] All 35 unit tests pass
- [x] Storybook browser verification for all 4 pages
- [x] Toggle/Select/navigation switching works correctly
- [x] Does not affect existing settings module