### PR TITLE
feat: add ExportDialog component with three view states (#124)

### DIFF
--- a/apps/desktop/renderer/src/features/export/ExportDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.stories.tsx
@@ -1,0 +1,405 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ExportDialog, defaultExportOptions } from "./ExportDialog";
+
+/**
+ * ExportDialog component stories
+ *
+ * Export dialog with 3 view states:
+ * - Config: Format selection, export options, preview
+ * - Progress: Export in progress with progress bar
+ * - Success: Export complete confirmation
+ *
+ * Based on design spec: 29-export-dialog.html
+ *
+ * Real document content used:
+ * - Title: "The Architecture of Silence"
+ * - Estimated size: ~2.4 MB
+ *
+ * Format options:
+ * - PDF (default selected, blue border)
+ * - Markdown
+ * - Word
+ * - Plain Text
+ *
+ * Export settings:
+ * - Include metadata (default checked)
+ * - Version history (default unchecked)
+ * - Embed images (default checked)
+ *
+ * Page size (PDF only):
+ * - A4 (default)
+ * - Letter
+ * - Legal
+ */
+const meta: Meta<typeof ExportDialog> = {
+  title: "Features/ExportDialog",
+  component: ExportDialog,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: {
+      default: "dark",
+    },
+  },
+  argTypes: {
+    open: { control: "boolean" },
+    onOpenChange: { action: "openChange" },
+    onExport: { action: "export" },
+    onCancel: { action: "cancel" },
+    view: {
+      control: "select",
+      options: ["config", "progress", "success"],
+    },
+    progress: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        className="w-full h-screen bg-[var(--color-bg-base)]"
+        data-theme="dark"
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExportDialog>;
+
+/**
+ * Story 1: ConfigViewDefault
+ *
+ * Default configuration view with PDF selected.
+ * Validates:
+ * - PDF default selected (blue border + inner dot)
+ * - "Include metadata" and "Embed images" checked by default
+ * - Page size A4 selected
+ * - Bottom shows "~2.4 MB"
+ */
+export const ConfigViewDefault: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~2.4 MB",
+    initialOptions: defaultExportOptions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default config view with PDF format selected. Include metadata and Embed images are checked. Page size is A4.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 2: SelectMarkdownFormat
+ *
+ * Markdown format selected.
+ * Validates:
+ * - Markdown card selected (blue border)
+ * - PDF card unselected
+ * - Page Size dropdown disabled (greyed out)
+ * - Preview area shows "MARKDOWN"
+ */
+export const SelectMarkdownFormat: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~1.2 MB",
+    initialOptions: {
+      ...defaultExportOptions,
+      format: "markdown",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Markdown format selected. Page Size is disabled since it only applies to PDF. Preview shows 'MARKDOWN • A4'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 3: ToggleAllOptions
+ *
+ * All options toggled to non-default state.
+ * Validates:
+ * - Include metadata unchecked
+ * - Version history checked
+ * - Embed images unchecked
+ * - File size estimate changes "~1.2 MB"
+ */
+export const ToggleAllOptions: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~1.2 MB",
+    initialOptions: {
+      ...defaultExportOptions,
+      includeMetadata: false,
+      versionHistory: true,
+      embedImages: false,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All export options toggled from defaults. Include metadata OFF, Version history ON, Embed images OFF. Estimated size reduced.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 4: ChangePageSize
+ *
+ * Page size changed to Letter.
+ * Validates:
+ * - Letter selected in dropdown
+ * - Preview area shows "PDF • LETTER"
+ */
+export const ChangePageSize: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~2.4 MB",
+    initialOptions: {
+      ...defaultExportOptions,
+      pageSize: "letter",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Page size changed to Letter. Preview badge shows 'PDF • LETTER'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 5: ProgressView
+ *
+ * Export in progress at 45%.
+ * Validates:
+ * - Progress bar animation at 45%
+ * - Current step text "Generating pages..."
+ * - Percentage display "45%"
+ * - Cancel button visible
+ */
+export const ProgressView: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    view: "progress",
+    progress: 45,
+    progressStep: "Generating pages...",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export in progress at 45%. Shows progress bar, step label 'Generating pages...', and Cancel button.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 6: ProgressViewAlmostDone
+ *
+ * Export almost complete at 95%.
+ * Validates:
+ * - Progress bar nearly full at 95%
+ * - Current step "Finalizing PDF..."
+ * - Progress bar almost at max
+ */
+export const ProgressViewAlmostDone: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    view: "progress",
+    progress: 95,
+    progressStep: "Finalizing PDF...",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export almost complete at 95%. Progress bar nearly full, step shows 'Finalizing PDF...'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 7: SuccessView
+ *
+ * Export complete successfully.
+ * Validates:
+ * - Green checkmark icon
+ * - "Export Complete" title
+ * - "Your file has been successfully downloaded." description
+ * - "Done" button with white background, black text
+ */
+export const SuccessView: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    view: "success",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export complete. Shows green checkmark, success message, and Done button with white background.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 8: SelectWordFormat
+ *
+ * Word format selected.
+ * Validates:
+ * - Word card selected (blue border)
+ * - Page Size dropdown disabled
+ * - Preview shows "WORD"
+ */
+export const SelectWordFormat: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~2.8 MB",
+    initialOptions: {
+      ...defaultExportOptions,
+      format: "word",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Word format selected. Page Size is disabled. Preview shows 'WORD • A4'.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 9: SelectPlainTextFormat
+ *
+ * Plain Text format selected.
+ * Validates:
+ * - Plain Text card selected
+ * - Page Size dropdown disabled
+ * - Smaller file size estimate
+ */
+export const SelectPlainTextFormat: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~128 KB",
+    initialOptions: {
+      ...defaultExportOptions,
+      format: "txt",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Plain Text format selected. Page Size disabled. File size much smaller at ~128 KB.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 10: ProgressViewPreparing
+ *
+ * Export just started, preparing phase.
+ * Validates:
+ * - Progress bar at low percentage (15%)
+ * - Step text "Preparing..."
+ */
+export const ProgressViewPreparing: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    view: "progress",
+    progress: 15,
+    progressStep: "Preparing...",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export just started at 15%. Shows 'Preparing...' step label.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 11: ProgressViewEmbeddingImages
+ *
+ * Export in embedding images phase.
+ * Validates:
+ * - Progress at 75%
+ * - Step text "Embedding images..."
+ */
+export const ProgressViewEmbeddingImages: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    view: "progress",
+    progress: 75,
+    progressStep: "Embedding images...",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Export at 75% progress. Shows 'Embedding images...' step label.",
+      },
+    },
+  },
+};
+
+/**
+ * Story 12: LegalPageSize
+ *
+ * Legal page size selected for PDF.
+ * Validates:
+ * - Legal selected in dropdown
+ * - Preview shows "PDF • LEGAL"
+ */
+export const LegalPageSize: Story = {
+  args: {
+    open: true,
+    documentTitle: "The Architecture of Silence",
+    estimatedSize: "~2.6 MB",
+    initialOptions: {
+      ...defaultExportOptions,
+      pageSize: "legal",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "PDF with Legal page size. Preview badge shows 'PDF • LEGAL'.",
+      },
+    },
+  },
+};

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ExportDialog, defaultExportOptions } from "./ExportDialog";
+
+describe("ExportDialog", () => {
+  // ===========================================================================
+  // Rendering tests
+  // ===========================================================================
+
+  it("renders config view by default when open", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        documentTitle="Test Document"
+      />
+    );
+
+    expect(screen.getByText("Export Document")).toBeInTheDocument();
+    expect(screen.getByText("Test Document")).toBeInTheDocument();
+    expect(screen.getByText("Format")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <ExportDialog
+        open={false}
+        onOpenChange={() => {}}
+        documentTitle="Test Document"
+      />
+    );
+
+    expect(screen.queryByText("Export Document")).not.toBeInTheDocument();
+  });
+
+  it("renders all format options", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+    expect(screen.getByText("Markdown")).toBeInTheDocument();
+    expect(screen.getByText("Word")).toBeInTheDocument();
+    expect(screen.getByText("Plain Text")).toBeInTheDocument();
+  });
+
+  it("renders all settings options", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText("Include metadata")).toBeInTheDocument();
+    expect(screen.getByText("Version history")).toBeInTheDocument();
+    expect(screen.getByText("Embed images")).toBeInTheDocument();
+  });
+
+  it("renders page size select", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText("Page Size")).toBeInTheDocument();
+  });
+
+  it("renders preview section", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByText("PDF • A4")).toBeInTheDocument();
+  });
+
+  it("renders estimated size", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        estimatedSize="~2.4 MB"
+      />
+    );
+
+    expect(screen.getByText("~2.4 MB")).toBeInTheDocument();
+  });
+
+  it("renders export and cancel buttons", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Format selection tests
+  // ===========================================================================
+
+  it("has PDF selected by default", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    const pdfCard = screen.getByText("PDF").closest("button");
+    expect(pdfCard).toHaveAttribute("data-state", "checked");
+  });
+
+  it("updates preview when format changes", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        initialOptions={{ ...defaultExportOptions, format: "markdown" }}
+      />
+    );
+
+    expect(screen.getByText("MARKDOWN • A4")).toBeInTheDocument();
+  });
+
+  it("shows description for format options", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    expect(screen.getByText("Portable Document")).toBeInTheDocument();
+    expect(screen.getByText(".md")).toBeInTheDocument();
+    expect(screen.getByText(".docx")).toBeInTheDocument();
+    expect(screen.getByText(".txt")).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Page size tests
+  // ===========================================================================
+
+  it("shows different page size in preview", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        initialOptions={{ ...defaultExportOptions, pageSize: "letter" }}
+      />
+    );
+
+    expect(screen.getByText("PDF • LETTER")).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Controlled view tests
+  // ===========================================================================
+
+  it("renders progress view when view='progress'", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        view="progress"
+        progress={45}
+        progressStep="Generating pages..."
+        documentTitle="Test Document"
+      />
+    );
+
+    // Use getAllByText because the title appears in both sr-only and visible heading
+    expect(screen.getAllByText("Exporting Document").length).toBeGreaterThan(0);
+    expect(screen.getByText("45%")).toBeInTheDocument();
+    expect(screen.getByText("Generating pages...")).toBeInTheDocument();
+  });
+
+  it("renders success view when view='success'", () => {
+    render(
+      <ExportDialog open={true} onOpenChange={() => {}} view="success" />
+    );
+
+    // Use getAllByText because the title appears in both sr-only and visible heading
+    expect(screen.getAllByText("Export Complete").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Your file has been successfully downloaded.").length
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+
+  it("shows document title in progress view", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        view="progress"
+        progress={50}
+        documentTitle="The Architecture of Silence"
+      />
+    );
+
+    expect(
+      screen.getByText(/Converting .+The Architecture of Silence.+ to PDF/)
+    ).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Callback tests
+  // ===========================================================================
+
+  it("calls onOpenChange when close button is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(<ExportDialog open={true} onOpenChange={onOpenChange} />);
+
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(closeButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onCancel when cancel button is clicked in config view", () => {
+    const onCancel = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onOpenChange(false) when Done button is clicked in success view", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        view="success"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ===========================================================================
+  // Accessibility tests
+  // ===========================================================================
+
+  it("has accessible title", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        documentTitle="Test Document"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Export Document" })
+    ).toBeInTheDocument();
+  });
+
+  it("has cancel button with cancel label in progress view", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        view="progress"
+        progress={50}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Default values tests
+  // ===========================================================================
+
+  it("uses default options when none provided", () => {
+    render(<ExportDialog open={true} onOpenChange={() => {}} />);
+
+    // PDF should be selected
+    const pdfCard = screen.getByText("PDF").closest("button");
+    expect(pdfCard).toHaveAttribute("data-state", "checked");
+
+    // Preview should show PDF • A4
+    expect(screen.getByText("PDF • A4")).toBeInTheDocument();
+  });
+
+  it("applies initial options correctly", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        initialOptions={{
+          format: "word",
+          pageSize: "legal",
+          includeMetadata: false,
+          versionHistory: true,
+          embedImages: false,
+        }}
+      />
+    );
+
+    // Word should be selected
+    const wordCard = screen.getByText("Word").closest("button");
+    expect(wordCard).toHaveAttribute("data-state", "checked");
+
+    // Preview should show WORD • LEGAL
+    expect(screen.getByText("WORD • LEGAL")).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Progress step tests
+  // ===========================================================================
+
+  it("shows correct progress percentage", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        view="progress"
+        progress={75}
+      />
+    );
+
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("shows provided progress step", () => {
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        view="progress"
+        progress={85}
+        progressStep="Embedding images..."
+      />
+    );
+
+    expect(screen.getByText("Embedding images...")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -1,0 +1,800 @@
+import React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Button, Checkbox, Select } from "../../components/primitives";
+
+/**
+ * Export format types
+ */
+export type ExportFormat = "pdf" | "markdown" | "word" | "txt";
+
+/**
+ * Page size options (PDF only)
+ */
+export type PageSize = "a4" | "letter" | "legal";
+
+/**
+ * Export view states
+ */
+export type ExportView = "config" | "progress" | "success";
+
+/**
+ * Export options configuration
+ */
+export interface ExportOptions {
+  format: ExportFormat;
+  pageSize: PageSize;
+  includeMetadata: boolean;
+  versionHistory: boolean;
+  embedImages: boolean;
+}
+
+/**
+ * Progress step definition
+ */
+export interface ProgressStep {
+  label: string;
+  threshold: number;
+}
+
+/**
+ * ExportDialog props
+ */
+export interface ExportDialogProps {
+  /** Controlled open state */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Document title to export */
+  documentTitle?: string;
+  /** Estimated file size */
+  estimatedSize?: string;
+  /** Initial export options */
+  initialOptions?: Partial<ExportOptions>;
+  /** Callback when export is triggered */
+  onExport?: (options: ExportOptions) => void;
+  /** Callback when export is cancelled */
+  onCancel?: () => void;
+  /** Current view state (for controlled mode/stories) */
+  view?: ExportView;
+  /** Current progress (0-100) for progress view */
+  progress?: number;
+  /** Current step label for progress view */
+  progressStep?: string;
+}
+
+/**
+ * Default export options
+ */
+export const defaultExportOptions: ExportOptions = {
+  format: "pdf",
+  pageSize: "a4",
+  includeMetadata: true,
+  versionHistory: false,
+  embedImages: true,
+};
+
+/**
+ * Progress steps configuration
+ */
+const progressSteps: ProgressStep[] = [
+  { label: "Preparing...", threshold: 30 },
+  { label: "Generating pages...", threshold: 60 },
+  { label: "Embedding images...", threshold: 90 },
+  { label: "Finalizing PDF...", threshold: 100 },
+];
+
+/**
+ * Get current step label based on progress
+ */
+function getProgressStepLabel(progress: number): string {
+  for (const step of progressSteps) {
+    if (progress < step.threshold) {
+      return step.label;
+    }
+  }
+  return progressSteps[progressSteps.length - 1].label;
+}
+
+/**
+ * Format option configuration
+ */
+interface FormatOption {
+  value: ExportFormat;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+/**
+ * Format options
+ */
+const formatOptions: FormatOption[] = [
+  {
+    value: "pdf",
+    label: "PDF",
+    description: "Portable Document",
+    icon: (
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <path d="M10 13H8v5h2" />
+        <path d="M15 15h-2v3h2" />
+        <path d="M16 13h-3v5" />
+      </svg>
+    ),
+  },
+  {
+    value: "markdown",
+    label: "Markdown",
+    description: ".md",
+    icon: (
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <path d="M12 18v-6" />
+        <path d="M9 15l3 3 3-3" />
+      </svg>
+    ),
+  },
+  {
+    value: "word",
+    label: "Word",
+    description: ".docx",
+    icon: (
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+        <polyline points="14 2 14 8 20 8" />
+        <path d="M8 13h8" />
+        <path d="M8 17h8" />
+        <path d="M8 9h5" />
+      </svg>
+    ),
+  },
+  {
+    value: "txt",
+    label: "Plain Text",
+    description: ".txt",
+    icon: (
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+        <line x1="10" y1="9" x2="8" y2="9" />
+      </svg>
+    ),
+  },
+];
+
+/**
+ * Page size options for Select
+ */
+const pageSizeOptions = [
+  { value: "a4", label: "A4" },
+  { value: "letter", label: "Letter" },
+  { value: "legal", label: "Legal" },
+];
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const overlayStyles = [
+  "fixed",
+  "inset-0",
+  "z-[var(--z-modal)]",
+  "bg-[rgba(0,0,0,0.6)]",
+  "backdrop-blur-sm",
+  "transition-opacity",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=closed]:opacity-0",
+].join(" ");
+
+const contentStyles = [
+  "fixed",
+  "left-1/2",
+  "top-1/2",
+  "-translate-x-1/2",
+  "-translate-y-1/2",
+  "z-[var(--z-modal)]",
+  "w-[480px]",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded-[var(--radius-lg)]",
+  "shadow-2xl",
+  "flex",
+  "flex-col",
+  "max-h-[90vh]",
+  "overflow-hidden",
+  // Animation
+  "transition-[opacity,transform]",
+  "duration-[var(--duration-normal)]",
+  "ease-[var(--ease-default)]",
+  "data-[state=open]:opacity-100",
+  "data-[state=open]:scale-100",
+  "data-[state=closed]:opacity-0",
+  "data-[state=closed]:scale-95",
+  "focus:outline-none",
+].join(" ");
+
+const closeButtonStyles = [
+  "p-1",
+  "rounded-[var(--radius-sm)]",
+  "text-[var(--color-fg-muted)]",
+  "hover:text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+].join(" ");
+
+const labelStyles = [
+  "text-[10px]",
+  "font-semibold",
+  "text-[var(--color-fg-placeholder)]",
+  "uppercase",
+  "tracking-[0.1em]",
+  "mb-3",
+  "block",
+].join(" ");
+
+const formatCardStyles = (isSelected: boolean) =>
+  [
+    "p-3",
+    "rounded-[var(--radius-md)]",
+    "border",
+    "cursor-pointer",
+    "transition-all",
+    "duration-[var(--duration-fast)]",
+    "h-full",
+    isSelected
+      ? [
+          "border-[var(--color-accent)]",
+          "bg-[var(--color-accent-subtle)]",
+        ].join(" ")
+      : [
+          "border-[var(--color-border-default)]",
+          "bg-[rgba(8,8,8,0.5)]",
+          "hover:bg-[var(--color-bg-hover)]",
+        ].join(" "),
+  ].join(" ");
+
+const radioIndicatorStyles = (isSelected: boolean) =>
+  [
+    "w-4",
+    "h-4",
+    "rounded-[var(--radius-full)]",
+    "border",
+    "flex",
+    "items-center",
+    "justify-center",
+    isSelected
+      ? "border-[var(--color-accent)] opacity-100"
+      : "border-[var(--color-border-default)] opacity-0",
+  ].join(" ");
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+/**
+ * Format card radio button
+ */
+function FormatCard({
+  option,
+  isSelected,
+}: {
+  option: FormatOption;
+  isSelected: boolean;
+}) {
+  return (
+    <RadioGroupPrimitive.Item
+      value={option.value}
+      className={formatCardStyles(isSelected)}
+    >
+      <div className="flex items-start justify-between mb-2">
+        <div
+          className={
+            isSelected
+              ? "text-[var(--color-accent)]"
+              : "text-[var(--color-fg-muted)]"
+          }
+        >
+          {option.icon}
+        </div>
+        <div className={radioIndicatorStyles(isSelected)}>
+          {isSelected && (
+            <span className="w-2 h-2 rounded-[var(--radius-full)] bg-[var(--color-accent)]" />
+          )}
+        </div>
+      </div>
+      <div className="font-medium text-sm text-[var(--color-fg-default)]">
+        {option.label}
+      </div>
+      <div
+        className={`text-xs mt-0.5 ${
+          option.value === "markdown" || option.value === "txt"
+            ? "font-mono"
+            : ""
+        } text-[var(--color-fg-muted)]`}
+      >
+        {option.description}
+      </div>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+/**
+ * Preview thumbnail
+ */
+function PreviewThumbnail({
+  format,
+  pageSize,
+}: {
+  format: ExportFormat;
+  pageSize: PageSize;
+}) {
+  const formatLabel = format.toUpperCase();
+  const pageSizeLabel = pageSize.toUpperCase();
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <span className={labelStyles}>Preview</span>
+        <span className="text-[10px] text-[var(--color-fg-placeholder)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 rounded">
+          {formatLabel} • {pageSizeLabel}
+        </span>
+      </div>
+      <div className="w-full h-32 bg-[#050505] border border-[var(--color-border-default)] rounded-[var(--radius-md)] p-4 overflow-hidden relative">
+        <div className="opacity-50 select-none pointer-events-none transform scale-[0.8] origin-top-left w-[120%]">
+          <div className="h-4 w-3/4 bg-[var(--color-fg-placeholder)]/40 rounded mb-3" />
+          <div className="h-2 w-full bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
+          <div className="h-2 w-full bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
+          <div className="h-2 w-5/6 bg-[var(--color-fg-placeholder)]/20 rounded mb-3" />
+          <div className="h-2 w-full bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
+          <div className="h-2 w-4/5 bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
+          <div className="w-full h-16 bg-[var(--color-fg-placeholder)]/10 rounded mt-4 border border-white/5" />
+        </div>
+        <div className="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-[#050505] to-transparent" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Config view - format selection and options
+ */
+function ConfigView({
+  options,
+  onOptionsChange,
+  onExport,
+  onCancel,
+  estimatedSize,
+}: {
+  options: ExportOptions;
+  onOptionsChange: (options: ExportOptions) => void;
+  onExport: () => void;
+  onCancel: () => void;
+  estimatedSize: string;
+}) {
+  const isPdfFormat = options.format === "pdf";
+
+  return (
+    <>
+      <div className="overflow-y-auto p-6 space-y-6">
+        {/* Format Selection */}
+        <div>
+          <span className={labelStyles}>Format</span>
+          <RadioGroupPrimitive.Root
+            value={options.format}
+            onValueChange={(value) =>
+              onOptionsChange({ ...options, format: value as ExportFormat })
+            }
+            className="grid grid-cols-2 gap-3"
+          >
+            {formatOptions.map((option) => (
+              <FormatCard
+                key={option.value}
+                option={option}
+                isSelected={options.format === option.value}
+              />
+            ))}
+          </RadioGroupPrimitive.Root>
+        </div>
+
+        {/* Settings Grid */}
+        <div className="grid grid-cols-2 gap-6">
+          {/* Settings Column */}
+          <div className="space-y-3">
+            <span className={labelStyles}>Settings</span>
+
+            <Checkbox
+              checked={options.includeMetadata}
+              onCheckedChange={(checked) =>
+                onOptionsChange({
+                  ...options,
+                  includeMetadata: checked === true,
+                })
+              }
+              label="Include metadata"
+            />
+
+            <Checkbox
+              checked={options.versionHistory}
+              onCheckedChange={(checked) =>
+                onOptionsChange({
+                  ...options,
+                  versionHistory: checked === true,
+                })
+              }
+              label="Version history"
+            />
+
+            <Checkbox
+              checked={options.embedImages}
+              onCheckedChange={(checked) =>
+                onOptionsChange({
+                  ...options,
+                  embedImages: checked === true,
+                })
+              }
+              label="Embed images"
+            />
+          </div>
+
+          {/* Page Size Column */}
+          <div className="space-y-3">
+            <span className={labelStyles}>Page Size</span>
+            <Select
+              value={options.pageSize}
+              onValueChange={(value) =>
+                onOptionsChange({ ...options, pageSize: value as PageSize })
+              }
+              options={pageSizeOptions}
+              disabled={!isPdfFormat}
+              fullWidth
+            />
+          </div>
+        </div>
+
+        {/* Preview */}
+        <PreviewThumbnail format={options.format} pageSize={options.pageSize} />
+      </div>
+
+      {/* Footer */}
+      <div className="p-6 pt-4 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-surface)]">
+        <span className="text-sm text-[var(--color-fg-muted)]">
+          {estimatedSize}
+        </span>
+        <div className="flex gap-3">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onExport}
+            className="!bg-[var(--color-accent)] !text-[var(--color-fg-inverse)] hover:!bg-[var(--color-accent-hover)] shadow-lg shadow-[var(--color-accent)]/20"
+          >
+            Export
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Progress view - export in progress
+ */
+function ProgressView({
+  documentTitle,
+  format,
+  progress,
+  progressStep,
+  onCancel,
+}: {
+  documentTitle: string;
+  format: ExportFormat;
+  progress: number;
+  progressStep: string;
+  onCancel: () => void;
+}) {
+  const formatLabel = format.toUpperCase();
+
+  return (
+    <div className="flex flex-col h-[400px] items-center justify-center p-8 text-center">
+      {/* Icon with pulse animation */}
+      <div className="w-16 h-16 rounded-2xl bg-[var(--color-accent-subtle)] flex items-center justify-center text-[var(--color-accent)] mb-6 relative">
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+      </div>
+
+      <h3 className="text-xl font-medium text-[var(--color-fg-default)] mb-2">
+        Exporting Document
+      </h3>
+      <p className="text-[var(--color-fg-muted)] text-sm mb-8">
+        Converting &ldquo;{documentTitle}&rdquo; to {formatLabel}...
+      </p>
+
+      {/* Progress bar */}
+      <div className="w-full max-w-xs mb-2">
+        <div className="h-1.5 w-full bg-[var(--color-bg-hover)] rounded-[var(--radius-full)] overflow-hidden">
+          <div
+            className="h-full bg-[var(--color-accent)] rounded-[var(--radius-full)] transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between w-full max-w-xs text-xs text-[var(--color-fg-placeholder)] font-mono">
+        <span>{progressStep}</span>
+        <span>{Math.floor(progress)}%</span>
+      </div>
+
+      <Button variant="ghost" onClick={onCancel} className="mt-8">
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Success view - export complete
+ */
+function SuccessView({ onDone }: { onDone: () => void }) {
+  return (
+    <div className="flex flex-col h-[400px] items-center justify-center p-8 text-center">
+      {/* Success icon */}
+      <div className="w-16 h-16 rounded-[var(--radius-full)] bg-[var(--color-success-subtle)] flex items-center justify-center text-[var(--color-success)] mb-6 border border-[var(--color-success)]/20">
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </div>
+
+      <h3 className="text-xl font-medium text-[var(--color-fg-default)] mb-2">
+        Export Complete
+      </h3>
+      <p className="text-[var(--color-fg-muted)] text-sm mb-8">
+        Your file has been successfully downloaded.
+      </p>
+
+      <Button
+        variant="primary"
+        onClick={onDone}
+        className="!bg-white !text-black hover:!bg-gray-200"
+      >
+        Done
+      </Button>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/**
+ * ExportDialog component
+ *
+ * A dialog for exporting documents with format selection, options configuration,
+ * progress tracking, and success feedback.
+ *
+ * Features:
+ * - 4 format options: PDF, Markdown, Word, Plain Text
+ * - Export settings: metadata, version history, embed images
+ * - Page size selection (PDF only)
+ * - Live preview thumbnail
+ * - Progress bar with step labels
+ * - Success confirmation
+ *
+ * @example
+ * ```tsx
+ * <ExportDialog
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   documentTitle="The Architecture of Silence"
+ *   onExport={(options) => handleExport(options)}
+ * />
+ * ```
+ */
+export function ExportDialog({
+  open,
+  onOpenChange,
+  documentTitle = "Untitled Document",
+  estimatedSize = "~2.4 MB",
+  initialOptions,
+  onExport,
+  onCancel,
+  view: controlledView,
+  progress: controlledProgress,
+  progressStep: controlledProgressStep,
+}: ExportDialogProps): JSX.Element {
+  // Internal state for uncontrolled mode
+  const [internalView, setInternalView] = React.useState<ExportView>("config");
+  const [internalProgress, setInternalProgress] = React.useState(0);
+  const [options, setOptions] = React.useState<ExportOptions>({
+    ...defaultExportOptions,
+    ...initialOptions,
+  });
+
+  // Use controlled or internal values
+  const view = controlledView ?? internalView;
+  const progress = controlledProgress ?? internalProgress;
+  const progressStep =
+    controlledProgressStep ?? getProgressStepLabel(progress);
+
+  // Reset state when dialog opens
+  React.useEffect(() => {
+    if (open) {
+      setInternalView("config");
+      setInternalProgress(0);
+      setOptions({
+        ...defaultExportOptions,
+        ...initialOptions,
+      });
+    }
+  }, [open, initialOptions]);
+
+  const handleExport = () => {
+    setInternalView("progress");
+
+    // Simulate export progress
+    let currentProgress = 0;
+    const interval = setInterval(() => {
+      currentProgress += Math.random() * 5;
+      if (currentProgress > 100) currentProgress = 100;
+      setInternalProgress(currentProgress);
+
+      if (currentProgress === 100) {
+        clearInterval(interval);
+        setTimeout(() => {
+          setInternalView("success");
+          onExport?.(options);
+        }, 600);
+      }
+    }, 100);
+  };
+
+  const handleCancel = () => {
+    if (view === "progress") {
+      setInternalView("config");
+      setInternalProgress(0);
+    } else {
+      onCancel?.();
+      onOpenChange(false);
+    }
+  };
+
+  const handleDone = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className={overlayStyles} />
+        <DialogPrimitive.Content className={contentStyles}>
+          {view === "config" && (
+            <>
+              {/* Header */}
+              <div className="flex items-start justify-between p-6 pb-4 border-b border-[var(--color-separator)]">
+                <div>
+                  <DialogPrimitive.Title className="text-lg font-medium text-[var(--color-fg-default)] mb-1">
+                    Export Document
+                  </DialogPrimitive.Title>
+                  <DialogPrimitive.Description className="text-sm text-[var(--color-fg-muted)]">
+                    {documentTitle}
+                  </DialogPrimitive.Description>
+                </div>
+                <DialogPrimitive.Close className={closeButtonStyles} aria-label="Close">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </DialogPrimitive.Close>
+              </div>
+
+              <ConfigView
+                options={options}
+                onOptionsChange={setOptions}
+                onExport={handleExport}
+                onCancel={handleCancel}
+                estimatedSize={estimatedSize}
+              />
+            </>
+          )}
+
+          {view === "progress" && (
+            <>
+              <DialogPrimitive.Title className="sr-only">
+                Exporting Document
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="sr-only">
+                Export in progress. Please wait.
+              </DialogPrimitive.Description>
+              <ProgressView
+                documentTitle={documentTitle}
+                format={options.format}
+                progress={progress}
+                progressStep={progressStep}
+                onCancel={handleCancel}
+              />
+            </>
+          )}
+
+          {view === "success" && (
+            <>
+              <DialogPrimitive.Title className="sr-only">
+                Export Complete
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="sr-only">
+                Your file has been successfully downloaded.
+              </DialogPrimitive.Description>
+              <SuccessView onDone={handleDone} />
+            </>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/desktop/renderer/src/features/export/index.ts
+++ b/apps/desktop/renderer/src/features/export/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Export feature module
+ *
+ * Provides document export functionality with support for multiple formats:
+ * - PDF (with page size options)
+ * - Markdown
+ * - Word (.docx)
+ * - Plain Text (.txt)
+ *
+ * @example
+ * ```tsx
+ * import { ExportDialog } from '@/features/export';
+ *
+ * <ExportDialog
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   documentTitle="My Document"
+ *   onExport={(options) => handleExport(options)}
+ * />
+ * ```
+ */
+
+export { ExportDialog, defaultExportOptions } from "./ExportDialog";
+export type {
+  ExportDialogProps,
+  ExportFormat,
+  ExportOptions,
+  ExportView,
+  PageSize,
+  ProgressStep,
+} from "./ExportDialog";

--- a/openspec/_ops/task_runs/ISSUE-124.md
+++ b/openspec/_ops/task_runs/ISSUE-124.md
@@ -1,0 +1,26 @@
+# ISSUE-124
+
+- Issue: #124
+- Branch: task/124-export-dialog
+- PR: <fill-after-created>
+
+## Plan
+
+- 实现 ExportDialog 组件，包含 Config/Progress/Success 三个视图状态
+- 复用 Dialog/Radio/Checkbox/Select 等原语组件
+- 使用 design tokens（白色强调色 `--color-accent`）
+- 编写 Storybook stories 和单元测试
+
+## Runs
+
+### 2026-02-03 14:10 Implementation
+
+- Command: `ExportDialog.tsx, ExportDialog.stories.tsx, ExportDialog.test.tsx, index.ts`
+- Key output:
+  - Config View: 格式选择卡片（PDF/Markdown/Word/PlainText）、设置选项、页面大小选择
+  - Progress View: 进度条、步骤标签
+  - Success View: 完成状态、Done 按钮
+- Design fixes:
+  - 将 `--color-info`（蓝色）替换为 `--color-accent`（白色）符合 design tokens
+  - 移除 Progress View 的 `animate-ping` 动画效果
+- Evidence: Storybook 视觉验证 + 24 个单元测试全部通过

--- a/openspec/_ops/task_runs/ISSUE-124.md
+++ b/openspec/_ops/task_runs/ISSUE-124.md
@@ -2,7 +2,7 @@
 
 - Issue: #124
 - Branch: task/124-export-dialog
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/125
 
 ## Plan
 


### PR DESCRIPTION
Closes #124

## Summary

- 实现 ExportDialog 组件，包含三个视图状态：
  - **Config View**: 格式选择（PDF/Markdown/Word/PlainText）、设置选项、页面大小
  - **Progress View**: 导出进度展示，带步骤标签
  - **Success View**: 完成状态，Done 按钮
- 复用 Dialog/RadioGroup/Checkbox/Select/Button 等原语组件
- 使用 design tokens（白色强调色 `--color-accent`）
- 包含 12 个 Storybook stories 和 24 个单元测试

## Test Plan

- [x] Storybook 视觉验证三个视图状态
- [x] 单元测试全部通过（24 tests）
- [x] 格式选择交互正常
- [x] 进度条状态正确显示
- [x] 完成状态回调正常