### PR TITLE
fix: ExportDialog layout - center format cards and fix Export button visibility (#126)

### DIFF
--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -278,6 +278,9 @@ const formatCardStyles = (isSelected: boolean) =>
     "transition-all",
     "duration-[var(--duration-fast)]",
     "h-full",
+    "flex",
+    "flex-col",
+    "justify-center",
     isSelected
       ? [
           "border-[var(--color-accent)]",
@@ -421,7 +424,7 @@ function ConfigView({
             onValueChange={(value) =>
               onOptionsChange({ ...options, format: value as ExportFormat })
             }
-            className="grid grid-cols-2 gap-3"
+            className="grid grid-cols-2 gap-3 auto-rows-[100px]"
           >
             {formatOptions.map((option) => (
               <FormatCard
@@ -493,10 +496,11 @@ function ConfigView({
       </div>
 
       {/* Footer */}
-      <div className="p-6 pt-4 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-surface)]">
+      <div className="p-6 pt-4 border-t border-[var(--color-separator)] flex items-center bg-[var(--color-bg-surface)]">
         <span className="text-sm text-[var(--color-fg-muted)]">
           {estimatedSize}
         </span>
+        <div className="flex-1" />
         <div className="flex gap-3">
           <Button variant="ghost" onClick={onCancel}>
             Cancel
@@ -504,7 +508,6 @@ function ConfigView({
           <Button
             variant="primary"
             onClick={onExport}
-            className="!bg-[var(--color-accent)] !text-[var(--color-fg-inverse)] hover:!bg-[var(--color-accent-hover)] shadow-lg shadow-[var(--color-accent)]/20"
           >
             Export
           </Button>

--- a/openspec/_ops/task_runs/ISSUE-126.md
+++ b/openspec/_ops/task_runs/ISSUE-126.md
@@ -1,0 +1,19 @@
+# ISSUE-126
+
+- Issue: #126
+- Branch: task/126-export-dialog-layout
+- PR: <fill-after-created>
+
+## Plan
+
+- 修复格式卡片文字垂直居中问题
+- 修复 Export 按钮可见性问题
+
+## Runs
+
+### 2026-02-03 14:25 Layout fixes
+
+- Changes:
+  1. 格式卡片添加 `flex flex-col justify-center`，设置 `auto-rows-[100px]` 固定行高
+  2. 移除 Export 按钮的自定义白色样式，使用 Button 组件默认 primary 样式
+- Evidence: Storybook 视觉验证 + 24 个单元测试通过

--- a/openspec/_ops/task_runs/ISSUE-126.md
+++ b/openspec/_ops/task_runs/ISSUE-126.md
@@ -2,7 +2,7 @@
 
 - Issue: #126
 - Branch: task/126-export-dialog-layout
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/127
 
 ## Plan
 


### PR DESCRIPTION
Closes #126

## Summary

- 格式卡片（PDF/Markdown/Word/Plain Text）文字垂直居中
- Export 按钮使用默认 primary 样式，提高可见性

## Changes

1. 格式卡片添加 `flex flex-col justify-center`，设置 `auto-rows-[100px]` 固定行高
2. 移除 Export 按钮的自定义白色样式，使用 Button 组件默认 primary variant

## Test Plan

- [x] Storybook 视觉验证
- [x] 单元测试通过（24 tests）