### PR TITLE
fix: ExportDialog format cards true centering and solid indicator (#128)

### DIFF
--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -281,6 +281,9 @@ const formatCardStyles = (isSelected: boolean) =>
     "flex",
     "flex-col",
     "justify-center",
+    "items-center",
+    "text-center",
+    "relative",
     isSelected
       ? [
           "border-[var(--color-accent)]",
@@ -294,18 +297,9 @@ const formatCardStyles = (isSelected: boolean) =>
   ].join(" ");
 
 const radioIndicatorStyles = (isSelected: boolean) =>
-  [
-    "w-4",
-    "h-4",
-    "rounded-[var(--radius-full)]",
-    "border",
-    "flex",
-    "items-center",
-    "justify-center",
-    isSelected
-      ? "border-[var(--color-accent)] opacity-100"
-      : "border-[var(--color-border-default)] opacity-0",
-  ].join(" ");
+  isSelected
+    ? "w-4 h-4 rounded-full bg-white"
+    : "w-4 h-4 rounded-full border border-[var(--color-border-default)] opacity-0";
 
 // ============================================================================
 // Sub-components
@@ -326,25 +320,26 @@ function FormatCard({
       value={option.value}
       className={formatCardStyles(isSelected)}
     >
-      <div className="flex items-start justify-between mb-2">
-        <div
-          className={
-            isSelected
-              ? "text-[var(--color-accent)]"
-              : "text-[var(--color-fg-muted)]"
-          }
-        >
-          {option.icon}
-        </div>
-        <div className={radioIndicatorStyles(isSelected)}>
-          {isSelected && (
-            <span className="w-2 h-2 rounded-[var(--radius-full)] bg-[var(--color-accent)]" />
-          )}
-        </div>
+      {/* 单选指示器 - 绝对定位在右上角，选中时为实心白色圆 */}
+      <div className={`absolute top-3 right-3 ${radioIndicatorStyles(isSelected)}`} />
+      
+      {/* 图标 */}
+      <div
+        className={`mb-2 ${
+          isSelected
+            ? "text-[var(--color-accent)]"
+            : "text-[var(--color-fg-muted)]"
+        }`}
+      >
+        {option.icon}
       </div>
+      
+      {/* 标签 */}
       <div className="font-medium text-sm text-[var(--color-fg-default)]">
         {option.label}
       </div>
+      
+      {/* 描述 */}
       <div
         className={`text-xs mt-0.5 ${
           option.value === "markdown" || option.value === "txt"

--- a/openspec/_ops/task_runs/ISSUE-128.md
+++ b/openspec/_ops/task_runs/ISSUE-128.md
@@ -2,7 +2,7 @@
 
 - Issue: #128
 - Branch: task/128-export-dialog-center
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/129
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-128.md
+++ b/openspec/_ops/task_runs/ISSUE-128.md
@@ -1,0 +1,20 @@
+# ISSUE-128
+
+- Issue: #128
+- Branch: task/128-export-dialog-center
+- PR: <fill-after-created>
+
+## Plan
+
+- 修复格式卡片文字真正垂直居中
+- 修复选中指示器为实心白色圆
+
+## Runs
+
+### 2026-02-03 14:38 Fixes
+
+- Changes:
+  1. 卡片添加 `items-center text-center relative`，使内容真正居中
+  2. 选中指示器使用绝对定位在右上角
+  3. 选中时为实心白色圆 (`bg-white`)，未选中时隐藏
+- Evidence: Storybook 视觉验证 + 24 个单元测试通过


### PR DESCRIPTION
Closes #128

## Summary

- 格式卡片内容真正垂直居中（添加 items-center text-center）
- 选中指示器改为实心白色圆，绝对定位在右上角

## Changes

1. 卡片添加 `items-center text-center relative`
2. 选中指示器使用 `absolute top-3 right-3`
3. 选中时 `bg-white`，未选中时 `opacity-0`

## Test Plan

- [x] Storybook 视觉验证
- [x] 单元测试通过（24 tests）