### PR TITLE
fix(character): Dialog 在 Storybook 中的渲染问题 (#132)

### DIFF
--- a/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
@@ -88,10 +88,8 @@ function getContentStyles(hasContainer: boolean): string {
     "ease-[cubic-bezier(0.16,1,0.3,1)]",
     "data-[state=open]:opacity-100",
     "data-[state=open]:scale-100",
-    "data-[state=open]:translate-y-0",
     "data-[state=closed]:opacity-0",
     "data-[state=closed]:scale-[0.98]",
-    "data-[state=closed]:translate-y-5",
     "focus:outline-none",
   ].join(" ");
 }

--- a/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
@@ -29,55 +29,72 @@ export interface CharacterDetailDialogProps {
   onNavigateToChapter?: (chapterId: string) => void;
   /** Available characters for adding relationships */
   availableCharacters?: Character[];
+  /**
+   * Container element for Portal rendering.
+   * Use in Storybook to constrain Dialog rendering within the story container.
+   * If not provided, Dialog renders to document.body.
+   */
+  container?: HTMLElement | null;
 }
 
 // ============================================================================
 // Styles
 // ============================================================================
 
-const overlayStyles = [
-  "fixed",
-  "inset-0",
-  "z-[var(--z-modal)]",
-  "bg-[rgba(0,0,0,0.7)]",
-  "backdrop-blur-[4px]",
-  "transition-opacity",
-  "duration-[var(--duration-slow)]",
-  "ease-[var(--ease-default)]",
-  "data-[state=open]:opacity-100",
-  "data-[state=closed]:opacity-0",
-].join(" ");
+/**
+ * Get overlay styles based on whether a container is provided
+ * When container is provided, use absolute positioning for Storybook compatibility
+ */
+function getOverlayStyles(hasContainer: boolean): string {
+  return [
+    hasContainer ? "absolute" : "fixed",
+    "inset-0",
+    "z-[var(--z-modal)]",
+    "bg-[rgba(0,0,0,0.7)]",
+    "backdrop-blur-[4px]",
+    "transition-opacity",
+    "duration-[var(--duration-slow)]",
+    "ease-[var(--ease-default)]",
+    "data-[state=open]:opacity-100",
+    "data-[state=closed]:opacity-0",
+  ].join(" ");
+}
 
-const contentStyles = [
-  "fixed",
-  "left-1/2",
-  "top-1/2",
-  "-translate-x-1/2",
-  "-translate-y-1/2",
-  "z-[var(--z-modal)]",
-  "w-[560px]",
-  "max-h-[92vh]",
-  "bg-[var(--color-bg-surface)]",
-  "border",
-  "border-[var(--color-border-default)]",
-  "rounded-[var(--radius-xl)]",
-  "shadow-2xl",
-  "flex",
-  "flex-col",
-  "overflow-hidden",
-  "relative",
-  // Animation
-  "transition-[opacity,transform]",
-  "duration-[var(--duration-slow)]",
-  "ease-[cubic-bezier(0.16,1,0.3,1)]",
-  "data-[state=open]:opacity-100",
-  "data-[state=open]:scale-100",
-  "data-[state=open]:translate-y-0",
-  "data-[state=closed]:opacity-0",
-  "data-[state=closed]:scale-[0.98]",
-  "data-[state=closed]:translate-y-5",
-  "focus:outline-none",
-].join(" ");
+/**
+ * Get content styles based on whether a container is provided
+ * When container is provided, use absolute positioning for Storybook compatibility
+ */
+function getContentStyles(hasContainer: boolean): string {
+  return [
+    hasContainer ? "absolute" : "fixed",
+    "left-1/2",
+    "top-1/2",
+    "-translate-x-1/2",
+    "-translate-y-1/2",
+    "z-[var(--z-modal)]",
+    "w-[560px]",
+    hasContainer ? "max-h-[90%]" : "max-h-[92vh]",
+    "bg-[var(--color-bg-surface)]",
+    "border",
+    "border-[var(--color-border-default)]",
+    "rounded-[var(--radius-xl)]",
+    "shadow-2xl",
+    "flex",
+    "flex-col",
+    "overflow-hidden",
+    // Animation
+    "transition-[opacity,transform]",
+    "duration-[var(--duration-slow)]",
+    "ease-[cubic-bezier(0.16,1,0.3,1)]",
+    "data-[state=open]:opacity-100",
+    "data-[state=open]:scale-100",
+    "data-[state=open]:translate-y-0",
+    "data-[state=closed]:opacity-0",
+    "data-[state=closed]:scale-[0.98]",
+    "data-[state=closed]:translate-y-5",
+    "focus:outline-none",
+  ].join(" ");
+}
 
 const labelStyles = [
   "text-[10px]",
@@ -404,6 +421,7 @@ export function CharacterDetailDialog({
   onSave,
   onDelete,
   onNavigateToChapter,
+  container,
 }: CharacterDetailDialogProps): JSX.Element | null {
   // Form state
   const [editedCharacter, setEditedCharacter] = React.useState<Character | null>(null);
@@ -487,11 +505,13 @@ export function CharacterDetailDialog({
     }
   };
 
+  const hasContainer = container !== undefined && container !== null;
+
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className={overlayStyles} />
-        <DialogPrimitive.Content className={contentStyles}>
+      <DialogPrimitive.Portal container={container}>
+        <DialogPrimitive.Overlay className={getOverlayStyles(hasContainer)} />
+        <DialogPrimitive.Content className={getContentStyles(hasContainer)}>
           {/* Gradient line at top */}
           <div className="absolute top-0 left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent opacity-50" />
 

--- a/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
@@ -217,10 +217,11 @@ export const EmptyProject: Story = {
  */
 function EditingCharacterFormRender() {
   const [open, setOpen] = React.useState(true);
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const character = SAMPLE_CHARACTERS[0]; // Elara
 
   return (
-    <div className="h-screen flex bg-[var(--color-bg-base)]">
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -230,6 +231,7 @@ function EditingCharacterFormRender() {
         open={open}
         onOpenChange={setOpen}
         character={character}
+        container={containerRef.current}
       />
     </div>
   );
@@ -252,6 +254,7 @@ export const EditingCharacterForm: Story = {
  * Render component for AddingPersonalityTrait story
  */
 function AddingPersonalityTraitRender() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const [character, setCharacter] = React.useState<Character>({
     ...SAMPLE_CHARACTERS[0],
     traits: ["Brave", "Impulsive", "Loyal", "Cunning"], // Added Cunning
@@ -262,7 +265,7 @@ function AddingPersonalityTraitRender() {
   };
 
   return (
-    <div className="h-screen flex bg-[var(--color-bg-base)]">
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -273,6 +276,7 @@ function AddingPersonalityTraitRender() {
         onOpenChange={() => {}}
         character={character}
         onSave={handleSave}
+        container={containerRef.current}
       />
     </div>
   );
@@ -292,6 +296,51 @@ export const AddingPersonalityTrait: Story = {
 };
 
 /**
+ * Render component for ManagingRelationships story
+ */
+function ManagingRelationshipsRender() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const characterWithManyRelations: Character = {
+    ...SAMPLE_CHARACTERS[0],
+    relationships: [
+      ...SAMPLE_CHARACTERS[0].relationships,
+      {
+        characterId: "darius",
+        characterName: "Darius",
+        characterRole: "deuteragonist",
+        characterAvatar:
+          "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=32&h=32&fit=crop&crop=faces",
+        type: "friend",
+      },
+      {
+        characterId: "sarah",
+        characterName: "Sarah",
+        characterRole: "ally",
+        characterAvatar:
+          "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=32&h=32&fit=crop&crop=faces",
+        type: "ally",
+      },
+    ],
+  };
+
+  return (
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+      <CharacterPanel
+        characters={SAMPLE_CHARACTERS}
+        selectedId="elara"
+      />
+      <main className="flex-1 relative" />
+      <CharacterDetailDialog
+        open
+        onOpenChange={() => {}}
+        character={characterWithManyRelations}
+        container={containerRef.current}
+      />
+    </div>
+  );
+}
+
+/**
  * Scene 5: ManagingRelationships
  *
  * 用户正在管理人物关系
@@ -301,46 +350,35 @@ export const AddingPersonalityTrait: Story = {
  * - 验证关系状态指示器颜色（红色=敌对，蓝色=友好）
  */
 export const ManagingRelationships: Story = {
-  render: () => {
-    const characterWithManyRelations: Character = {
-      ...SAMPLE_CHARACTERS[0],
-      relationships: [
-        ...SAMPLE_CHARACTERS[0].relationships,
-        {
-          characterId: "darius",
-          characterName: "Darius",
-          characterRole: "deuteragonist",
-          characterAvatar:
-            "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=32&h=32&fit=crop&crop=faces",
-          type: "friend",
-        },
-        {
-          characterId: "sarah",
-          characterName: "Sarah",
-          characterRole: "ally",
-          characterAvatar:
-            "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=32&h=32&fit=crop&crop=faces",
-          type: "ally",
-        },
-      ],
-    };
-
-    return (
-      <div className="h-screen flex bg-[var(--color-bg-base)]">
-        <CharacterPanel
-          characters={SAMPLE_CHARACTERS}
-          selectedId="elara"
-        />
-        <main className="flex-1 relative" />
-        <CharacterDetailDialog
-          open
-          onOpenChange={() => {}}
-          character={characterWithManyRelations}
-        />
-      </div>
-    );
-  },
+  render: () => <ManagingRelationshipsRender />,
 };
+
+/**
+ * Render component for UploadingAvatar story
+ */
+function UploadingAvatarRender() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  // Character without avatar to show initials fallback
+  const characterWithoutAvatar: Character = {
+    ...SAMPLE_CHARACTERS[3], // Jax has no avatar
+  };
+
+  return (
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+      <CharacterPanel
+        characters={SAMPLE_CHARACTERS}
+        selectedId="jax"
+      />
+      <main className="flex-1 relative" />
+      <CharacterDetailDialog
+        open
+        onOpenChange={() => {}}
+        character={characterWithoutAvatar}
+        container={containerRef.current}
+      />
+    </div>
+  );
+}
 
 /**
  * Scene 6: UploadingAvatar
@@ -352,27 +390,7 @@ export const ManagingRelationships: Story = {
  * - 验证无头像时显示首字母 fallback
  */
 export const UploadingAvatar: Story = {
-  render: () => {
-    // Character without avatar to show initials fallback
-    const characterWithoutAvatar: Character = {
-      ...SAMPLE_CHARACTERS[3], // Jax has no avatar
-    };
-
-    return (
-      <div className="h-screen flex bg-[var(--color-bg-base)]">
-        <CharacterPanel
-          characters={SAMPLE_CHARACTERS}
-          selectedId="jax"
-        />
-        <main className="flex-1 relative" />
-        <CharacterDetailDialog
-          open
-          onOpenChange={() => {}}
-          character={characterWithoutAvatar}
-        />
-      </div>
-    );
-  },
+  render: () => <UploadingAvatarRender />,
 };
 
 /**
@@ -404,6 +422,7 @@ export const DeletingCharacterConfirm: Story = {
  * Render component for SwitchingBetweenCharacters story
  */
 function SwitchingBetweenCharactersRender() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const [selectedId, setSelectedId] = React.useState("elara");
   const [dialogOpen, setDialogOpen] = React.useState(true);
   const selectedCharacter = SAMPLE_CHARACTERS.find((c) => c.id === selectedId);
@@ -414,7 +433,7 @@ function SwitchingBetweenCharactersRender() {
   };
 
   return (
-    <div className="h-screen flex bg-[var(--color-bg-base)]">
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId={selectedId}
@@ -432,6 +451,7 @@ function SwitchingBetweenCharactersRender() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         character={selectedCharacter || null}
+        container={containerRef.current}
       />
     </div>
   );
@@ -454,10 +474,11 @@ export const SwitchingBetweenCharacters: Story = {
  * Render component for ChapterAppearanceNavigation story
  */
 function ChapterAppearanceNavigationRender() {
+  const containerRef = React.useRef<HTMLDivElement>(null);
   const [lastNavigatedChapter, setLastNavigatedChapter] = React.useState<string | null>(null);
 
   return (
-    <div className="h-screen flex bg-[var(--color-bg-base)]">
+    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -478,6 +499,7 @@ function ChapterAppearanceNavigationRender() {
         onOpenChange={() => {}}
         character={SAMPLE_CHARACTERS[0]}
         onNavigateToChapter={(chapterId) => setLastNavigatedChapter(chapterId)}
+        container={containerRef.current}
       />
     </div>
   );

--- a/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
@@ -217,11 +217,17 @@ export const EmptyProject: Story = {
  */
 function EditingCharacterFormRender() {
   const [open, setOpen] = React.useState(true);
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   const character = SAMPLE_CHARACTERS[0]; // Elara
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -231,7 +237,7 @@ function EditingCharacterFormRender() {
         open={open}
         onOpenChange={setOpen}
         character={character}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );
@@ -254,7 +260,10 @@ export const EditingCharacterForm: Story = {
  * Render component for AddingPersonalityTrait story
  */
 function AddingPersonalityTraitRender() {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   const [character, setCharacter] = React.useState<Character>({
     ...SAMPLE_CHARACTERS[0],
     traits: ["Brave", "Impulsive", "Loyal", "Cunning"], // Added Cunning
@@ -265,7 +274,10 @@ function AddingPersonalityTraitRender() {
   };
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -276,7 +288,7 @@ function AddingPersonalityTraitRender() {
         onOpenChange={() => {}}
         character={character}
         onSave={handleSave}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );
@@ -299,7 +311,10 @@ export const AddingPersonalityTrait: Story = {
  * Render component for ManagingRelationships story
  */
 function ManagingRelationshipsRender() {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   const characterWithManyRelations: Character = {
     ...SAMPLE_CHARACTERS[0],
     relationships: [
@@ -324,7 +339,10 @@ function ManagingRelationshipsRender() {
   };
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -334,7 +352,7 @@ function ManagingRelationshipsRender() {
         open
         onOpenChange={() => {}}
         character={characterWithManyRelations}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );
@@ -357,14 +375,20 @@ export const ManagingRelationships: Story = {
  * Render component for UploadingAvatar story
  */
 function UploadingAvatarRender() {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   // Character without avatar to show initials fallback
   const characterWithoutAvatar: Character = {
     ...SAMPLE_CHARACTERS[3], // Jax has no avatar
   };
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="jax"
@@ -374,7 +398,7 @@ function UploadingAvatarRender() {
         open
         onOpenChange={() => {}}
         character={characterWithoutAvatar}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );
@@ -422,7 +446,10 @@ export const DeletingCharacterConfirm: Story = {
  * Render component for SwitchingBetweenCharacters story
  */
 function SwitchingBetweenCharactersRender() {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   const [selectedId, setSelectedId] = React.useState("elara");
   const [dialogOpen, setDialogOpen] = React.useState(true);
   const selectedCharacter = SAMPLE_CHARACTERS.find((c) => c.id === selectedId);
@@ -433,7 +460,10 @@ function SwitchingBetweenCharactersRender() {
   };
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId={selectedId}
@@ -451,7 +481,7 @@ function SwitchingBetweenCharactersRender() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         character={selectedCharacter || null}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );
@@ -474,11 +504,17 @@ export const SwitchingBetweenCharacters: Story = {
  * Render component for ChapterAppearanceNavigation story
  */
 function ChapterAppearanceNavigationRender() {
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLDivElement | null>(null);
+  const setContainerRef = React.useCallback((el: HTMLDivElement | null) => {
+    setContainerEl(el);
+  }, []);
   const [lastNavigatedChapter, setLastNavigatedChapter] = React.useState<string | null>(null);
 
   return (
-    <div ref={containerRef} className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative">
+    <div
+      ref={setContainerRef}
+      className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)] relative"
+    >
       <CharacterPanel
         characters={SAMPLE_CHARACTERS}
         selectedId="elara"
@@ -499,7 +535,7 @@ function ChapterAppearanceNavigationRender() {
         onOpenChange={() => {}}
         character={SAMPLE_CHARACTERS[0]}
         onNavigateToChapter={(chapterId) => setLastNavigatedChapter(chapterId)}
-        container={containerRef.current}
+        container={containerEl}
       />
     </div>
   );

--- a/openspec/_ops/task_runs/ISSUE-132.md
+++ b/openspec/_ops/task_runs/ISSUE-132.md
@@ -42,3 +42,8 @@
 
 - Command: `Edit apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx`
 - Key output: 移除 `data-[state=open]:translate-y-0` / `data-[state=closed]:translate-y-5`，避免覆盖 `-translate-y-1/2` 导致 Dialog 下移
+
+### 2026-02-03 16:05 修复 Storybook stories 的 ref 访问 lint
+
+- Command: `Edit apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx`
+- Key output: 使用 `useState + callback ref` 替代 `containerRef.current`，通过 `container={containerEl}` 传入，修复 `react-hooks/refs` 报错

--- a/openspec/_ops/task_runs/ISSUE-132.md
+++ b/openspec/_ops/task_runs/ISSUE-132.md
@@ -37,3 +37,8 @@
 ### 验证
 - Command: `npx tsc --noEmit`
 - Key output: `Exit code: 0` (编译通过)
+
+### 2026-02-03 15:55 调整 Dialog 居中定位
+
+- Command: `Edit apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx`
+- Key output: 移除 `data-[state=open]:translate-y-0` / `data-[state=closed]:translate-y-5`，避免覆盖 `-translate-y-1/2` 导致 Dialog 下移

--- a/openspec/_ops/task_runs/ISSUE-132.md
+++ b/openspec/_ops/task_runs/ISSUE-132.md
@@ -2,7 +2,7 @@
 
 - Issue: #132
 - Branch: task/132-dialog-storybook-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/133
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-132.md
+++ b/openspec/_ops/task_runs/ISSUE-132.md
@@ -1,0 +1,39 @@
+# ISSUE-132
+
+- Issue: #132
+- Branch: task/132-dialog-storybook-fix
+- PR: <fill-after-created>
+
+## Plan
+
+1. 为 CharacterDetailDialog 添加 `container` prop 支持
+2. 当提供 container 时，使用 `absolute` 定位替代 `fixed`
+3. 更新所有包含 Dialog 的 Storybook stories 使用 container ref
+
+## Runs
+
+### 2026-02-03 15:47 实现修复
+
+#### CharacterDetailDialog 修改
+- 添加 `container?: HTMLElement | null` prop
+- 传递给 `DialogPrimitive.Portal container={container}`
+- 创建动态样式函数 `getOverlayStyles` 和 `getContentStyles`
+- 当 hasContainer=true 时使用 `absolute` 定位
+- 当 hasContainer=false 时保持原有 `fixed` 定位
+
+#### Storybook stories 修改
+- 为所有包含 Dialog 的 render 函数添加 `containerRef`
+- 将容器 div 添加 `ref={containerRef}` 和 `relative` class
+- 将 `container={containerRef.current}` 传递给 CharacterDetailDialog
+
+修改的 stories:
+- EditingCharacterFormRender
+- AddingPersonalityTraitRender
+- ManagingRelationshipsRender (新建)
+- UploadingAvatarRender (新建)
+- SwitchingBetweenCharactersRender
+- ChapterAppearanceNavigationRender
+
+### 验证
+- Command: `npx tsc --noEmit`
+- Key output: `Exit code: 0` (编译通过)


### PR DESCRIPTION
Closes #132

## Summary

- 为 CharacterDetailDialog 添加 `container` prop 支持
- 当提供 container 时使用 `absolute` 定位替代 `fixed`
- 更新所有包含 Dialog 的 Storybook stories 使用 container ref
- 解决 Radix Portal 在 Storybook iframe 中的定位问题

## Technical Details

Radix UI Dialog 使用 Portal 将内容渲染到 `<body>`，结合 `fixed` 定位，在 Storybook 的 iframe 环境中会导致 Dialog 不可见。

解决方案：
1. 添加 `container` prop 传递给 `DialogPrimitive.Portal`
2. 创建动态样式函数，当 `hasContainer=true` 时使用 `absolute` 定位
3. 在 Storybook stories 中使用 `useRef` 创建容器引用并传递给 Dialog

## Test Plan

- [x] TypeScript 编译通过
- [ ] Storybook 中所有包含 Dialog 的 stories 正常显示

## RUN_LOG

`openspec/_ops/task_runs/ISSUE-132.md`