### PR TITLE
feat(character): Profile 默认折叠并完善关系设定 (#134)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Popover.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Popover.tsx
@@ -14,6 +14,14 @@ export interface PopoverProps {
   onOpenChange?: (open: boolean) => void;
   /** Default open state (uncontrolled) */
   defaultOpen?: boolean;
+  /**
+   * Z-layer for popover content.
+   * - "popover": default layer using `--z-popover`
+   * - "modal": render above modal overlay/content (`--z-modal`)
+   */
+  layer?: "popover" | "modal";
+  /** Optional portal container for rendering content */
+  portalContainer?: HTMLElement | null;
   /** Trigger element */
   trigger: React.ReactNode;
   /** Popover content */
@@ -32,7 +40,7 @@ export interface PopoverProps {
  * Uses CSS transitions for animation (no tailwindcss-animate dependency).
  */
 const contentStyles = [
-  "z-[var(--z-popover)]",
+  "pointer-events-auto",
   // Visual
   "bg-[var(--color-bg-raised)]",
   "border",
@@ -56,6 +64,13 @@ const contentStyles = [
 ].join(" ");
 
 /**
+ * Get z-index class based on layer.
+ */
+function getZIndexClass(layer: "popover" | "modal"): string {
+  return layer === "modal" ? "z-[var(--z-modal)]" : "z-[var(--z-popover)]";
+}
+
+/**
  * Popover component following design spec §5.2
  *
  * A floating popover built on Radix UI Popover for proper positioning and focus management.
@@ -72,12 +87,16 @@ export function Popover({
   open,
   onOpenChange,
   defaultOpen,
+  layer = "popover",
+  portalContainer,
   trigger,
   children,
   side = "bottom",
   sideOffset = 8,
   align = "center",
 }: PopoverProps): JSX.Element {
+  const contentClassName = [getZIndexClass(layer), contentStyles].join(" ");
+
   return (
     <PopoverPrimitive.Root
       open={open}
@@ -85,9 +104,9 @@ export function Popover({
       defaultOpen={defaultOpen}
     >
       <PopoverPrimitive.Trigger asChild>{trigger}</PopoverPrimitive.Trigger>
-      <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Portal container={portalContainer ?? undefined}>
         <PopoverPrimitive.Content
-          className={contentStyles}
+          className={contentClassName}
           side={side}
           sideOffset={sideOffset}
           align={align}

--- a/apps/desktop/renderer/src/components/primitives/Select.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Select.tsx
@@ -51,6 +51,14 @@ export interface SelectProps extends Omit<
   fullWidth?: boolean;
   /** Custom class name for trigger */
   className?: string;
+  /**
+   * Z-layer for dropdown content.
+   * - "dropdown": default layer using `--z-dropdown`
+   * - "modal": render above modal overlay/content (`--z-modal`)
+   */
+  layer?: "dropdown" | "modal";
+  /** Optional portal container for rendering dropdown content */
+  portalContainer?: HTMLElement | null;
 }
 
 /**
@@ -103,7 +111,7 @@ const triggerStyles = [
  * Uses CSS transitions for animation (no tailwindcss-animate dependency).
  */
 const contentStyles = [
-  "z-[var(--z-dropdown)]",
+  "pointer-events-auto",
   "overflow-hidden",
   // Visual
   "bg-[var(--color-bg-raised)]",
@@ -120,6 +128,13 @@ const contentStyles = [
   "data-[state=closed]:opacity-0",
   "data-[state=closed]:scale-95",
 ].join(" ");
+
+/**
+ * Get z-index class based on layer.
+ */
+function getZIndexClass(layer: "dropdown" | "modal"): string {
+  return layer === "modal" ? "z-[var(--z-modal)]" : "z-[var(--z-dropdown)]";
+}
 
 /**
  * Viewport styles
@@ -249,8 +264,11 @@ export function Select({
   name,
   fullWidth = false,
   className = "",
+  layer = "dropdown",
+  portalContainer,
   ...triggerProps
 }: SelectProps): JSX.Element {
+  const contentClassName = [getZIndexClass(layer), contentStyles].join(" ");
   const triggerClasses = [triggerStyles, fullWidth ? "w-full" : "", className]
     .filter(Boolean)
     .join(" ");
@@ -274,8 +292,8 @@ export function Select({
         </SelectPrimitive.Icon>
       </SelectPrimitive.Trigger>
 
-      <SelectPrimitive.Portal>
-        <SelectPrimitive.Content className={contentStyles} position="popper">
+      <SelectPrimitive.Portal container={portalContainer ?? undefined}>
+        <SelectPrimitive.Content className={contentClassName} position="popper">
           <SelectPrimitive.Viewport className={viewportStyles}>
             {isGrouped(options)
               ? options.map((group, groupIndex) => (

--- a/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
+++ b/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
@@ -18,6 +18,10 @@ export interface AddRelationshipPopoverProps {
   onAdd: (relationship: Omit<CharacterRelationship, "characterId"> & { characterId: string }) => void;
   /** Custom trigger element */
   trigger?: React.ReactNode;
+  /** Optional portal container for popover content */
+  portalContainer?: HTMLElement | null;
+  /** Z-layer for popover content */
+  layer?: "popover" | "modal";
 }
 
 /**
@@ -74,6 +78,8 @@ export function AddRelationshipPopover({
   existingRelationships,
   onAdd,
   trigger,
+  portalContainer,
+  layer = "popover",
 }: AddRelationshipPopoverProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const [selectedCharacter, setSelectedCharacter] = React.useState<Character | null>(null);
@@ -120,6 +126,8 @@ export function AddRelationshipPopover({
           setTimeout(handleReset, 150);
         }
       }}
+      layer={layer}
+      portalContainer={portalContainer}
       trigger={
         trigger ?? (
           <button

--- a/apps/desktop/renderer/src/features/character/CharacterDetailDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterDetailDialog.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CharacterDetailDialog } from "./CharacterDetailDialog";
+import type { Character } from "./types";
+
+/**
+ * CharacterDetailDialog component tests
+ *
+ * Tests cover:
+ * - Dialog renders with structured profile table
+ * - Add Relationship flow updates relationships list
+ */
+describe("CharacterDetailDialog", () => {
+  const elara: Character = {
+    id: "elara",
+    name: "Elara Vance",
+    age: 24,
+    birthDate: "2002-03-25",
+    zodiac: "aries",
+    role: "protagonist",
+    group: "main",
+    archetype: "reluctant-hero",
+    description: "A skilled pilot with a mysterious past.",
+    features: ["Flight jacket"],
+    traits: ["Brave"],
+    relationships: [],
+    appearances: [],
+  };
+
+  const darius: Character = {
+    id: "darius",
+    name: "Darius",
+    age: 28,
+    role: "deuteragonist",
+    group: "main",
+    traits: ["Steady"],
+    relationships: [],
+    appearances: [],
+  };
+
+  it("renders when open is true and profile can expand", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CharacterDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        character={elara}
+        availableCharacters={[elara, darius]}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("2002-03-25")).not.toBeInTheDocument();
+    expect(screen.getByText("2002-03-25")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /expand profile/i }));
+    expect(screen.getByDisplayValue("2002-03-25")).toBeInTheDocument();
+  });
+
+  it("adds a relationship via Add Relation popover", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CharacterDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        character={elara}
+        availableCharacters={[elara, darius]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add relation/i }));
+
+    expect(screen.getByText("Add Relationship")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /darius/i }));
+    await user.click(screen.getByRole("button", { name: "Friend" }));
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(screen.getByText("Darius")).toBeInTheDocument();
+  });
+});
+

--- a/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanel.stories.tsx
@@ -23,6 +23,8 @@ const SAMPLE_CHARACTERS: Character[] = [
     id: "elara",
     name: "Elara Vance",
     age: 24,
+    birthDate: "2002-03-25",
+    zodiac: "aries",
     role: "protagonist",
     group: "main",
     archetype: "reluctant-hero",
@@ -30,6 +32,7 @@ const SAMPLE_CHARACTERS: Character[] = [
       "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=64&h=64&fit=crop&crop=faces",
     description:
       "A skilled pilot with a mysterious past, determined to find the lost coordinates of Earth. She wears a faded flight jacket with an emblem no one recognizes.",
+    features: ["Wears a faded flight jacket", "Quick reflexes", "Pilot calluses"],
     traits: ["Brave", "Impulsive", "Loyal"],
     relationships: [
       {
@@ -152,23 +155,21 @@ const meta: Meta<typeof CharacterPanel> = {
   },
   decorators: [
     (Story) => (
-      <div className="h-screen min-h-[700px] flex bg-[var(--color-bg-base)]">
-        <Story />
-        <main className="flex-1 bg-[var(--color-bg-base)] relative">
-          {/* 占位背景 - 移除 opacity-30，改用淡色占位 */}
-          <div className="absolute inset-0 p-12 pointer-events-none select-none">
-            <div className="max-w-4xl mx-auto space-y-12">
-              <h1 className="text-5xl font-bold text-[var(--color-fg-placeholder)]/20 mb-6">
-                The Last Horizon
-              </h1>
-              <div className="space-y-4">
-                <div className="h-4 w-full bg-[var(--color-bg-hover)]/50 rounded" />
-                <div className="h-4 w-[90%] bg-[var(--color-bg-hover)]/50 rounded" />
-                <div className="h-4 w-[95%] bg-[var(--color-bg-hover)]/50 rounded" />
-              </div>
+      <div className="h-screen min-h-[700px] bg-[var(--color-bg-base)] relative">
+        {/* 占位背景（仅作为背景，不参与布局） */}
+        <div className="absolute inset-0 p-12 pointer-events-none select-none">
+          <div className="max-w-4xl mx-auto space-y-12">
+            <h1 className="text-5xl font-bold text-[var(--color-fg-placeholder)]/20 mb-6">
+              The Last Horizon
+            </h1>
+            <div className="space-y-4">
+              <div className="h-4 w-full bg-[var(--color-bg-hover)]/50 rounded" />
+              <div className="h-4 w-[90%] bg-[var(--color-bg-hover)]/50 rounded" />
+              <div className="h-4 w-[95%] bg-[var(--color-bg-hover)]/50 rounded" />
             </div>
           </div>
-        </main>
+        </div>
+        <Story />
       </div>
     ),
   ],
@@ -237,6 +238,7 @@ function EditingCharacterFormRender() {
         open={open}
         onOpenChange={setOpen}
         character={character}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>
@@ -288,6 +290,7 @@ function AddingPersonalityTraitRender() {
         onOpenChange={() => {}}
         character={character}
         onSave={handleSave}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>
@@ -352,6 +355,7 @@ function ManagingRelationshipsRender() {
         open
         onOpenChange={() => {}}
         character={characterWithManyRelations}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>
@@ -398,6 +402,7 @@ function UploadingAvatarRender() {
         open
         onOpenChange={() => {}}
         character={characterWithoutAvatar}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>
@@ -481,6 +486,7 @@ function SwitchingBetweenCharactersRender() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         character={selectedCharacter || null}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>
@@ -535,6 +541,7 @@ function ChapterAppearanceNavigationRender() {
         onOpenChange={() => {}}
         character={SAMPLE_CHARACTERS[0]}
         onNavigateToChapter={(chapterId) => setLastNavigatedChapter(chapterId)}
+        availableCharacters={SAMPLE_CHARACTERS}
         container={containerEl}
       />
     </div>

--- a/apps/desktop/renderer/src/features/character/GroupSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/GroupSelector.tsx
@@ -14,6 +14,10 @@ export interface GroupSelectorProps {
   value: CharacterGroup;
   /** Callback when group changes */
   onChange: (group: CharacterGroup) => void;
+  /** Optional portal container for popover content */
+  portalContainer?: HTMLElement | null;
+  /** Z-layer for popover content */
+  layer?: "popover" | "modal";
 }
 
 /**
@@ -35,6 +39,8 @@ export interface GroupSelectorProps {
 export function GroupSelector({
   value,
   onChange,
+  portalContainer,
+  layer = "popover",
 }: GroupSelectorProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const currentGroup = GROUP_OPTIONS.find((g) => g.value === value);
@@ -48,6 +54,8 @@ export function GroupSelector({
     <Popover
       open={open}
       onOpenChange={setOpen}
+      layer={layer}
+      portalContainer={portalContainer}
       trigger={
         <button
           type="button"

--- a/apps/desktop/renderer/src/features/character/RoleSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/RoleSelector.tsx
@@ -14,6 +14,10 @@ export interface RoleSelectorProps {
   value: CharacterRole;
   /** Callback when role changes */
   onChange: (role: CharacterRole) => void;
+  /** Optional portal container for popover content */
+  portalContainer?: HTMLElement | null;
+  /** Z-layer for popover content */
+  layer?: "popover" | "modal";
 }
 
 /**
@@ -47,6 +51,8 @@ const ROLE_OPTIONS: CharacterRole[] = [
 export function RoleSelector({
   value,
   onChange,
+  portalContainer,
+  layer = "popover",
 }: RoleSelectorProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const currentRole = ROLE_DISPLAY[value];
@@ -60,6 +66,8 @@ export function RoleSelector({
     <Popover
       open={open}
       onOpenChange={setOpen}
+      layer={layer}
+      portalContainer={portalContainer}
       trigger={
         <button
           type="button"

--- a/apps/desktop/renderer/src/features/character/types.ts
+++ b/apps/desktop/renderer/src/features/character/types.ts
@@ -20,6 +20,23 @@ export type CharacterRole =
 export type CharacterGroup = "main" | "supporting" | "others";
 
 /**
+ * Zodiac sign (12 Western zodiac signs)
+ */
+export type ZodiacSign =
+  | "aries"
+  | "taurus"
+  | "gemini"
+  | "cancer"
+  | "leo"
+  | "virgo"
+  | "libra"
+  | "scorpio"
+  | "sagittarius"
+  | "capricorn"
+  | "aquarius"
+  | "pisces";
+
+/**
  * Relationship types between characters
  */
 export type RelationshipType =
@@ -77,6 +94,14 @@ export interface Character {
   name: string;
   /** Character age */
   age?: number;
+  /**
+   * Birth date in ISO format (YYYY-MM-DD)
+   *
+   * Stored as string to avoid timezone issues across platforms.
+   */
+  birthDate?: string;
+  /** Zodiac sign */
+  zodiac?: ZodiacSign;
   /** Character role */
   role: CharacterRole;
   /** Character group */
@@ -87,6 +112,8 @@ export interface Character {
   avatarUrl?: string;
   /** Character description */
   description?: string;
+  /** Character features / characteristics */
+  features?: string[];
   /** Personality traits */
   traits: string[];
   /** Relationships with other characters */
@@ -131,4 +158,22 @@ export const GROUP_OPTIONS: { value: CharacterGroup; label: string }[] = [
   { value: "main", label: "Main Cast" },
   { value: "supporting", label: "Supporting" },
   { value: "others", label: "Others" },
+];
+
+/**
+ * Zodiac sign options
+ */
+export const ZODIAC_OPTIONS: { value: ZodiacSign; label: string }[] = [
+  { value: "aries", label: "Aries (白羊座)" },
+  { value: "taurus", label: "Taurus (金牛座)" },
+  { value: "gemini", label: "Gemini (双子座)" },
+  { value: "cancer", label: "Cancer (巨蟹座)" },
+  { value: "leo", label: "Leo (狮子座)" },
+  { value: "virgo", label: "Virgo (处女座)" },
+  { value: "libra", label: "Libra (天秤座)" },
+  { value: "scorpio", label: "Scorpio (天蝎座)" },
+  { value: "sagittarius", label: "Sagittarius (射手座)" },
+  { value: "capricorn", label: "Capricorn (摩羯座)" },
+  { value: "aquarius", label: "Aquarius (水瓶座)" },
+  { value: "pisces", label: "Pisces (双鱼座)" },
 ];

--- a/openspec/_ops/task_runs/ISSUE-134.md
+++ b/openspec/_ops/task_runs/ISSUE-134.md
@@ -1,0 +1,31 @@
+# ISSUE-134
+
+- Issue: #134
+- Branch: task/134-character-detail-table-relations
+- PR: <fill-after-created>
+
+## Plan
+
+- 让 `CharacterDetailDialog` 的 “Add Relation” 在对话框内可用（选择角色 + 关系类型 + 写回列表）
+- 增加“人物设定表格”字段：出生年月日、星座、特征、性格
+- 补充 Storybook 场景/可视验证与单测
+
+## Runs
+
+### 2026-02-03 Profile 默认折叠 + 关系/表格可用性修复
+- Command: `cd apps/desktop && npx tsc --noEmit`
+- Key output: `exit 0`
+- Evidence: `apps/desktop`
+
+- Command: `cd apps/desktop && npx eslint renderer/src/features/character/CharacterDetailDialog.tsx renderer/src/features/character/CharacterDetailDialog.test.tsx --max-warnings=0`
+- Key output: `exit 0`
+- Evidence: `apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx`
+
+- Command: `cd apps/desktop && npx vitest run renderer/src/features/character/*.test.tsx`
+- Key output: `2 files passed, 18 tests passed`
+- Evidence: `apps/desktop/renderer/src/features/character/CharacterDetailDialog.test.tsx`
+
+- Notes:
+  - `Profile` 默认折叠，折叠态展示摘要（Age/Birth/Zodiac/Archetype/Features/Traits），可展开查看/编辑完整表格
+  - `Add Relation` 弹层在对话框内可见且可点击（选择人物 + 关系类型后写回列表）
+  - 未再改动 `design/system/01-tokens.css`：改为在 `Select`/`Popover` 支持 `layer="modal"`，避免被 Dialog overlay 覆盖

--- a/openspec/_ops/task_runs/ISSUE-134.md
+++ b/openspec/_ops/task_runs/ISSUE-134.md
@@ -2,7 +2,7 @@
 
 - Issue: #134
 - Branch: task/134-character-detail-table-relations
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/135
 
 ## Plan
 


### PR DESCRIPTION
Closes #134

## Summary
- Profile 默认折叠，折叠态展示关键信息摘要，展开后编辑完整设定表
- 关系添加弹层在对话框内可见可用（选择人物 + 关系类型后写回列表）
- `Select`/`Popover` 支持 `layer=\"modal\"`，避免在 Dialog 中被遮罩覆盖；Storybook decorator 调整以避免布局挤压

## Test Plan
- [x] `cd apps/desktop && npx tsc --noEmit`
- [x] `cd apps/desktop && npx eslint renderer/src/features/character/*.tsx renderer/src/components/primitives/{Popover,Select}.tsx --max-warnings=0`
- [x] `cd apps/desktop && npx vitest run renderer/src/features/character/*.test.tsx`
- [x] Storybook（WSL IP）验证：Profile 折叠/展开、Add Relation 添加关系后列表更新