### PR TITLE
feat(knowledge-graph): 完整实现 KnowledgeGraph 组件

### DIFF
--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.tsx
@@ -1,0 +1,213 @@
+import React, { useCallback, useRef, useState } from "react";
+import { GraphNode } from "./GraphNode";
+import { GraphEdge, EdgeMarkerDefs } from "./GraphEdge";
+import type { GraphCanvasProps, GraphNode as GraphNodeType, NodeFilter } from "./types";
+
+/**
+ * Canvas container styles
+ */
+const canvasStyles = [
+  "absolute",
+  "inset-0",
+  "w-full",
+  "h-full",
+  "cursor-grab",
+  "active:cursor-grabbing",
+].join(" ");
+
+/**
+ * Grid background styles
+ */
+const gridStyles = [
+  "absolute",
+  "inset-0",
+  "pointer-events-none",
+  "opacity-20",
+].join(" ");
+
+/**
+ * Check if a node should be visible based on filter
+ */
+function isNodeVisible(node: GraphNodeType, filter: NodeFilter): boolean {
+  if (filter === "all") return true;
+  return node.type === filter;
+}
+
+/**
+ * GraphCanvas component
+ *
+ * The main canvas area for the knowledge graph. Handles:
+ * - Rendering nodes and edges
+ * - Node dragging
+ * - Canvas panning
+ * - Filtering by node type
+ */
+export function GraphCanvas({
+  data,
+  selectedNodeId,
+  filter,
+  transform,
+  onNodeSelect,
+  onNodeMove,
+  onCanvasPan,
+}: GraphCanvasProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [draggingNodeId, setDraggingNodeId] = useState<string | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const lastMousePos = useRef<{ x: number; y: number } | null>(null);
+
+  // Create a map for quick node lookup
+  const nodeMap = new Map(data.nodes.map((n) => [n.id, n]));
+
+  // Filter visible nodes
+  const visibleNodes = data.nodes.filter((node) => isNodeVisible(node, filter));
+  const visibleNodeIds = new Set(visibleNodes.map((n) => n.id));
+
+  // Filter edges to only show those connecting visible nodes
+  const visibleEdges = data.edges.filter(
+    (edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
+  );
+
+  /**
+   * Handle node drag start
+   */
+  const handleNodeDragStart = useCallback(
+    (nodeId: string) => (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setDraggingNodeId(nodeId);
+      lastMousePos.current = { x: e.clientX, y: e.clientY };
+
+      // Select the node
+      onNodeSelect(nodeId);
+    },
+    [onNodeSelect],
+  );
+
+  /**
+   * Handle mouse move for dragging/panning
+   */
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!lastMousePos.current) return;
+
+      const deltaX = e.clientX - lastMousePos.current.x;
+      const deltaY = e.clientY - lastMousePos.current.y;
+
+      if (draggingNodeId) {
+        // Dragging a node
+        const node = nodeMap.get(draggingNodeId);
+        if (node) {
+          const newX = node.position.x + deltaX / transform.scale;
+          const newY = node.position.y + deltaY / transform.scale;
+          onNodeMove(draggingNodeId, { x: newX, y: newY });
+        }
+      } else if (isPanning) {
+        // Panning the canvas
+        onCanvasPan(deltaX, deltaY);
+      }
+
+      lastMousePos.current = { x: e.clientX, y: e.clientY };
+    },
+    [draggingNodeId, isPanning, nodeMap, transform.scale, onNodeMove, onCanvasPan],
+  );
+
+  /**
+   * Handle mouse up - stop dragging/panning
+   */
+  const handleMouseUp = useCallback(() => {
+    setDraggingNodeId(null);
+    setIsPanning(false);
+    lastMousePos.current = null;
+  }, []);
+
+  /**
+   * Handle canvas mouse down - start panning
+   */
+  const handleCanvasMouseDown = useCallback((e: React.MouseEvent) => {
+    // Only start panning if clicking on the canvas itself
+    if (e.target === e.currentTarget || (e.target as HTMLElement).tagName === "svg") {
+      setIsPanning(true);
+      lastMousePos.current = { x: e.clientX, y: e.clientY };
+    }
+  }, []);
+
+  /**
+   * Handle canvas click - deselect node
+   */
+  const handleCanvasClick = useCallback(
+    (e: React.MouseEvent) => {
+      // Only deselect if clicking on the canvas background
+      if (e.target === e.currentTarget || (e.target as HTMLElement).classList.contains("bg-grid-dots")) {
+        onNodeSelect(null);
+      }
+    },
+    [onNodeSelect],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className={canvasStyles}
+      onMouseDown={handleCanvasMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onClick={handleCanvasClick}
+    >
+      {/* Grid background */}
+      <div
+        className={gridStyles}
+        style={{
+          backgroundImage: "radial-gradient(circle, var(--color-border-default) 1px, transparent 1px)",
+          backgroundSize: "24px 24px",
+        }}
+      />
+
+      {/* Transform container */}
+      <div
+        className="absolute inset-0 w-full h-full transition-transform duration-100 ease-out"
+        style={{
+          transform: `scale(${transform.scale}) translate(${transform.translateX}px, ${transform.translateY}px)`,
+          transformOrigin: "center center",
+        }}
+      >
+        {/* SVG layer for edges */}
+        <svg className="absolute inset-0 w-full h-full pointer-events-none z-0">
+          <EdgeMarkerDefs />
+          {visibleEdges.map((edge) => {
+            const sourceNode = nodeMap.get(edge.source);
+            const targetNode = nodeMap.get(edge.target);
+            if (!sourceNode || !targetNode) return null;
+
+            return (
+              <GraphEdge
+                key={edge.id}
+                edge={edge}
+                sourcePosition={sourceNode.position}
+                targetPosition={targetNode.position}
+                highlighted={
+                  selectedNodeId === edge.source ||
+                  selectedNodeId === edge.target
+                }
+              />
+            );
+          })}
+        </svg>
+
+        {/* Nodes layer */}
+        {visibleNodes.map((node) => (
+          <GraphNode
+            key={node.id}
+            node={node}
+            selected={selectedNodeId === node.id}
+            dragging={draggingNodeId === node.id}
+            onClick={() => onNodeSelect(node.id)}
+            onDragStart={handleNodeDragStart(node.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+GraphCanvas.displayName = "GraphCanvas";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphEdge.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphEdge.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import type { GraphEdgeProps } from "./types";
+
+/**
+ * Calculate the midpoint of a line for label placement
+ */
+function getMidpoint(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): { x: number; y: number } {
+  return {
+    x: (x1 + x2) / 2,
+    y: (y1 + y2) / 2,
+  };
+}
+
+/**
+ * GraphEdge component
+ *
+ * Renders a directed edge (arrow) between two nodes with an optional label.
+ * Selected edges are highlighted in blue.
+ */
+export function GraphEdge({
+  edge,
+  sourcePosition,
+  targetPosition,
+  highlighted = false,
+}: GraphEdgeProps): JSX.Element {
+  const { id, label, selected } = edge;
+  const isHighlighted = highlighted || selected;
+
+  // Calculate line coordinates
+  const x1 = sourcePosition.x;
+  const y1 = sourcePosition.y;
+  const x2 = targetPosition.x;
+  const y2 = targetPosition.y;
+
+  // Midpoint for label
+  const midpoint = getMidpoint(x1, y1, x2, y2);
+
+  // Label background size (approximate)
+  const labelWidth = label.length * 6 + 20;
+  const labelHeight = 16;
+
+  // Line colors
+  const lineColor = isHighlighted
+    ? "var(--color-node-character)"
+    : "var(--color-border-hover)";
+  const lineWidth = isHighlighted ? 2 : 1;
+  const markerEnd = isHighlighted
+    ? "url(#arrowhead-selected)"
+    : "url(#arrowhead)";
+
+  return (
+    <g data-edge-id={id}>
+      {/* Main line */}
+      <line
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        stroke={lineColor}
+        strokeWidth={lineWidth}
+        markerEnd={markerEnd}
+        opacity={isHighlighted ? 0.9 : 0.7}
+        className="transition-all duration-[var(--duration-fast)]"
+      />
+
+      {/* Label background */}
+      <rect
+        x={midpoint.x - labelWidth / 2}
+        y={midpoint.y - labelHeight / 2}
+        width={labelWidth}
+        height={labelHeight}
+        fill="var(--color-bg-base)"
+        stroke={isHighlighted ? lineColor : "transparent"}
+        strokeWidth={1}
+        rx={4}
+        ry={4}
+      />
+
+      {/* Label text */}
+      <text
+        x={midpoint.x}
+        y={midpoint.y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={isHighlighted ? lineColor : "var(--color-fg-subtle)"}
+        fontSize={10}
+        fontFamily="var(--font-family-ui)"
+        className="select-none pointer-events-none"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+/**
+ * SVG defs for arrow markers
+ * Should be included once in the SVG container
+ */
+export function EdgeMarkerDefs(): JSX.Element {
+  return (
+    <defs>
+      {/* Default arrow (gray) */}
+      <marker
+        id="arrowhead"
+        markerWidth="10"
+        markerHeight="7"
+        refX="28"
+        refY="3.5"
+        orient="auto"
+      >
+        <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-border-hover)" />
+      </marker>
+
+      {/* Selected/highlighted arrow (blue) */}
+      <marker
+        id="arrowhead-selected"
+        markerWidth="10"
+        markerHeight="7"
+        refX="28"
+        refY="3.5"
+        orient="auto"
+      >
+        <polygon
+          points="0 0, 10 3.5, 0 7"
+          fill="var(--color-node-character)"
+        />
+      </marker>
+    </defs>
+  );
+}
+
+GraphEdge.displayName = "GraphEdge";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphEdge.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphEdge.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { GraphEdgeProps } from "./types";
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import type { GraphLegendProps, NodeType } from "./types";
+
+/**
+ * Legend items configuration
+ */
+const legendItems: Array<{
+  type: NodeType;
+  label: string;
+  colorVar: string;
+  shape: "circle" | "square" | "diamond" | "rounded";
+}> = [
+  {
+    type: "character",
+    label: "Character",
+    colorVar: "var(--color-node-character)",
+    shape: "circle",
+  },
+  {
+    type: "location",
+    label: "Location",
+    colorVar: "var(--color-node-location)",
+    shape: "square",
+  },
+  {
+    type: "event",
+    label: "Event",
+    colorVar: "var(--color-node-event)",
+    shape: "diamond",
+  },
+  {
+    type: "item",
+    label: "Item",
+    colorVar: "var(--color-node-item)",
+    shape: "rounded",
+  },
+];
+
+/**
+ * Shape indicator component
+ */
+function ShapeIndicator({
+  shape,
+  colorVar,
+}: {
+  shape: "circle" | "square" | "diamond" | "rounded";
+  colorVar: string;
+}): JSX.Element {
+  const baseClass = "w-2 h-2 border";
+  const bgColor = `color-mix(in srgb, ${colorVar} 10%, transparent)`;
+
+  switch (shape) {
+    case "circle":
+      return (
+        <div
+          className={`${baseClass} rounded-full`}
+          style={{ borderColor: colorVar, backgroundColor: bgColor }}
+        />
+      );
+    case "square":
+      return (
+        <div
+          className={`${baseClass} rounded-sm`}
+          style={{ borderColor: colorVar, backgroundColor: bgColor }}
+        />
+      );
+    case "diamond":
+      return (
+        <div
+          className={`${baseClass} rounded-sm rotate-45`}
+          style={{ borderColor: colorVar, backgroundColor: bgColor }}
+        />
+      );
+    case "rounded":
+      return (
+        <div
+          className={`${baseClass} rounded-full`}
+          style={{ borderColor: colorVar, backgroundColor: bgColor }}
+        />
+      );
+    default:
+      return <></>;
+  }
+}
+
+/**
+ * Legend container styles
+ */
+const legendStyles = [
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "border-[var(--color-border-default)]",
+  "rounded",
+  "p-3",
+  "flex",
+  "flex-col",
+  "gap-2",
+].join(" ");
+
+/**
+ * GraphLegend component
+ *
+ * Displays a legend showing the meaning of different node shapes and colors.
+ * Positioned in the bottom-right corner of the graph canvas.
+ */
+export function GraphLegend({ className = "" }: GraphLegendProps): JSX.Element {
+  return (
+    <div className={`${legendStyles} ${className}`}>
+      {/* Title */}
+      <div className="text-[10px] uppercase tracking-wider text-[var(--color-fg-subtle)] font-medium mb-1">
+        Graph Legend
+      </div>
+
+      {/* Legend items */}
+      {legendItems.map((item) => (
+        <div key={item.type} className="flex items-center gap-2">
+          <ShapeIndicator shape={item.shape} colorVar={item.colorVar} />
+          <span className="text-[11px] text-[var(--color-fg-muted)]">
+            {item.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+GraphLegend.displayName = "GraphLegend";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { GraphLegendProps, NodeType } from "./types";
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import type { GraphNodeProps, NodeType } from "./types";
+
+/**
+ * Node type to CSS color token mapping
+ * Uses design tokens from 01-tokens.css
+ */
+const nodeColorVars: Record<NodeType, string> = {
+  character: "var(--color-node-character)",
+  location: "var(--color-node-location)",
+  event: "var(--color-node-event)",
+  item: "var(--color-node-item)",
+  other: "var(--color-node-other)",
+};
+
+/**
+ * Node type icons with explicit colors
+ */
+function NodeIcon({ type, color }: { type: NodeType; color: string }): JSX.Element {
+  const iconClass = "w-5 h-5";
+
+  switch (type) {
+    case "location":
+      return (
+        <svg
+          className={iconClass}
+          style={{ color }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+          <circle cx="12" cy="10" r="3" />
+        </svg>
+      );
+    case "event":
+      return (
+        <svg
+          className={iconClass}
+          style={{ color }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      );
+    case "item":
+      return (
+        <svg
+          className={iconClass}
+          style={{ color }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
+        </svg>
+      );
+    default:
+      // character and other types show avatar or initials
+      return <></>;
+  }
+}
+
+/**
+ * Base styles for all nodes
+ */
+const baseStyles = [
+  "w-12",
+  "h-12",
+  "flex",
+  "items-center",
+  "justify-center",
+  "bg-[var(--color-bg-surface)]",
+  "border",
+  "absolute",
+  "cursor-grab",
+  "transition-[box-shadow,transform]",
+  "duration-[var(--duration-normal)]",
+  "z-10",
+  "select-none",
+  "active:cursor-grabbing",
+].join(" ");
+
+/**
+ * Node type specific styles (shape only, color via inline style)
+ */
+const typeStyles: Record<NodeType, string> = {
+  character: "rounded-full",
+  location: "rounded-lg",
+  event: "rounded-lg rotate-45",
+  item: "rounded-xl",
+  other: "rounded-full",
+};
+
+/**
+ * Selected state base styles (shadow via inline style for color)
+ */
+const selectedBaseStyles = "border-2";
+
+/**
+ * Label styles
+ */
+const labelBaseStyles = [
+  "absolute",
+  "top-14",
+  "left-1/2",
+  "-translate-x-1/2",
+  "text-[11px]",
+  "whitespace-nowrap",
+  "px-1.5",
+  "py-0.5",
+  "rounded",
+  "pointer-events-none",
+  "text-[var(--color-fg-default)]",
+  "opacity-90",
+  "transition-opacity",
+  "duration-[var(--duration-fast)]",
+].join(" ");
+
+const labelHoverStyles =
+  "opacity-100 border border-[var(--color-border-default)]";
+
+const labelBgBase =
+  "color-mix(in srgb, var(--color-bg-base) 80%, transparent)";
+const labelBgHover =
+  "color-mix(in srgb, var(--color-bg-base) 92%, transparent)";
+
+/**
+ * GraphNode component
+ *
+ * Renders a node in the knowledge graph with type-specific styling:
+ * - Character: Circle with avatar/initials
+ * - Location: Rounded square with map icon
+ * - Event: Diamond (45deg rotation) with alert icon
+ * - Item: Rounded rectangle with key icon
+ */
+export function GraphNode({
+  node,
+  selected = false,
+  dragging = false,
+  onClick,
+  onDragStart,
+}: GraphNodeProps): JSX.Element {
+  const { id, label, type, avatar, position } = node;
+  const isEventType = type === "event";
+  const color = nodeColorVars[type];
+
+  const nodeClasses = [
+    baseStyles,
+    typeStyles[type],
+    selected && selectedBaseStyles,
+    selected && "z-20",
+    dragging && "opacity-40",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const labelClasses = [
+    labelBaseStyles,
+    (selected || dragging) && labelHoverStyles,
+    // Event nodes need counter-rotation for label
+    isEventType && "-rotate-45",
+    isEventType && "top-[60px]",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // Build inline styles with color
+  const nodeStyle: React.CSSProperties = {
+    top: position.y,
+    left: position.x,
+    transform: `translate(-50%, -50%)${isEventType ? " rotate(45deg)" : ""}`,
+    borderColor: color,
+    ...(selected && {
+      boxShadow: `0 0 0 2px var(--color-bg-base), 0 0 0 4px ${color}`,
+    }),
+  };
+
+  return (
+    <div
+      data-node-id={id}
+      className={nodeClasses}
+      style={nodeStyle}
+      onClick={onClick}
+      onMouseDown={onDragStart}
+    >
+      {/* Node content */}
+      <div className={`flex items-center justify-center ${isEventType ? "-rotate-45" : ""}`}>
+        {type === "character" || type === "other" ? (
+          avatar ? (
+            <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+              <img
+                src={avatar}
+                alt={label}
+                className="w-full h-full object-cover opacity-80 hover:opacity-100 transition-opacity"
+              />
+            </div>
+          ) : (
+            <span className="text-sm font-medium" style={{ color }}>
+              {label.charAt(0).toUpperCase()}
+            </span>
+          )
+        ) : (
+          <NodeIcon type={type} color={color} />
+        )}
+      </div>
+
+      {/* Label below node */}
+      <div
+        className={labelClasses}
+        style={{
+          backgroundColor: selected || dragging ? labelBgHover : labelBgBase,
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Dragging indicator */}
+      {dragging && (
+        <span
+          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-white rounded"
+          style={{ backgroundColor: color }}
+        >
+          Dragging
+        </span>
+      )}
+    </div>
+  );
+}
+
+GraphNode.displayName = "GraphNode";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { GraphNodeProps, NodeType } from "./types";
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import { Button } from "../../primitives/Button";
+import type { GraphToolbarProps, NodeFilter } from "./types";
+
+/**
+ * Filter button configuration
+ */
+const filterButtons: Array<{
+  filter: NodeFilter;
+  label: string;
+  colorClass: string;
+}> = [
+  { filter: "all", label: "All", colorClass: "bg-[var(--color-fg-muted)]" },
+  {
+    filter: "character",
+    label: "Roles",
+    colorClass: "bg-[var(--color-node-character)]",
+  },
+  {
+    filter: "location",
+    label: "Locations",
+    colorClass: "bg-[var(--color-node-location)]",
+  },
+  {
+    filter: "event",
+    label: "Events",
+    colorClass: "bg-[var(--color-node-event)]",
+  },
+  { filter: "item", label: "Items", colorClass: "bg-[var(--color-node-item)]" },
+];
+
+/**
+ * Filter button styles
+ */
+const filterButtonBase = [
+  "px-3",
+  "py-1",
+  "rounded-full",
+  "text-xs",
+  "font-medium",
+  "border",
+  "transition-all",
+  "duration-[var(--duration-fast)]",
+  "flex",
+  "items-center",
+  "gap-2",
+  "cursor-pointer",
+].join(" ");
+
+const filterButtonInactive = [
+  "text-[var(--color-fg-muted)]",
+  "border-transparent",
+  "hover:text-[var(--color-fg-default)]",
+  "hover:border-[var(--color-border-hover)]",
+].join(" ");
+
+const filterButtonActive = [
+  "bg-[var(--color-bg-raised)]",
+  "text-[var(--color-fg-default)]",
+  "border-[var(--color-border-hover)]",
+].join(" ");
+
+/**
+ * Toolbar container styles
+ */
+const toolbarStyles = [
+  "h-12",
+  "flex-shrink-0",
+  "bg-[var(--color-bg-surface)]",
+  "border-b",
+  "border-[var(--color-border-default)]",
+  "flex",
+  "items-center",
+  "justify-between",
+  "px-4",
+  "z-30",
+].join(" ");
+
+/**
+ * GraphToolbar component
+ *
+ * Header toolbar for the knowledge graph with:
+ * - Back button
+ * - Title
+ * - Filter buttons (by node type)
+ * - Zoom controls
+ * - Add node button
+ */
+export function GraphToolbar({
+  activeFilter,
+  onFilterChange,
+  zoom,
+  onZoomIn,
+  onZoomOut,
+  onAddNode,
+  onBack,
+}: GraphToolbarProps): JSX.Element {
+  return (
+    <header className={toolbarStyles}>
+      {/* Left section: Back button + Title */}
+      <div className="flex items-center gap-4 w-[240px]">
+        {onBack && (
+          <>
+            <button
+              onClick={onBack}
+              className="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+              aria-label="Go back"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M19 12H5M12 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <div className="h-4 w-px bg-[var(--color-border-hover)]" />
+          </>
+        )}
+        <h1 className="text-sm font-medium tracking-wide text-[var(--color-fg-default)]">
+          Knowledge Graph
+        </h1>
+      </div>
+
+      {/* Center section: Filter buttons */}
+      <div className="flex items-center gap-2">
+        {filterButtons.map(({ filter, label, colorClass }) => (
+          <button
+            key={filter}
+            onClick={() => onFilterChange(filter)}
+            className={`${filterButtonBase} ${
+              activeFilter === filter
+                ? filterButtonActive
+                : filterButtonInactive
+            }`}
+          >
+            {filter !== "all" && (
+              <span className={`w-1.5 h-1.5 rounded-full ${colorClass}`} />
+            )}
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Right section: Zoom + Add Node */}
+      <div className="flex items-center gap-3 w-[240px] justify-end">
+        {/* Zoom controls */}
+        <div className="flex items-center bg-[var(--color-bg-raised)] rounded border border-[var(--color-border-default)]">
+          <button
+            onClick={onZoomOut}
+            className="p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            aria-label="Zoom out"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+          <span className="text-[10px] w-8 text-center text-[var(--color-fg-subtle)]">
+            {Math.round(zoom * 100)}%
+          </span>
+          <button
+            onClick={onZoomIn}
+            className="p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            aria-label="Zoom in"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Add Node button */}
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onAddNode}
+          className="whitespace-nowrap flex-shrink-0"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Add Node
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+GraphToolbar.displayName = "GraphToolbar";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "../../primitives/Button";
 import type { GraphToolbarProps, NodeFilter } from "./types";
 

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.stories.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { KnowledgeGraph } from "./KnowledgeGraph";
 import type { GraphData, GraphNode, NodeType } from "./types";
@@ -274,6 +274,7 @@ export const SelectedNodeWithCard: Story = {
  * - 释放后新位置保持
  */
 export const DraggingNode: Story = {
+  args: { data: DEMO_DATA },
   render: function DraggingNodeStory() {
     const [data, setData] = useState<GraphData>(DEMO_DATA);
 
@@ -428,6 +429,7 @@ export const HoverHighlight: Story = {
  * - 自动打开详情卡片编辑
  */
 export const AddNewNode: Story = {
+  args: { data: DEMO_DATA },
   render: function AddNewNodeStory() {
     const [data, setData] = useState<GraphData>(DEMO_DATA);
     const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -537,6 +539,7 @@ export const SelectItemNode: Story = {
  * - 保存后节点数据更新
  */
 export const EditNodeDialog: Story = {
+  args: { data: DEMO_DATA },
   render: function EditNodeDialogStory() {
     const [data, setData] = useState<GraphData>(DEMO_DATA);
     const [selectedId, setSelectedId] = useState<string | null>("elara");
@@ -604,6 +607,7 @@ export const EditNodeDialog: Story = {
  * - 保存后新节点出现在画布
  */
 export const CreateNodeDialog: Story = {
+  args: { data: DEMO_DATA },
   render: function CreateNodeDialogStory() {
     const [data, setData] = useState<GraphData>({
       nodes: [
@@ -683,6 +687,7 @@ export const CreateNodeDialog: Story = {
  * 展示所有节点类型和交互状态，包括编辑和删除功能
  */
 export const FullFeatureMatrix: Story = {
+  args: { data: DEMO_DATA },
   render: function FullFeatureMatrixStory() {
     const [data, setData] = useState<GraphData>(DEMO_DATA);
     const [selectedId, setSelectedId] = useState<string | null>("elara");

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.stories.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.stories.tsx
@@ -1,0 +1,751 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { KnowledgeGraph } from "./KnowledgeGraph";
+import type { GraphData, GraphNode, NodeType } from "./types";
+
+/**
+ * KnowledgeGraph Component Stories
+ *
+ * 设计稿: 19-knowledge-graph.html
+ *
+ * 知识图谱组件，用于可视化实体之间的关系。
+ * 支持多种节点类型（角色、地点、事件、物品），
+ * 使用 design tokens 中的专用颜色。
+ *
+ * 节点类型及颜色:
+ * - Character: 圆形, var(--color-node-character) #3b82f6 蓝色
+ * - Location: 方形, var(--color-node-location) #22c55e 绿色
+ * - Event: 菱形(45度旋转), var(--color-node-event) #f97316 橙色
+ * - Item: 圆角方形, var(--color-node-item) #06b6d4 青色
+ */
+
+// ============================================================================
+// 真实数据（MUST 使用）
+// ============================================================================
+
+const DEMO_NODES: GraphNode[] = [
+  {
+    id: "elara",
+    label: "Elara",
+    type: "character",
+    avatar:
+      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=100&q=80",
+    position: { x: 400, y: 300 },
+    metadata: {
+      role: "Protagonist",
+      attributes: [
+        { key: "Age", value: "24" },
+        { key: "Race", value: "Human" },
+        { key: "Class", value: "Mage" },
+      ],
+      description:
+        "A skilled weaver of arcana who seeks to unravel the mystery of the Silent Void. Born in the outskirts of the capital.",
+    },
+  },
+  {
+    id: "shadow-keep",
+    label: "Shadow Keep",
+    type: "location",
+    position: { x: 600, y: 150 },
+    metadata: {
+      role: "Fortress",
+      attributes: [
+        { key: "Region", value: "Northern Wastes" },
+        { key: "Status", value: "Abandoned" },
+      ],
+      description:
+        "An ancient fortress shrouded in perpetual darkness, said to hold the secrets of the old world.",
+    },
+  },
+  {
+    id: "great-war",
+    label: "The Great War",
+    type: "event",
+    position: { x: 400, y: 500 },
+    metadata: {
+      role: "Historical Event",
+      attributes: [
+        { key: "Era", value: "Third Age" },
+        { key: "Duration", value: "7 years" },
+      ],
+      description:
+        "A catastrophic conflict that reshaped the continent and led to the fall of the old kingdoms.",
+    },
+  },
+  {
+    id: "crystal-key",
+    label: "Crystal Key",
+    type: "item",
+    position: { x: 200, y: 300 },
+    metadata: {
+      role: "Artifact",
+      attributes: [
+        { key: "Rarity", value: "Legendary" },
+        { key: "Power", value: "Unknown" },
+      ],
+      description:
+        "A mysterious key made of pure crystallized magic, capable of unlocking any door in existence.",
+    },
+  },
+];
+
+const DEMO_EDGES = [
+  {
+    id: "e1",
+    source: "elara",
+    target: "shadow-keep",
+    label: "Travels to",
+  },
+  {
+    id: "e2",
+    source: "elara",
+    target: "great-war",
+    label: "Participant",
+  },
+  {
+    id: "e3",
+    source: "elara",
+    target: "crystal-key",
+    label: "Owns",
+    selected: true,
+  },
+  {
+    id: "e4",
+    source: "shadow-keep",
+    target: "great-war",
+    label: "Scene of",
+  },
+];
+
+const DEMO_DATA: GraphData = {
+  nodes: DEMO_NODES,
+  edges: DEMO_EDGES,
+};
+
+const EMPTY_DATA: GraphData = {
+  nodes: [],
+  edges: [],
+};
+
+// ============================================================================
+// Meta Configuration
+// ============================================================================
+
+const meta = {
+  title: "Features/KnowledgeGraph",
+  component: KnowledgeGraph,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    data: {
+      control: false,
+      description: "Graph data containing nodes and edges",
+    },
+    selectedNodeId: {
+      control: "text",
+      description: "ID of the currently selected node",
+    },
+    onNodeSelect: {
+      action: "nodeSelected",
+      description: "Callback when a node is selected",
+    },
+    onNodeMove: {
+      action: "nodeMoved",
+      description: "Callback when a node is dragged to a new position",
+    },
+    onAddNode: {
+      action: "addNode",
+      description: "Callback when Add Node button is clicked",
+    },
+    onEditNode: {
+      action: "editNode",
+      description: "Callback when Edit Node button is clicked",
+    },
+    onViewDetails: {
+      action: "viewDetails",
+      description: "Callback when View Details button is clicked",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "100vh", width: "100%" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof KnowledgeGraph>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ============================================================================
+// 场景 1: DefaultGraphWithConnections - 完整图谱，4 个节点 + 连线
+// ============================================================================
+
+/**
+ * 场景 1: 完整图谱展示
+ *
+ * 验证点:
+ * - 4 种节点类型的形状和颜色正确
+ * - 连线正确连接
+ * - 连线标签 "Travels to" / "Owns" 显示
+ * - 网格背景点阵
+ */
+export const DefaultGraphWithConnections: Story = {
+  args: {
+    data: DEMO_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "完整的知识图谱，包含 4 种节点类型和连线。验证节点形状/颜色、连线标签、网格背景。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 2: EmptyGraph - 空图谱
+// ============================================================================
+
+/**
+ * 场景 2: 空图谱
+ *
+ * 验证点:
+ * - 空状态 UI
+ * - "Add Node" 按钮可见
+ */
+export const EmptyGraph: Story = {
+  args: {
+    data: EMPTY_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "空状态的知识图谱，显示引导用户添加第一个节点的 UI。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 3: SelectedNodeWithCard - 选中 Elara，显示详情卡片
+// ============================================================================
+
+/**
+ * 场景 3: 选中节点显示详情卡片
+ *
+ * 验证点:
+ * - 节点选中态（外圈光晕 + 2px 边框）
+ * - 详情卡片显示在节点右侧
+ * - 卡片内容完整（头像/名字/类型/属性/描述）
+ * - Edit Node / View Details 按钮
+ */
+export const SelectedNodeWithCard: Story = {
+  args: {
+    data: DEMO_DATA,
+    selectedNodeId: "elara",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "选中 Elara 节点，显示详情卡片。验证选中态样式和卡片内容完整性。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 4: DraggingNode - 拖拽节点重新布局（交互式）
+// ============================================================================
+
+/**
+ * 场景 4: 拖拽节点重新布局
+ *
+ * 验证点:
+ * - 按住 Elara 节点
+ * - 拖动到新位置
+ * - 连线跟随节点移动
+ * - 拖拽时 cursor 变为 grabbing
+ * - 释放后新位置保持
+ */
+export const DraggingNode: Story = {
+  render: function DraggingNodeStory() {
+    const [data, setData] = useState<GraphData>(DEMO_DATA);
+
+    const handleNodeMove = (
+      nodeId: string,
+      position: { x: number; y: number },
+    ) => {
+      setData((prev) => ({
+        ...prev,
+        nodes: prev.nodes.map((node) =>
+          node.id === nodeId ? { ...node, position } : node,
+        ),
+      }));
+    };
+
+    return (
+      <KnowledgeGraph
+        data={data}
+        onNodeMove={handleNodeMove}
+        onNodeSelect={() => {}}
+        onAddNode={() => {}}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "交互式场景：拖拽节点重新布局。按住节点并拖动，验证连线跟随移动。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 5: ZoomingCanvas - 缩放画布
+// ============================================================================
+
+/**
+ * 场景 5: 缩放画布
+ *
+ * 验证点:
+ * - 点击 "+" 放大，100% → 110% → 120%
+ * - 点击 "-" 缩小，100% → 90% → 80%
+ * - 缩放时节点和连线同步缩放
+ * - 最小/最大缩放限制
+ */
+export const ZoomingCanvas: Story = {
+  args: {
+    data: DEMO_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "测试缩放功能。使用工具栏的 +/- 按钮验证缩放效果和限制。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 6: PanningCanvas - 平移画布
+// ============================================================================
+
+/**
+ * 场景 6: 平移画布
+ *
+ * 验证点:
+ * - 在空白区域按住拖拽
+ * - 整个画布移动
+ * - cursor 变为 grab/grabbing
+ */
+export const PanningCanvas: Story = {
+  args: {
+    data: DEMO_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "测试平移功能。在空白区域按住并拖拽来移动整个画布。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 7: FilterByType - 按类型筛选
+// ============================================================================
+
+/**
+ * 场景 7: 按类型筛选
+ *
+ * 验证点:
+ * - 点击 "Locations" 筛选按钮
+ * - 只显示 Shadow Keep
+ * - 其他节点隐藏
+ * - 相关连线隐藏
+ * - 点击 "All" 恢复
+ */
+export const FilterByType: Story = {
+  args: {
+    data: DEMO_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "测试筛选功能。点击工具栏的筛选按钮，验证节点过滤效果。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 8: HoverHighlight - 悬停高亮
+// ============================================================================
+
+/**
+ * 场景 8: 悬停高亮
+ *
+ * 验证点:
+ * - 悬停 Elara 节点，边框高亮
+ * - 悬停 "Owns" 连线，连线变蓝色
+ * - 悬停节点标签，显示完整文字
+ */
+export const HoverHighlight: Story = {
+  args: {
+    data: DEMO_DATA,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "测试悬停效果。移动鼠标到节点和连线上验证高亮效果。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 9: AddNewNode - 添加新节点
+// ============================================================================
+
+/**
+ * 场景 9: 添加新节点
+ *
+ * 验证点:
+ * - 点击 "Add Node" 按钮
+ * - 弹出节点类型选择
+ * - 选择 "Character"
+ * - 新节点出现在画布中心
+ * - 自动打开详情卡片编辑
+ */
+export const AddNewNode: Story = {
+  render: function AddNewNodeStory() {
+    const [data, setData] = useState<GraphData>(DEMO_DATA);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    const handleAddNode = (type: NodeType) => {
+      const newNode: GraphNode = {
+        id: `new-${Date.now()}`,
+        label: "New Node",
+        type,
+        position: { x: 400, y: 300 },
+        metadata: {
+          role: "Undefined",
+          attributes: [],
+          description: "A newly created node. Edit to add details.",
+        },
+      };
+
+      setData((prev) => ({
+        ...prev,
+        nodes: [...prev.nodes, newNode],
+      }));
+
+      setSelectedId(newNode.id);
+    };
+
+    return (
+      <KnowledgeGraph
+        data={data}
+        selectedNodeId={selectedId}
+        onNodeSelect={setSelectedId}
+        onAddNode={handleAddNode}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "交互式场景：添加新节点。点击 Add Node 按钮创建新节点并自动选中。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 额外场景: 多节点选中对比
+// ============================================================================
+
+/**
+ * 额外场景: 选中不同类型的节点
+ *
+ * 展示不同节点类型的选中状态和详情卡片
+ */
+export const SelectLocationNode: Story = {
+  args: {
+    data: DEMO_DATA,
+    selectedNodeId: "shadow-keep",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "选中 Location 类型节点 Shadow Keep，展示其详情卡片。",
+      },
+    },
+  },
+};
+
+export const SelectEventNode: Story = {
+  args: {
+    data: DEMO_DATA,
+    selectedNodeId: "great-war",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "选中 Event 类型节点 The Great War，展示其详情卡片。",
+      },
+    },
+  },
+};
+
+export const SelectItemNode: Story = {
+  args: {
+    data: DEMO_DATA,
+    selectedNodeId: "crystal-key",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "选中 Item 类型节点 Crystal Key，展示其详情卡片。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 10: EditNodeDialog - 编辑节点对话框
+// ============================================================================
+
+/**
+ * 场景 10: 编辑节点对话框
+ *
+ * 验证点:
+ * - 选中节点后点击 "Edit Node" 按钮
+ * - 打开编辑对话框
+ * - 修改名称、类型、描述、属性
+ * - 保存后节点数据更新
+ */
+export const EditNodeDialog: Story = {
+  render: function EditNodeDialogStory() {
+    const [data, setData] = useState<GraphData>(DEMO_DATA);
+    const [selectedId, setSelectedId] = useState<string | null>("elara");
+
+    const handleNodeMove = (
+      nodeId: string,
+      position: { x: number; y: number },
+    ) => {
+      setData((prev) => ({
+        ...prev,
+        nodes: prev.nodes.map((node) =>
+          node.id === nodeId ? { ...node, position } : node,
+        ),
+      }));
+    };
+
+    const handleNodeSave = (node: GraphNode, isNew: boolean) => {
+      if (isNew) {
+        // Add new node
+        setData((prev) => ({
+          ...prev,
+          nodes: [...prev.nodes, node],
+        }));
+      } else {
+        // Update existing node
+        setData((prev) => ({
+          ...prev,
+          nodes: prev.nodes.map((n) => (n.id === node.id ? node : n)),
+        }));
+      }
+    };
+
+    return (
+      <KnowledgeGraph
+        data={data}
+        selectedNodeId={selectedId}
+        onNodeSelect={setSelectedId}
+        onNodeMove={handleNodeMove}
+        onNodeSave={handleNodeSave}
+        enableEditDialog={true}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "交互式场景：编辑节点对话框。选中节点后点击 Edit Node，修改属性并保存。点击 Add Node 创建新节点。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 场景 11: CreateNodeDialog - 创建新节点对话框
+// ============================================================================
+
+/**
+ * 场景 11: 创建新节点对话框
+ *
+ * 验证点:
+ * - 点击 "Add Node" 按钮
+ * - 打开创建对话框
+ * - 填写名称、选择类型、添加描述和属性
+ * - 保存后新节点出现在画布
+ */
+export const CreateNodeDialog: Story = {
+  render: function CreateNodeDialogStory() {
+    const [data, setData] = useState<GraphData>({
+      nodes: [
+        {
+          id: "elara",
+          label: "Elara",
+          type: "character",
+          avatar:
+            "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=100&q=80",
+          position: { x: 400, y: 300 },
+          metadata: {
+            role: "Protagonist",
+            attributes: [{ key: "Age", value: "24" }],
+            description: "A skilled weaver of arcana.",
+          },
+        },
+      ],
+      edges: [],
+    });
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    const handleNodeSave = (node: GraphNode, isNew: boolean) => {
+      if (isNew) {
+        setData((prev) => ({
+          ...prev,
+          nodes: [...prev.nodes, node],
+        }));
+        setSelectedId(node.id);
+      } else {
+        setData((prev) => ({
+          ...prev,
+          nodes: prev.nodes.map((n) => (n.id === node.id ? node : n)),
+        }));
+      }
+    };
+
+    const handleNodeMove = (
+      nodeId: string,
+      position: { x: number; y: number },
+    ) => {
+      setData((prev) => ({
+        ...prev,
+        nodes: prev.nodes.map((node) =>
+          node.id === nodeId ? { ...node, position } : node,
+        ),
+      }));
+    };
+
+    return (
+      <KnowledgeGraph
+        data={data}
+        selectedNodeId={selectedId}
+        onNodeSelect={setSelectedId}
+        onNodeMove={handleNodeMove}
+        onNodeSave={handleNodeSave}
+        enableEditDialog={true}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "交互式场景：创建新节点。点击 Add Node 按钮打开创建对话框，填写信息后保存。",
+      },
+    },
+  },
+};
+
+// ============================================================================
+// 完整矩阵展示
+// ============================================================================
+
+/**
+ * 完整功能矩阵
+ *
+ * 展示所有节点类型和交互状态，包括编辑和删除功能
+ */
+export const FullFeatureMatrix: Story = {
+  render: function FullFeatureMatrixStory() {
+    const [data, setData] = useState<GraphData>(DEMO_DATA);
+    const [selectedId, setSelectedId] = useState<string | null>("elara");
+
+    const handleNodeMove = (
+      nodeId: string,
+      position: { x: number; y: number },
+    ) => {
+      setData((prev) => ({
+        ...prev,
+        nodes: prev.nodes.map((node) =>
+          node.id === nodeId ? { ...node, position } : node,
+        ),
+      }));
+    };
+
+    const handleNodeSave = (node: GraphNode, isNew: boolean) => {
+      if (isNew) {
+        setData((prev) => ({
+          ...prev,
+          nodes: [...prev.nodes, node],
+        }));
+        setSelectedId(node.id);
+      } else {
+        setData((prev) => ({
+          ...prev,
+          nodes: prev.nodes.map((n) => (n.id === node.id ? node : n)),
+        }));
+      }
+    };
+
+    const handleNodeDelete = (nodeId: string) => {
+      // Confirm before delete
+      const node = data.nodes.find((n) => n.id === nodeId);
+      if (node && confirm(`确定要删除节点 "${node.label}" 吗？此操作不可撤销。`)) {
+        setData((prev) => ({
+          nodes: prev.nodes.filter((n) => n.id !== nodeId),
+          edges: prev.edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
+        }));
+        setSelectedId(null);
+      }
+    };
+
+    return (
+      <KnowledgeGraph
+        data={data}
+        selectedNodeId={selectedId}
+        onNodeSelect={setSelectedId}
+        onNodeMove={handleNodeMove}
+        onNodeSave={handleNodeSave}
+        onNodeDelete={handleNodeDelete}
+        onEditNode={(id) => console.log("Edit triggered:", id)}
+        onViewDetails={(id) => alert(`查看详情: ${id}\n\n完整详情功能可在此实现更复杂的面板或页面跳转。`)}
+        enableEditDialog={true}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "完整功能演示：支持节点选择、拖拽、添加、编辑、删除、筛选、缩放等所有交互。点击垃圾桶图标删除节点。",
+      },
+    },
+  },
+};

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.test.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.test.tsx
@@ -1,0 +1,752 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { KnowledgeGraph } from "./KnowledgeGraph";
+import { GraphNode } from "./GraphNode";
+import { GraphLegend } from "./GraphLegend";
+import { GraphToolbar } from "./GraphToolbar";
+import { NodeDetailCard } from "./NodeDetailCard";
+import type { GraphData, GraphNode as GraphNodeType } from "./types";
+
+// Test data
+const mockNodes: GraphNodeType[] = [
+  {
+    id: "1",
+    label: "Elara",
+    type: "character",
+    avatar: "https://example.com/avatar.jpg",
+    position: { x: 300, y: 200 },
+    metadata: {
+      role: "Protagonist",
+      attributes: [{ key: "Age", value: "24" }],
+      description: "A skilled mage.",
+    },
+  },
+  {
+    id: "2",
+    label: "Shadow Keep",
+    type: "location",
+    position: { x: 500, y: 100 },
+    metadata: {
+      role: "Fortress",
+      attributes: [],
+      description: "An ancient fortress.",
+    },
+  },
+  {
+    id: "3",
+    label: "The Great War",
+    type: "event",
+    position: { x: 300, y: 400 },
+    metadata: {
+      role: "Historical Event",
+      attributes: [],
+      description: "A catastrophic conflict.",
+    },
+  },
+  {
+    id: "4",
+    label: "Crystal Key",
+    type: "item",
+    position: { x: 100, y: 200 },
+    metadata: {
+      role: "Artifact",
+      attributes: [],
+      description: "A mysterious key.",
+    },
+  },
+];
+
+const mockEdges = [
+  { id: "e1", source: "1", target: "2", label: "Travels to" },
+  { id: "e2", source: "1", target: "3", label: "Participant" },
+  { id: "e3", source: "1", target: "4", label: "Owns" },
+];
+
+const mockData: GraphData = {
+  nodes: mockNodes,
+  edges: mockEdges,
+};
+
+const emptyData: GraphData = {
+  nodes: [],
+  edges: [],
+};
+
+// ============================================================================
+// KnowledgeGraph Component Tests
+// ============================================================================
+
+describe("KnowledgeGraph", () => {
+  it("renders with data", () => {
+    render(<KnowledgeGraph data={mockData} />);
+
+    // Check toolbar is rendered
+    expect(screen.getByText("Knowledge Graph")).toBeInTheDocument();
+    expect(screen.getByText("Add Node")).toBeInTheDocument();
+
+    // Check legend is rendered
+    expect(screen.getByText("Graph Legend")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no nodes", () => {
+    render(<KnowledgeGraph data={emptyData} />);
+
+    expect(screen.getByText("No nodes in the graph yet")).toBeInTheDocument();
+    expect(screen.getByText("Add First Node")).toBeInTheDocument();
+  });
+
+  it("calls onNodeSelect when node is clicked", async () => {
+    const handleSelect = vi.fn();
+    render(<KnowledgeGraph data={mockData} onNodeSelect={handleSelect} />);
+
+    // Find and click a node
+    const node = screen.getByText("Elara").closest("[data-node-id]");
+    if (node) {
+      await userEvent.click(node);
+      expect(handleSelect).toHaveBeenCalledWith("1");
+    }
+  });
+
+  it("displays node detail card when node is selected", () => {
+    render(<KnowledgeGraph data={mockData} selectedNodeId="1" />);
+
+    // Check detail card content (multiple "Elara" elements exist: node label + detail card)
+    const elaraElements = screen.getAllByText("Elara");
+    expect(elaraElements.length).toBeGreaterThanOrEqual(2); // Node label + detail card
+
+    expect(screen.getByText("Protagonist")).toBeInTheDocument();
+    expect(screen.getByText("A skilled mage.")).toBeInTheDocument();
+    expect(screen.getByText("Edit Node")).toBeInTheDocument();
+    expect(screen.getByText("View Details")).toBeInTheDocument();
+  });
+
+  it("calls onAddNode when add button is clicked", async () => {
+    const handleAdd = vi.fn();
+    render(<KnowledgeGraph data={mockData} onAddNode={handleAdd} />);
+
+    const addButton = screen.getByText("Add Node");
+    await userEvent.click(addButton);
+
+    expect(handleAdd).toHaveBeenCalledWith("character");
+  });
+
+  it("shows zoom percentage in toolbar", () => {
+    render(<KnowledgeGraph data={mockData} />);
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("clears selection on Escape key", () => {
+    const handleSelect = vi.fn();
+    render(
+      <KnowledgeGraph
+        data={mockData}
+        selectedNodeId="1"
+        onNodeSelect={handleSelect}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(handleSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onNodeDelete on Delete key and clears selection", () => {
+    const handleSelect = vi.fn();
+    const handleDelete = vi.fn();
+    render(
+      <KnowledgeGraph
+        data={mockData}
+        selectedNodeId="1"
+        onNodeSelect={handleSelect}
+        onNodeDelete={handleDelete}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Delete" });
+    expect(handleDelete).toHaveBeenCalledWith("1");
+    expect(handleSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("does not clear selection when edit dialog is open (Escape handled by dialog)", async () => {
+    const user = userEvent.setup();
+    const handleSelect = vi.fn();
+
+    render(
+      <KnowledgeGraph
+        data={mockData}
+        selectedNodeId="1"
+        onNodeSelect={handleSelect}
+        enableEditDialog={true}
+      />,
+    );
+
+    // Open edit dialog
+    await user.click(screen.getByText("Edit Node"));
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    // Should not force-clear selection while dialog is open
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// GraphNode Component Tests
+// ============================================================================
+
+describe("GraphNode", () => {
+  const baseNode: GraphNodeType = {
+    id: "test",
+    label: "Test Node",
+    type: "character",
+    position: { x: 100, y: 100 },
+  };
+
+  it("renders character node with avatar", () => {
+    const nodeWithAvatar = {
+      ...baseNode,
+      avatar: "https://example.com/avatar.jpg",
+    };
+    render(<GraphNode node={nodeWithAvatar} />);
+
+    expect(screen.getByText("Test Node")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute("src", nodeWithAvatar.avatar);
+  });
+
+  it("renders character node with initial when no avatar", () => {
+    render(<GraphNode node={baseNode} />);
+
+    expect(screen.getByText("T")).toBeInTheDocument(); // First letter of "Test Node"
+  });
+
+  it("applies selected styles when selected", () => {
+    const { container } = render(<GraphNode node={baseNode} selected />);
+
+    const nodeEl = container.querySelector("[data-node-id]");
+    expect(nodeEl).toHaveClass("z-20");
+  });
+
+  it("shows dragging indicator when dragging", () => {
+    render(<GraphNode node={baseNode} dragging />);
+
+    expect(screen.getByText("Dragging")).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const handleClick = vi.fn();
+    render(<GraphNode node={baseNode} onClick={handleClick} />);
+
+    const node = screen.getByText("Test Node").closest("[data-node-id]");
+    if (node) {
+      await userEvent.click(node);
+      expect(handleClick).toHaveBeenCalled();
+    }
+  });
+
+  it("renders different node types with correct icons", () => {
+    const locationNode = { ...baseNode, type: "location" as const };
+    const { rerender, container } = render(<GraphNode node={locationNode} />);
+
+    // Location node should have an SVG icon
+    expect(container.querySelector("svg")).toBeInTheDocument();
+
+    const eventNode = { ...baseNode, type: "event" as const };
+    rerender(<GraphNode node={eventNode} />);
+
+    // Event node should have an SVG icon
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// GraphLegend Component Tests
+// ============================================================================
+
+describe("GraphLegend", () => {
+  it("renders all node types", () => {
+    render(<GraphLegend />);
+
+    expect(screen.getByText("Graph Legend")).toBeInTheDocument();
+    expect(screen.getByText("Character")).toBeInTheDocument();
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Event")).toBeInTheDocument();
+    expect(screen.getByText("Item")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<GraphLegend className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});
+
+// ============================================================================
+// GraphToolbar Component Tests
+// ============================================================================
+
+describe("GraphToolbar", () => {
+  const defaultProps = {
+    activeFilter: "all" as const,
+    onFilterChange: vi.fn(),
+    zoom: 1,
+    onZoomIn: vi.fn(),
+    onZoomOut: vi.fn(),
+    onAddNode: vi.fn(),
+  };
+
+  it("renders title and buttons", () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    expect(screen.getByText("Knowledge Graph")).toBeInTheDocument();
+    expect(screen.getByText("Add Node")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("renders all filter buttons", () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+    expect(screen.getByText("Locations")).toBeInTheDocument();
+    expect(screen.getByText("Events")).toBeInTheDocument();
+    expect(screen.getByText("Items")).toBeInTheDocument();
+  });
+
+  it("calls onFilterChange when filter button is clicked", async () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    await userEvent.click(screen.getByText("Roles"));
+    expect(defaultProps.onFilterChange).toHaveBeenCalledWith("character");
+  });
+
+  it("calls onZoomIn when + button is clicked", async () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    const zoomInButton = screen.getByLabelText("Zoom in");
+    await userEvent.click(zoomInButton);
+    expect(defaultProps.onZoomIn).toHaveBeenCalled();
+  });
+
+  it("calls onZoomOut when - button is clicked", async () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    const zoomOutButton = screen.getByLabelText("Zoom out");
+    await userEvent.click(zoomOutButton);
+    expect(defaultProps.onZoomOut).toHaveBeenCalled();
+  });
+
+  it("calls onAddNode when Add Node button is clicked", async () => {
+    render(<GraphToolbar {...defaultProps} />);
+
+    await userEvent.click(screen.getByText("Add Node"));
+    expect(defaultProps.onAddNode).toHaveBeenCalled();
+  });
+
+  it("renders back button when onBack is provided", async () => {
+    const handleBack = vi.fn();
+    render(<GraphToolbar {...defaultProps} onBack={handleBack} />);
+
+    const backButton = screen.getByLabelText("Go back");
+    expect(backButton).toBeInTheDocument();
+
+    await userEvent.click(backButton);
+    expect(handleBack).toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// NodeDetailCard Component Tests
+// ============================================================================
+
+describe("NodeDetailCard", () => {
+  const mockNode: GraphNodeType = {
+    id: "1",
+    label: "Elara Vance",
+    type: "character",
+    avatar: "https://example.com/avatar.jpg",
+    position: { x: 0, y: 0 },
+    metadata: {
+      role: "Protagonist",
+      attributes: [
+        { key: "Age", value: "24" },
+        { key: "Race", value: "Human" },
+      ],
+      description: "A skilled mage seeking the truth.",
+    },
+  };
+
+  it("renders node details", () => {
+    render(<NodeDetailCard node={mockNode} />);
+
+    expect(screen.getByText("Elara Vance")).toBeInTheDocument();
+    expect(screen.getByText("Protagonist")).toBeInTheDocument();
+    expect(screen.getByText("Age: 24")).toBeInTheDocument();
+    expect(screen.getByText("Race: Human")).toBeInTheDocument();
+    expect(
+      screen.getByText("A skilled mage seeking the truth."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders action buttons", () => {
+    render(<NodeDetailCard node={mockNode} />);
+
+    expect(screen.getByText("Edit Node")).toBeInTheDocument();
+    expect(screen.getByText("View Details")).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Edit Node is clicked", async () => {
+    const handleEdit = vi.fn();
+    render(<NodeDetailCard node={mockNode} onEdit={handleEdit} />);
+
+    await userEvent.click(screen.getByText("Edit Node"));
+    expect(handleEdit).toHaveBeenCalled();
+  });
+
+  it("calls onViewDetails when View Details is clicked", async () => {
+    const handleViewDetails = vi.fn();
+    render(<NodeDetailCard node={mockNode} onViewDetails={handleViewDetails} />);
+
+    await userEvent.click(screen.getByText("View Details"));
+    expect(handleViewDetails).toHaveBeenCalled();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const handleClose = vi.fn();
+    render(<NodeDetailCard node={mockNode} onClose={handleClose} />);
+
+    const closeButton = screen.getByLabelText("Close");
+    await userEvent.click(closeButton);
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it("renders avatar image when provided", () => {
+    render(<NodeDetailCard node={mockNode} />);
+
+    // Avatar primitive wraps img in a div with role="img"
+    const avatarContainer = screen.getAllByRole("img")[0];
+    const img = avatarContainer.querySelector("img");
+    expect(img).toHaveAttribute("src", mockNode.avatar);
+  });
+
+  it("renders initial when no avatar", () => {
+    const nodeWithoutAvatar = { ...mockNode, avatar: undefined };
+    render(<NodeDetailCard node={nodeWithoutAvatar} />);
+
+    // Avatar primitive shows initials: "Elara Vance" -> "EV"
+    expect(screen.getByText("EV")).toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// Design Token Usage Tests
+// ============================================================================
+
+describe("Design Token Usage", () => {
+  it("uses node color tokens - legend renders correctly", () => {
+    const { container } = render(<GraphLegend />);
+
+    // Check that the component renders (tokens are applied via CSS)
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("GraphNode applies character type class", () => {
+    const node: GraphNodeType = {
+      id: "test",
+      label: "Test",
+      type: "character",
+      position: { x: 0, y: 0 },
+    };
+    const { container } = render(<GraphNode node={node} />);
+
+    const nodeEl = container.querySelector("[data-node-id]");
+    // Check node renders and has rounded-full class for character type
+    expect(nodeEl).toBeInTheDocument();
+    expect(nodeEl).toHaveClass("rounded-full");
+  });
+
+  it("GraphNode applies location type class", () => {
+    const node: GraphNodeType = {
+      id: "test",
+      label: "Test",
+      type: "location",
+      position: { x: 0, y: 0 },
+    };
+    const { container } = render(<GraphNode node={node} />);
+
+    const nodeEl = container.querySelector("[data-node-id]");
+    // Check node renders and has rounded-lg class for location type
+    expect(nodeEl).toBeInTheDocument();
+    expect(nodeEl).toHaveClass("rounded-lg");
+  });
+
+  it("GraphNode applies event type class with rotation", () => {
+    const node: GraphNodeType = {
+      id: "test",
+      label: "Test",
+      type: "event",
+      position: { x: 0, y: 0 },
+    };
+    const { container } = render(<GraphNode node={node} />);
+
+    const nodeEl = container.querySelector("[data-node-id]");
+    // Check node renders and has rotate-45 class for event type (diamond shape)
+    expect(nodeEl).toBeInTheDocument();
+    expect(nodeEl).toHaveClass("rotate-45");
+  });
+
+  it("GraphNode applies item type class", () => {
+    const node: GraphNodeType = {
+      id: "test",
+      label: "Test",
+      type: "item",
+      position: { x: 0, y: 0 },
+    };
+    const { container } = render(<GraphNode node={node} />);
+
+    const nodeEl = container.querySelector("[data-node-id]");
+    // Check node renders and has rounded-xl class for item type
+    expect(nodeEl).toBeInTheDocument();
+    expect(nodeEl).toHaveClass("rounded-xl");
+  });
+});
+
+// ============================================================================
+// NodeEditDialog Tests
+// ============================================================================
+
+import { NodeEditDialog } from "./NodeEditDialog";
+
+describe("NodeEditDialog", () => {
+  const mockNode: GraphNodeType = {
+    id: "test-node",
+    label: "Test Node",
+    type: "character",
+    position: { x: 100, y: 100 },
+    metadata: {
+      role: "Protagonist",
+      attributes: [{ key: "Age", value: "25" }],
+      description: "A test character",
+    },
+  };
+
+  it("renders dialog when open", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    expect(screen.getByText(/编辑节点/)).toBeInTheDocument();
+  });
+
+  it("does not render dialog when closed", () => {
+    render(
+      <NodeEditDialog
+        open={false}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    expect(screen.queryByText(/编辑节点/)).not.toBeInTheDocument();
+  });
+
+  it("shows create title in create mode", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={null}
+        onSave={() => {}}
+        mode="create"
+      />
+    );
+
+    expect(screen.getByText(/创建新节点/)).toBeInTheDocument();
+  });
+
+  it("populates form with node data in edit mode", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    // Check that the input has the node's label
+    const nameInput = screen.getByDisplayValue("Test Node");
+    expect(nameInput).toBeInTheDocument();
+  });
+
+  it("calls onSave with updated node data", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={onSave}
+        mode="edit"
+      />
+    );
+
+    // Clear and type new name
+    const nameInput = screen.getByDisplayValue("Test Node");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Node");
+
+    // Click save button
+    const saveButton = screen.getByText("保存");
+    await user.click(saveButton);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "test-node",
+        label: "Updated Node",
+        type: "character",
+      })
+    );
+  });
+
+  it("calls onOpenChange when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    const cancelButton = screen.getByText("取消");
+    await user.click(cancelButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("disables save button when name is empty", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={null}
+        onSave={() => {}}
+        mode="create"
+      />
+    );
+
+    // In create mode with no node, name should be empty
+    // Find the button by role and check its disabled state
+    const saveButton = screen.getByRole("button", { name: "创建" });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("shows role field for character type", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    expect(screen.getByText("角色定位")).toBeInTheDocument();
+  });
+
+  it("shows all node type options in select", () => {
+    render(
+      <NodeEditDialog
+        open={true}
+        onOpenChange={() => {}}
+        node={mockNode}
+        onSave={() => {}}
+        mode="edit"
+      />
+    );
+
+    // Radix Select renders both visible span and hidden native option
+    // Use combobox role to verify the select is present with correct value
+    const select = screen.getByRole("combobox");
+    expect(select).toBeInTheDocument();
+    // The selected value should be displayed
+    expect(screen.getAllByText("角色 (Character)").length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// NodeDetailCard Delete Tests
+// ============================================================================
+
+describe("NodeDetailCard delete functionality", () => {
+  const mockNode: GraphNodeType = {
+    id: "test",
+    label: "Test Node",
+    type: "character",
+    position: { x: 0, y: 0 },
+    metadata: {
+      role: "Protagonist",
+      description: "A test character",
+    },
+  };
+
+  it("renders delete button when onDelete is provided", () => {
+    render(
+      <NodeDetailCard
+        node={mockNode}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />
+    );
+
+    const deleteButton = screen.getByLabelText("Delete node");
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it("does not render delete button when onDelete is not provided", () => {
+    render(
+      <NodeDetailCard
+        node={mockNode}
+        onClose={() => {}}
+      />
+    );
+
+    const deleteButton = screen.queryByLabelText("Delete node");
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it("calls onDelete when delete button is clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+
+    render(
+      <NodeDetailCard
+        node={mockNode}
+        onDelete={onDelete}
+        onClose={() => {}}
+      />
+    );
+
+    const deleteButton = screen.getByLabelText("Delete node");
+    await user.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.test.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -1,0 +1,390 @@
+import React, { useState, useCallback, useMemo, useEffect } from "react";
+import { GraphToolbar } from "./GraphToolbar";
+import { GraphCanvas } from "./GraphCanvas";
+import { GraphLegend } from "./GraphLegend";
+import { NodeDetailCard } from "./NodeDetailCard";
+import { NodeEditDialog } from "./NodeEditDialog";
+import type {
+  KnowledgeGraphProps,
+  NodeFilter,
+  CanvasTransform,
+  GraphNode,
+} from "./types";
+
+/**
+ * Min/max zoom levels
+ */
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2.0;
+const ZOOM_STEP = 0.1;
+
+/**
+ * Container styles
+ */
+const containerStyles = [
+  "flex",
+  "flex-col",
+  "h-full",
+  "w-full",
+  "bg-[var(--color-bg-base)]",
+  "overflow-hidden",
+].join(" ");
+
+const mainStyles = [
+  "flex-1",
+  "relative",
+  "overflow-hidden",
+].join(" ");
+
+/**
+ * Empty state component
+ */
+function EmptyState({ onAddNode }: { onAddNode: () => void }): JSX.Element {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="text-center space-y-4">
+        <div className="w-16 h-16 mx-auto rounded-full border-2 border-dashed border-[var(--color-border-default)] flex items-center justify-center">
+          <svg
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="text-[var(--color-fg-subtle)]"
+          >
+            <circle cx="12" cy="5" r="3" />
+            <circle cx="5" cy="19" r="3" />
+            <circle cx="19" cy="19" r="3" />
+            <line x1="12" y1="8" x2="5" y2="16" />
+            <line x1="12" y1="8" x2="19" y2="16" />
+          </svg>
+        </div>
+        <div>
+          <p className="text-sm text-[var(--color-fg-muted)]">
+            No nodes in the graph yet
+          </p>
+          <p className="text-xs text-[var(--color-fg-subtle)] mt-1">
+            Start building your knowledge graph by adding nodes
+          </p>
+        </div>
+        <button
+          onClick={onAddNode}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] text-sm font-medium rounded-[var(--radius-md)] hover:bg-[var(--color-fg-muted)] transition-colors"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Add First Node
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * KnowledgeGraph component
+ *
+ * A full-featured knowledge graph visualization with:
+ * - Multiple node types (character, location, event, item) with distinct shapes/colors
+ * - Directed edges with labels
+ * - Node dragging for layout adjustment
+ * - Canvas panning and zooming
+ * - Filtering by node type
+ * - Node selection with detail card
+ *
+ * @example
+ * ```tsx
+ * <KnowledgeGraph
+ *   data={{
+ *     nodes: [
+ *       { id: "1", label: "Elara", type: "character", position: { x: 300, y: 200 } },
+ *       { id: "2", label: "Shadow Keep", type: "location", position: { x: 500, y: 100 } },
+ *     ],
+ *     edges: [
+ *       { id: "e1", source: "1", target: "2", label: "Travels to" },
+ *     ],
+ *   }}
+ *   onNodeSelect={(id) => console.log("Selected:", id)}
+ * />
+ * ```
+ */
+export function KnowledgeGraph({
+  data,
+  selectedNodeId: controlledSelectedId,
+  onNodeSelect,
+  onNodeMove,
+  onAddNode,
+  onEditNode,
+  onViewDetails,
+  onNodeSave,
+  onNodeDelete,
+  enableEditDialog = true,
+  className = "",
+}: KnowledgeGraphProps): JSX.Element {
+  // Internal state for uncontrolled mode
+  const [internalSelectedId, setInternalSelectedId] = useState<string | null>(
+    null,
+  );
+  const [filter, setFilter] = useState<NodeFilter>("all");
+  const [transform, setTransform] = useState<CanvasTransform>({
+    scale: 1,
+    translateX: 0,
+    translateY: 0,
+  });
+
+  // Edit dialog state
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [editingNode, setEditingNode] = useState<GraphNode | null>(null);
+  const [editMode, setEditMode] = useState<"edit" | "create">("edit");
+
+  // Use controlled or uncontrolled selection
+  const selectedNodeId =
+    controlledSelectedId !== undefined
+      ? controlledSelectedId
+      : internalSelectedId;
+
+  const handleNodeSelect = useCallback(
+    (nodeId: string | null) => {
+      if (onNodeSelect) {
+        onNodeSelect(nodeId);
+      } else {
+        setInternalSelectedId(nodeId);
+      }
+    },
+    [onNodeSelect],
+  );
+
+  // Get selected node data
+  const selectedNode = useMemo(() => {
+    if (!selectedNodeId) return null;
+    return data.nodes.find((n) => n.id === selectedNodeId) || null;
+  }, [data.nodes, selectedNodeId]);
+
+  // Zoom handlers
+  const handleZoomIn = useCallback(() => {
+    setTransform((prev) => ({
+      ...prev,
+      scale: Math.min(prev.scale + ZOOM_STEP, MAX_ZOOM),
+    }));
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    setTransform((prev) => ({
+      ...prev,
+      scale: Math.max(prev.scale - ZOOM_STEP, MIN_ZOOM),
+    }));
+  }, []);
+
+  // Pan handler
+  const handleCanvasPan = useCallback((deltaX: number, deltaY: number) => {
+    setTransform((prev) => ({
+      ...prev,
+      translateX: prev.translateX + deltaX / prev.scale,
+      translateY: prev.translateY + deltaY / prev.scale,
+    }));
+  }, []);
+
+  // Node move handler (for dragging)
+  const handleNodeMove = useCallback(
+    (nodeId: string, position: { x: number; y: number }) => {
+      if (onNodeMove) {
+        onNodeMove(nodeId, position);
+      }
+    },
+    [onNodeMove],
+  );
+
+  // Add node handler
+  const handleAddNode = useCallback(() => {
+    if (enableEditDialog) {
+      // Open create dialog
+      setEditingNode(null);
+      setEditMode("create");
+      setEditDialogOpen(true);
+    }
+    if (onAddNode) {
+      onAddNode("character"); // Default to character type
+    }
+  }, [onAddNode, enableEditDialog]);
+
+  // Edit node handler
+  const handleEditNode = useCallback(() => {
+    if (selectedNode && enableEditDialog) {
+      // Open edit dialog with selected node
+      setEditingNode(selectedNode);
+      setEditMode("edit");
+      setEditDialogOpen(true);
+    }
+    if (selectedNodeId && onEditNode) {
+      onEditNode(selectedNodeId);
+    }
+  }, [selectedNode, selectedNodeId, onEditNode, enableEditDialog]);
+
+  // View details handler (currently shows alert, can be expanded)
+  const handleViewDetails = useCallback(() => {
+    if (selectedNodeId && onViewDetails) {
+      onViewDetails(selectedNodeId);
+    }
+  }, [selectedNodeId, onViewDetails]);
+
+  // Delete node handler
+  const handleDeleteNode = useCallback(() => {
+    if (selectedNodeId && onNodeDelete) {
+      onNodeDelete(selectedNodeId);
+      // Clear selection after delete
+      handleNodeSelect(null);
+    }
+  }, [selectedNodeId, onNodeDelete, handleNodeSelect]);
+
+  // Keyboard shortcuts: Escape to close, Delete to remove
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't hijack keys while editing in dialog
+      if (editDialogOpen) return;
+
+      // Don't hijack keys while typing in an input/textarea/select/contenteditable
+      const active = document.activeElement as HTMLElement | null;
+      const isTyping =
+        !!active &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          active.tagName === "SELECT" ||
+          active.isContentEditable);
+      if (isTyping) return;
+
+      if (e.key === "Escape") {
+        if (selectedNodeId) {
+          e.preventDefault();
+          handleNodeSelect(null);
+        }
+        return;
+      }
+
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (selectedNodeId && onNodeDelete) {
+          e.preventDefault();
+          handleDeleteNode();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [editDialogOpen, handleDeleteNode, handleNodeSelect, onNodeDelete, selectedNodeId]);
+
+  // Save node handler (from edit dialog)
+  const handleNodeSave = useCallback(
+    (node: GraphNode) => {
+      const isNew = editMode === "create";
+      if (onNodeSave) {
+        onNodeSave(node, isNew);
+      }
+      // Select the saved node
+      handleNodeSelect(node.id);
+    },
+    [editMode, onNodeSave, handleNodeSelect],
+  );
+
+  // Close detail card
+  const handleCloseDetailCard = useCallback(() => {
+    handleNodeSelect(null);
+  }, [handleNodeSelect]);
+
+  const isEmpty = data.nodes.length === 0;
+
+  return (
+    <div className={`${containerStyles} ${className}`}>
+      {/* Toolbar */}
+      <GraphToolbar
+        activeFilter={filter}
+        onFilterChange={setFilter}
+        zoom={transform.scale}
+        onZoomIn={handleZoomIn}
+        onZoomOut={handleZoomOut}
+        onAddNode={handleAddNode}
+      />
+
+      {/* Main canvas area */}
+      <main className={mainStyles}>
+        {isEmpty ? (
+          <EmptyState onAddNode={handleAddNode} />
+        ) : (
+          <>
+            {/* Canvas */}
+            <GraphCanvas
+              data={data}
+              selectedNodeId={selectedNodeId}
+              filter={filter}
+              transform={transform}
+              onNodeSelect={handleNodeSelect}
+              onNodeMove={handleNodeMove}
+              onCanvasPan={handleCanvasPan}
+            />
+
+            {/* Node Detail Card (fixed position, right side of canvas) */}
+            {selectedNode && (
+              <div className="absolute top-4 right-4 z-[var(--z-popover)]">
+                <NodeDetailCard
+                  node={selectedNode}
+                  onEdit={handleEditNode}
+                  onViewDetails={handleViewDetails}
+                  onDelete={onNodeDelete ? handleDeleteNode : undefined}
+                  onClose={handleCloseDetailCard}
+                />
+              </div>
+            )}
+
+            {/* Legend */}
+            <div className="absolute bottom-6 right-6 z-30">
+              <GraphLegend />
+            </div>
+
+            {/* Floating add button (bottom-left) */}
+            <div className="absolute bottom-6 left-6 z-30">
+              <button
+                onClick={handleAddNode}
+                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
+                aria-label="Add node"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+              </button>
+            </div>
+          </>
+        )}
+      </main>
+
+      {/* Node Edit Dialog */}
+      {enableEditDialog && (
+        <NodeEditDialog
+          key={editingNode?.id ?? "new"}
+          open={editDialogOpen}
+          onOpenChange={setEditDialogOpen}
+          node={editingNode}
+          onSave={handleNodeSave}
+          mode={editMode}
+        />
+      )}
+    </div>
+  );
+}
+
+KnowledgeGraph.displayName = "KnowledgeGraph";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { GraphToolbar } from "./GraphToolbar";
 import { GraphCanvas } from "./GraphCanvas";
 import { GraphLegend } from "./GraphLegend";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "../../primitives/Button";
 import { Avatar } from "../../primitives/Avatar";
 import { Badge } from "../../primitives/Badge";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { Button } from "../../primitives/Button";
+import { Avatar } from "../../primitives/Avatar";
+import { Badge } from "../../primitives/Badge";
+import type { NodeDetailCardProps, NodeType } from "./types";
+
+/**
+ * Node type to badge variant mapping
+ */
+const typeToVariant: Record<NodeType, "info" | "success" | "warning" | "default"> = {
+  character: "info",
+  location: "success",
+  event: "warning",
+  item: "default",
+  other: "default",
+};
+
+/**
+ * Node type to CSS color token mapping
+ */
+const typeColorVars: Record<NodeType, string> = {
+  character: "var(--color-node-character)",
+  location: "var(--color-node-location)",
+  event: "var(--color-node-event)",
+  item: "var(--color-node-item)",
+  other: "var(--color-node-other)",
+};
+
+const typeLabels: Record<NodeType, string> = {
+  character: "Character",
+  location: "Location",
+  event: "Event",
+  item: "Item",
+  other: "Other",
+};
+
+/**
+ * Card base styles
+ */
+const cardStyles = [
+  "w-[280px]",
+  "bg-[var(--color-bg-surface)]/95",
+  "backdrop-blur-md",
+  "border",
+  "border-[var(--color-border-hover)]",
+  "rounded-lg",
+  "shadow-[var(--shadow-xl)]",
+  "p-4",
+  "flex",
+  "flex-col",
+  "gap-3",
+  "z-[var(--z-popover)]",
+].join(" ");
+
+/**
+ * NodeDetailCard component
+ *
+ * Displays detailed information about a selected node in the knowledge graph.
+ * Includes avatar, name, type badge, attributes, description, and action buttons.
+ */
+export function NodeDetailCard({
+  node,
+  onEdit,
+  onViewDetails,
+  onDelete,
+  onClose,
+}: NodeDetailCardProps): JSX.Element {
+  const { label, type, avatar, metadata } = node;
+  const { role, attributes, description } = metadata || {};
+  const typeColor = typeColorVars[type];
+
+  return (
+    <div className={cardStyles}>
+      {/* Header: Avatar + Name + Type */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={avatar}
+            alt={label}
+            fallback={label}
+            size="md"
+            className="border"
+            style={{ borderColor: typeColor }}
+          />
+
+          {/* Name and role */}
+          <div>
+            <div className="flex items-center gap-2">
+              <div className="text-sm font-semibold text-[var(--color-fg-default)]">
+                {label}
+              </div>
+              <Badge variant={typeToVariant[type]} size="sm">
+                {typeLabels[type]}
+              </Badge>
+            </div>
+            {role && (
+              <div
+                className="text-[10px] uppercase tracking-wider font-medium"
+                style={{ color: typeColor }}
+              >
+                {role}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Header actions */}
+        <div className="flex items-center gap-1">
+          {/* Delete button */}
+          {onDelete && (
+            <button
+              onClick={onDelete}
+              className="p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
+              aria-label="Delete node"
+              title="删除节点"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <polyline points="3,6 5,6 21,6" />
+                <path d="M19,6v14a2,2,0,0,1-2,2H7a2,2,0,0,1-2-2V6m3,0V4a2,2,0,0,1,2-2h4a2,2,0,0,1,2,2V6" />
+                <line x1="10" y1="11" x2="10" y2="17" />
+                <line x1="14" y1="11" x2="14" y2="17" />
+              </svg>
+            </button>
+          )}
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            className="p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-fg-default)] transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Attributes tags */}
+      {attributes && attributes.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {attributes.map((attr, index) => (
+            <span
+              key={`${attr.key}-${index}`}
+              className="px-2 py-0.5 rounded bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] text-[10px] text-[var(--color-fg-muted)]"
+            >
+              {attr.key}: {attr.value}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Description */}
+      {description && (
+        <p className="text-xs text-[var(--color-fg-muted)] leading-relaxed line-clamp-3">
+          {description}
+        </p>
+      )}
+
+      {/* Divider */}
+      <div className="h-px bg-[var(--color-border-default)] w-full my-1" />
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onEdit}
+          className="flex-1"
+        >
+          Edit Node
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onViewDetails}
+          className="flex-1"
+        >
+          View Details
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+NodeDetailCard.displayName = "NodeDetailCard";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -1,0 +1,267 @@
+import React, { useState } from "react";
+import { Dialog } from "../../primitives/Dialog";
+import { Button } from "../../primitives/Button";
+import { Input } from "../../primitives/Input";
+import { Select } from "../../primitives/Select";
+import { Textarea } from "../../primitives/Textarea";
+import type { GraphNode, NodeEditDialogProps, NodeType } from "./types";
+
+/**
+ * Node type options for the select dropdown
+ */
+const nodeTypeOptions: Array<{
+  value: NodeType;
+  label: string;
+  colorVar: string;
+}> = [
+  {
+    value: "character",
+    label: "角色 (Character)",
+    colorVar: "var(--color-node-character)",
+  },
+  {
+    value: "location",
+    label: "地点 (Location)",
+    colorVar: "var(--color-node-location)",
+  },
+  { value: "event", label: "事件 (Event)", colorVar: "var(--color-node-event)" },
+  { value: "item", label: "物品 (Item)", colorVar: "var(--color-node-item)" },
+  { value: "other", label: "其他 (Other)", colorVar: "var(--color-node-other)" },
+];
+
+/**
+ * Label styles
+ */
+const labelStyles =
+  "block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5";
+
+/**
+ * Generate a unique ID for new nodes
+ */
+function generateNodeId(): string {
+  return `node-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/**
+ * NodeEditDialog component
+ *
+ * A dialog for creating or editing knowledge graph nodes.
+ * Supports editing name, type, role, description, and attributes.
+ */
+export function NodeEditDialog({
+  open,
+  onOpenChange,
+  node,
+  onSave,
+  mode = "edit",
+}: NodeEditDialogProps): JSX.Element {
+  // Form state - initialized from node prop (component is keyed by node.id)
+  const [label, setLabel] = useState(node?.label ?? "");
+  const [type, setType] = useState<NodeType>(node?.type ?? "character");
+  const [role, setRole] = useState(node?.metadata?.role ?? "");
+  const [description, setDescription] = useState(
+    node?.metadata?.description ?? "",
+  );
+  const [attributes, setAttributes] = useState<
+    Array<{ key: string; value: string }>
+  >(node?.metadata?.attributes ?? []);
+  const typeColor =
+    nodeTypeOptions.find((o) => o.value === type)?.colorVar ??
+    "var(--color-fg-muted)";
+
+  /**
+   * Handle adding a new attribute
+   */
+  const handleAddAttribute = (): void => {
+    setAttributes([...attributes, { key: "", value: "" }]);
+  };
+
+  /**
+   * Handle updating an attribute
+   */
+  const handleUpdateAttribute = (
+    index: number,
+    field: "key" | "value",
+    value: string,
+  ): void => {
+    const newAttributes = [...attributes];
+    newAttributes[index] = { ...newAttributes[index], [field]: value };
+    setAttributes(newAttributes);
+  };
+
+  /**
+   * Handle removing an attribute
+   */
+  const handleRemoveAttribute = (index: number): void => {
+    setAttributes(attributes.filter((_, i) => i !== index));
+  };
+
+  /**
+   * Handle form submission
+   */
+  const handleSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+
+    if (!label.trim()) {
+      return;
+    }
+
+    const updatedNode: GraphNode = {
+      id: node?.id || generateNodeId(),
+      label: label.trim(),
+      type,
+      avatar: node?.avatar,
+      position: node?.position || { x: 300, y: 300 },
+      metadata: {
+        role: role.trim() || undefined,
+        description: description.trim() || undefined,
+        attributes: attributes.filter((a) => a.key.trim() && a.value.trim()),
+      },
+    };
+
+    onSave(updatedNode);
+    onOpenChange(false);
+  };
+
+  const title = mode === "create" ? "创建新节点" : `编辑节点: ${node?.label || ""}`;
+  const submitLabel = mode === "create" ? "创建" : "保存";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={mode === "create" ? "添加一个新的知识图谱节点" : "修改节点的属性和信息"}
+      footer={
+        <>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            取消
+          </Button>
+          <Button variant="primary" onClick={handleSubmit} disabled={!label.trim()}>
+            {submitLabel}
+          </Button>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Name */}
+        <div>
+          <label className={labelStyles}>名称 *</label>
+          <Input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="输入节点名称..."
+            fullWidth
+            autoFocus
+          />
+        </div>
+
+        {/* Type */}
+        <div>
+          <label className={labelStyles}>
+            <span className="flex items-center gap-2">
+              类型
+              <span
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: typeColor }}
+              />
+            </span>
+          </label>
+          <Select
+            value={type}
+            onValueChange={(value) => setType(value as NodeType)}
+            options={nodeTypeOptions.map((o) => ({ value: o.value, label: o.label }))}
+            fullWidth
+            layer="modal"
+          />
+        </div>
+
+        {/* Role (for characters) */}
+        {(type === "character" || type === "other") && (
+          <div>
+            <label className={labelStyles}>角色定位</label>
+            <Input
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="如: 主角、反派、导师..."
+              fullWidth
+            />
+          </div>
+        )}
+
+        {/* Description */}
+        <div>
+          <label className={labelStyles}>描述</label>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="输入节点的详细描述..."
+            rows={3}
+            fullWidth
+            className="resize-none"
+          />
+        </div>
+
+        {/* Attributes */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className={labelStyles + " mb-0"}>属性</label>
+            <button
+              type="button"
+              onClick={handleAddAttribute}
+              className="text-[11px] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+            >
+              + 添加属性
+            </button>
+          </div>
+          
+          {attributes.length === 0 ? (
+            <p className="text-xs text-[var(--color-fg-subtle)] italic">
+              暂无属性，点击上方添加
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {attributes.map((attr, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Input
+                    value={attr.key}
+                    onChange={(e) => handleUpdateAttribute(index, "key", e.target.value)}
+                    placeholder="属性名"
+                    className="flex-1"
+                  />
+                  <span className="text-[var(--color-fg-subtle)]">:</span>
+                  <Input
+                    value={attr.value}
+                    onChange={(e) => handleUpdateAttribute(index, "value", e.target.value)}
+                    placeholder="属性值"
+                    className="flex-1"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveAttribute(index)}
+                    className="w-8 h-8 flex items-center justify-center text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
+                    aria-label="删除属性"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+NodeEditDialog.displayName = "NodeEditDialog";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/index.ts
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/index.ts
@@ -1,0 +1,58 @@
+/**
+ * KnowledgeGraph Component
+ *
+ * A knowledge graph visualization component for displaying and managing
+ * relationships between entities (characters, locations, events, items).
+ *
+ * Features:
+ * - Multiple node types with distinct shapes and colors (design tokens)
+ * - Directed edges with labels
+ * - Node dragging for layout adjustment
+ * - Canvas panning and zooming
+ * - Filtering by node type
+ * - Node selection with detail card
+ *
+ * @example
+ * ```tsx
+ * import { KnowledgeGraph } from '@/components/features/KnowledgeGraph';
+ *
+ * <KnowledgeGraph
+ *   data={{
+ *     nodes: [
+ *       { id: "1", label: "Elara", type: "character", position: { x: 300, y: 200 } },
+ *       { id: "2", label: "Shadow Keep", type: "location", position: { x: 500, y: 100 } },
+ *     ],
+ *     edges: [
+ *       { id: "e1", source: "1", target: "2", label: "Travels to" },
+ *     ],
+ *   }}
+ *   onNodeSelect={(id) => console.log("Selected:", id)}
+ * />
+ * ```
+ */
+
+export { KnowledgeGraph } from "./KnowledgeGraph";
+export { GraphNode } from "./GraphNode";
+export { GraphEdge, EdgeMarkerDefs } from "./GraphEdge";
+export { GraphCanvas } from "./GraphCanvas";
+export { GraphToolbar } from "./GraphToolbar";
+export { GraphLegend } from "./GraphLegend";
+export { NodeDetailCard } from "./NodeDetailCard";
+export { NodeEditDialog } from "./NodeEditDialog";
+
+export type {
+  NodeType,
+  GraphNode as GraphNodeData,
+  GraphEdge as GraphEdgeData,
+  GraphData,
+  NodeFilter,
+  CanvasTransform,
+  KnowledgeGraphProps,
+  GraphNodeProps,
+  GraphEdgeProps,
+  NodeDetailCardProps,
+  GraphToolbarProps,
+  GraphLegendProps,
+  GraphCanvasProps,
+  NodeEditDialogProps,
+} from "./types";

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/types.ts
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/types.ts
@@ -1,0 +1,160 @@
+/**
+ * KnowledgeGraph Types
+ *
+ * Type definitions for the Knowledge Graph component.
+ * Uses design tokens from `design/system/01-tokens.css`:
+ * - --color-node-character: #3b82f6 (蓝色)
+ * - --color-node-location: #22c55e (绿色)
+ * - --color-node-event: #f97316 (橙色)
+ * - --color-node-item: #06b6d4 (青色)
+ * - --color-node-other: #8b5cf6 (紫色)
+ */
+
+/** Node types in the knowledge graph */
+export type NodeType = "character" | "location" | "event" | "item" | "other";
+
+/** Graph node representing an entity */
+export interface GraphNode {
+  /** Unique identifier */
+  id: string;
+  /** Display label */
+  label: string;
+  /** Node type determines shape and color */
+  type: NodeType;
+  /** Optional avatar/image URL (primarily for characters) */
+  avatar?: string;
+  /** Position on canvas */
+  position: { x: number; y: number };
+  /** Additional metadata */
+  metadata?: {
+    /** Character role (Protagonist, Antagonist, etc.) */
+    role?: string;
+    /** Additional attributes */
+    attributes?: Array<{ key: string; value: string }>;
+    /** Description text */
+    description?: string;
+  };
+}
+
+/** Edge connecting two nodes */
+export interface GraphEdge {
+  /** Unique identifier */
+  id: string;
+  /** Source node ID */
+  source: string;
+  /** Target node ID */
+  target: string;
+  /** Relationship label */
+  label: string;
+  /** Whether edge is selected/highlighted */
+  selected?: boolean;
+}
+
+/** Graph data structure */
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/** Node filter state */
+export type NodeFilter = NodeType | "all";
+
+/** Canvas transform state for pan/zoom */
+export interface CanvasTransform {
+  scale: number;
+  translateX: number;
+  translateY: number;
+}
+
+/** Props for the main KnowledgeGraph component */
+export interface KnowledgeGraphProps {
+  /** Graph data (nodes and edges) */
+  data: GraphData;
+  /** Currently selected node ID */
+  selectedNodeId?: string | null;
+  /** Callback when node is selected */
+  onNodeSelect?: (nodeId: string | null) => void;
+  /** Callback when node position changes (drag) */
+  onNodeMove?: (nodeId: string, position: { x: number; y: number }) => void;
+  /** Callback when "Add Node" is clicked */
+  onAddNode?: (type: NodeType) => void;
+  /** Callback when "Edit Node" is clicked in detail card */
+  onEditNode?: (nodeId: string) => void;
+  /** Callback when "View Details" is clicked in detail card */
+  onViewDetails?: (nodeId: string) => void;
+  /** Callback when a node is saved (created or edited) */
+  onNodeSave?: (node: GraphNode, isNew: boolean) => void;
+  /** Callback when a node is deleted */
+  onNodeDelete?: (nodeId: string) => void;
+  /** Enable built-in edit dialog (default: true) */
+  enableEditDialog?: boolean;
+  /** Optional className for styling */
+  className?: string;
+}
+
+/** Props for GraphNode component */
+export interface GraphNodeProps {
+  node: GraphNode;
+  selected?: boolean;
+  dragging?: boolean;
+  onClick?: () => void;
+  onDragStart?: (e: React.MouseEvent) => void;
+}
+
+/** Props for GraphEdge component */
+export interface GraphEdgeProps {
+  edge: GraphEdge;
+  sourcePosition: { x: number; y: number };
+  targetPosition: { x: number; y: number };
+  highlighted?: boolean;
+}
+
+/** Props for NodeDetailCard component */
+export interface NodeDetailCardProps {
+  node: GraphNode;
+  onEdit?: () => void;
+  onViewDetails?: () => void;
+  onDelete?: () => void;
+  onClose?: () => void;
+}
+
+/** Props for GraphToolbar component */
+export interface GraphToolbarProps {
+  activeFilter: NodeFilter;
+  onFilterChange: (filter: NodeFilter) => void;
+  zoom: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onAddNode: () => void;
+  onBack?: () => void;
+}
+
+/** Props for GraphLegend component */
+export interface GraphLegendProps {
+  className?: string;
+}
+
+/** Props for NodeEditDialog component */
+export interface NodeEditDialogProps {
+  /** Whether the dialog is open */
+  open: boolean;
+  /** Callback when open state changes */
+  onOpenChange: (open: boolean) => void;
+  /** Node being edited (null for creating new node) */
+  node: GraphNode | null;
+  /** Callback when node is saved */
+  onSave: (node: GraphNode) => void;
+  /** Mode: 'edit' or 'create' */
+  mode?: "edit" | "create";
+}
+
+/** Props for GraphCanvas component */
+export interface GraphCanvasProps {
+  data: GraphData;
+  selectedNodeId?: string | null;
+  filter: NodeFilter;
+  transform: CanvasTransform;
+  onNodeSelect: (nodeId: string | null) => void;
+  onNodeMove: (nodeId: string, position: { x: number; y: number }) => void;
+  onCanvasPan: (deltaX: number, deltaY: number) => void;
+}

--- a/apps/desktop/renderer/src/components/features/index.ts
+++ b/apps/desktop/renderer/src/components/features/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Features - Complex UI Components
+ *
+ * This module exports feature-level components that compose multiple
+ * primitives and patterns into complete UI features.
+ *
+ * Features are organized by domain:
+ * - KnowledgeGraph: Entity relationship visualization
+ *
+ * @example
+ * ```tsx
+ * import { KnowledgeGraph } from '@/components/features';
+ *
+ * <KnowledgeGraph data={graphData} onNodeSelect={handleSelect} />
+ * ```
+ */
+
+export {
+  KnowledgeGraph,
+  GraphNode,
+  GraphEdge,
+  EdgeMarkerDefs,
+  GraphCanvas,
+  GraphToolbar,
+  GraphLegend,
+  NodeDetailCard,
+} from "./KnowledgeGraph";
+
+export type {
+  NodeType,
+  GraphNodeData,
+  GraphEdgeData,
+  GraphData,
+  NodeFilter,
+  CanvasTransform,
+  KnowledgeGraphProps,
+  GraphNodeProps,
+  GraphEdgeProps,
+  NodeDetailCardProps,
+  GraphToolbarProps,
+  GraphLegendProps,
+  GraphCanvasProps,
+} from "./KnowledgeGraph";

--- a/apps/desktop/renderer/src/components/primitives/Button.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Button.tsx
@@ -186,7 +186,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {loading && <Spinner />}
-        <span className="truncate">{children}</span>
+        <span className="inline-flex items-center gap-2 truncate">{children}</span>
       </button>
     );
   },

--- a/apps/desktop/renderer/src/styles/tokens.css
+++ b/apps/desktop/renderer/src/styles/tokens.css
@@ -65,6 +65,13 @@
   --color-accent-cyan: #06b6d4;
   --color-accent-purple: #8b5cf6;
 
+  /* 知识图谱节点色 - 保持多色区分 */
+  --color-node-character: #3b82f6; /* 角色 - 蓝色 */
+  --color-node-location: #22c55e; /* 地点 - 绿色 */
+  --color-node-event: #f97316; /* 事件 - 橙色 */
+  --color-node-item: #06b6d4; /* 物品 - 青色 */
+  --color-node-other: #8b5cf6; /* 其他 - 紫色 */
+
   /* 阴影系统 §3.7 - 几何保持一致，颜色来自主题内 --color-shadow */
   --shadow-sm: 0 1px 2px var(--color-shadow);
   --shadow-md: 0 4px 8px var(--color-shadow);

--- a/openspec/_ops/task_runs/ISSUE-136.md
+++ b/openspec/_ops/task_runs/ISSUE-136.md
@@ -31,3 +31,15 @@
   - 修复 Button 原语的 icon+text 对齐问题
   - 使用 key 属性强制 NodeEditDialog 重新挂载，避免 useEffect 中 setState 的 lint 错误
   - 重构测试以适配 Avatar/Select 原语的 DOM 结构
+
+### 2026-02-03 修复节点颜色不显示问题
+
+- Command: `检查 Storybook 截图`
+- Key output: `节点边框和图例显示为灰色/无色`
+- Evidence: 用户截图
+
+- Root cause: `--color-node-*` 变量定义在 `design/system/01-tokens.css`，但 Storybook 导入的是 `apps/desktop/renderer/src/styles/tokens.css`，后者缺少这些变量
+
+- Fix: 将 `--color-node-character/location/event/item/other` 变量添加到 `apps/desktop/renderer/src/styles/tokens.css`
+
+- Verified: Storybook 刷新后节点多色正确显示

--- a/openspec/_ops/task_runs/ISSUE-136.md
+++ b/openspec/_ops/task_runs/ISSUE-136.md
@@ -1,0 +1,33 @@
+# ISSUE-136
+
+- Issue: #136
+- Branch: task/136-knowledge-graph-polish
+- PR: https://github.com/Leeky1017/CreoNow/pull/137
+
+## Plan
+
+- 完整实现 KnowledgeGraph 组件：节点渲染、边渲染、交互功能
+- 使用 Design Token 专用色 (--color-node-*)
+- 复用原语组件 (Button/Badge/Avatar/Select/Textarea/Dialog)
+- 实现节点编辑/创建对话框 (NodeEditDialog)
+- 实现节点删除功能
+- 实现键盘快捷键 (Escape/Delete)
+- 补充单元测试和 Storybook stories
+
+## Runs
+
+### 2026-02-03 完整实现 KnowledgeGraph 组件
+
+- Command: `pnpm -C apps/desktop test -- --run KnowledgeGraph`
+- Key output: `48 tests passed`
+- Evidence: `apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.test.tsx`
+
+- Command: `pnpm -C apps/desktop lint`
+- Key output: `0 errors, 1 warning (pre-existing)`
+- Evidence: `apps/desktop/renderer/src/components/features/KnowledgeGraph/`
+
+- Notes:
+  - 新增 12 个文件：GraphNode/GraphEdge/GraphCanvas/GraphToolbar/GraphLegend/NodeDetailCard/NodeEditDialog/KnowledgeGraph 及 types/index/stories/test
+  - 修复 Button 原语的 icon+text 对齐问题
+  - 使用 key 属性强制 NodeEditDialog 重新挂载，避免 useEffect 中 setState 的 lint 错误
+  - 重构测试以适配 Avatar/Select 原语的 DOM 结构

--- a/rulebook/tasks/issue-136-knowledge-graph-polish/.metadata.json
+++ b/rulebook/tasks/issue-136-knowledge-graph-polish/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-03T10:58:42.392Z",
+  "updatedAt": "2026-02-03T10:58:42.392Z"
+}

--- a/rulebook/tasks/issue-136-knowledge-graph-polish/proposal.md
+++ b/rulebook/tasks/issue-136-knowledge-graph-polish/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: issue-136-knowledge-graph-polish
+
+## Why
+[Explain why this change is needed - minimum 20 characters]
+
+## What Changes
+[Describe what will change]
+
+## Impact
+- Affected specs: [list]
+- Affected code: [list]
+- Breaking change: YES/NO
+- User benefit: [describe]

--- a/rulebook/tasks/issue-136-knowledge-graph-polish/tasks.md
+++ b/rulebook/tasks/issue-136-knowledge-graph-polish/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+- [ ] 1.1 First task
+- [ ] 1.2 Second task
+
+## 2. Testing
+- [ ] 2.1 Write tests
+- [ ] 2.2 Verify coverage
+
+## 3. Documentation
+- [ ] 3.1 Update README
+- [ ] 3.2 Update CHANGELOG


### PR DESCRIPTION
## Summary

完整实现知识图谱组件，支持节点可视化、交互操作和编辑功能：

- **节点渲染**：5 种类型 (角色/地点/事件/物品/其他)，使用 Design Token 专用色
- **边渲染**：实线/虚线/粗线样式，带箭头和标签
- **交互功能**：节点拖拽、画布缩放平移、类型筛选、详情卡片
- **编辑功能**：NodeEditDialog 支持创建/编辑节点
- **删除功能**：NodeDetailCard 支持删除按钮
- **键盘快捷键**：Escape 取消选择，Delete/Backspace 删除节点
- **代码质量**：48 个单元测试全部通过，完整 Storybook stories

## Test Plan

- [x] 单元测试：`pnpm -C apps/desktop test -- --run KnowledgeGraph` (48 tests passed)
- [x] Lint：`pnpm -C apps/desktop lint` (0 errors)
- [ ] Storybook 视觉验证：各 story 正常渲染
- [ ] 手动测试：节点拖拽、缩放、筛选、编辑、删除功能

Closes #136