### PR TITLE
Phase 7.0: 面板布局重构（IconBar/LeftPanel/RightPanel）(#153)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
@@ -149,11 +149,9 @@ describe("AppShell", () => {
     it("应该渲染 IconBar", () => {
       renderWithWrapper();
 
-      // IconBar 通过 toggle sidebar 按钮识别
-      const toggleButton = screen.getByRole("button", {
-        name: /toggle sidebar/i,
-      });
-      expect(toggleButton).toBeInTheDocument();
+      // IconBar 通过 testid 识别
+      const iconBar = screen.getByTestId("icon-bar");
+      expect(iconBar).toBeInTheDocument();
     });
 
     it("应该渲染 Sidebar", () => {
@@ -286,17 +284,17 @@ describe("AppShell", () => {
   // 侧边栏交互测试
   // ===========================================================================
   describe("侧边栏交互", () => {
-    it("点击 IconBar 按钮应该切换侧边栏", () => {
+    it("点击 IconBar Files 按钮应该切换侧边栏", () => {
       renderWithWrapper();
 
-      const toggleButton = screen.getByRole("button", {
-        name: /toggle sidebar/i,
-      });
+      const filesButton = screen.getByTestId("icon-bar-files");
       const sidebar = screen.getByTestId("layout-sidebar");
 
+      // 初始状态：sidebar 展开（files 是默认 activeLeftPanel）
       expect(sidebar).not.toHaveClass("hidden");
 
-      fireEvent.click(toggleButton);
+      // 点击同一按钮会切换折叠
+      fireEvent.click(filesButton);
 
       expect(sidebar).toHaveClass("hidden");
     });

--- a/apps/desktop/renderer/src/components/layout/IconBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/IconBar.tsx
@@ -1,8 +1,15 @@
-import { useLayoutStore, LAYOUT_DEFAULTS } from "../../stores/layoutStore";
+import {
+  useLayoutStore,
+  LAYOUT_DEFAULTS,
+  type LeftPanelType,
+} from "../../stores/layoutStore";
 
 const iconButtonBase = [
   "w-10",
   "h-10",
+  "flex",
+  "items-center",
+  "justify-center",
   "rounded-[var(--radius-sm)]",
   "bg-transparent",
   "text-[var(--color-fg-muted)]",
@@ -18,13 +25,40 @@ const iconButtonBase = [
   "focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 
-const iconButtonInactive = "border-[var(--color-border-default)]";
+const iconButtonInactive = "border-transparent";
 const iconButtonActive =
-  "border-[var(--color-border-focus)] bg-[var(--color-bg-selected)]";
+  "border-[var(--color-border-focus)] bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]";
 
 /**
- * IconBar is the fixed 48px navigation rail. For P0 it provides a minimal
- * toggle for the sidebar and stable sizing for layout E2E.
+ * Icon configuration for each left panel view.
+ *
+ * Each icon maps to a LeftPanelType and provides:
+ * - icon: Display character/emoji (will be replaced with proper icons later)
+ * - label: Accessible label for screen readers
+ * - testId: Test ID for E2E automation
+ */
+const LEFT_PANEL_ICONS: Array<{
+  panel: LeftPanelType;
+  icon: string;
+  label: string;
+  testId: string;
+}> = [
+  { panel: "files", icon: "📁", label: "Files", testId: "icon-bar-files" },
+  { panel: "search", icon: "🔍", label: "Search", testId: "icon-bar-search" },
+  { panel: "outline", icon: "📑", label: "Outline", testId: "icon-bar-outline" },
+  { panel: "versionHistory", icon: "📜", label: "Version History", testId: "icon-bar-version-history" },
+  { panel: "memory", icon: "🧠", label: "Memory", testId: "icon-bar-memory" },
+  { panel: "characters", icon: "👤", label: "Characters", testId: "icon-bar-characters" },
+  { panel: "knowledgeGraph", icon: "🕸️", label: "Knowledge Graph", testId: "icon-bar-knowledge-graph" },
+  { panel: "settings", icon: "⚙️", label: "Settings", testId: "icon-bar-settings" },
+];
+
+/**
+ * IconBar is the fixed 48px navigation rail (Windsurf-style).
+ *
+ * Behavior:
+ * - Click an icon: switch to that view and expand sidebar if collapsed
+ * - Click the same icon again: toggle sidebar collapse
  *
  * Design spec §5.2: Icon Bar width is 48px, icons are 24px, click area is 40x40px.
  */
@@ -34,20 +68,15 @@ export function IconBar(): JSX.Element {
   const activeLeftPanel = useLayoutStore((s) => s.activeLeftPanel);
   const setActiveLeftPanel = useLayoutStore((s) => s.setActiveLeftPanel);
 
-  const handleSidebarToggle = () => {
-    if (activeLeftPanel !== "sidebar") {
-      setActiveLeftPanel("sidebar");
-      if (sidebarCollapsed) {
-        setSidebarCollapsed(false);
-      }
-    } else {
-      setSidebarCollapsed(!sidebarCollapsed);
-    }
-  };
-
-  const handleMemoryClick = () => {
-    if (activeLeftPanel !== "memory") {
-      setActiveLeftPanel("memory");
+  /**
+   * Handle icon click with Windsurf-style toggle behavior.
+   *
+   * - If clicking a different panel: switch to it and expand
+   * - If clicking the current panel: toggle collapse
+   */
+  const handleIconClick = (panel: LeftPanelType) => {
+    if (activeLeftPanel !== panel) {
+      setActiveLeftPanel(panel);
       if (sidebarCollapsed) {
         setSidebarCollapsed(false);
       }
@@ -58,29 +87,27 @@ export function IconBar(): JSX.Element {
 
   return (
     <div
-      className="flex flex-col items-center pt-2 gap-2 bg-[var(--color-bg-surface)] border-r border-[var(--color-separator)]"
+      className="flex flex-col items-center pt-2 gap-1 bg-[var(--color-bg-surface)] border-r border-[var(--color-separator)]"
       style={{ width: LAYOUT_DEFAULTS.iconBarWidth }}
+      data-testid="icon-bar"
     >
-      {/* Sidebar toggle button */}
-      <button
-        type="button"
-        onClick={handleSidebarToggle}
-        className={`${iconButtonBase} ${activeLeftPanel === "sidebar" && !sidebarCollapsed ? iconButtonActive : iconButtonInactive}`}
-        aria-label="Toggle sidebar"
-      >
-        ≡
-      </button>
-
-      {/* Memory panel button */}
-      <button
-        type="button"
-        onClick={handleMemoryClick}
-        className={`${iconButtonBase} ${activeLeftPanel === "memory" && !sidebarCollapsed ? iconButtonActive : iconButtonInactive}`}
-        aria-label="Memory"
-        data-testid="icon-bar-memory"
-      >
-        🧠
-      </button>
+      {LEFT_PANEL_ICONS.map(({ panel, icon, label, testId }) => {
+        const isActive = activeLeftPanel === panel && !sidebarCollapsed;
+        return (
+          <button
+            key={panel}
+            type="button"
+            onClick={() => handleIconClick(panel)}
+            className={`${iconButtonBase} ${isActive ? iconButtonActive : iconButtonInactive}`}
+            aria-label={label}
+            aria-pressed={isActive}
+            data-testid={testId}
+            title={label}
+          >
+            <span className="text-lg">{icon}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/Layout.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/Layout.test.tsx
@@ -251,10 +251,8 @@ describe("Layout 综合测试", () => {
     it("应该包含所有必要的布局组件", () => {
       renderWithWrapper();
 
-      // IconBar（通过按钮识别）
-      expect(
-        screen.getByRole("button", { name: /toggle sidebar/i }),
-      ).toBeInTheDocument();
+      // IconBar（通过 testid 识别）
+      expect(screen.getByTestId("icon-bar")).toBeInTheDocument();
 
       // Sidebar
       expect(screen.getByTestId("layout-sidebar")).toBeInTheDocument();

--- a/apps/desktop/renderer/src/components/layout/RightPanel.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { RightPanel } from "./RightPanel";
 import { LayoutTestWrapper } from "./test-utils";
 import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
@@ -40,6 +40,14 @@ describe("RightPanel", () => {
         width: `${LAYOUT_DEFAULTS.panel.default}px`,
       });
     });
+
+    it("应该渲染所有 3 个 tab 按钮", () => {
+      renderWithWrapper();
+
+      expect(screen.getByTestId("right-panel-tab-ai")).toBeInTheDocument();
+      expect(screen.getByTestId("right-panel-tab-info")).toBeInTheDocument();
+      expect(screen.getByTestId("right-panel-tab-quality")).toBeInTheDocument();
+    });
   });
 
   // ===========================================================================
@@ -58,6 +66,48 @@ describe("RightPanel", () => {
 
       const panel = screen.getByTestId("layout-panel");
       expect(panel).toHaveClass("w-0");
+    });
+  });
+
+  // ===========================================================================
+  // Tab 切换测试
+  // ===========================================================================
+  describe("Tab 切换", () => {
+    it("默认应该显示 AI tab 激活", () => {
+      renderWithWrapper();
+
+      const aiTab = screen.getByTestId("right-panel-tab-ai");
+      expect(aiTab).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("点击 Info tab 应该切换激活状态", () => {
+      renderWithWrapper();
+
+      const aiTab = screen.getByTestId("right-panel-tab-ai");
+      const infoTab = screen.getByTestId("right-panel-tab-info");
+
+      // 初始状态
+      expect(aiTab).toHaveAttribute("aria-pressed", "true");
+      expect(infoTab).toHaveAttribute("aria-pressed", "false");
+
+      // 点击 Info
+      fireEvent.click(infoTab);
+
+      // Info 激活
+      expect(infoTab).toHaveAttribute("aria-pressed", "true");
+      expect(aiTab).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("点击 Quality tab 应该切换激活状态", () => {
+      renderWithWrapper();
+
+      const qualityTab = screen.getByTestId("right-panel-tab-quality");
+
+      // 点击 Quality
+      fireEvent.click(qualityTab);
+
+      // Quality 激活
+      expect(qualityTab).toHaveAttribute("aria-pressed", "true");
     });
   });
 
@@ -120,6 +170,34 @@ describe("RightPanel", () => {
 
       const panel = screen.getByTestId("layout-panel");
       expect(panel.tagName).toBe("ASIDE");
+    });
+
+    it("Tab 按钮应该有 aria-pressed 状态", () => {
+      renderWithWrapper();
+
+      const tabs = [
+        screen.getByTestId("right-panel-tab-ai"),
+        screen.getByTestId("right-panel-tab-info"),
+        screen.getByTestId("right-panel-tab-quality"),
+      ];
+
+      tabs.forEach((tab) => {
+        expect(tab).toHaveAttribute("aria-pressed");
+      });
+    });
+
+    it("Tab 按钮应该有 type='button'", () => {
+      renderWithWrapper();
+
+      const tabs = [
+        screen.getByTestId("right-panel-tab-ai"),
+        screen.getByTestId("right-panel-tab-info"),
+        screen.getByTestId("right-panel-tab-quality"),
+      ];
+
+      tabs.forEach((tab) => {
+        expect(tab).toHaveAttribute("type", "button");
+      });
     });
   });
 });

--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -1,20 +1,110 @@
-import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
+import {
+  LAYOUT_DEFAULTS,
+  useLayoutStore,
+  type RightPanelType,
+} from "../../stores/layoutStore";
 import { AiPanel } from "../../features/ai/AiPanel";
-import { SettingsPanel } from "../../features/settings/SettingsPanel";
+import { QualityGatesPanel } from "../../features/quality-gates/QualityGatesPanel";
 
 /**
- * RightPanel is the right-side panel container (AI/Info). P0 wires visibility
- * and resizing; feature content comes in later task cards.
+ * Tab button styles for right panel.
+ */
+const tabButtonBase = [
+  "text-xs",
+  "px-3",
+  "py-1.5",
+  "rounded-[var(--radius-md)]",
+  "border",
+  "cursor-pointer",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+const tabButtonActive =
+  "border-[var(--color-border-focus)] bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]";
+const tabButtonInactive =
+  "border-transparent bg-transparent text-[var(--color-fg-muted)]";
+
+/**
+ * Right panel tab configuration.
+ */
+const RIGHT_PANEL_TABS: Array<{
+  type: RightPanelType;
+  label: string;
+  testId: string;
+}> = [
+  { type: "ai", label: "AI", testId: "right-panel-tab-ai" },
+  { type: "info", label: "Info", testId: "right-panel-tab-info" },
+  { type: "quality", label: "Quality", testId: "right-panel-tab-quality" },
+];
+
+/**
+ * InfoPanel placeholder content.
+ *
+ * TODO: Replace with full implementation showing document info,
+ * writing statistics, and context summaries.
+ */
+function InfoPanelContent(): JSX.Element {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center p-4">
+      <div className="text-[var(--color-fg-muted)] text-sm">
+        Document Info
+      </div>
+      <div className="text-[var(--color-fg-subtle)] text-xs mt-2">
+        Statistics and context will appear here
+      </div>
+    </div>
+  );
+}
+
+/**
+ * RightPanel is the right-side panel container with 3 tabs:
+ * AI Assistant, Info, and Quality Gates.
  *
  * Design spec §5.3: Right panel default width 320px, min 240px, max 600px.
+ *
+ * Behavior:
+ * - Tab switching is controlled by layoutStore.activeRightPanel
+ * - Clicking a tab auto-expands the panel if collapsed
  */
 export function RightPanel(props: {
   width: number;
   collapsed: boolean;
 }): JSX.Element {
+  const activeRightPanel = useLayoutStore((s) => s.activeRightPanel);
+  const setActiveRightPanel = useLayoutStore((s) => s.setActiveRightPanel);
+
   if (props.collapsed) {
     return <aside data-testid="layout-panel" className="hidden w-0" />;
   }
+
+  /**
+   * Render the content for the active tab.
+   */
+  const renderContent = () => {
+    switch (activeRightPanel) {
+      case "ai":
+        return <AiPanel />;
+      case "info":
+        return <InfoPanelContent />;
+      case "quality":
+        return (
+          <QualityGatesPanel
+            checkGroups={[]}
+            panelStatus="all-passed"
+          />
+        );
+      default: {
+        const _exhaustive: never = activeRightPanel;
+        return _exhaustive;
+      }
+    }
+  };
 
   return (
     <aside
@@ -26,9 +116,29 @@ export function RightPanel(props: {
         maxWidth: LAYOUT_DEFAULTS.panel.max,
       }}
     >
-      <SettingsPanel />
-      <div className="h-px bg-[var(--color-separator)]" />
-      <AiPanel />
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 px-2 py-2 border-b border-[var(--color-separator)]">
+        {RIGHT_PANEL_TABS.map(({ type, label, testId }) => {
+          const isActive = activeRightPanel === type;
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => setActiveRightPanel(type)}
+              className={`${tabButtonBase} ${isActive ? tabButtonActive : tabButtonInactive}`}
+              aria-pressed={isActive}
+              data-testid={testId}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        {renderContent()}
+      </div>
     </aside>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/Sidebar.stories.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.stories.tsx
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Sidebar } from "./Sidebar";
 import { layoutDecorator } from "./test-utils";
-import { LAYOUT_DEFAULTS } from "../../stores/layoutStore";
+import { LAYOUT_DEFAULTS, type LeftPanelType } from "../../stores/layoutStore";
 
 /**
- * Sidebar 组件 Story
+ * Sidebar (LeftPanel) 组件 Story
  *
  * 设计规范: Sidebar 默认宽度 240px，最小 180px，最大 400px。
  *
  * 功能：
  * - 可调整宽度的左侧面板
- * - 包含 Files/Outline/Search/KG 标签页
+ * - 根据 activePanel 显示不同的面板内容
  * - 支持折叠/展开
  */
 const meta = {
@@ -36,8 +36,17 @@ const meta = {
     },
     activePanel: {
       control: "select",
-      options: ["sidebar", "memory"],
-      description: "Active left panel mode",
+      options: [
+        "files",
+        "search",
+        "outline",
+        "versionHistory",
+        "memory",
+        "characters",
+        "knowledgeGraph",
+        "settings",
+      ] as LeftPanelType[],
+      description: "Active left panel view",
     },
   },
 } satisfies Meta<typeof Sidebar>;
@@ -45,8 +54,32 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const RenderWrapper = (args: {
+  width: number;
+  collapsed: boolean;
+  projectId: string | null;
+  activePanel: LeftPanelType;
+}) => (
+  <div style={{ display: "flex", height: "500px" }}>
+    <Sidebar {...args} />
+    <div
+      style={{
+        flex: 1,
+        backgroundColor: "var(--color-bg-base)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "var(--color-fg-muted)",
+        fontSize: "14px",
+      }}
+    >
+      Main Content Area
+    </div>
+  </div>
+);
+
 /**
- * 默认状态
+ * 默认状态 - Files 面板
  *
  * 默认宽度 240px 的展开状态
  */
@@ -55,26 +88,9 @@ export const Default: Story = {
     width: LAYOUT_DEFAULTS.sidebar.default,
     collapsed: false,
     projectId: null,
-    activePanel: "sidebar",
+    activePanel: "files",
   },
-  render: (args) => (
-    <div style={{ display: "flex", height: "400px" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-        }}
-      >
-        Main Content Area
-      </div>
-    </div>
-  ),
+  render: RenderWrapper,
 };
 
 /**
@@ -87,58 +103,100 @@ export const Collapsed: Story = {
     width: 0,
     collapsed: true,
     projectId: null,
-    activePanel: "sidebar",
+    activePanel: "files",
   },
-  render: (args) => (
-    <div style={{ display: "flex", height: "400px" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-        }}
-      >
-        Sidebar is collapsed
-      </div>
-    </div>
-  ),
+  render: RenderWrapper,
 };
 
 /**
- * 最小宽度
- *
- * 180px 最小宽度状态
+ * Search 面板
  */
-export const MinWidth: Story = {
+export const SearchPanel: Story = {
   args: {
-    width: LAYOUT_DEFAULTS.sidebar.min,
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: "test-project",
+    activePanel: "search",
+  },
+  render: RenderWrapper,
+};
+
+/**
+ * Outline 面板
+ */
+export const OutlinePanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: "test-project",
+    activePanel: "outline",
+  },
+  render: RenderWrapper,
+};
+
+/**
+ * Version History 面板
+ */
+export const VersionHistoryPanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: "test-project",
+    activePanel: "versionHistory",
+  },
+  render: RenderWrapper,
+};
+
+/**
+ * Memory 面板
+ */
+export const MemoryPanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
     collapsed: false,
     projectId: null,
-    activePanel: "sidebar",
+    activePanel: "memory",
   },
-  render: (args) => (
-    <div style={{ display: "flex", height: "400px" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-        }}
-      >
-        Sidebar at minimum width (180px)
-      </div>
-    </div>
-  ),
+  render: RenderWrapper,
+};
+
+/**
+ * Characters 面板
+ */
+export const CharactersPanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: "test-project",
+    activePanel: "characters",
+  },
+  render: RenderWrapper,
+};
+
+/**
+ * Knowledge Graph 面板
+ */
+export const KnowledgeGraphPanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: "test-project",
+    activePanel: "knowledgeGraph",
+  },
+  render: RenderWrapper,
+};
+
+/**
+ * Settings 面板
+ */
+export const SettingsPanel: Story = {
+  args: {
+    width: LAYOUT_DEFAULTS.sidebar.default,
+    collapsed: false,
+    projectId: null,
+    activePanel: "settings",
+  },
+  render: RenderWrapper,
 };
 
 /**
@@ -150,27 +208,10 @@ export const MaxWidth: Story = {
   args: {
     width: LAYOUT_DEFAULTS.sidebar.max,
     collapsed: false,
-    projectId: null,
-    activePanel: "sidebar",
+    projectId: "test-project",
+    activePanel: "files",
   },
-  render: (args) => (
-    <div style={{ display: "flex", height: "400px" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-        }}
-      >
-        Sidebar at maximum width (400px)
-      </div>
-    </div>
-  ),
+  render: RenderWrapper,
 };
 
 /**
@@ -183,85 +224,7 @@ export const WithProject: Story = {
     width: LAYOUT_DEFAULTS.sidebar.default,
     collapsed: false,
     projectId: "test-project-id",
-    activePanel: "sidebar",
+    activePanel: "files",
   },
-  render: (args) => (
-    <div style={{ display: "flex", height: "400px" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-        }}
-      >
-        Sidebar with project content
-      </div>
-    </div>
-  ),
-};
-
-/**
- * 所有 Tab 切换演示
- *
- * 点击 Files / Outline / Search / KG 切换不同面板
- * - Files: 文件树
- * - Outline: 文档大纲（新增）
- * - Search: 搜索面板
- * - KG: 知识图谱
- */
-export const AllTabs: Story = {
-  args: {
-    width: 280,
-    collapsed: false,
-    projectId: "demo-project",
-    activePanel: "sidebar",
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: `Sidebar 包含 4 个 Tab: Files / **Outline** / Search / KG。
-        
-点击 **Outline** Tab 查看文档大纲面板，功能包括：
-- 搜索/过滤
-- 单节点展开/折叠
-- 字数统计
-- 拖拽排序
-- 多选批量操作
-- 键盘导航`,
-      },
-    },
-  },
-  render: (args) => (
-    <div style={{ display: "flex", height: "600px", width: "100%" }}>
-      <Sidebar {...args} />
-      <div
-        style={{
-          flex: 1,
-          backgroundColor: "var(--color-bg-base)",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--color-fg-muted)",
-          fontSize: "14px",
-          padding: "24px",
-        }}
-      >
-        <div style={{ fontSize: "24px", fontWeight: "bold", marginBottom: "16px", color: "var(--color-fg-default)" }}>
-          Main Editor Area
-        </div>
-        <div style={{ textAlign: "center", maxWidth: "400px", lineHeight: "1.6" }}>
-          <p>← 点击左侧 Tab 切换面板</p>
-          <p style={{ marginTop: "8px", fontSize: "12px", color: "var(--color-fg-subtle)" }}>
-            Files | <strong>Outline</strong> | Search | KG
-          </p>
-        </div>
-      </div>
-    </div>
-  ),
+  render: RenderWrapper,
 };

--- a/apps/desktop/renderer/src/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Sidebar } from "./Sidebar";
 import { LayoutTestWrapper } from "./test-utils";
 import { LAYOUT_DEFAULTS, type LeftPanelType } from "../../stores/layoutStore";
@@ -14,7 +14,7 @@ describe("Sidebar", () => {
     width: LAYOUT_DEFAULTS.sidebar.default,
     collapsed: false,
     projectId: null,
-    activePanel: "sidebar",
+    activePanel: "files",
   };
 
   const renderWithWrapper = (props: typeof defaultProps = defaultProps) => {
@@ -45,16 +45,11 @@ describe("Sidebar", () => {
       });
     });
 
-    it("应该渲染标签页按钮", () => {
+    it("应该渲染当前面板的标题", () => {
       renderWithWrapper();
 
-      expect(
-        screen.getByRole("button", { name: /files/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /search/i }),
-      ).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /kg/i })).toBeInTheDocument();
+      // Files 面板标题应该是 "Explorer"
+      expect(screen.getByText("Explorer")).toBeInTheDocument();
     });
   });
 
@@ -107,41 +102,60 @@ describe("Sidebar", () => {
   });
 
   // ===========================================================================
-  // 标签页交互测试
+  // 面板切换测试
   // ===========================================================================
-  describe("标签页交互", () => {
-    it("点击 Files 标签应该激活", () => {
-      renderWithWrapper();
+  describe("面板切换", () => {
+    it("activePanel=files 应该显示 Explorer 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "files" });
 
-      const filesTab = screen.getByRole("button", { name: /files/i });
-      fireEvent.click(filesTab);
-
-      // Files 标签应该有激活样式
-      expect(filesTab.className).toContain(
-        "border-[var(--color-border-focus)]",
-      );
+      expect(screen.getByText("Explorer")).toBeInTheDocument();
     });
 
-    it("点击 Search 标签应该激活", () => {
-      renderWithWrapper();
+    it("activePanel=search 应该显示 Search 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "search" });
 
-      const searchTab = screen.getByRole("button", { name: /search/i });
-      fireEvent.click(searchTab);
-
-      // Search 标签应该有激活样式
-      expect(searchTab.className).toContain(
-        "border-[var(--color-border-focus)]",
-      );
+      expect(screen.getByText("Search")).toBeInTheDocument();
     });
 
-    it("点击 KG 标签应该激活", () => {
-      renderWithWrapper();
+    it("activePanel=outline 应该显示 Outline 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "outline" });
 
-      const kgTab = screen.getByRole("button", { name: /kg/i });
-      fireEvent.click(kgTab);
+      expect(screen.getByText("Outline")).toBeInTheDocument();
+    });
 
-      // KG 标签应该有激活样式
-      expect(kgTab.className).toContain("border-[var(--color-border-focus)]");
+    it("activePanel=memory 应该显示 Memory 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "memory" });
+
+      // MemoryPanel 内部也有 "Memory" 文本，使用更宽松的断言
+      const headers = screen.getAllByText("Memory");
+      expect(headers.length).toBeGreaterThan(0);
+    });
+
+    it("activePanel=settings 应该显示 Settings 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "settings" });
+
+      // 使用更具体的选择器：标题在 header 中
+      const headers = screen.getAllByText("Settings");
+      // 第一个应该是 header 中的
+      expect(headers.length).toBeGreaterThan(0);
+    });
+
+    it("activePanel=versionHistory 应该显示 Version History 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "versionHistory" });
+
+      expect(screen.getByText("Version History")).toBeInTheDocument();
+    });
+
+    it("activePanel=characters 应该显示 Characters 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "characters" });
+
+      expect(screen.getByText("Characters")).toBeInTheDocument();
+    });
+
+    it("activePanel=knowledgeGraph 应该显示 Knowledge Graph 标题", () => {
+      renderWithWrapper({ ...defaultProps, activePanel: "knowledgeGraph" });
+
+      expect(screen.getByText("Knowledge Graph")).toBeInTheDocument();
     });
   });
 
@@ -198,15 +212,6 @@ describe("Sidebar", () => {
 
       const sidebar = screen.getByTestId("layout-sidebar");
       expect(sidebar.tagName).toBe("ASIDE");
-    });
-
-    it("标签页按钮应该有 type='button'", () => {
-      renderWithWrapper();
-
-      const buttons = screen.getAllByRole("button");
-      buttons.forEach((button) => {
-        expect(button).toHaveAttribute("type", "button");
-      });
     });
   });
 });

--- a/apps/desktop/renderer/src/stores/layoutStore.tsx
+++ b/apps/desktop/renderer/src/stores/layoutStore.tsx
@@ -13,7 +13,27 @@ export const LAYOUT_DEFAULTS = {
   mainMinWidth: 400,
 } as const;
 
-export type LeftPanelType = "sidebar" | "memory";
+/**
+ * Left panel view types.
+ *
+ * Each type corresponds to an icon in IconBar and a view in LeftPanel.
+ */
+export type LeftPanelType =
+  | "files"
+  | "search"
+  | "outline"
+  | "versionHistory"
+  | "memory"
+  | "characters"
+  | "knowledgeGraph"
+  | "settings";
+
+/**
+ * Right panel tab types.
+ *
+ * Only AI Assistant, Info, and Quality Gates are shown in the right panel.
+ */
+export type RightPanelType = "ai" | "info" | "quality";
 
 export type LayoutState = {
   sidebarWidth: number;
@@ -22,6 +42,7 @@ export type LayoutState = {
   panelCollapsed: boolean;
   zenMode: boolean;
   activeLeftPanel: LeftPanelType;
+  activeRightPanel: RightPanelType;
 };
 
 export type LayoutActions = {
@@ -33,6 +54,12 @@ export type LayoutActions = {
   resetSidebarWidth: () => void;
   resetPanelWidth: () => void;
   setActiveLeftPanel: (panel: LeftPanelType) => void;
+  /**
+   * Set the active right panel tab.
+   *
+   * If the panel is collapsed, it will be automatically expanded.
+   */
+  setActiveRightPanel: (panel: RightPanelType) => void;
 };
 
 export type LayoutStore = LayoutState & LayoutActions;
@@ -79,7 +106,8 @@ export function createLayoutStore(preferences: PreferenceStore) {
     sidebarCollapsed: initialSidebarCollapsed,
     panelCollapsed: initialPanelCollapsed,
     zenMode: false,
-    activeLeftPanel: "sidebar",
+    activeLeftPanel: "files",
+    activeRightPanel: "ai",
 
     setSidebarWidth: (width) => {
       set({ sidebarWidth: width });
@@ -134,6 +162,15 @@ export function createLayoutStore(preferences: PreferenceStore) {
     },
     setActiveLeftPanel: (panel) => {
       set({ activeLeftPanel: panel });
+    },
+    setActiveRightPanel: (panel) => {
+      const current = get();
+      // Auto-expand if collapsed when switching tabs
+      if (current.panelCollapsed) {
+        set({ activeRightPanel: panel, panelCollapsed: false });
+      } else {
+        set({ activeRightPanel: panel });
+      }
     },
   }));
 }

--- a/openspec/_ops/task_runs/ISSUE-153.md
+++ b/openspec/_ops/task_runs/ISSUE-153.md
@@ -1,0 +1,53 @@
+# ISSUE-153
+
+- Issue: #153
+- Branch: task/153-panel-layout-v2
+- PR: <fill-after-created>
+
+## Plan
+
+- 扩展 layoutStore（LeftPanelType 8 views + RightPanelType 3 tabs + activeRightPanel）
+- 重做 IconBar 多入口 + 重构 Sidebar→LeftPanel
+- 右侧 RightPanel 3-tab（AI/Info/Quality）+ Settings 迁移左侧
+- 面板组件解耦 + 测试/Storybook 更新
+
+## Runs
+
+### 2026-02-04 开始
+
+- Worktree: `.worktrees/issue-153-panel-layout-v2`
+- 开始扩展 layoutStore
+
+### 2026-02-04 Phase 7.0 核心任务完成
+
+已完成：
+1. **layoutStore 扩展**
+   - LeftPanelType: 8 种 view (files/search/outline/versionHistory/memory/characters/knowledgeGraph/settings)
+   - RightPanelType: 3 种 tab (ai/info/quality)
+   - 新增 activeRightPanel + setActiveRightPanel
+
+2. **IconBar 重做** (Windsurf 风格)
+   - 8 个导航按钮对应 8 个左侧 view
+   - 点击逻辑：不同 view 切换并展开，相同 view 切换折叠
+   - 完善的 aria-label/aria-pressed/testid
+
+3. **Sidebar 重构**
+   - 删除内部 tabs，改为按 activeLeftPanel 渲染对应面板
+   - 添加 header 显示当前 view 标题
+   - 支持所有 8 个面板：Files/Search/Outline/VersionHistory/Memory/Characters/KnowledgeGraph/Settings
+
+4. **RightPanel 3-tab**
+   - 移除 SettingsPanel（迁移到左侧）
+   - 添加 AI/Info/Quality 三个 tab
+   - Tab 切换由 layoutStore 控制
+
+5. **测试更新**
+   - IconBar.test.tsx: 14 个测试全通过
+   - Sidebar.test.tsx: 21 个测试全通过
+   - RightPanel.test.tsx: 16 个测试全通过
+   - Layout.test.tsx/AppShell.test.tsx: 更新选择器
+
+6. **验证**
+   - TypeScript 编译通过
+   - 布局测试 104 个全通过
+   - Storybook build 成功

--- a/openspec/_ops/task_runs/ISSUE-153.md
+++ b/openspec/_ops/task_runs/ISSUE-153.md
@@ -2,7 +2,7 @@
 
 - Issue: #153
 - Branch: task/153-panel-layout-v2
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/154
 
 ## Plan
 


### PR DESCRIPTION
Closes #153

## Summary

- 扩展 `layoutStore`：LeftPanelType 8 种 view + RightPanelType 3 种 tab + activeRightPanel 状态
- 重做 `IconBar`（Windsurf 风格多入口导航，8 个图标按钮）
- 重构 `Sidebar` 为按 activeLeftPanel 渲染的纯容器
- 重构 `RightPanel` 为 AI/Info/Quality 3-tab 结构
- Settings 从右侧迁移到左侧
- 更新所有相关测试和 Storybook

## Test Plan

- [x] TypeScript 编译通过
- [x] 布局测试 104 个全通过
- [x] Storybook build 成功
- [x] RUN_LOG 已更新