### PR TITLE
修复 E2E 测试以适配 Phase 7.0 面板布局 (#155)

### DIFF
--- a/apps/desktop/tests/e2e/analytics.spec.ts
+++ b/apps/desktop/tests/e2e/analytics.spec.ts
@@ -137,6 +137,8 @@ test("analytics: wordsWritten + skillsUsed increment and are visible", async () 
     before.data.summary.skillsUsed,
   );
 
+  // Navigate to Settings panel (now in left sidebar) to access analytics button
+  await page.getByTestId("icon-bar-settings").click();
   await page.getByTestId("open-analytics").click();
   await expect(page.getByTestId("analytics-page")).toBeVisible();
   await expect(page.getByTestId("analytics-today-words")).not.toHaveText("0");

--- a/apps/desktop/tests/e2e/judge.spec.ts
+++ b/apps/desktop/tests/e2e/judge.spec.ts
@@ -37,6 +37,8 @@ test("judge: settings shows state + ensure transitions", async () => {
   await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
   await expect(page.getByTestId("app-shell")).toBeVisible();
 
+  // Navigate to Settings panel (now in left sidebar)
+  await page.getByTestId("icon-bar-settings").click();
   await expect(page.getByTestId("settings-panel")).toBeVisible();
   const status = page.getByTestId("judge-status");
   await expect(status).toBeVisible();

--- a/apps/desktop/tests/e2e/knowledge-graph.spec.ts
+++ b/apps/desktop/tests/e2e/knowledge-graph.spec.ts
@@ -81,8 +81,8 @@ test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", a
   }
   const projectId = project.data.projectId;
 
-  await page.getByRole("button", { name: "KG" }).click();
-  await expect(page.getByTestId("sidebar-kg")).toBeVisible();
+  await page.getByTestId("icon-bar-knowledge-graph").click();
+  await expect(page.getByTestId("layout-sidebar")).toBeVisible();
   await expect(page.getByTestId("kg-entity-create")).toBeEnabled();
 
   await page.getByTestId("kg-entity-name").fill("Alice");

--- a/apps/desktop/tests/e2e/theme.spec.ts
+++ b/apps/desktop/tests/e2e/theme.spec.ts
@@ -44,6 +44,8 @@ test("theme: switch to light + persist across restart", async () => {
   }
 
   const first = await launch();
+  // Navigate to Settings panel (now in left sidebar)
+  await first.page.getByTestId("icon-bar-settings").click();
   await expect(first.page.getByTestId("settings-panel")).toBeVisible();
 
   await first.page.getByTestId("theme-mode-light").click();

--- a/openspec/_ops/task_runs/ISSUE-155.md
+++ b/openspec/_ops/task_runs/ISSUE-155.md
@@ -2,7 +2,7 @@
 
 - Issue: #155
 - Branch: task/155-e2e-panel-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/156
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-155.md
+++ b/openspec/_ops/task_runs/ISSUE-155.md
@@ -1,0 +1,19 @@
+# ISSUE-155
+
+- Issue: #155
+- Branch: task/155-e2e-panel-fix
+- PR: <fill-after-created>
+
+## Plan
+
+- 修复 E2E 测试以适配 Phase 7.0 面板布局变更
+
+## Runs
+
+### 2026-02-04 E2E 测试修复
+
+修改的文件：
+- knowledge-graph.spec.ts: 使用 `icon-bar-knowledge-graph` testid
+- theme.spec.ts: 先导航到 Settings 面板
+- judge.spec.ts: 先导航到 Settings 面板
+- analytics.spec.ts: 先导航到 Settings 面板


### PR DESCRIPTION
Closes #155

## Summary

修复 E2E 测试以适配 Phase 7.0 面板布局变更：

- knowledge-graph.spec.ts: 使用新的 `icon-bar-knowledge-graph` testid
- theme.spec.ts: 先导航到 Settings 面板（现在在左侧）
- judge.spec.ts: 先导航到 Settings 面板
- analytics.spec.ts: 先导航到 Settings 面板访问 analytics 按钮

## Test Plan

- [x] TypeScript 编译通过
- [ ] windows-e2e 检查通过