### PR TITLE
fix: E2E 测试 app-shell 未找到问题 (#159)

### DIFF
--- a/apps/desktop/preload/src/index.ts
+++ b/apps/desktop/preload/src/index.ts
@@ -8,3 +8,16 @@ registerAiStreamBridge();
 contextBridge.exposeInMainWorld("creonow", {
   invoke: creonowInvoke,
 });
+
+/**
+ * Expose E2E mode flag to renderer.
+ *
+ * Why: E2E tests need to skip onboarding and other flows.
+ * The flag is set via CREONOW_E2E environment variable.
+ */
+const isE2E = process.env.CREONOW_E2E === "1";
+
+contextBridge.exposeInMainWorld("__CN_E2E__", {
+  enabled: isE2E,
+  ready: false, // Will be set to true by main.tsx after React mounts
+});

--- a/apps/desktop/renderer/src/global.d.ts
+++ b/apps/desktop/renderer/src/global.d.ts
@@ -15,6 +15,9 @@ declare global {
       ) => Promise<IpcInvokeResult<C>>;
     };
     __CN_E2E__?: {
+      /** Whether E2E mode is enabled (set by preload from CREONOW_E2E env) */
+      enabled?: boolean;
+      /** Whether the React app has mounted (set by main.tsx) */
       ready: boolean;
     };
   }

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -5,8 +5,9 @@ import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
 
+// Signal that React app has mounted (preserves enabled flag set by preload)
 if (typeof window.__CN_E2E__ !== "object") {
-  window.__CN_E2E__ = { ready: true };
+  window.__CN_E2E__ = { ready: true, enabled: false };
 } else {
   window.__CN_E2E__.ready = true;
 }

--- a/apps/desktop/renderer/src/stores/onboardingStore.tsx
+++ b/apps/desktop/renderer/src/stores/onboardingStore.tsx
@@ -45,13 +45,26 @@ const OnboardingStoreContext = React.createContext<UseOnboardingStore | null>(
 );
 
 /**
+ * Check if running in E2E test mode.
+ *
+ * Why: E2E tests need to skip onboarding to test the main app directly.
+ */
+function isE2EMode(): boolean {
+  // Check for E2E environment variable exposed via preload
+  return typeof window !== "undefined" && window.__CN_E2E__?.enabled === true;
+}
+
+/**
  * Create a zustand store for onboarding state.
  *
  * Why: Track whether the user has completed onboarding to determine
  * the initial screen to show (onboarding vs welcome/dashboard).
  */
 export function createOnboardingStore(preferences: PreferenceStore) {
-  const initialCompleted = preferences.get<boolean>(ONBOARDING_KEY) ?? false;
+  // In E2E mode, skip onboarding to allow testing main app
+  const e2eMode = isE2EMode();
+  const initialCompleted =
+    e2eMode || (preferences.get<boolean>(ONBOARDING_KEY) ?? false);
 
   return create<OnboardingStore>((set) => ({
     completed: initialCompleted,

--- a/openspec/_ops/task_runs/ISSUE-159.md
+++ b/openspec/_ops/task_runs/ISSUE-159.md
@@ -1,0 +1,27 @@
+# ISSUE-159
+
+- Issue: #159
+- Branch: task/159-e2e-appshell-fix
+- PR: <fill-after-created>
+
+## Plan
+
+1. 在 preload 中暴露 E2E 模式标志
+2. 在 onboardingStore 中检测 E2E 模式并跳过 onboarding
+3. 验证 E2E 测试通过
+
+## Runs
+
+### 2026-02-04 16:00 Root cause analysis
+
+- Problem: E2E tests fail because `app-shell` element not found
+- Root cause: AppRouter shows OnboardingPage when onboarding not completed
+- E2E uses isolated userDataDir, so onboarding is never completed
+- Solution: Expose CREONOW_E2E flag to renderer and skip onboarding in E2E mode
+
+### 2026-02-04 16:00 Implementation
+
+- Modified: `preload/src/index.ts` - expose `__CN_E2E__.enabled` flag
+- Modified: `renderer/src/global.d.ts` - add `enabled` property to type
+- Modified: `renderer/src/main.tsx` - preserve `enabled` flag when setting `ready`
+- Modified: `renderer/src/stores/onboardingStore.tsx` - skip onboarding in E2E mode

--- a/openspec/_ops/task_runs/ISSUE-159.md
+++ b/openspec/_ops/task_runs/ISSUE-159.md
@@ -2,7 +2,7 @@
 
 - Issue: #159
 - Branch: task/159-e2e-appshell-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/160
 
 ## Plan
 


### PR DESCRIPTION
Closes #159

## Summary

修复 E2E 测试因 `app-shell` 元素未找到而全部失败的问题。

### 根本原因
- `AppRouter` 在 onboarding 未完成时显示 `OnboardingPage` 而非 `AppShell`
- E2E 测试使用隔离的 `userDataDir`，所以 onboarding 永远不会被标记为已完成
- 导致 E2E 测试等待 `app-shell` 元素超时

### 解决方案
- 在 preload 脚本中暴露 `__CN_E2E__.enabled` 标志（基于 `CREONOW_E2E` 环境变量）
- 在 `onboardingStore` 中检测 E2E 模式，自动跳过 onboarding

## Test plan

- [x] onboardingStore 测试通过
- [x] TypeScript 类型检查通过
- [ ] E2E 测试通过（CI 验证）

## Evidence

- RUN_LOG: `openspec/_ops/task_runs/ISSUE-159.md`