### PR TITLE
fix: 使用单独属性暴露 E2E 标志避免 frozen object 问题 (#161)

### DIFF
--- a/apps/desktop/preload/src/index.ts
+++ b/apps/desktop/preload/src/index.ts
@@ -10,14 +10,10 @@ contextBridge.exposeInMainWorld("creonow", {
 });
 
 /**
- * Expose E2E mode flag to renderer.
+ * Expose E2E mode flag to renderer via separate property.
  *
  * Why: E2E tests need to skip onboarding and other flows.
- * The flag is set via CREONOW_E2E environment variable.
+ * We use a separate property because contextBridge objects are frozen
+ * and main.tsx needs to manage __CN_E2E__.ready separately.
  */
-const isE2E = process.env.CREONOW_E2E === "1";
-
-contextBridge.exposeInMainWorld("__CN_E2E__", {
-  enabled: isE2E,
-  ready: false, // Will be set to true by main.tsx after React mounts
-});
+contextBridge.exposeInMainWorld("__CN_E2E_ENABLED__", process.env.CREONOW_E2E === "1");

--- a/apps/desktop/renderer/src/global.d.ts
+++ b/apps/desktop/renderer/src/global.d.ts
@@ -14,10 +14,10 @@ declare global {
         payload: IpcRequest<C>,
       ) => Promise<IpcInvokeResult<C>>;
     };
+    /** E2E mode flag set by preload (frozen, read-only) */
+    __CN_E2E_ENABLED__?: boolean;
+    /** E2E ready state managed by main.tsx (mutable) */
     __CN_E2E__?: {
-      /** Whether E2E mode is enabled (set by preload from CREONOW_E2E env) */
-      enabled?: boolean;
-      /** Whether the React app has mounted (set by main.tsx) */
       ready: boolean;
     };
   }

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -5,9 +5,9 @@ import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
 
-// Signal that React app has mounted (preserves enabled flag set by preload)
+// Signal that React app has mounted
 if (typeof window.__CN_E2E__ !== "object") {
-  window.__CN_E2E__ = { ready: true, enabled: false };
+  window.__CN_E2E__ = { ready: true };
 } else {
   window.__CN_E2E__.ready = true;
 }

--- a/apps/desktop/renderer/src/stores/onboardingStore.tsx
+++ b/apps/desktop/renderer/src/stores/onboardingStore.tsx
@@ -50,8 +50,8 @@ const OnboardingStoreContext = React.createContext<UseOnboardingStore | null>(
  * Why: E2E tests need to skip onboarding to test the main app directly.
  */
 function isE2EMode(): boolean {
-  // Check for E2E environment variable exposed via preload
-  return typeof window !== "undefined" && window.__CN_E2E__?.enabled === true;
+  // Check for E2E flag exposed via preload (separate from __CN_E2E__ which is mutable)
+  return typeof window !== "undefined" && window.__CN_E2E_ENABLED__ === true;
 }
 
 /**

--- a/openspec/_ops/task_runs/ISSUE-161.md
+++ b/openspec/_ops/task_runs/ISSUE-161.md
@@ -1,0 +1,25 @@
+# ISSUE-161
+
+- Issue: #161
+- Branch: task/161-e2e-frozen-fix
+- PR: <fill-after-created>
+
+## Plan
+
+1. 使用单独的 __CN_E2E_ENABLED__ 属性暴露 E2E 模式标志
+2. 避免 contextBridge frozen object 问题
+
+## Runs
+
+### 2026-02-04 16:30 Fix frozen object issue
+
+- Problem: contextBridge.exposeInMainWorld creates frozen objects
+- main.tsx cannot set ready=true on frozen object
+- Solution: Use separate __CN_E2E_ENABLED__ property for E2E flag
+
+### Files modified
+
+- `preload/src/index.ts` - Use __CN_E2E_ENABLED__ instead of __CN_E2E__.enabled
+- `renderer/src/global.d.ts` - Update type definitions
+- `renderer/src/main.tsx` - Remove enabled property
+- `renderer/src/stores/onboardingStore.tsx` - Use __CN_E2E_ENABLED__

--- a/openspec/_ops/task_runs/ISSUE-161.md
+++ b/openspec/_ops/task_runs/ISSUE-161.md
@@ -2,7 +2,7 @@
 
 - Issue: #161
 - Branch: task/161-e2e-frozen-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/162
 
 ## Plan
 


### PR DESCRIPTION
Closes #161

## Summary

修复 #159 引入的问题：`contextBridge.exposeInMainWorld` 创建的对象是 frozen 的，导致 `main.tsx` 无法设置 `ready=true`。

### 解决方案
- 使用单独的 `__CN_E2E_ENABLED__` 属性暴露 E2E 模式标志
- `__CN_E2E__` 对象由 main.tsx 完全管理（mutable）

## Test plan

- [ ] E2E 测试能够检测到 `__CN_E2E__.ready === true`
- [ ] onboardingStore 能够检测 E2E 模式并跳过 onboarding
- [ ] windows-e2e CI 通过

## Evidence

- RUN_LOG: `openspec/_ops/task_runs/ISSUE-161.md`