### PR TITLE
fix: proxy-error-semantics 测试使用 E2E 模式 (#163)

### DIFF
--- a/apps/desktop/tests/e2e/proxy-error-semantics.spec.ts
+++ b/apps/desktop/tests/e2e/proxy-error-semantics.spec.ts
@@ -53,7 +53,7 @@ test("proxy disabled + missing api key => INVALID_ARGUMENT", async () => {
     args: [appRoot],
     env: {
       ...process.env,
-      CREONOW_E2E: "0",
+      CREONOW_E2E: "1",
       CREONOW_OPEN_DEVTOOLS: "0",
       CREONOW_USER_DATA_DIR: userDataDir,
       CREONOW_AI_PROVIDER: "anthropic",
@@ -89,7 +89,7 @@ test("proxy enabled + missing baseUrl => INVALID_ARGUMENT", async () => {
     args: [appRoot],
     env: {
       ...process.env,
-      CREONOW_E2E: "0",
+      CREONOW_E2E: "1",
       CREONOW_OPEN_DEVTOOLS: "0",
       CREONOW_USER_DATA_DIR: userDataDir,
       CREONOW_AI_PROXY_ENABLED: "1",

--- a/openspec/_ops/task_runs/ISSUE-163.md
+++ b/openspec/_ops/task_runs/ISSUE-163.md
@@ -2,7 +2,7 @@
 
 - Issue: #163
 - Branch: task/163-proxy-e2e-fix
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/164
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-163.md
+++ b/openspec/_ops/task_runs/ISSUE-163.md
@@ -1,0 +1,16 @@
+# ISSUE-163
+
+- Issue: #163
+- Branch: task/163-proxy-e2e-fix
+- PR: <fill-after-created>
+
+## Plan
+
+1. 修复 proxy-error-semantics.spec.ts 使用 CREONOW_E2E=1
+
+## Runs
+
+### 2026-02-04 16:40 Fix proxy E2E tests
+
+- Problem: proxy-error-semantics.spec.ts uses CREONOW_E2E=0, cannot skip onboarding
+- Solution: Change to CREONOW_E2E=1 to enable E2E mode


### PR DESCRIPTION
Closes #163

## Summary

修复最后 2 个 E2E 测试失败：`proxy-error-semantics.spec.ts` 使用 `CREONOW_E2E=0`，导致无法跳过 onboarding。

## Test plan

- [ ] 27 个 E2E 测试全部通过

## Evidence

- RUN_LOG: `openspec/_ops/task_runs/ISSUE-163.md`