### PR TITLE
refactor: AI Panel 和 Skill Picker 组件重构 (#169)

### DIFF
--- a/apps/desktop/renderer/src/features/ai/AiPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.stories.tsx
@@ -10,7 +10,7 @@ import { layoutDecorator } from "../../components/layout/test-utils";
  * - Header Tabs（Assistant / Info 切换）
  * - 用户输入（有框）和 AI 回复（无框）
  * - 发送/停止复合按钮
- * - 输入框内嵌工具栏（Mode / Model / Skill）
+ * - 输入框内嵌工具栏（Mode / Model / SKILL）
  * - 代码块带 Copy/Apply 按钮
  */
 const meta = {
@@ -168,13 +168,13 @@ function ConversationDemo(): JSX.Element {
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1.5">
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded">
-                  Ask ▼
+                  Ask
                 </button>
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded">
-                  GPT-5.2 ▼
+                  GPT-5.2
                 </button>
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded">
-                  Skill ▼
+                  SKILL
                 </button>
               </div>
               <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]">
@@ -414,6 +414,20 @@ function EmptyConversationDemo(): JSX.Element {
               Info
             </button>
           </div>
+          <div className="ml-auto flex items-center gap-1">
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="History">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="New Chat">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+          </div>
         </header>
 
         {/* Empty State */}
@@ -451,10 +465,13 @@ function EmptyConversationDemo(): JSX.Element {
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1.5">
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  Ask ▼
+                  Ask
                 </button>
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  GPT-5.2 ▼
+                  GPT-5.2
+                </button>
+                <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
+                  SKILL
                 </button>
               </div>
               {/* Disabled send button */}
@@ -739,6 +756,20 @@ function ErrorStateDemo(): JSX.Element {
               Info
             </button>
           </div>
+          <div className="ml-auto flex items-center gap-1">
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="History">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="New Chat">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+          </div>
         </header>
 
         {/* Content */}
@@ -791,10 +822,13 @@ function ErrorStateDemo(): JSX.Element {
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1.5">
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  Ask ▼
+                  Ask
                 </button>
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  GPT-5.2 ▼
+                  GPT-5.2
+                </button>
+                <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
+                  SKILL
                 </button>
               </div>
               <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]">
@@ -889,6 +923,20 @@ function LongConversationDemo(): JSX.Element {
               Info
             </button>
           </div>
+          <div className="ml-auto flex items-center gap-1">
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="History">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
+            <button className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)]" title="New Chat">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+          </div>
         </header>
 
         {/* Content */}
@@ -924,10 +972,13 @@ function LongConversationDemo(): JSX.Element {
             <div className="flex items-center justify-between px-2 pb-2">
               <div className="flex items-center gap-1.5">
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  Ask ▼
+                  Ask
                 </button>
                 <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                  GPT-5.2 ▼
+                  GPT-5.2
+                </button>
+                <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
+                  SKILL
                 </button>
               </div>
               <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]">

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -10,7 +10,6 @@ import { DiffView } from "../diff/DiffView";
 import { applySelection, captureSelectionRef } from "./applySelection";
 import { SkillPicker } from "./SkillPicker";
 import { ChatHistory } from "./ChatHistory";
-import { ContextViewer } from "./ContextViewer";
 import { ModePicker, getModeName, type AiMode } from "./ModePicker";
 import { ModelPicker, getModelName, type AiModel } from "./ModelPicker";
 import { useAiStream } from "./useAiStream";
@@ -177,7 +176,6 @@ export function AiPanel(): JSX.Element {
   useAiStream();
 
   const status = useAiStore((s) => s.status);
-  const stream = useAiStore((s) => s.stream);
   const selectedSkillId = useAiStore((s) => s.selectedSkillId);
   const skills = useAiStore((s) => s.skills);
   const skillsStatus = useAiStore((s) => s.skillsStatus);
@@ -192,7 +190,6 @@ export function AiPanel(): JSX.Element {
   const applyStatus = useAiStore((s) => s.applyStatus);
 
   const setInput = useAiStore((s) => s.setInput);
-  const setStream = useAiStore((s) => s.setStream);
   const setSelectedSkillId = useAiStore((s) => s.setSelectedSkillId);
   const refreshSkills = useAiStore((s) => s.refreshSkills);
   const clearError = useAiStore((s) => s.clearError);
@@ -210,8 +207,6 @@ export function AiPanel(): JSX.Element {
 
   const currentProject = useProjectStore((s) => s.current);
 
-  const contextViewerOpen = useContextStore((s) => s.viewerOpen);
-  const toggleContextViewer = useContextStore((s) => s.toggleViewer);
   const refreshContext = useContextStore((s) => s.refresh);
 
   const [activeTab, setActiveTab] = React.useState<"assistant" | "info">(
@@ -405,46 +400,6 @@ export function AiPanel(): JSX.Element {
         </div>
 
         <div className="ml-auto flex items-center gap-1 relative">
-          <Text
-            data-testid="ai-status"
-            size="tiny"
-            color="muted"
-            className="mr-1"
-          >
-            {status}
-          </Text>
-
-          <button
-            data-testid="ai-context-toggle"
-            type="button"
-            title="Context"
-            onClick={() => {
-              void toggleContextViewer({
-                projectId: currentProject?.projectId ?? projectId ?? null,
-                skillId: selectedSkillId ?? null,
-                immediateInput: lastRequest ?? input,
-              });
-            }}
-            className={`w-5 h-5 flex items-center justify-center rounded transition-colors ${
-              contextViewerOpen
-                ? "text-[var(--color-fg-default)] bg-[var(--color-bg-selected)]"
-                : "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
-            }`}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <rect x="4" y="4" width="16" height="16" rx="2" />
-              <line x1="7" y1="9" x2="17" y2="9" />
-              <line x1="7" y1="13" x2="17" y2="13" />
-            </svg>
-          </button>
-
           {/* History button */}
           <button
             data-testid="ai-history-toggle"
@@ -623,12 +578,6 @@ export function AiPanel(): JSX.Element {
               )}
             </div>
 
-            {contextViewerOpen && (
-              <div className="shrink-0 px-1.5 pb-1.5">
-                <ContextViewer />
-              </div>
-            )}
-
             {/* Input Area - Fixed at bottom, minimal padding like Cursor */}
             <div className="shrink-0 px-1.5 pb-1.5 pt-2 border-t border-[var(--color-separator)]">
               {/* Unified input wrapper */}
@@ -657,15 +606,6 @@ export function AiPanel(): JSX.Element {
                         }}
                       >
                         {getModeName(selectedMode)}
-                        <svg
-                          className="inline-block ml-0.5 w-3 h-3"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <polyline points="6 9 12 15 18 9" />
-                        </svg>
                       </ToolButton>
                       <ModePicker
                         open={modeOpen}
@@ -689,15 +629,6 @@ export function AiPanel(): JSX.Element {
                         }}
                       >
                         {getModelName(selectedModel)}
-                        <svg
-                          className="inline-block ml-0.5 w-3 h-3"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <polyline points="6 9 12 15 18 9" />
-                        </svg>
                       </ToolButton>
                       <ModelPicker
                         open={modelOpen}
@@ -722,15 +653,6 @@ export function AiPanel(): JSX.Element {
                         }}
                       >
                         {skillsStatus === "loading" ? "Loading" : "SKILL"}
-                        <svg
-                          className="inline-block ml-0.5 w-3 h-3"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <polyline points="6 9 12 15 18 9" />
-                        </svg>
                       </ToolButton>
                       <SkillPicker
                         open={skillsOpen}
@@ -741,19 +663,13 @@ export function AiPanel(): JSX.Element {
                           setSelectedSkillId(skillId);
                           setSkillsOpen(false);
                         }}
+                        onOpenSettings={() => {
+                          // TODO: Open SKILL settings dialog
+                          console.log("Open SKILL settings");
+                        }}
                       />
                     </div>
 
-                    <label className="flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)]">
-                      <input
-                        data-testid="ai-stream-toggle"
-                        type="checkbox"
-                        checked={stream}
-                        onChange={(e) => setStream(e.target.checked)}
-                        className="accent-[var(--color-accent)]"
-                      />
-                      <span>Stream</span>
-                    </label>
                   </div>
 
                   <SendStopButton

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.stories.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.stories.tsx
@@ -1,32 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 import { fn } from "@storybook/test";
 import { SkillPicker } from "./SkillPicker";
+import { layoutDecorator } from "../../components/layout/test-utils";
 
 /**
  * SkillPicker 组件 Story
  *
- * 功能：
- * - 技能列表弹窗
- * - 选中/禁用状态
- * - 点击选择
+ * SKILL 选择器从工具栏按钮上方弹出，用于选择 AI 技能。
+ * 布局与 AiPanel 保持一致。
  */
 const meta: Meta<typeof SkillPicker> = {
   title: "Features/SkillPicker",
   component: SkillPicker,
+  decorators: [layoutDecorator],
   parameters: {
-    layout: "centered",
+    layout: "fullscreen",
   },
   tags: ["autodocs"],
-  argTypes: {
-    open: {
-      control: "boolean",
-      description: "Whether the picker is open",
-    },
-    selectedSkillId: {
-      control: "text",
-      description: "Currently selected skill ID",
-    },
-  },
   args: {
     onOpenChange: fn(),
     onSelectSkillId: fn(),
@@ -84,141 +75,232 @@ const sampleSkills = [
   },
 ];
 
+function SkillPickerDemo(props: {
+  skills: typeof sampleSkills;
+  selectedSkillId: string;
+  defaultOpen?: boolean;
+}): JSX.Element {
+  const [open, setOpen] = React.useState(props.defaultOpen ?? false);
+  const [selectedId, setSelectedId] = React.useState(props.selectedSkillId);
+
+  return (
+    <div
+      style={{ width: "360px", height: "100vh" }}
+      className="bg-[var(--color-bg-surface)]"
+    >
+      <section className="flex flex-col h-full">
+        {/* Header */}
+        <header className="flex items-center h-8 px-2 border-b border-[var(--color-separator)] shrink-0">
+          <div className="flex items-center gap-3 h-full">
+            <button className="h-full text-[10px] font-semibold uppercase tracking-wide text-[var(--color-fg-default)] border-b border-[var(--color-accent)]">
+              Assistant
+            </button>
+            <button className="h-full text-[10px] font-semibold uppercase tracking-wide text-[var(--color-fg-muted)] border-b border-transparent">
+              Info
+            </button>
+          </div>
+          <div className="ml-auto flex items-center gap-1">
+            {/* History button */}
+            <button
+              type="button"
+              title="History"
+              className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] rounded transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
+            {/* New Chat button */}
+            <button
+              type="button"
+              title="New Chat"
+              className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] rounded transition-colors"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 flex items-center justify-center p-4">
+          <span className="text-[13px] text-[var(--color-fg-muted)]">
+            Ask the AI to help with your writing
+          </span>
+        </div>
+
+        {/* Input Area with SKILL Picker */}
+        <div className="shrink-0 px-1.5 pb-1.5 pt-2 border-t border-[var(--color-separator)]">
+          <div className="border border-[var(--color-border-default)] rounded-[var(--radius-md)] bg-[var(--color-bg-base)]">
+            <textarea
+              placeholder="Ask the AI to help with your writing..."
+              className="w-full min-h-[60px] px-3 py-2 bg-transparent border-none resize-none text-[13px] text-[var(--color-fg-default)] placeholder:text-[var(--color-fg-placeholder)] focus:outline-none"
+            />
+            <div className="flex items-center justify-between px-2 pb-2">
+              <div className="flex items-center gap-1">
+                <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded">
+                  Ask
+                </button>
+                <button className="px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded">
+                  GPT-5.2
+                </button>
+                {/* SKILL button with picker */}
+                <div className="relative">
+                  <button
+                    onClick={() => setOpen((v) => !v)}
+                    className={`px-1.5 py-0.5 text-[11px] font-medium rounded transition-colors cursor-pointer ${
+                      open
+                        ? "text-[var(--color-fg-default)] bg-[var(--color-bg-selected)]"
+                        : "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]"
+                    }`}
+                  >
+                    SKILL
+                  </button>
+                  <SkillPicker
+                    open={open}
+                    items={props.skills}
+                    selectedSkillId={selectedId}
+                    onOpenChange={setOpen}
+                    onSelectSkillId={(id) => {
+                      setSelectedId(id);
+                      setOpen(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <button className="w-7 h-7 rounded flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <line x1="12" y1="19" x2="12" y2="5" />
+                  <polyline points="5 12 12 5 19 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * 默认状态
+ *
+ * SKILL 选择器关闭，点击 SKILL 按钮可打开
+ */
+export const Default: Story = {
+  render: () => (
+    <SkillPickerDemo skills={sampleSkills} selectedSkillId="default" />
+  ),
+};
+
 /**
  * 打开状态
  *
- * 技能选择器打开
+ * SKILL 选择器已打开，从按钮上方弹出
  */
 export const Open: Story = {
-  args: {
-    open: true,
-    items: sampleSkills,
-    selectedSkillId: "default",
-  },
-  render: (args) => (
-    <div style={{ position: "relative", width: "300px", height: "400px" }}>
-      <SkillPicker {...args} />
-    </div>
+  render: () => (
+    <SkillPickerDemo
+      skills={sampleSkills}
+      selectedSkillId="default"
+      defaultOpen
+    />
   ),
 };
 
 /**
- * 关闭状态
- *
- * 技能选择器关闭（不渲染）
- */
-export const Closed: Story = {
-  args: {
-    open: false,
-    items: sampleSkills,
-    selectedSkillId: "default",
-  },
-  render: (args) => (
-    <div style={{ position: "relative", width: "300px", height: "400px" }}>
-      <SkillPicker {...args} />
-      <div style={{ padding: "20px", color: "var(--color-fg-muted)" }}>
-        Picker is closed (nothing rendered)
-      </div>
-    </div>
-  ),
-};
-
-/**
- * 选中其他技能
+ * 选中 Rewrite
  *
  * 选中 Rewrite 技能
  */
 export const SelectedRewrite: Story = {
-  args: {
-    open: true,
-    items: sampleSkills,
-    selectedSkillId: "rewrite",
-  },
-  render: (args) => (
-    <div style={{ position: "relative", width: "300px", height: "400px" }}>
-      <SkillPicker {...args} />
-    </div>
+  render: () => (
+    <SkillPickerDemo
+      skills={sampleSkills}
+      selectedSkillId="rewrite"
+      defaultOpen
+    />
   ),
 };
 
 /**
  * 空列表
  *
- * 无技能可选
+ * 无 SKILL 可选
  */
 export const EmptyList: Story = {
-  args: {
-    open: true,
-    items: [],
-    selectedSkillId: "",
-  },
-  render: (args) => (
-    <div style={{ position: "relative", width: "300px", height: "200px" }}>
-      <SkillPicker {...args} />
-    </div>
+  render: () => (
+    <SkillPickerDemo skills={[]} selectedSkillId="" defaultOpen />
   ),
 };
 
 /**
  * 多项禁用
  *
- * 多个技能禁用或无效
+ * 多个 SKILL 禁用或无效
  */
 export const ManyDisabled: Story = {
-  args: {
-    open: true,
-    items: [
-      {
-        id: "enabled",
-        name: "Enabled Skill",
-        enabled: true,
-        valid: true,
-        scope: "global" as const,
-        packageId: "pkg-1",
-        version: "1.0.0",
-      },
-      {
-        id: "disabled-1",
-        name: "Disabled 1",
-        enabled: false,
-        valid: true,
-        scope: "global" as const,
-        packageId: "pkg-2",
-        version: "1.0.0",
-      },
-      {
-        id: "disabled-2",
-        name: "Disabled 2",
-        enabled: false,
-        valid: true,
-        scope: "global" as const,
-        packageId: "pkg-3",
-        version: "1.0.0",
-      },
-      {
-        id: "invalid-1",
-        name: "Invalid 1",
-        enabled: true,
-        valid: false,
-        scope: "global" as const,
-        packageId: "pkg-4",
-        version: "1.0.0",
-      },
-      {
-        id: "invalid-2",
-        name: "Invalid 2",
-        enabled: true,
-        valid: false,
-        scope: "global" as const,
-        packageId: "pkg-5",
-        version: "1.0.0",
-      },
-    ],
-    selectedSkillId: "enabled",
-  },
-  render: (args) => (
-    <div style={{ position: "relative", width: "300px", height: "400px" }}>
-      <SkillPicker {...args} />
-    </div>
+  render: () => (
+    <SkillPickerDemo
+      skills={[
+        {
+          id: "enabled",
+          name: "Enabled Skill",
+          enabled: true,
+          valid: true,
+          scope: "global" as const,
+          packageId: "pkg-1",
+          version: "1.0.0",
+        },
+        {
+          id: "disabled-1",
+          name: "Disabled 1",
+          enabled: false,
+          valid: true,
+          scope: "global" as const,
+          packageId: "pkg-2",
+          version: "1.0.0",
+        },
+        {
+          id: "disabled-2",
+          name: "Disabled 2",
+          enabled: false,
+          valid: true,
+          scope: "global" as const,
+          packageId: "pkg-3",
+          version: "1.0.0",
+        },
+        {
+          id: "invalid-1",
+          name: "Invalid 1",
+          enabled: true,
+          valid: false,
+          scope: "global" as const,
+          packageId: "pkg-4",
+          version: "1.0.0",
+        },
+        {
+          id: "invalid-2",
+          name: "Invalid 2",
+          enabled: true,
+          valid: false,
+          scope: "global" as const,
+          packageId: "pkg-5",
+          version: "1.0.0",
+        },
+      ]}
+      selectedSkillId="enabled"
+      defaultOpen
+    />
   ),
 };

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
@@ -10,6 +10,7 @@ export function SkillPicker(props: {
   selectedSkillId: string;
   onOpenChange: (open: boolean) => void;
   onSelectSkillId: (skillId: string) => void;
+  onOpenSettings?: () => void;
 }): JSX.Element | null {
   if (!props.open) {
     return null;
@@ -30,9 +31,31 @@ export function SkillPicker(props: {
         onClick={(e) => e.stopPropagation()}
         className="absolute bottom-full left-0 mb-1 w-56 p-2.5 z-30 bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[0_18px_48px_rgba(0,0,0,0.45)]"
       >
-        <Text size="label" color="muted">
-          SKILL
-        </Text>
+        <div className="flex items-center justify-between">
+          <Text size="label" color="muted">
+            SKILL
+          </Text>
+          <button
+            type="button"
+            title="SKILL Settings"
+            className="w-5 h-5 flex items-center justify-center text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
+            onClick={() => {
+              props.onOpenSettings?.();
+            }}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+        </div>
 
         <div className="flex flex-col mt-2 gap-1.5 max-h-65 overflow-auto">
           {props.items.map((s) => {

--- a/openspec/_ops/task_runs/ISSUE-169.md
+++ b/openspec/_ops/task_runs/ISSUE-169.md
@@ -1,0 +1,22 @@
+# ISSUE-169
+
+- Issue: #169
+- Branch: task/169-ai-panel-skill-refactor
+- PR: https://github.com/Leeky1017/CreoNow/pull/170
+
+## Plan
+- 移除 AiPanel idle 状态显示和 Context 图标
+- 将 SKILL 设置按钮移至 SkillPicker 弹窗右上角
+- 统一所有 AiPanel stories 的 header 布局
+
+## Runs
+
+### 2026-02-04 20:15 Worktree Setup
+- Command: `scripts/agent_worktree_setup.sh 169 ai-panel-skill-refactor`
+- Key output: Worktree created at `.worktrees/issue-169-ai-panel-skill-refactor`
+- Evidence: Branch `task/169-ai-panel-skill-refactor` tracking origin/main
+
+### 2026-02-04 20:16 Apply Changes
+- Command: `git stash pop`
+- Key output: 4 files modified (AiPanel.tsx, AiPanel.stories.tsx, SkillPicker.tsx, SkillPicker.stories.tsx)
+- Evidence: Changes from main worktree successfully applied


### PR DESCRIPTION
Closes #169

## 变更摘要

重构 AI Panel 和 Skill Picker 组件，统一布局和视觉样式。

### 主要改动
- 移除 AiPanel 头部的 idle 状态显示
- 移除 Context 图标及其相关代码
- 将 SKILL 设置按钮（+）从工具栏移至 SkillPicker 弹窗右上角
- 删除 Stream 复选框
- 移除模式/模型/SKILL 按钮的下拉箭头
- 统一所有 AiPanel stories 的 header 布局
- 统一 SKILL 大写

### 文件变更
- 
- 
- 
- 

### 测试计划
- [ ] Storybook 中 AiPanel 和 SkillPicker 布局统一
- [ ] 无 idle 状态显示
- [ ] 无 Context 图标
- [ ] SKILL 弹窗右上角有 + 按钮
- [ ] 所有按钮无下拉箭头