### PR TITLE
fix: sync E2E tests with refactored AI Panel components (#173)

### DIFF
--- a/apps/desktop/tests/e2e/skills.spec.ts
+++ b/apps/desktop/tests/e2e/skills.spec.ts
@@ -90,16 +90,12 @@ test("skills: list + toggle disables run + command palette opens", async () => {
   ).toBeVisible();
   await page.getByTestId(`ai-skill-${firstEnabledValid.id}`).click();
 
-  // Ensure we're in non-stream mode so the send/stop button is stable for back-to-back runs.
-  const streamToggle = page.getByTestId("ai-stream-toggle");
-  if (await streamToggle.isChecked()) {
-    await streamToggle.click();
-  }
-  await expect(page.getByTestId("ai-status")).toContainText("idle");
+  // Wait for AI panel to be ready (stream toggle removed in UI refactoring)
+  await expect(page.getByTestId("ai-input")).toBeVisible();
+  await expect(page.getByTestId("ai-send-stop")).toBeVisible();
 
   await runInput(page, "hello");
   await expect(page.getByTestId("ai-output")).toContainText("E2E_RESULT");
-  await expect(page.getByTestId("ai-status")).toContainText("idle");
 
   const toggled = await page.evaluate(async (id) => {
     if (!window.creonow) {

--- a/openspec/_ops/task_runs/ISSUE-173.md
+++ b/openspec/_ops/task_runs/ISSUE-173.md
@@ -1,0 +1,23 @@
+# ISSUE-173
+- Issue: #173
+- Branch: task/173-sync-e2e-tests
+- PR: <fill-after-created>
+
+## Plan
+- Remove references to `ai-stream-toggle` (element removed in UI refactoring)
+- Remove references to `ai-status` (element removed in UI refactoring)
+- Update E2E tests to work with new Send/Stop button behavior
+
+## Runs
+### 2026-02-04 21:40 Analysis
+- E2E tests failing due to missing UI elements after AI Panel refactoring
+- `ai-stream-toggle` - removed (no Stream checkbox in new UI)
+- `ai-status` - removed (no status display in new UI)
+
+### 2026-02-04 21:45 Fix Implementation
+- Updated ai-runtime.spec.ts:
+  - Replaced `setStreamEnabled()` with `waitForAiReady()`
+  - Removed all `ai-status` assertions
+- Updated skills.spec.ts:
+  - Removed stream toggle usage
+  - Removed `ai-status` assertions

--- a/openspec/_ops/task_runs/ISSUE-173.md
+++ b/openspec/_ops/task_runs/ISSUE-173.md
@@ -1,7 +1,7 @@
 # ISSUE-173
 - Issue: #173
 - Branch: task/173-sync-e2e-tests
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/174
 
 ## Plan
 - Remove references to `ai-stream-toggle` (element removed in UI refactoring)


### PR DESCRIPTION
Closes #173

## Summary
- Remove `setStreamEnabled()` function - stream toggle no longer exists in new UI
- Replace with `waitForAiReady()` for AI panel readiness checks
- Remove all `ai-status` assertions - status element removed in UI refactoring
- Update test names to reflect removal of stream/non-stream distinction

## Test Plan
- [ ] All E2E tests pass on Windows CI

## Evidence
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-173.md`