### PR TITLE
[SPEC] 固化 frontend-full-assembly 规范建议项为必须约束 (#182)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-182.md
+++ b/openspec/_ops/task_runs/ISSUE-182.md
@@ -1,0 +1,34 @@
+# ISSUE-182
+
+- Issue: #182
+- Branch: task/182-spec-hardening
+- PR: <fill-after-created>
+
+## Plan
+
+- 把 `design/07` 中 `project:duplicate` 复制范围从"建议"改为 MUST，并写死统一超时 30s
+- 把 `design/06` 和 `P0-003` 中 Settings 默认值具体化
+- 把 `P0-005` 中模板路径选择从"推荐"改为 MUST
+
+## Runs
+
+### 2026-02-05 固化"建议"为"必须"
+
+- Command: `StrReplace` on multiple files
+- Key changes:
+  - `design/07-ipc-interface-spec.md`:
+    - 添加统一超时 30s（MUST）
+    - `project:rename` name 长度上限 MUST 为 1-80
+    - `project:duplicate` 复制范围 MUST 为"项目元数据 + documents + KG"
+    - `project:archive` 归档行为 MUST 从默认列表隐藏
+    - `version:read` Response MUST 保持与 documents 字段一致
+    - compare/diff 分工从 SHOULD 改为 MUST
+    - KG Characters 约定从 SHOULD 改为 MUST + 写死 metadataJson schema
+    - 模板语义选定路径 A 为 MUST
+  - `task_cards/p0/P0-003`:
+    - Settings 默认值写死（theme/proxyEnabled/proxyUrl/judgeModelEnabled/analyticsEnabled）
+  - `task_cards/p0/P0-005`:
+    - 模板路径选择固化为路径 A（MUST）
+  - `design/06-asset-completion-checklist.md`:
+    - Settings 默认值添加到补齐步骤
+- Evidence: See git diff

--- a/openspec/_ops/task_runs/ISSUE-182.md
+++ b/openspec/_ops/task_runs/ISSUE-182.md
@@ -2,7 +2,7 @@
 
 - Issue: #182
 - Branch: task/182-spec-hardening
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/183
 
 ## Plan
 

--- a/openspec/specs/creonow-frontend-full-assembly/design/06-asset-completion-checklist.md
+++ b/openspec/specs/creonow-frontend-full-assembly/design/06-asset-completion-checklist.md
@@ -125,6 +125,7 @@
   - [ ] 删除或内部化 SettingsPanel（确保用户路径只有一个）
   - [ ] 持久化：至少一个设置项可在重启后保持（E2E 必测）
   - [ ] 错误可观察：Proxy/Judge IPC 失败时显示 `code: message`
+  - [ ] **默认值（MUST）**：初始值缺失/损坏时使用：`theme: "system"`, `proxyEnabled: false`, `proxyUrl: ""`, `judgeModelEnabled: false`, `analyticsEnabled: false`
 - IPC：
   - 已有：`ai:proxy:settings:get/update/test`、`judge:model:getState/ensure`、`stats:*`
 - 测试：

--- a/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-003-settingsdialog-as-single-settings-surface.md
+++ b/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-003-settingsdialog-as-single-settings-surface.md
@@ -86,9 +86,16 @@ Status: todo
 ## Edge cases & Failure modes
 
 - Settings 初始值缺失/损坏：
-  - 必须有默认值与迁移策略（不崩溃）
+  - MUST 使用以下默认值（不崩溃）：
+    - `theme`: `"system"`（跟随系统）
+    - `proxyEnabled`: `false`
+    - `proxyUrl`: `""`（空字符串）
+    - `judgeModelEnabled`: `false`
+    - `analyticsEnabled`: `false`
+  - 迁移策略：若 schema 变更，MUST 保留已有有效值，缺失字段用默认值填充
 - IPC 超时/不可用：
-  - 必须显示明确错误，不得 silent failure
+  - MUST 显示明确错误（`code: message`），不得 silent failure
+  - 统一超时 30s（见 `design/07-ipc-interface-spec.md`）
 
 ## Observability
 

--- a/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-005-dashboard-project-actions-and-templates.md
+++ b/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-005-dashboard-project-actions-and-templates.md
@@ -71,9 +71,10 @@ Status: todo
   - [ ] Delete：必须二次确认；删除后从列表消失；若删除的是 current project，AppShell 状态必须一致（回到 Dashboard/Welcome）
 - [ ] CreateProjectDialog：
   - [ ] 不允许 silent catch（禁止 `catch {}`）
-  - [ ] 模板/描述/封面字段：
-    - [ ] 若暂不支持持久化/应用，必须在 UI 上明确标注（例如“Coming soon”并禁用输入），避免误导
-    - [ ] 若支持模板应用：必须创建对应文档结构（可用 `file:document:create + write`），并在 Files 可见
+  - [ ] 模板/描述/封面字段（**MUST 选择路径 A**）：
+    - [ ] MUST 在 UI 上标注 "Coming soon" 并禁用交互（`disabled` + `aria-disabled`）
+    - [ ] MUST 只提交 `project:create(name)`，禁止提交 template/description/cover（避免误导）
+    - [ ] 真模板应用属于 P1 范围（见 `P1-001`），P0 禁止实现
 - [ ] 确认对话框统一：
   - [ ] 删除项目使用 `SystemDialog`（来自 `Features/AiDialogs`）
 


### PR DESCRIPTION
Closes #182

## Summary

把 `creonow-frontend-full-assembly` 规范中的"建议/推荐"项固化为"必须"（MUST），消除执行时的自由裁量空间。

## Changes

### `design/07-ipc-interface-spec.md`
- 添加统一超时 30s（MUST）
- `project:rename` name 长度上限 MUST 为 1-80 字符
- `project:duplicate` 复制范围 MUST 为"项目元数据 + documents + KG entities/relations"
- `project:archive` 归档行为 MUST 从默认列表隐藏
- `version:read` Response MUST 保持与 documents 字段一致
- compare/diff 分工从 SHOULD 改为 MUST（renderer 侧负责）
- KG Characters 约定从 SHOULD 改为 MUST + 写死 metadataJson schema
- 模板语义选定路径 A 为 MUST（P0 禁用模板 UI）

### `task_cards/p0/P0-003`
- Settings 默认值写死（theme/proxyEnabled/proxyUrl/judgeModelEnabled/analyticsEnabled）

### `task_cards/p0/P0-005`
- 模板路径选择固化为路径 A（MUST）

### `design/06-asset-completion-checklist.md`
- Settings 默认值添加到补齐步骤

## Test Plan

- [x] 规范语义检查：所有"建议/推荐"已改为 MUST 或写死具体值
- [x] 无歧义措辞：执行者不需要自行判断


Made with [Cursor](https://cursor.com)