### PR TITLE
[P0-014] Storybook WSL-IP QA Gate：流程固化 + 证据格式 (#186)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint . --ext .ts,.tsx",
     "storybook": "storybook dev -p 6006",
+    "storybook:wsl": "storybook dev --host 0.0.0.0 -p 6006",
     "storybook:build": "storybook build -o storybook-static",
     "test": "vitest",
     "test:run": "vitest run",

--- a/openspec/_ops/task_runs/ISSUE-186.md
+++ b/openspec/_ops/task_runs/ISSUE-186.md
@@ -1,7 +1,7 @@
 # ISSUE-186
 - Issue: #186
 - Branch: task/186-storybook-wsl-qa-gate
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/187
 
 ## Plan
 - 添加 `storybook:wsl` script 到 package.json（绑定 0.0.0.0）

--- a/openspec/_ops/task_runs/ISSUE-186.md
+++ b/openspec/_ops/task_runs/ISSUE-186.md
@@ -1,0 +1,22 @@
+# ISSUE-186
+- Issue: #186
+- Branch: task/186-storybook-wsl-qa-gate
+- PR: <fill-after-created>
+
+## Plan
+- 添加 `storybook:wsl` script 到 package.json（绑定 0.0.0.0）
+- 创建 `scripts/wsl_storybook_url.sh`（动态输出 WSL IP 与访问 URL）
+- 更新设计文档 04/08，固化证据格式与快速启动命令
+
+## Runs
+### 2026-02-05 验证脚本输出
+- Command: `./scripts/wsl_storybook_url.sh`
+- Key output:
+  ```
+  WSL IP: 172.18.248.30
+  Storybook URL: http://172.18.248.30:6006
+  ```
+- Evidence:
+  - 脚本成功动态获取 WSL IP（不写死）
+  - 输出格式固定（WSL IP + Storybook URL）
+  - Notes: 端口可通过 STORYBOOK_PORT 环境变量自定义

--- a/openspec/specs/creonow-frontend-full-assembly/design/04-qa-gates-storybook-wsl.md
+++ b/openspec/specs/creonow-frontend-full-assembly/design/04-qa-gates-storybook-wsl.md
@@ -19,23 +19,34 @@
 
 ## 2) Storybook 启动方式（WSL）
 
-在 WSL（Linux）里运行：
+### 2.1 启动 Storybook（绑定 0.0.0.0）
+
+在 WSL（Linux）仓库根目录运行：
 
 ```bash
-pnpm -C apps/desktop storybook -- --host 0.0.0.0 -p 6006
+pnpm -C apps/desktop storybook:wsl
 ```
 
-获取 WSL IP（示例命令，任选其一）：
+此命令等价于 `storybook dev --host 0.0.0.0 -p 6006`，使 Storybook 可从 Windows 浏览器通过 WSL IP 访问。
+
+### 2.2 获取 WSL IP 与访问 URL（一键脚本）
 
 ```bash
-hostname -I
-# 或：
-ip addr | rg -n \"inet \" 
+./scripts/wsl_storybook_url.sh
 ```
 
-在 Windows 浏览器中访问：
+输出示例：
 
-- `http://<WSL_IP>:6006`
+```
+WSL IP: 172.25.160.1
+Storybook URL: http://172.25.160.1:6006
+```
+
+> 脚本每次运行动态读取 WSL IP，不会写死。若需要自定义端口，设置环境变量 `STORYBOOK_PORT`。
+
+### 2.3 在 Windows 浏览器中访问
+
+复制脚本输出的 URL，在 Windows 浏览器中打开即可。
 
 > 若你环境里 `http://localhost:6006` 也能访问，依然建议记录 WSL_IP 的访问证据，以满足本规范门禁口径。
 

--- a/openspec/specs/creonow-frontend-full-assembly/design/08-test-and-qa-matrix.md
+++ b/openspec/specs/creonow-frontend-full-assembly/design/08-test-and-qa-matrix.md
@@ -14,7 +14,17 @@
 
 ## 1) Evidence 标准（RUN_LOG 模板）
 
-### 1.1 每个 PR 必须包含的证据块（MUST）
+### 1.1 快速启动（两条命令）
+
+```bash
+# 1) 启动 Storybook（绑定 0.0.0.0）
+pnpm -C apps/desktop storybook:wsl
+
+# 2) 获取 Windows 浏览器访问 URL
+./scripts/wsl_storybook_url.sh
+```
+
+### 1.2 每个 PR 必须包含的证据块（MUST）
 
 在 `openspec/_ops/task_runs/ISSUE-<N>.md` 的 `Runs` 里追加一个小节（只追加不回写）：
 
@@ -29,11 +39,26 @@
   - Notes: <what you verified + edge cases>
 ```
 
-### 1.2 Storybook 证据最小要求（MUST）
+### 1.3 Storybook 证据最小要求（MUST）
 
 - 必须包含：WSL-IP URL（Windows 浏览器访问的地址）
 - 必须列出：本 PR 影响的 stories（至少 2 个）
 - 必须提供：截图或短录屏路径（可 repo 外，但 reviewer 必须可拿到）
+
+### 1.4 可复制粘贴的证据模板
+
+```md
+### YYYY-MM-DD HH:MM Storybook WSL-IP QA
+- Command: `pnpm -C apps/desktop storybook:wsl`
+- Key output: Storybook 9.0.3 for react-vite started (localhost:6006)
+- Evidence:
+  - Storybook WSL-IP URL: `http://<WSL_IP>:6006`
+  - Checked stories:
+    - Features/XXX（检查点：...）
+    - Layout/YYY（检查点：...）
+  - Screenshots/recordings: N/A（文本证据描述）
+  - Notes: hover/focus 正常、ESC 关闭正常、无布局溢出
+```
 
 ---
 

--- a/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-014-storybook-wsl-ip-qa-gate.md
+++ b/openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-014-storybook-wsl-ip-qa-gate.md
@@ -1,6 +1,6 @@
 # P0-014: Storybook WSL-IP QA Gate（流程固化 + 证据格式）
 
-Status: todo
+Status: in-progress
 
 ## Goal
 

--- a/scripts/wsl_storybook_url.sh
+++ b/scripts/wsl_storybook_url.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# wsl_storybook_url.sh — 输出 WSL IP 与 Storybook 访问 URL
+# 
+# Usage:
+#   ./scripts/wsl_storybook_url.sh
+#
+# Output (示例):
+#   WSL IP: 172.25.160.1
+#   Storybook URL: http://172.25.160.1:6006
+#
+# 用途：
+#   在 Windows 浏览器中访问 WSL 内运行的 Storybook，用于 QA Gate 验收。
+
+set -euo pipefail
+
+PORT="${STORYBOOK_PORT:-6006}"
+
+# 动态获取 WSL IP（每次运行都重新读取，不写死）
+# 优先使用 hostname -I 的第一个 IP
+WSL_IP=$(hostname -I | awk '{print $1}')
+
+if [[ -z "${WSL_IP}" ]]; then
+    echo "Error: 无法获取 WSL IP 地址" >&2
+    exit 1
+fi
+
+echo "WSL IP: ${WSL_IP}"
+echo "Storybook URL: http://${WSL_IP}:${PORT}"


### PR DESCRIPTION
Closes #186

## Summary

把「Storybook 必须经 WSL-IP 在 Windows 浏览器验收」的要求固化为团队可执行的门禁流程：

- **一条命令启动 Storybook**：`pnpm -C apps/desktop storybook:wsl`（绑定 0.0.0.0）
- **一条命令打印 WSL IP 与访问 URL**：`./scripts/wsl_storybook_url.sh`
- **RUN_LOG 证据格式固定**：见 `design/08-test-and-qa-matrix.md` 的可复制粘贴模板

## Changes

| 文件 | 变更 |
| --- | --- |
| `apps/desktop/package.json` | 新增 `storybook:wsl` script |
| `scripts/wsl_storybook_url.sh` | 新增脚本，动态输出 WSL IP 与访问 URL |
| `design/04-qa-gates-storybook-wsl.md` | 回填真实脚本命令与启动方式 |
| `design/08-test-and-qa-matrix.md` | 添加快速启动命令与可复制粘贴的证据模板 |
| `task_cards/p0/P0-014-*.md` | 更新状态为 in-progress |
| `ISSUE-186.md` | 新增 RUN_LOG |

## Test Plan

- [x] `./scripts/wsl_storybook_url.sh` 输出格式正确（WSL IP + Storybook URL）
- [x] 脚本每次运行动态获取 IP（不写死）
- [ ] （可选）在 Windows 浏览器中验证 URL 可访问

Made with [Cursor](https://cursor.com)