### PR TITLE
[P0-002] Command Palette + Shortcuts 命令补齐与快捷键对齐

### DIFF
--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -8,12 +8,19 @@
  * - 搜索过滤：实时过滤命令/文件
  * - 键盘导航：↑↓ 移动，Enter 确认，Esc 关闭
  * - 搜索高亮：匹配文字高亮显示
+ *
+ * 快捷键对齐 design/DESIGN_DECISIONS.md：
+ * - Cmd/Ctrl+P: Command Palette
+ * - Cmd/Ctrl+,: Open Settings
+ * - Cmd/Ctrl+\: Toggle Sidebar（禁止使用 Cmd/Ctrl+B）
+ * - Cmd/Ctrl+L: Toggle Right Panel
+ * - F11: Toggle Zen Mode
+ * - Cmd/Ctrl+N: New Document
+ * - Cmd/Ctrl+Shift+N: New Project
  */
 import React from "react";
 
 import { Text } from "../../components/primitives/Text";
-import { invoke } from "../../lib/ipcClient";
-import { useEditorStore } from "../../stores/editorStore";
 import { useProjectStore } from "../../stores/projectStore";
 
 // =============================================================================
@@ -44,6 +51,38 @@ interface CommandGroup {
   items: CommandItem[];
 }
 
+/**
+ * Layout action callbacks for CommandPalette
+ */
+export interface CommandPaletteLayoutActions {
+  /** Toggle sidebar collapsed state */
+  onToggleSidebar: () => void;
+  /** Toggle right panel collapsed state */
+  onToggleRightPanel: () => void;
+  /** Toggle zen mode */
+  onToggleZenMode: () => void;
+}
+
+/**
+ * Dialog open callbacks for CommandPalette
+ */
+export interface CommandPaletteDialogActions {
+  /** Open settings dialog */
+  onOpenSettings: () => void;
+  /** Open export dialog */
+  onOpenExport: () => void;
+  /** Open create project dialog */
+  onOpenCreateProject: () => void;
+}
+
+/**
+ * Document action callbacks for CommandPalette
+ */
+export interface CommandPaletteDocumentActions {
+  /** Create new document in current project */
+  onCreateDocument: () => Promise<void>;
+}
+
 export interface CommandPaletteProps {
   /** 面板是否打开 */
   open: boolean;
@@ -51,6 +90,12 @@ export interface CommandPaletteProps {
   onOpenChange: (open: boolean) => void;
   /** 自定义命令列表（可选，用于测试） */
   commands?: CommandItem[];
+  /** Layout actions (sidebar/panel/zen) */
+  layoutActions?: CommandPaletteLayoutActions;
+  /** Dialog actions (settings/export/createProject) */
+  dialogActions?: CommandPaletteDialogActions;
+  /** Document actions (createDocument) */
+  documentActions?: CommandPaletteDocumentActions;
 }
 
 // =============================================================================
@@ -148,6 +193,68 @@ function SettingsIcon({ className }: { className?: string }): JSX.Element {
   );
 }
 
+/** 右侧面板图标 */
+function PanelRightIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <line x1="15" y1="3" x2="15" y2="21" />
+    </svg>
+  );
+}
+
+/** 禅模式图标 */
+function MaximizeIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+    </svg>
+  );
+}
+
+/** 文件夹加号图标（新建项目） */
+function FolderPlusIcon({ className }: { className?: string }): JSX.Element {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+      <line x1="12" y1="11" x2="12" y2="17" />
+      <line x1="9" y1="14" x2="15" y2="14" />
+    </svg>
+  );
+}
+
+/**
+ * 获取平台相关的修饰键显示
+ * macOS: ⌘ (Cmd), Windows/Linux: Ctrl
+ */
+function getModKey(): string {
+  return navigator.platform.toLowerCase().includes("mac") ? "⌘" : "Ctrl+";
+}
+
 // =============================================================================
 // Utilities
 // =============================================================================
@@ -228,9 +335,11 @@ export function CommandPalette({
   open,
   onOpenChange,
   commands: customCommands,
+  layoutActions,
+  dialogActions,
+  documentActions,
 }: CommandPaletteProps): JSX.Element | null {
   const currentProjectId = useProjectStore((s) => s.current?.projectId ?? null);
-  const documentId = useEditorStore((s) => s.documentId);
 
   const [query, setQuery] = React.useState("");
   const [activeIndex, setActiveIndex] = React.useState(0);
@@ -239,68 +348,151 @@ export function CommandPalette({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
 
-  // 默认命令列表
+  // 获取平台相关的修饰键
+  const modKey = React.useMemo(() => getModKey(), []);
+
+  // 默认命令列表 - 对齐 design/DESIGN_DECISIONS.md 快捷键规范
   const defaultCommands = React.useMemo<CommandItem[]>(
     () => [
+      // === Settings ===
       {
         id: "open-settings",
         label: "Open Settings",
         icon: <SettingsIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: "⌘,",
+        shortcut: `${modKey},`,
         group: "Suggestions",
         onSelect: () => {
-          // TODO: Implement settings
-          onOpenChange(false);
+          setErrorText(null);
+          if (dialogActions?.onOpenSettings) {
+            dialogActions.onOpenSettings();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Settings dialog not available");
+          }
         },
       },
+      // === Export ===
+      {
+        id: "export",
+        label: "Export…",
+        icon: <DownloadIcon className="text-[var(--color-fg-muted)]" />,
+        group: "Suggestions",
+        onSelect: () => {
+          setErrorText(null);
+          if (!currentProjectId) {
+            setErrorText("NO_PROJECT: Please open a project first");
+            return;
+          }
+          if (dialogActions?.onOpenExport) {
+            dialogActions.onOpenExport();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Export dialog not available");
+          }
+        },
+      },
+      // === Layout: Toggle Sidebar ===
       {
         id: "toggle-sidebar",
         label: "Toggle Sidebar",
         icon: <SidebarIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: "⌘B",
-        group: "Suggestions",
+        shortcut: `${modKey}\\`,
+        group: "Layout",
         onSelect: () => {
-          // TODO: Implement toggle sidebar
-          onOpenChange(false);
+          setErrorText(null);
+          if (layoutActions?.onToggleSidebar) {
+            layoutActions.onToggleSidebar();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Layout actions not available");
+          }
         },
       },
+      // === Layout: Toggle Right Panel ===
       {
-        id: "create-new-file",
-        label: "Create New File",
+        id: "toggle-right-panel",
+        label: "Toggle Right Panel",
+        icon: <PanelRightIcon className="text-[var(--color-fg-muted)]" />,
+        shortcut: `${modKey}L`,
+        group: "Layout",
+        onSelect: () => {
+          setErrorText(null);
+          if (layoutActions?.onToggleRightPanel) {
+            layoutActions.onToggleRightPanel();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Layout actions not available");
+          }
+        },
+      },
+      // === Layout: Zen Mode ===
+      {
+        id: "toggle-zen-mode",
+        label: "Toggle Zen Mode",
+        icon: <MaximizeIcon className="text-[var(--color-fg-muted)]" />,
+        shortcut: "F11",
+        group: "Layout",
+        onSelect: () => {
+          setErrorText(null);
+          if (layoutActions?.onToggleZenMode) {
+            layoutActions.onToggleZenMode();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Layout actions not available");
+          }
+        },
+      },
+      // === Document: Create New Document ===
+      {
+        id: "create-new-document",
+        label: "Create New Document",
         icon: <EditIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: "⌘N",
-        group: "Suggestions",
-        onSelect: () => {
-          // TODO: Implement create new file
-          onOpenChange(false);
-        },
-      },
-      {
-        id: "export-markdown",
-        label: "Export Markdown",
-        icon: <DownloadIcon className="text-[var(--color-fg-muted)]" />,
-        group: "Suggestions",
+        shortcut: `${modKey}N`,
+        group: "Document",
         onSelect: async () => {
           setErrorText(null);
           if (!currentProjectId) {
-            setErrorText("No current project");
+            setErrorText("NO_PROJECT: Please open a project first");
             return;
           }
-
-          const res = await invoke("export:markdown", {
-            projectId: currentProjectId,
-            documentId: documentId ?? undefined,
-          });
-          if (!res.ok) {
-            setErrorText(`${res.error.code}: ${res.error.message}`);
-            return;
+          if (documentActions?.onCreateDocument) {
+            try {
+              await documentActions.onCreateDocument();
+              onOpenChange(false);
+            } catch {
+              setErrorText("ACTION_FAILED: Failed to create document");
+            }
+          } else {
+            setErrorText("ACTION_FAILED: Document actions not available");
           }
-
-          onOpenChange(false);
+        },
+      },
+      // === Project: Create New Project ===
+      {
+        id: "create-new-project",
+        label: "Create New Project",
+        icon: <FolderPlusIcon className="text-[var(--color-fg-muted)]" />,
+        shortcut: `${modKey}⇧N`,
+        group: "Project",
+        onSelect: () => {
+          setErrorText(null);
+          if (dialogActions?.onOpenCreateProject) {
+            dialogActions.onOpenCreateProject();
+            onOpenChange(false);
+          } else {
+            setErrorText("ACTION_FAILED: Create project dialog not available");
+          }
         },
       },
     ],
-    [currentProjectId, documentId, onOpenChange],
+    [
+      currentProjectId,
+      dialogActions,
+      documentActions,
+      layoutActions,
+      modKey,
+      onOpenChange,
+    ],
   );
 
   const commands = customCommands ?? defaultCommands;

--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * E2E tests for Command Palette + Keyboard Shortcuts
+ *
+ * Tests coverage per P0-002-command-palette-commands-and-shortcuts.md:
+ * - Cmd/Ctrl+P opens Command Palette
+ * - Search "Settings" → Enter → SettingsDialog visible
+ * - Search "Export" → Enter → ExportDialog visible
+ * - Cmd/Ctrl+\ toggles Sidebar (NOT Cmd+B per DESIGN_DECISIONS.md)
+ * - Cmd/Ctrl+L toggles Right Panel
+ * - F11 toggles Zen Mode
+ * - Cmd/Ctrl+, opens Settings directly
+ * - Cmd/Ctrl+Shift+N opens Create Project dialog
+ */
+import {
+  _electron as electron,
+  expect,
+  test,
+  type Page,
+} from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E CommandPalette ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+/**
+ * Get the platform-specific modifier key
+ */
+function getModKey(): "Meta" | "Control" {
+  return process.platform === "darwin" ? "Meta" : "Control";
+}
+
+test.describe("Command Palette + Shortcuts", () => {
+  let userDataDir: string;
+  let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+  });
+
+  test.afterAll(async () => {
+    await electronApp.close();
+  });
+
+  test("Cmd/Ctrl+P opens Command Palette", async () => {
+    const modKey = getModKey();
+
+    // Ensure command palette is not visible initially
+    await expect(page.getByTestId("command-palette")).not.toBeVisible();
+
+    // Press Cmd/Ctrl+P
+    await page.keyboard.press(`${modKey}+p`);
+
+    // Command palette should now be visible
+    await expect(page.getByTestId("command-palette")).toBeVisible();
+
+    // Close with Escape
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("command-palette")).not.toBeVisible();
+  });
+
+  test("Search 'Settings' in Command Palette → SettingsDialog visible", async () => {
+    const modKey = getModKey();
+
+    // Open command palette
+    await page.keyboard.press(`${modKey}+p`);
+    await expect(page.getByTestId("command-palette")).toBeVisible();
+
+    // Type "Settings" to filter
+    await page.getByRole("textbox", { name: "Search commands" }).fill("Settings");
+
+    // Press Enter to select first result
+    await page.keyboard.press("Enter");
+
+    // SettingsDialog should be visible (check for the dialog content)
+    // Note: SettingsDialog uses Radix which renders in a portal
+    await expect(
+      page.getByRole("dialog", { name: /settings/i }),
+    ).toBeVisible();
+
+    // Close the dialog
+    await page.keyboard.press("Escape");
+  });
+
+  test("Cmd/Ctrl+\\ toggles Sidebar visibility", async () => {
+    const modKey = getModKey();
+
+    // Get initial sidebar state
+    const sidebar = page.getByTestId("layout-sidebar");
+    const initiallyVisible = await sidebar.isVisible();
+
+    // Press Cmd/Ctrl+\
+    await page.keyboard.press(`${modKey}+\\`);
+
+    // Sidebar should toggle
+    if (initiallyVisible) {
+      await expect(sidebar).not.toBeVisible();
+    } else {
+      await expect(sidebar).toBeVisible();
+    }
+
+    // Toggle back
+    await page.keyboard.press(`${modKey}+\\`);
+
+    // Should be back to initial state
+    if (initiallyVisible) {
+      await expect(sidebar).toBeVisible();
+    } else {
+      await expect(sidebar).not.toBeVisible();
+    }
+  });
+
+  test("Cmd/Ctrl+L toggles Right Panel visibility", async () => {
+    const modKey = getModKey();
+
+    // Get initial panel state
+    const panel = page.getByTestId("layout-panel");
+    const initiallyVisible = await panel.isVisible();
+
+    // Press Cmd/Ctrl+L
+    await page.keyboard.press(`${modKey}+l`);
+
+    // Panel should toggle
+    if (initiallyVisible) {
+      await expect(panel).not.toBeVisible();
+    } else {
+      await expect(panel).toBeVisible();
+    }
+
+    // Toggle back
+    await page.keyboard.press(`${modKey}+l`);
+
+    // Should be back to initial state
+    if (initiallyVisible) {
+      await expect(panel).toBeVisible();
+    } else {
+      await expect(panel).not.toBeVisible();
+    }
+  });
+
+  test("F11 toggles Zen Mode", async () => {
+    // Press F11 to enter Zen Mode
+    await page.keyboard.press("F11");
+
+    // In Zen Mode, sidebar and panel should be collapsed
+    await expect(page.getByTestId("layout-sidebar")).not.toBeVisible();
+    await expect(page.getByTestId("layout-panel")).not.toBeVisible();
+
+    // Press F11 again to exit
+    await page.keyboard.press("F11");
+
+    // Panels should be restored (the exact state depends on previous state)
+    // Just verify the app shell is still there
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+  });
+
+  test("Escape exits Zen Mode", async () => {
+    // Enter Zen Mode
+    await page.keyboard.press("F11");
+    await expect(page.getByTestId("layout-sidebar")).not.toBeVisible();
+
+    // Press Escape to exit
+    await page.keyboard.press("Escape");
+
+    // Should have exited Zen Mode (app shell still visible)
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+  });
+
+  test("Cmd/Ctrl+, opens Settings directly", async () => {
+    const modKey = getModKey();
+
+    // Press Cmd/Ctrl+,
+    await page.keyboard.press(`${modKey}+,`);
+
+    // SettingsDialog should be visible
+    await expect(
+      page.getByRole("dialog", { name: /settings/i }),
+    ).toBeVisible();
+
+    // Close the dialog
+    await page.keyboard.press("Escape");
+  });
+
+  test("Cmd/Ctrl+Shift+N opens Create Project dialog", async () => {
+    const modKey = getModKey();
+
+    // Press Cmd/Ctrl+Shift+N
+    await page.keyboard.press(`${modKey}+Shift+n`);
+
+    // CreateProjectDialog should be visible
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+
+    // Close the dialog
+    await page.keyboard.press("Escape");
+  });
+
+  test("Command Palette shows error when Export without project", async () => {
+    const modKey = getModKey();
+
+    // Open command palette
+    await page.keyboard.press(`${modKey}+p`);
+    await expect(page.getByTestId("command-palette")).toBeVisible();
+
+    // Search for Export
+    await page.getByRole("textbox", { name: "Search commands" }).fill("Export");
+
+    // Press Enter
+    await page.keyboard.press("Enter");
+
+    // Should show error (no project selected in initial state)
+    // The error testid is command-palette-error
+    await expect(page.getByTestId("command-palette-error")).toBeVisible();
+
+    // Close palette
+    await page.keyboard.press("Escape");
+  });
+
+  test("Command Palette keyboard navigation works", async () => {
+    const modKey = getModKey();
+
+    // Open command palette
+    await page.keyboard.press(`${modKey}+p`);
+    await expect(page.getByTestId("command-palette")).toBeVisible();
+
+    // First item should be active by default
+    const firstItem = page.locator('[data-index="0"]');
+    await expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+    // Press down arrow
+    await page.keyboard.press("ArrowDown");
+
+    // Second item should now be active
+    const secondItem = page.locator('[data-index="1"]');
+    await expect(secondItem).toHaveAttribute("aria-selected", "true");
+
+    // Press up arrow
+    await page.keyboard.press("ArrowUp");
+
+    // First item should be active again
+    await expect(firstItem).toHaveAttribute("aria-selected", "true");
+
+    // Close palette
+    await page.keyboard.press("Escape");
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-188.md
+++ b/openspec/_ops/task_runs/ISSUE-188.md
@@ -1,0 +1,46 @@
+# ISSUE-188
+
+- Issue: #188
+- Branch: task/188-p0-002-command-palette
+- PR: https://github.com/Leeky1017/CreoNow/pull/189
+
+## Plan
+
+- 补齐 CommandPalette 命令（Settings/Export/Toggle Panels/Zen Mode/New Doc/New Project）
+- 对齐快捷键到 design/DESIGN_DECISIONS.md（修复 Cmd+B → Cmd+\）
+- 新增 E2E 测试 command-palette.spec.ts
+
+## Runs
+
+### 2026-02-05 12:10 Initial Implementation
+
+- Files changed:
+  - `apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx`
+  - `apps/desktop/renderer/src/components/layout/AppShell.tsx`
+  - `apps/desktop/tests/e2e/command-palette.spec.ts` (new)
+
+- Command: `pnpm tsc --noEmit`
+- Key output: `Exit code: 0` (no type errors)
+
+- Command: `pnpm lint`
+- Key output: `✖ 3 problems (0 errors, 3 warnings)` (pre-existing warnings only)
+
+- Command: `pnpm vitest run CommandPalette.test.tsx AppShell.test.tsx`
+- Key output: `Test Files  2 passed (2), Tests  44 passed (44)`
+
+### Implementation Summary
+
+**CommandPalette.tsx changes:**
+- Fixed Toggle Sidebar shortcut: `⌘B` → `⌘\` (per DESIGN_DECISIONS.md)
+- Added commands: Toggle Right Panel, Toggle Zen Mode, Export…, Create New Project
+- Added platform-aware shortcut display (⌘ on Mac, Ctrl+ on Windows)
+- Added callback props for layout/dialog/document actions
+- Added error handling with `error.code: message` format
+
+**AppShell.tsx changes:**
+- Added keyboard shortcuts: `Cmd/Ctrl+,` (Settings), `Cmd/Ctrl+N` (New Doc), `Cmd/Ctrl+Shift+N` (New Project)
+- Added dialog state management and rendering (SettingsDialog, ExportDialog, CreateProjectDialog)
+- Created callback objects for CommandPalette
+
+**New E2E test:**
+- `command-palette.spec.ts` covering all shortcuts and command execution


### PR DESCRIPTION
## Summary

- 补齐 CommandPalette 命令：Toggle Right Panel、Toggle Zen Mode、Export…、Create New Project
- 修复 Toggle Sidebar 快捷键 `⌘B` → `⌘\`（符合 `design/DESIGN_DECISIONS.md`）
- 添加平台感知快捷键显示（Mac: ⌘, Windows: Ctrl+）
- AppShell 新增全局快捷键：`Cmd/Ctrl+,`、`Cmd/Ctrl+N`、`Cmd/Ctrl+Shift+N`
- 新增 E2E 测试 `command-palette.spec.ts`

## Test plan

- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm vitest run CommandPalette.test.tsx AppShell.test.tsx` 44 tests 通过
- [x] `pnpm lint` 无新增 error（3 个 pre-existing warnings）
- [ ] CI checks 通过

## RUN_LOG

详见 `openspec/_ops/task_runs/ISSUE-188.md`

Closes #188

Made with [Cursor](https://cursor.com)