### PR TITLE
P0-012: SystemDialog/Confirm unify (#190)

### DIFF
--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -355,6 +355,7 @@ const dismissButtonStyles = [
  */
 export function AiErrorCard({
   error,
+  errorCodeTestId,
   onRetry,
   onUpgradePlan,
   onViewUsage,
@@ -505,7 +506,9 @@ export function AiErrorCard({
 
           {/* Error code for service errors */}
           {error.errorCode && (
-            <div className={errorCodeStyles}>{error.errorCode}</div>
+            <div data-testid={errorCodeTestId} className={errorCodeStyles}>
+              {error.errorCode}
+            </div>
           )}
 
           {/* Countdown for rate limit */}

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
@@ -405,7 +405,7 @@ export function SystemDialog({
   primaryLabel,
   secondaryLabel,
   tertiaryLabel,
-  simulateDelay = 1000,
+  simulateDelay = 0,
   showKeyboardHints = true,
 }: SystemDialogProps): JSX.Element {
   const [actionState, setActionState] = useState<ActionState>("idle");

--- a/apps/desktop/renderer/src/components/features/AiDialogs/types.ts
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/types.ts
@@ -118,6 +118,8 @@ export interface AiDiffModalProps {
 export interface AiErrorCardProps {
   /** Error configuration */
   error: AiErrorConfig;
+  /** Optional test id for the rendered error code element */
+  errorCodeTestId?: string;
   /** Callback when user clicks retry */
   onRetry?: () => void;
   /** Callback when user clicks upgrade plan (for usage limit) */

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -10,8 +10,10 @@ import {
   Text,
   type ContextMenuItem,
 } from "../../components/primitives";
+import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { useEditorStore } from "../../stores/editorStore";
 import { useFileStore } from "../../stores/fileStore";
+import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 
 type EditingState =
   | { mode: "idle" }
@@ -45,6 +47,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
   const clearError = useFileStore((s) => s.clearError);
 
   const openDocument = useEditorStore((s) => s.openDocument);
+  const { confirm, dialogProps } = useConfirmDialog();
   const openCurrentForProject = useEditorStore(
     (s) => s.openCurrentDocumentForProject,
   );
@@ -122,8 +125,14 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
   }
 
   async function onDelete(documentId: string): Promise<void> {
-    const ok = window.confirm("Delete this document?");
-    if (!ok) {
+    const confirmed = await confirm({
+      title: "Delete Document?",
+      description:
+        "This action cannot be undone. The document and its version history will be permanently deleted.",
+      primaryLabel: "Delete",
+      secondaryLabel: "Cancel",
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -335,6 +344,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
           </div>
         )}
       </div>
+      <SystemDialog {...dialogProps} />
     </div>
   );
 }

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
@@ -23,10 +23,19 @@ function createMockProjectStore() {
     createAndSetCurrent: async () => {
       // Simulate delay
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      return { ok: true, data: { projectId: "mock-id", rootPath: "/mock/path" } };
+      return {
+        ok: true,
+        data: { projectId: "mock-id", rootPath: "/mock/path" },
+      };
     },
     setCurrentProject: async () => {
-      return { ok: true, data: { projectId: "mock-id", rootPath: "/mock/path" } };
+      return {
+        ok: true,
+        data: { projectId: "mock-id", rootPath: "/mock/path" },
+      };
+    },
+    deleteProject: async () => {
+      return { ok: true, data: { deleted: true } };
     },
   }));
 }
@@ -125,7 +134,14 @@ function InteractiveDemo() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "center" }}>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+        alignItems: "center",
+      }}
+    >
       <Button onClick={() => setOpen(true)}>Create New Project</Button>
       <CreateProjectDialog open={open} onOpenChange={setOpen} />
     </div>

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -26,10 +26,30 @@ vi.mock("../../stores/templateStore", () => ({
   useTemplateStore: vi.fn((selector) => {
     const state = {
       presets: [
-        { id: "preset-novel", name: "Novel", type: "preset", structure: { folders: [], files: [] } },
-        { id: "preset-short", name: "Short Story", type: "preset", structure: { folders: [], files: [] } },
-        { id: "preset-script", name: "Screenplay", type: "preset", structure: { folders: [], files: [] } },
-        { id: "preset-other", name: "Other", type: "preset", structure: { folders: [], files: [] } },
+        {
+          id: "preset-novel",
+          name: "Novel",
+          type: "preset",
+          structure: { folders: [], files: [] },
+        },
+        {
+          id: "preset-short",
+          name: "Short Story",
+          type: "preset",
+          structure: { folders: [], files: [] },
+        },
+        {
+          id: "preset-script",
+          name: "Screenplay",
+          type: "preset",
+          structure: { folders: [], files: [] },
+        },
+        {
+          id: "preset-other",
+          name: "Other",
+          type: "preset",
+          structure: { folders: [], files: [] },
+        },
       ],
       customs: [],
       loading: false,
@@ -49,7 +69,9 @@ vi.mock("../../stores/templateStore", () => ({
 // Mock CreateTemplateDialog
 vi.mock("./CreateTemplateDialog", () => ({
   CreateTemplateDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="create-template-dialog">Create Template Dialog</div> : null,
+    open ? (
+      <div data-testid="create-template-dialog">Create Template Dialog</div>
+    ) : null,
 }));
 
 describe("CreateProjectDialog", () => {
@@ -104,7 +126,9 @@ describe("CreateProjectDialog", () => {
     it("应该显示描述输入框", () => {
       render(<CreateProjectDialog open={true} onOpenChange={vi.fn()} />);
 
-      expect(screen.getByTestId("create-project-description")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("create-project-description"),
+      ).toBeInTheDocument();
     });
 
     it("应该显示 Create Template 按钮", () => {
@@ -195,6 +219,7 @@ describe("CreateProjectDialog", () => {
           bootstrap: vi.fn(),
           createAndSetCurrent,
           setCurrentProject: vi.fn(),
+          deleteProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -207,7 +232,9 @@ describe("CreateProjectDialog", () => {
       await user.click(screen.getByTestId("create-project-submit"));
 
       await waitFor(() => {
-        expect(createAndSetCurrent).toHaveBeenCalledWith({ name: "New Project" });
+        expect(createAndSetCurrent).toHaveBeenCalledWith({
+          name: "New Project",
+        });
       });
     });
 
@@ -239,6 +266,7 @@ describe("CreateProjectDialog", () => {
           bootstrap: vi.fn(),
           createAndSetCurrent: vi.fn(),
           setCurrentProject: vi.fn(),
+          deleteProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -273,6 +301,7 @@ describe("CreateProjectDialog", () => {
           bootstrap: vi.fn(),
           createAndSetCurrent,
           setCurrentProject: vi.fn(),
+          deleteProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -281,7 +310,10 @@ describe("CreateProjectDialog", () => {
       const user = userEvent.setup();
       render(<CreateProjectDialog open={true} onOpenChange={vi.fn()} />);
 
-      await user.type(screen.getByTestId("create-project-name"), "Test Project");
+      await user.type(
+        screen.getByTestId("create-project-name"),
+        "Test Project",
+      );
       await user.click(screen.getByTestId("create-project-submit"));
 
       await waitFor(() => {
@@ -306,6 +338,7 @@ describe("CreateProjectDialog", () => {
           bootstrap: vi.fn(),
           createAndSetCurrent: vi.fn(),
           setCurrentProject: vi.fn(),
+          deleteProject: vi.fn(),
           clearError,
         };
         return selector(state);

--- a/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
+++ b/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
@@ -13,6 +13,7 @@ import {
  * @param overrides - Partial store state to override defaults
  */
 function createMockProjectStore(overrides: Partial<ProjectStore> = {}) {
+  const { deleteProject, ...rest } = overrides;
   return create<ProjectStore>(() => ({
     current: null,
     items: [],
@@ -22,12 +23,23 @@ function createMockProjectStore(overrides: Partial<ProjectStore> = {}) {
     bootstrap: async () => {},
     createAndSetCurrent: async () => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      return { ok: true, data: { projectId: "mock-id", rootPath: "/mock/path" } };
+      return {
+        ok: true,
+        data: { projectId: "mock-id", rootPath: "/mock/path" },
+      };
     },
     setCurrentProject: async () => {
-      return { ok: true, data: { projectId: "mock-id", rootPath: "/mock/path" } };
+      return {
+        ok: true,
+        data: { projectId: "mock-id", rootPath: "/mock/path" },
+      };
     },
-    ...overrides,
+    ...rest,
+    deleteProject:
+      deleteProject ??
+      (async () => {
+        return { ok: true, data: { deleted: true } };
+      }),
   }));
 }
 

--- a/apps/desktop/renderer/src/hooks/useConfirmDialog.ts
+++ b/apps/desktop/renderer/src/hooks/useConfirmDialog.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { SystemDialogProps } from "../components/features/AiDialogs/types";
+
+type ConfirmDialogOptions = Pick<
+  SystemDialogProps,
+  "title" | "description" | "primaryLabel" | "secondaryLabel"
+>;
+
+type ConfirmDialogState = ConfirmDialogOptions & {
+  open: boolean;
+};
+
+export type UseConfirmDialogReturn = {
+  confirm: (options: ConfirmDialogOptions) => Promise<boolean>;
+  dialogProps: Pick<
+    SystemDialogProps,
+    | "open"
+    | "onOpenChange"
+    | "type"
+    | "title"
+    | "description"
+    | "primaryLabel"
+    | "secondaryLabel"
+    | "onPrimaryAction"
+    | "onSecondaryAction"
+    | "simulateDelay"
+  >;
+};
+
+/**
+ * useConfirmDialog provides a single, promise-based confirmation flow.
+ *
+ * Why: destructive actions must avoid `window.confirm` while remaining fully
+ * testable and deterministic in React (SystemDialog renders as a real surface).
+ *
+ * Concurrency strategy: when `confirm()` is called while a previous confirmation
+ * is still open, the previous confirmation is canceled (resolved to `false`)
+ * and replaced by the new one.
+ */
+export function useConfirmDialog(): UseConfirmDialogReturn {
+  const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
+  const [dialog, setDialog] = useState<ConfirmDialogState>({ open: false });
+
+  const resolvePending = useCallback((confirmed: boolean) => {
+    const resolver = resolverRef.current;
+    resolverRef.current = null;
+    resolver?.(confirmed);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      resolvePending(false);
+    };
+  }, [resolvePending]);
+
+  const confirm = useCallback(
+    (options: ConfirmDialogOptions): Promise<boolean> => {
+      resolvePending(false);
+
+      return new Promise((resolve) => {
+        resolverRef.current = resolve;
+        setDialog({ open: true, ...options });
+      });
+    },
+    [resolvePending],
+  );
+
+  const handlePrimaryAction = useCallback(() => {
+    resolvePending(true);
+    setDialog((prev) => ({ ...prev, open: false }));
+  }, [resolvePending]);
+
+  const handleSecondaryAction = useCallback(() => {
+    resolvePending(false);
+    setDialog((prev) => ({ ...prev, open: false }));
+  }, [resolvePending]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        resolvePending(false);
+      }
+      setDialog((prev) => ({ ...prev, open }));
+    },
+    [resolvePending],
+  );
+
+  return {
+    confirm,
+    dialogProps: {
+      open: dialog.open,
+      onOpenChange: handleOpenChange,
+      type: "delete",
+      title: dialog.title,
+      description: dialog.description,
+      primaryLabel: dialog.primaryLabel,
+      secondaryLabel: dialog.secondaryLabel,
+      onPrimaryAction: handlePrimaryAction,
+      onSecondaryAction: handleSecondaryAction,
+      simulateDelay: 0,
+    },
+  };
+}

--- a/apps/desktop/tests/e2e/documents-filetree.spec.ts
+++ b/apps/desktop/tests/e2e/documents-filetree.spec.ts
@@ -202,10 +202,14 @@ test("documents filetree: create/switch/rename/delete + current restore", async 
     "Alpha content",
   );
 
-  page.once("dialog", (dialog) => void dialog.accept());
   await page.getByTestId(`file-row-${docBId}`).hover();
   await page.getByTestId(`file-actions-${docBId}`).click();
   await page.getByTestId(`file-delete-${docBId}`).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete" }).click();
+  await expect(dialog).not.toBeVisible();
 
   await expect(page.getByTestId(`file-row-${docBId}`)).toHaveCount(0);
   await expect(page.getByTestId("editor-pane")).toHaveAttribute(

--- a/apps/desktop/tests/e2e/knowledge-graph.spec.ts
+++ b/apps/desktop/tests/e2e/knowledge-graph.spec.ts
@@ -107,8 +107,13 @@ test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", a
 
   await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toBeVisible();
 
-  page.once("dialog", (dialog) => void dialog.accept());
   await page.getByTestId(`kg-entity-delete-${entityId}`).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete" }).click();
+  await expect(dialog).not.toBeVisible();
+
   await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toHaveCount(0);
 
   const tooLarge = JSON.stringify({ x: "a".repeat(33_000) });

--- a/apps/desktop/tests/e2e/system-dialog.spec.ts
+++ b/apps/desktop/tests/e2e/system-dialog.spec.ts
@@ -1,0 +1,166 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+/**
+ * Parse the documentId from a `file-row-<documentId>` test id.
+ *
+ * Why: E2E must be resilient to UUID-based document ids.
+ */
+function parseDocumentId(testId: string): string {
+  const prefix = "file-row-";
+  if (!testId.startsWith(prefix)) {
+    throw new Error(`Unexpected file row test id: ${testId}`);
+  }
+  const id = testId.slice(prefix.length);
+  if (id.length === 0) {
+    throw new Error("Missing document id");
+  }
+  return id;
+}
+
+test("system dialog: cancel/confirm across file tree + knowledge graph", async () => {
+  const userDataDir = await createIsolatedUserDataDir();
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const appRoot = path.resolve(__dirname, "../..");
+
+  const electronApp = await electron.launch({
+    args: [appRoot],
+    env: {
+      ...process.env,
+      CREONOW_E2E: "1",
+      CREONOW_OPEN_DEVTOOLS: "0",
+      CREONOW_USER_DATA_DIR: userDataDir,
+    },
+  });
+  const page = await electronApp.firstWindow();
+  await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+
+  // Create a project via UI
+  await expect(page.getByTestId("welcome-screen")).toBeVisible();
+  await page.getByTestId("welcome-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.getByTestId("create-project-name").fill("Demo Project");
+  await page.getByTestId("create-project-submit").click();
+
+  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+  await expect(page.getByTestId("sidebar-files")).toBeVisible();
+
+  // ---------------------------------------------------------------------------
+  // FileTreePanel: Cancel keeps document, Confirm deletes document
+  // ---------------------------------------------------------------------------
+  const firstRow = page.locator('[data-testid^="file-row-"]').first();
+  await expect(firstRow).toBeVisible();
+  const firstRowIdAttr = await firstRow.getAttribute("data-testid");
+  if (!firstRowIdAttr) {
+    throw new Error("Missing data-testid on file row");
+  }
+  const docAId = parseDocumentId(firstRowIdAttr);
+
+  await page.getByTestId("file-create").click();
+
+  const rowsAfterCreate = page.locator('[data-testid^="file-row-"]');
+  await expect(rowsAfterCreate).toHaveCount(2);
+  const row0Attr = await rowsAfterCreate.nth(0).getAttribute("data-testid");
+  const row1Attr = await rowsAfterCreate.nth(1).getAttribute("data-testid");
+  if (!row0Attr || !row1Attr) {
+    throw new Error("Missing data-testid on file rows after create");
+  }
+  const id0 = parseDocumentId(row0Attr);
+  const id1 = parseDocumentId(row1Attr);
+  const docToDeleteId = id0 === docAId ? id1 : id0;
+
+  await page.getByTestId(`file-row-${docToDeleteId}`).hover();
+  await page.getByTestId(`file-actions-${docToDeleteId}`).click();
+  await page.getByTestId(`file-delete-${docToDeleteId}`).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Delete Document?")).toBeVisible();
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId(`file-row-${docToDeleteId}`)).toBeVisible();
+
+  await page.getByTestId(`file-row-${docToDeleteId}`).hover();
+  await page.getByTestId(`file-actions-${docToDeleteId}`).click();
+  await page.getByTestId(`file-delete-${docToDeleteId}`).click();
+
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId(`file-row-${docToDeleteId}`)).toHaveCount(0);
+
+  // ---------------------------------------------------------------------------
+  // KnowledgeGraphPanel: Cancel keeps entity, Confirm deletes entity
+  // ---------------------------------------------------------------------------
+  await page.getByTestId("icon-bar-knowledge-graph").click();
+  await expect(page.getByTestId("layout-sidebar")).toBeVisible();
+
+  await page.getByTestId("kg-entity-name").fill("Test Entity");
+  await page.getByTestId("kg-entity-create").click();
+
+  const project = await page.evaluate(async () => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    return await window.creonow.invoke("project:getCurrent", {});
+  });
+  expect(project.ok).toBe(true);
+  if (!project.ok) {
+    throw new Error(
+      `Expected ok project:getCurrent, got: ${project.error.code}`,
+    );
+  }
+  const projectId = project.data.projectId;
+
+  const entityId = await page.evaluate(async (projectIdParam) => {
+    if (!window.creonow) {
+      throw new Error("Missing window.creonow bridge");
+    }
+    const res = await window.creonow.invoke("kg:entity:list", {
+      projectId: projectIdParam,
+    });
+    if (!res.ok) {
+      throw new Error(`Expected ok kg:entity:list, got: ${res.error.code}`);
+    }
+    const item = res.data.items.find((e) => e.name === "Test Entity") ?? null;
+    if (!item) {
+      throw new Error("Missing created entity in list");
+    }
+    return item.entityId;
+  }, projectId);
+
+  await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toBeVisible();
+
+  await page.getByTestId(`kg-entity-delete-${entityId}`).click();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Delete Entity?")).toBeVisible();
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toBeVisible();
+
+  await page.getByTestId(`kg-entity-delete-${entityId}`).click();
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId(`kg-entity-row-${entityId}`)).toHaveCount(0);
+
+  await electronApp.close();
+});

--- a/openspec/_ops/task_runs/ISSUE-190.md
+++ b/openspec/_ops/task_runs/ISSUE-190.md
@@ -1,0 +1,45 @@
+# ISSUE-190
+
+- Issue: #190
+- Branch: task/190-p0-012-systemdialog-confirm
+- PR: <fill-after-created>
+
+## Plan
+
+- Replace destructive confirms with `SystemDialog` (no `window.confirm`)
+- Wire AiPanel errors to `AiErrorCard` (keep `ai-error-code`)
+- Add/adjust Playwright E2E coverage
+
+## Runs
+
+### 2026-02-05 12:50 Worktree setup
+
+- Command: `git worktree add -b task/190-p0-012-systemdialog-confirm .worktrees/issue-190-p0-012-systemdialog-confirm origin/main`
+- Key output: worktree created
+
+### 2026-02-05 14:32 Rulebook task
+
+- Command: `rulebook task create issue-190-p0-012-systemdialog-confirm && rulebook task validate issue-190-p0-012-systemdialog-confirm`
+- Key output: `✅ Task issue-190-p0-012-systemdialog-confirm is valid`
+- Evidence:
+  - `rulebook/tasks/issue-190-p0-012-systemdialog-confirm/`
+
+### 2026-02-05 14:34 Typecheck
+
+- Command: `pnpm typecheck`
+- Key output: exit code 0
+
+### 2026-02-05 14:35 Unit tests (vitest)
+
+- Command: `pnpm -C apps/desktop test:run -- renderer/src/features/ai/AiPanel.test.tsx`
+- Key output: `Test Files  57 passed (57)`
+
+### 2026-02-05 14:36 Playwright Electron E2E (targeted)
+
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/system-dialog.spec.ts tests/e2e/documents-filetree.spec.ts tests/e2e/knowledge-graph.spec.ts`
+- Key output: `3 passed`
+
+### 2026-02-05 14:40 PR preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: exit code 0 (lint warnings only; `test:unit` + inventory gate passed)

--- a/openspec/_ops/task_runs/ISSUE-190.md
+++ b/openspec/_ops/task_runs/ISSUE-190.md
@@ -2,7 +2,7 @@
 
 - Issue: #190
 - Branch: task/190-p0-012-systemdialog-confirm
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/191
 
 ## Plan
 

--- a/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/.metadata.json
+++ b/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-05T06:34:14.443Z",
+  "updatedAt": "2026-02-05T06:34:14.443Z"
+}

--- a/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/proposal.md
+++ b/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: issue-190-p0-012-systemdialog-confirm
+
+## Why
+
+P0-012 要求把 destructive 操作从 `window.confirm` 收敛到 `SystemDialog`，确保一致的焦点/键盘交互与可断言的 E2E 行为；同时 AI Surface 的错误态需要统一到 `AiErrorCard`，避免分散的 error box 与 silent failure。
+
+## What Changes
+
+- Renderer：新增 `useConfirmDialog()`（promise-based confirm），统一驱动 `SystemDialog`。
+- Renderer：替换 Files/KG/Dashboard 的 destructive confirm 入口为 `SystemDialog`（包含 KG relation delete）。
+- Renderer：AiPanel 错误态改为渲染 `AiErrorCard`，并保持稳定选择器 `ai-error-code`。
+- Components：`SystemDialog` 默认 `simulateDelay` 调整为 `0`（生产路径不模拟延迟）。
+- Tests：更新 Playwright E2E（documents-filetree / knowledge-graph）从原生 dialog 改为点击 `SystemDialog`；新增 `system-dialog.spec.ts` 覆盖 Cancel/Confirm + 两个入口。
+
+## Impact
+
+- Affected specs:
+  - openspec/specs/creonow-frontend-full-assembly/spec.md#cnfa-req-003
+  - openspec/specs/creonow-frontend-full-assembly/task_cards/p0/P0-012-aidialogs-systemdialog-and-confirm-unification.md
+- Affected code:
+  - apps/desktop/renderer/src/hooks/useConfirmDialog.ts
+  - apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+  - apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+  - apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
+  - apps/desktop/renderer/src/features/ai/AiPanel.tsx
+  - apps/desktop/renderer/src/components/features/AiDialogs/\*
+  - apps/desktop/tests/e2e/system-dialog.spec.ts
+  - apps/desktop/tests/e2e/documents-filetree.spec.ts
+  - apps/desktop/tests/e2e/knowledge-graph.spec.ts
+- Breaking change: NO
+- User benefit: destructive 操作确认弹窗一致且可预期；AI 错误态统一并保留稳定错误码展示，提升可观测性与 E2E 稳定性。

--- a/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/specs/creonow-frontend-full-assembly/spec.md
+++ b/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/specs/creonow-frontend-full-assembly/spec.md
@@ -1,0 +1,45 @@
+# Spec Delta: P0-012 SystemDialog/Confirm unification
+
+## Scope
+
+This task integrates `Features/AiDialogs` into real app surfaces and removes native confirms:
+
+- Files: delete document confirmation uses `SystemDialog`
+- Knowledge Graph: delete entity / relation confirmation uses `SystemDialog`
+- Dashboard: delete project confirmation uses `SystemDialog` + `project:delete`
+- AI Panel: error UI uses `AiErrorCard` with stable selectors
+
+## Confirmation semantics (renderer)
+
+- Destructive confirms MUST NOT use `window.confirm`.
+- The renderer MUST render `SystemDialog` as a real surface (Radix Dialog).
+- Confirm API is promise-based: `confirm(options) -> Promise<boolean>`.
+- Concurrency strategy MUST be deterministic:
+  - If `confirm()` is called while another confirmation is still open, the previous
+    confirmation is canceled (resolves to `false`) and replaced by the new one.
+
+## UX + Accessibility
+
+- Dialog MUST close via `Esc` / overlay click (Radix default).
+- Focus SHOULD move into the dialog on open and return to the trigger on close.
+- Production path MUST NOT simulate latency by default:
+  - `SystemDialog.simulateDelay` default is `0`.
+
+## Testing hooks (stable selectors)
+
+- Files:
+  - `file-delete-<documentId>` opens SystemDialog for delete
+- Knowledge Graph:
+  - `kg-entity-delete-<entityId>` opens SystemDialog for delete
+  - `kg-relation-delete-<relationId>` opens SystemDialog for delete
+- AI:
+  - Error code MUST remain `data-testid="ai-error-code"` (Playwright E2E contract)
+
+## E2E coverage
+
+- `apps/desktop/tests/e2e/system-dialog.spec.ts` covers:
+  - FileTreePanel: Cancel keeps doc, Confirm deletes doc
+  - KnowledgeGraphPanel: Cancel keeps entity, Confirm deletes entity
+- Existing tests updated to click SystemDialog buttons:
+  - `apps/desktop/tests/e2e/documents-filetree.spec.ts`
+  - `apps/desktop/tests/e2e/knowledge-graph.spec.ts`

--- a/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/tasks.md
+++ b/rulebook/tasks/issue-190-p0-012-systemdialog-confirm/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 新增 `useConfirmDialog()`：SystemDialog 的 promise-based confirm（并写死并发策略）
+- [x] 1.2 替换 destructive confirm：Files/KG（entity+relation）/Dashboard（project:delete）
+- [x] 1.3 AiPanel 错误态统一为 `AiErrorCard`（保留 `ai-error-code` 选择器）
+
+## 2. Testing
+
+- [x] 2.1 `pnpm typecheck`
+- [x] 2.2 `pnpm -C apps/desktop test:run`
+- [x] 2.3 `pnpm -C apps/desktop test:e2e -- tests/e2e/system-dialog.spec.ts tests/e2e/documents-filetree.spec.ts tests/e2e/knowledge-graph.spec.ts`
+
+## 3. Documentation
+
+- [ ] 3.1 更新 P0-012 task card Completion（PR + RUN_LOG）
+- [ ] 3.2 归档 rulebook task（merge 后）


### PR DESCRIPTION
Closes #190

### Summary
- Promise-based `useConfirmDialog()` for SystemDialog confirmations
- Replace destructive confirms in Files/KG/Dashboard (no `window.confirm`)
- Unify AiPanel error UI via `AiErrorCard` (keep `ai-error-code`)
- Add/update Playwright E2E coverage for SystemDialog

### Test Plan
- `pnpm typecheck`
- `pnpm -C apps/desktop test:run`
- `pnpm -C apps/desktop test:e2e -- tests/e2e/system-dialog.spec.ts tests/e2e/documents-filetree.spec.ts tests/e2e/knowledge-graph.spec.ts`