### PR TITLE
fix(settings): adjust close button position to dialog corner (#196)

### DIFF
--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -110,11 +110,12 @@ const navButtonBaseStyles = [
 
 /**
  * Close button styles.
+ * Positioned at dialog's top-right corner (outside content padding).
  */
 const closeButtonStyles = [
   "absolute",
-  "top-6",
-  "right-8",
+  "top-4",
+  "right-4",
   "p-2",
   "text-[var(--color-fg-placeholder)]",
   "hover:text-[var(--color-fg-default)]",

--- a/openspec/_ops/task_runs/ISSUE-196.md
+++ b/openspec/_ops/task_runs/ISSUE-196.md
@@ -1,0 +1,19 @@
+# ISSUE-196
+
+- Issue: #196
+- Branch: task/196-settingsdialog-close-button
+- PR: <fill-after-created>
+
+## Plan
+
+- Fix SettingsDialog close button positioning from `top-6 right-8` to `top-4 right-4`
+- Verify in Storybook that button appears at dialog corner
+- Run CI checks to ensure no regressions
+
+## Runs
+
+### 2026-02-05 18:55 Initial fix
+
+- Command: `StrReplace on SettingsDialog.tsx`
+- Key output: Changed `top-6 right-8` to `top-4 right-4` in closeButtonStyles
+- Evidence: Visual confirmation in Storybook - close button now at top-right corner

--- a/openspec/_ops/task_runs/ISSUE-196.md
+++ b/openspec/_ops/task_runs/ISSUE-196.md
@@ -2,7 +2,7 @@
 
 - Issue: #196
 - Branch: task/196-settingsdialog-close-button
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/197
 
 ## Plan
 


### PR DESCRIPTION
Closes #196

## Summary

- Move SettingsDialog close button from `top-6 right-8` (24px/32px) to `top-4 right-4` (16px/16px)
- Button now appears at the dialog's top-right corner instead of inside the content area

## Test Plan

- [x] Visual verification in Storybook - close button at corner
- [ ] CI checks pass

Made with [Cursor](https://cursor.com)