### PR TITLE
feat(dashboard): project rename/duplicate/archive IPC (#198)

### DIFF
--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -20,6 +20,7 @@ import searchFtsSql from "./migrations/0006_search_fts.sql?raw";
 import statsSql from "./migrations/0007_stats.sql?raw";
 import userMemoryVecSql from "./migrations/0008_user_memory_vec.sql?raw";
 import memoryDocumentScopeSql from "./migrations/0009_memory_document_scope.sql?raw";
+import projectArchiveSql from "./migrations/0010_project_archive.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -53,6 +54,7 @@ const MIGRATIONS_BASE: readonly Migration[] = [
     name: "0009_memory_document_scope",
     sql: memoryDocumentScopeSql,
   },
+  { version: 10, name: "0010_project_archive", sql: projectArchiveSql },
 ];
 
 const SQLITE_VEC_MIGRATION: Migration = {

--- a/apps/desktop/main/src/db/migrations/0010_project_archive.sql
+++ b/apps/desktop/main/src/db/migrations/0010_project_archive.sql
@@ -1,0 +1,10 @@
+-- P0-005: Add archived_at column to projects table for archive functionality.
+--
+-- Why: Dashboard needs to support archiving projects. Archived projects are hidden
+-- from the default list but can be restored. Using nullable timestamp allows
+-- both archive and unarchive operations.
+ALTER TABLE projects ADD COLUMN archived_at INTEGER;
+
+-- Index for efficient filtering of non-archived projects
+CREATE INDEX IF NOT EXISTS idx_projects_archived
+  ON projects(archived_at, updated_at DESC, project_id ASC);

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -565,7 +565,10 @@ export const ipcContract = {
       response: s.object({ projectId: s.string(), rootPath: s.string() }),
     },
     "project:list": {
-      request: s.object({ includeDeleted: s.optional(s.boolean()) }),
+      request: s.object({
+        includeDeleted: s.optional(s.boolean()),
+        includeArchived: s.optional(s.boolean()),
+      }),
       response: s.object({
         items: s.array(
           s.object({
@@ -573,6 +576,7 @@ export const ipcContract = {
             name: s.string(),
             rootPath: s.string(),
             updatedAt: s.number(),
+            archivedAt: s.optional(s.number()),
           }),
         ),
       }),
@@ -588,6 +592,38 @@ export const ipcContract = {
     "project:delete": {
       request: s.object({ projectId: s.string() }),
       response: s.object({ deleted: s.literal(true) }),
+    },
+    "project:rename": {
+      request: s.object({
+        projectId: s.string(),
+        name: s.string(),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        name: s.string(),
+        updatedAt: s.number(),
+      }),
+    },
+    "project:duplicate": {
+      request: s.object({
+        projectId: s.string(),
+        name: s.optional(s.string()),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        rootPath: s.string(),
+      }),
+    },
+    "project:archive": {
+      request: s.object({
+        projectId: s.string(),
+        archived: s.boolean(),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        archived: s.boolean(),
+        updatedAt: s.number(),
+      }),
     },
     "context:creonow:ensure": {
       request: s.object({ projectId: s.string() }),

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -42,13 +42,17 @@ export function registerProjectIpcHandlers(deps: {
 
   deps.ipcMain.handle(
     "project:list",
-    async (): Promise<
+    async (
+      _e,
+      payload: { includeDeleted?: boolean; includeArchived?: boolean },
+    ): Promise<
       IpcResponse<{
         items: Array<{
           projectId: string;
           name: string;
           rootPath: string;
           updatedAt: number;
+          archivedAt?: number;
         }>;
       }>
     > => {
@@ -63,7 +67,7 @@ export function registerProjectIpcHandlers(deps: {
         userDataDir: deps.userDataDir,
         logger: deps.logger,
       });
-      const res = svc.list();
+      const res = svc.list({ includeArchived: payload?.includeArchived });
       return res.ok
         ? { ok: true, data: res.data }
         : { ok: false, error: res.error };
@@ -133,6 +137,91 @@ export function registerProjectIpcHandlers(deps: {
         logger: deps.logger,
       });
       const res = svc.delete({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:rename",
+    async (
+      _e,
+      payload: { projectId: string; name: string },
+    ): Promise<
+      IpcResponse<{ projectId: string; name: string; updatedAt: number }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.rename({
+        projectId: payload.projectId,
+        name: payload.name,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:duplicate",
+    async (
+      _e,
+      payload: { projectId: string; name?: string },
+    ): Promise<IpcResponse<{ projectId: string; rootPath: string }>> => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.duplicate({
+        projectId: payload.projectId,
+        name: payload.name,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:archive",
+    async (
+      _e,
+      payload: { projectId: string; archived: boolean },
+    ): Promise<
+      IpcResponse<{ projectId: string; archived: boolean; updatedAt: number }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.archive({
+        projectId: payload.projectId,
+        archived: payload.archived,
+      });
       return res.ok
         ? { ok: true, data: res.data }
         : { ok: false, error: res.error };

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
@@ -37,6 +37,24 @@ function createMockProjectStore() {
     deleteProject: async () => {
       return { ok: true, data: { deleted: true } };
     },
+    renameProject: async (_projectId: string, name: string) => {
+      return {
+        ok: true,
+        data: { projectId: "mock-id", name, updatedAt: Date.now() },
+      };
+    },
+    duplicateProject: async () => {
+      return {
+        ok: true,
+        data: { projectId: "new-mock-id", rootPath: "/mock/path/new" },
+      };
+    },
+    archiveProject: async (_projectId: string, archived: boolean) => {
+      return {
+        ok: true,
+        data: { projectId: "mock-id", archived, updatedAt: Date.now() },
+      };
+    },
   }));
 }
 

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -220,6 +220,9 @@ describe("CreateProjectDialog", () => {
           createAndSetCurrent,
           setCurrentProject: vi.fn(),
           deleteProject: vi.fn(),
+          renameProject: vi.fn(),
+          duplicateProject: vi.fn(),
+          archiveProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -267,6 +270,9 @@ describe("CreateProjectDialog", () => {
           createAndSetCurrent: vi.fn(),
           setCurrentProject: vi.fn(),
           deleteProject: vi.fn(),
+          renameProject: vi.fn(),
+          duplicateProject: vi.fn(),
+          archiveProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -302,6 +308,9 @@ describe("CreateProjectDialog", () => {
           createAndSetCurrent,
           setCurrentProject: vi.fn(),
           deleteProject: vi.fn(),
+          renameProject: vi.fn(),
+          duplicateProject: vi.fn(),
+          archiveProject: vi.fn(),
           clearError: vi.fn(),
         };
         return selector(state);
@@ -339,6 +348,9 @@ describe("CreateProjectDialog", () => {
           createAndSetCurrent: vi.fn(),
           setCurrentProject: vi.fn(),
           deleteProject: vi.fn(),
+          renameProject: vi.fn(),
+          duplicateProject: vi.fn(),
+          archiveProject: vi.fn(),
           clearError,
         };
         return selector(state);

--- a/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
+++ b/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
@@ -13,7 +13,13 @@ import {
  * @param overrides - Partial store state to override defaults
  */
 function createMockProjectStore(overrides: Partial<ProjectStore> = {}) {
-  const { deleteProject, ...rest } = overrides;
+  const {
+    deleteProject,
+    renameProject,
+    duplicateProject,
+    archiveProject,
+    ...rest
+  } = overrides;
   return create<ProjectStore>(() => ({
     current: null,
     items: [],
@@ -39,6 +45,30 @@ function createMockProjectStore(overrides: Partial<ProjectStore> = {}) {
       deleteProject ??
       (async () => {
         return { ok: true, data: { deleted: true } };
+      }),
+    renameProject:
+      renameProject ??
+      (async (_projectId: string, name: string) => {
+        return {
+          ok: true,
+          data: { projectId: "mock-id", name, updatedAt: Date.now() },
+        };
+      }),
+    duplicateProject:
+      duplicateProject ??
+      (async () => {
+        return {
+          ok: true,
+          data: { projectId: "new-mock-id", rootPath: "/mock/path/new" },
+        };
+      }),
+    archiveProject:
+      archiveProject ??
+      (async (_projectId: string, archived: boolean) => {
+        return {
+          ok: true,
+          data: { projectId: "mock-id", archived, updatedAt: Date.now() },
+        };
       }),
   }));
 }

--- a/apps/desktop/tests/e2e/dashboard-project-actions.spec.ts
+++ b/apps/desktop/tests/e2e/dashboard-project-actions.spec.ts
@@ -1,0 +1,411 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+test.describe("Dashboard project actions", () => {
+  test("project:rename - rename project and verify list update", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+
+    // Create a project first
+    const created = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      const res = await window.creonow.invoke("project:create", {
+        name: "Original Name",
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create: ${res.error.code}`);
+      }
+      return res.data;
+    });
+
+    expect(created.projectId).toBeTruthy();
+
+    // Rename via IPC
+    const renamed = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("project:rename", {
+          projectId,
+          name: "Renamed Project",
+        });
+      },
+      { projectId: created.projectId },
+    );
+
+    expect(renamed.ok).toBe(true);
+    if (!renamed.ok) {
+      throw new Error(`Expected ok project:rename, got: ${renamed.error.code}`);
+    }
+    expect(renamed.data.name).toBe("Renamed Project");
+    expect(renamed.data.projectId).toBe(created.projectId);
+
+    // Verify in list
+    const list = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:list", {});
+    });
+
+    expect(list.ok).toBe(true);
+    if (!list.ok) {
+      throw new Error(`Expected ok project:list, got: ${list.error.code}`);
+    }
+
+    const found = list.data.items.find(
+      (p) => p.projectId === created.projectId,
+    );
+    expect(found).toBeTruthy();
+    expect(found?.name).toBe("Renamed Project");
+
+    await electronApp.close();
+  });
+
+  test("project:rename - validation errors", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+
+    // Create a project first
+    const created = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      const res = await window.creonow.invoke("project:create", {
+        name: "Test",
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create: ${res.error.code}`);
+      }
+      return res.data;
+    });
+
+    // Try rename with empty name
+    const emptyNameRes = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("project:rename", {
+          projectId,
+          name: "   ",
+        });
+      },
+      { projectId: created.projectId },
+    );
+
+    expect(emptyNameRes.ok).toBe(false);
+    if (emptyNameRes.ok) {
+      throw new Error("Expected INVALID_ARGUMENT for empty name");
+    }
+    expect(emptyNameRes.error.code).toBe("INVALID_ARGUMENT");
+
+    // Try rename non-existent project
+    const notFoundRes = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:rename", {
+        projectId: "non-existent-id",
+        name: "New Name",
+      });
+    });
+
+    expect(notFoundRes.ok).toBe(false);
+    if (notFoundRes.ok) {
+      throw new Error("Expected NOT_FOUND for non-existent project");
+    }
+    expect(notFoundRes.error.code).toBe("NOT_FOUND");
+
+    await electronApp.close();
+  });
+
+  test("project:duplicate - duplicate project with documents", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+
+    // Create a project
+    const created = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      const res = await window.creonow.invoke("project:create", {
+        name: "Source Project",
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create: ${res.error.code}`);
+      }
+      return res.data;
+    });
+
+    // Create a document in the project
+    await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        const docRes = await window.creonow.invoke("file:document:create", {
+          projectId,
+          title: "Test Document",
+        });
+        if (!docRes.ok) {
+          throw new Error(`Failed to create doc: ${docRes.error.code}`);
+        }
+        return docRes.data;
+      },
+      { projectId: created.projectId },
+    );
+
+    // Duplicate the project
+    const duplicated = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("project:duplicate", { projectId });
+      },
+      { projectId: created.projectId },
+    );
+
+    expect(duplicated.ok).toBe(true);
+    if (!duplicated.ok) {
+      throw new Error(
+        `Expected ok project:duplicate, got: ${duplicated.error.code}`,
+      );
+    }
+    expect(duplicated.data.projectId).not.toBe(created.projectId);
+
+    // Verify in list - should have both projects
+    const list = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:list", {});
+    });
+
+    expect(list.ok).toBe(true);
+    if (!list.ok) {
+      throw new Error(`Expected ok project:list, got: ${list.error.code}`);
+    }
+    expect(list.data.items.length).toBe(2);
+
+    // Verify duplicated project has default name "(copy)"
+    const dupProject = list.data.items.find(
+      (p) => p.projectId === duplicated.data.projectId,
+    );
+    expect(dupProject).toBeTruthy();
+    expect(dupProject?.name).toBe("Source Project (copy)");
+
+    // Verify document was copied
+    const docs = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("file:document:list", { projectId });
+      },
+      { projectId: duplicated.data.projectId },
+    );
+
+    expect(docs.ok).toBe(true);
+    if (!docs.ok) {
+      throw new Error(`Expected ok file:document:list, got: ${docs.error.code}`);
+    }
+    expect(docs.data.items.length).toBe(1);
+    expect(docs.data.items[0]?.title).toBe("Test Document");
+
+    await electronApp.close();
+  });
+
+  test("project:archive - archive and hide from list", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+
+    // Create a project
+    const created = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      const res = await window.creonow.invoke("project:create", {
+        name: "Project to Archive",
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create: ${res.error.code}`);
+      }
+      return res.data;
+    });
+
+    // Archive the project
+    const archived = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("project:archive", {
+          projectId,
+          archived: true,
+        });
+      },
+      { projectId: created.projectId },
+    );
+
+    expect(archived.ok).toBe(true);
+    if (!archived.ok) {
+      throw new Error(
+        `Expected ok project:archive, got: ${archived.error.code}`,
+      );
+    }
+    expect(archived.data.archived).toBe(true);
+
+    // Verify hidden from default list
+    const listDefault = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:list", {});
+    });
+
+    expect(listDefault.ok).toBe(true);
+    if (!listDefault.ok) {
+      throw new Error(
+        `Expected ok project:list, got: ${listDefault.error.code}`,
+      );
+    }
+    expect(listDefault.data.items.length).toBe(0);
+
+    // Verify visible with includeArchived
+    const listWithArchived = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:list", {
+        includeArchived: true,
+      });
+    });
+
+    expect(listWithArchived.ok).toBe(true);
+    if (!listWithArchived.ok) {
+      throw new Error(
+        `Expected ok project:list, got: ${listWithArchived.error.code}`,
+      );
+    }
+    expect(listWithArchived.data.items.length).toBe(1);
+    expect(listWithArchived.data.items[0]?.archivedAt).toBeTruthy();
+
+    // Unarchive the project
+    const unarchived = await page.evaluate(
+      async ({ projectId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("project:archive", {
+          projectId,
+          archived: false,
+        });
+      },
+      { projectId: created.projectId },
+    );
+
+    expect(unarchived.ok).toBe(true);
+    if (!unarchived.ok) {
+      throw new Error(
+        `Expected ok project:archive, got: ${unarchived.error.code}`,
+      );
+    }
+    expect(unarchived.data.archived).toBe(false);
+
+    // Verify back in default list
+    const listAfterUnarchive = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:list", {});
+    });
+
+    expect(listAfterUnarchive.ok).toBe(true);
+    if (!listAfterUnarchive.ok) {
+      throw new Error(
+        `Expected ok project:list, got: ${listAfterUnarchive.error.code}`,
+      );
+    }
+    expect(listAfterUnarchive.data.items.length).toBe(1);
+
+    await electronApp.close();
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-198.md
+++ b/openspec/_ops/task_runs/ISSUE-198.md
@@ -2,7 +2,7 @@
 
 - Issue: #198
 - Branch: task/198-dashboard-project-actions
-- PR: <fill-after-created>
+- PR: #199
 
 ## Plan
 
@@ -20,3 +20,16 @@
 - Command: `gh issue create` + `agent_worktree_setup.sh 198 dashboard-project-actions`
 - Key output: Issue #198 created, worktree at `.worktrees/issue-198-dashboard-project-actions`
 - Evidence: Branch `task/198-dashboard-project-actions` created from `origin/main`
+
+### 2026-02-05 Implementation complete
+- Command: `pnpm lint` + `pnpm test:e2e --grep "Dashboard project actions"`
+- Key output: Lint passed, 4 E2E tests passed
+- Evidence:
+  ```
+  Running 4 tests using 1 worker
+  ····
+    4 passed (5.2s)
+  ```
+- Commits:
+  - `5330adf feat(dashboard): project rename/duplicate/archive IPC (#198)`
+  - `bdc50d4 fix(db): register 0010_project_archive migration (#198)`

--- a/openspec/_ops/task_runs/ISSUE-198.md
+++ b/openspec/_ops/task_runs/ISSUE-198.md
@@ -1,0 +1,22 @@
+# ISSUE-198
+
+- Issue: #198
+- Branch: task/198-dashboard-project-actions
+- PR: <fill-after-created>
+
+## Plan
+
+- 新增数据库迁移 `0010_project_archive.sql` 添加 `archived_at` 字段
+- 扩展 IPC contract: `project:rename`, `project:duplicate`, `project:archive`
+- 实现 projectService 的 rename/duplicate/archive 方法
+- 注册 IPC handlers
+- 更新 projectStore 添加新 actions
+- 更新 DashboardPage 使用真实 IPC
+- 新增 E2E 测试
+
+## Runs
+
+### 2026-02-05 Initial setup
+- Command: `gh issue create` + `agent_worktree_setup.sh 198 dashboard-project-actions`
+- Key output: Issue #198 created, worktree at `.worktrees/issue-198-dashboard-project-actions`
+- Evidence: Branch `task/198-dashboard-project-actions` created from `origin/main`

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -98,10 +98,13 @@ export const IPC_CHANNELS = [
   "memory:settings:get",
   "memory:settings:update",
   "memory:update",
+  "project:archive",
   "project:create",
   "project:delete",
+  "project:duplicate",
   "project:getCurrent",
   "project:list",
+  "project:rename",
   "project:setCurrent",
   "rag:retrieve",
   "search:fulltext",
@@ -852,6 +855,17 @@ export type IpcChannelSpec = {
       updatedAt: number;
     };
   };
+  "project:archive": {
+    request: {
+      archived: boolean;
+      projectId: string;
+    };
+    response: {
+      archived: boolean;
+      projectId: string;
+      updatedAt: number;
+    };
+  };
   "project:create": {
     request: {
       name?: string;
@@ -869,6 +883,16 @@ export type IpcChannelSpec = {
       deleted: true;
     };
   };
+  "project:duplicate": {
+    request: {
+      name?: string;
+      projectId: string;
+    };
+    response: {
+      projectId: string;
+      rootPath: string;
+    };
+  };
   "project:getCurrent": {
     request: Record<string, never>;
     response: {
@@ -878,15 +902,28 @@ export type IpcChannelSpec = {
   };
   "project:list": {
     request: {
+      includeArchived?: boolean;
       includeDeleted?: boolean;
     };
     response: {
       items: Array<{
+        archivedAt?: number;
         name: string;
         projectId: string;
         rootPath: string;
         updatedAt: number;
       }>;
+    };
+  };
+  "project:rename": {
+    request: {
+      name: string;
+      projectId: string;
+    };
+    response: {
+      name: string;
+      projectId: string;
+      updatedAt: number;
     };
   };
   "project:setCurrent": {


### PR DESCRIPTION
## Summary

- 新增 `project:rename`, `project:duplicate`, `project:archive` IPC 通道
- 更新 `project:list` 支持 `includeArchived` 参数
- 添加数据库迁移 `0010_project_archive.sql`（`archived_at` 列）
- 实现 `ProjectService` 的重命名、复制、归档逻辑
- 更新 `projectStore` 与 `DashboardPage` UI 集成
- 创建 E2E 测试覆盖所有新功能

## Test Plan

- [x] TypeScript 编译通过
- [x] ESLint 无新增错误
- [ ] E2E 测试：`dashboard-project-actions.spec.ts`
- [ ] CI checks 通过

Closes #198

Made with [Cursor](https://cursor.com)