### PR TITLE
feat(version): add version:read IPC for version history (#200)

### DIFF
--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -753,6 +753,25 @@ export const ipcContract = {
         ),
       }),
     },
+    "version:read": {
+      request: s.object({ documentId: s.string(), versionId: s.string() }),
+      response: s.object({
+        documentId: s.string(),
+        projectId: s.string(),
+        versionId: s.string(),
+        actor: s.union(
+          s.literal("user"),
+          s.literal("auto"),
+          s.literal("ai"),
+        ),
+        reason: s.string(),
+        contentJson: s.string(),
+        contentText: s.string(),
+        contentMd: s.string(),
+        contentHash: s.string(),
+        createdAt: s.number(),
+      }),
+    },
     "version:restore": {
       request: s.object({ documentId: s.string(), versionId: s.string() }),
       response: s.object({ restored: s.literal(true) }),

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -25,6 +25,10 @@ import {
   createProjectStore,
   ProjectStoreProvider,
 } from "./stores/projectStore";
+import {
+  createVersionStore,
+  VersionStoreProvider,
+} from "./stores/versionStore";
 
 /**
  * AppRouter decides which screen to show based on onboarding status.
@@ -121,6 +125,10 @@ export function App(): JSX.Element {
     return createMemoryStore({ invoke });
   }, []);
 
+  const versionStore = React.useMemo(() => {
+    return createVersionStore({ invoke });
+  }, []);
+
   return (
     <ThemeStoreProvider store={themeStore}>
       <OnboardingStoreProvider store={onboardingStore}>
@@ -131,9 +139,11 @@ export function App(): JSX.Element {
                 <KgStoreProvider store={kgStore}>
                   <SearchStoreProvider store={searchStore}>
                     <MemoryStoreProvider store={memoryStore}>
-                      <LayoutStoreProvider store={layoutStore}>
-                        <AppRouter />
-                      </LayoutStoreProvider>
+                      <VersionStoreProvider store={versionStore}>
+                        <LayoutStoreProvider store={layoutStore}>
+                          <AppRouter />
+                        </LayoutStoreProvider>
+                      </VersionStoreProvider>
                     </MemoryStoreProvider>
                   </SearchStoreProvider>
                 </KgStoreProvider>

--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { KnowledgeGraphPanel } from "../../features/kg/KnowledgeGraphPanel";
 import { MemoryPanel } from "../../features/memory/MemoryPanel";
 import { OutlinePanel } from "../../features/outline/OutlinePanel";
 import { SearchPanel } from "../../features/search/SearchPanel";
-import { VersionHistoryPanelContent } from "../../features/version-history/VersionHistoryPanel";
+import { VersionHistoryContainer } from "../../features/version-history/VersionHistoryContainer";
 import { LAYOUT_DEFAULTS, type LeftPanelType } from "../../stores/layoutStore";
 
 /**
@@ -96,13 +96,7 @@ export function Sidebar(props: {
 
       case "versionHistory":
         return props.projectId ? (
-          <VersionHistoryPanelContent
-            timeGroups={[]}
-            showCloseButton={false}
-            onRestore={(versionId) => {
-              console.log("Restore version:", versionId);
-            }}
-          />
+          <VersionHistoryContainer projectId={props.projectId} />
         ) : (
           <div className="p-3 text-xs text-[var(--color-fg-muted)]">
             Open a document to view history

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -1,0 +1,317 @@
+import React from "react";
+import {
+  VersionHistoryPanelContent,
+  type TimeGroup,
+  type VersionEntry,
+  type VersionAuthorType,
+} from "./VersionHistoryPanel";
+import { useVersionCompare } from "./useVersionCompare";
+import { useEditorStore } from "../../stores/editorStore";
+import { invoke } from "../../lib/ipcClient";
+
+type VersionListItem = {
+  versionId: string;
+  actor: "user" | "auto" | "ai";
+  reason: string;
+  contentHash: string;
+  createdAt: number;
+};
+
+/**
+ * Map backend actor to UI author type.
+ */
+function mapActorToAuthorType(actor: "user" | "auto" | "ai"): VersionAuthorType {
+  switch (actor) {
+    case "user":
+      return "user";
+    case "ai":
+      return "ai";
+    case "auto":
+      return "auto-save";
+    default:
+      return "user";
+  }
+}
+
+/**
+ * Get display name for actor type.
+ */
+function getAuthorName(actor: "user" | "auto" | "ai"): string {
+  switch (actor) {
+    case "user":
+      return "You";
+    case "ai":
+      return "AI";
+    case "auto":
+      return "Auto";
+    default:
+      return "Unknown";
+  }
+}
+
+/**
+ * Format timestamp for display.
+ */
+function formatTimestamp(createdAt: number): string {
+  const now = Date.now();
+  const diff = now - createdAt;
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+
+  if (minutes < 1) {
+    return "Just now";
+  }
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  if (hours < 24) {
+    const date = new Date(createdAt);
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  const date = new Date(createdAt);
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/**
+ * Get time group label for a timestamp.
+ */
+function getTimeGroupLabel(createdAt: number): string {
+  const now = new Date();
+  const date = new Date(createdAt);
+
+  const isToday =
+    date.getDate() === now.getDate() &&
+    date.getMonth() === now.getMonth() &&
+    date.getFullYear() === now.getFullYear();
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const isYesterday =
+    date.getDate() === yesterday.getDate() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getFullYear() === yesterday.getFullYear();
+
+  if (isToday) {
+    return "Today";
+  }
+  if (isYesterday) {
+    return "Yesterday";
+  }
+  return "Earlier";
+}
+
+/**
+ * Get description for a version based on reason.
+ */
+function getDescription(reason: string): string {
+  if (reason === "autosave") {
+    return "自动保存";
+  }
+  if (reason === "manual-save") {
+    return "手动保存";
+  }
+  if (reason === "restore") {
+    return "恢复版本";
+  }
+  if (reason.startsWith("ai-apply:")) {
+    return "AI 修改";
+  }
+  return reason || "版本快照";
+}
+
+/**
+ * Convert backend version list to UI timeGroups format.
+ */
+function convertToTimeGroups(
+  items: VersionListItem[],
+  currentHash: string | null,
+): TimeGroup[] {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const groupMap = new Map<string, VersionEntry[]>();
+
+  for (const item of items) {
+    const label = getTimeGroupLabel(item.createdAt);
+    const isCurrent = item.contentHash === currentHash;
+
+    const entry: VersionEntry = {
+      id: item.versionId,
+      timestamp: formatTimestamp(item.createdAt),
+      authorType: mapActorToAuthorType(item.actor),
+      authorName: getAuthorName(item.actor),
+      description: getDescription(item.reason),
+      wordChange: { type: "none", count: 0 }, // TODO: calculate actual word diff
+      isCurrent,
+      reason: item.reason,
+    };
+
+    const existing = groupMap.get(label) ?? [];
+    existing.push(entry);
+    groupMap.set(label, existing);
+  }
+
+  // Sort groups: Today first, then Yesterday, then Earlier
+  const order = ["Today", "Yesterday", "Earlier"];
+  const groups: TimeGroup[] = [];
+
+  for (const label of order) {
+    const versions = groupMap.get(label);
+    if (versions && versions.length > 0) {
+      groups.push({ label, versions });
+    }
+  }
+
+  return groups;
+}
+
+type VersionHistoryContainerProps = {
+  projectId: string;
+};
+
+/**
+ * Container component for VersionHistoryPanel.
+ *
+ * Manages:
+ * - Fetching version list from backend
+ * - Converting to timeGroups format
+ * - Compare and restore actions
+ */
+export function VersionHistoryContainer(
+  props: VersionHistoryContainerProps,
+): JSX.Element {
+  const documentId = useEditorStore((s) => s.documentId);
+  const { startCompare } = useVersionCompare();
+
+  const [items, setItems] = React.useState<VersionListItem[]>([]);
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [status, setStatus] = React.useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
+  const [currentHash, setCurrentHash] = React.useState<string | null>(null);
+
+  // Fetch version list when documentId changes
+  React.useEffect(() => {
+    if (!documentId) {
+      setItems([]);
+      setStatus("idle");
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchVersions(): Promise<void> {
+      setStatus("loading");
+
+      // Get current document hash
+      const docRes = await invoke("file:document:read", {
+        projectId: props.projectId,
+        documentId: documentId!,
+      });
+      if (!cancelled && docRes.ok) {
+        setCurrentHash(docRes.data.contentHash);
+      }
+
+      // Get version list
+      const res = await invoke("version:list", { documentId: documentId! });
+      if (cancelled) return;
+
+      if (res.ok) {
+        setItems(res.data.items);
+        setStatus("ready");
+      } else {
+        setItems([]);
+        setStatus("error");
+      }
+    }
+
+    void fetchVersions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId, props.projectId]);
+
+  const timeGroups = React.useMemo(
+    () => convertToTimeGroups(items, currentHash),
+    [items, currentHash],
+  );
+
+  const handleCompare = React.useCallback(
+    (versionId: string) => {
+      if (!documentId) return;
+      void startCompare(documentId, versionId);
+    },
+    [documentId, startCompare],
+  );
+
+  const handleRestore = React.useCallback(
+    async (versionId: string) => {
+      if (!documentId) return;
+
+      // TODO: Show SystemDialog confirmation before restore
+      // For now, call restore directly
+      const res = await invoke("version:restore", { documentId, versionId });
+      if (res.ok) {
+        // Refresh version list
+        const listRes = await invoke("version:list", { documentId });
+        if (listRes.ok) {
+          setItems(listRes.data.items);
+        }
+        // TODO: Refresh editor content
+      }
+    },
+    [documentId],
+  );
+
+  const handlePreview = React.useCallback((versionId: string) => {
+    // TODO: Implement preview (read-only view of version)
+    console.log("Preview version:", versionId);
+  }, []);
+
+  if (!documentId) {
+    return (
+      <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+        Open a document to view history
+      </div>
+    );
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+        Loading versions...
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="p-3 text-xs text-[var(--color-error)]">
+        Failed to load version history
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+        No versions yet. Save your document to create versions.
+      </div>
+    );
+  }
+
+  return (
+    <VersionHistoryPanelContent
+      timeGroups={timeGroups}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      onCompare={handleCompare}
+      onRestore={handleRestore}
+      onPreview={handlePreview}
+      showCloseButton={false}
+    />
+  );
+}

--- a/apps/desktop/renderer/src/features/version-history/index.ts
+++ b/apps/desktop/renderer/src/features/version-history/index.ts
@@ -8,3 +8,5 @@ export {
 } from "./VersionHistoryPanel";
 
 export { useVersionCompare, type CompareState } from "./useVersionCompare";
+
+export { VersionHistoryContainer } from "./VersionHistoryContainer";

--- a/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
+++ b/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
@@ -1,30 +1,34 @@
 /**
- * Hook for comparing versions
- *
- * TODO: When `version:diff` or `version:read` IPC is available, this should
- * fetch actual version content from the backend. For now, it provides a
- * placeholder implementation.
+ * Hook for comparing versions using real version:read IPC.
  */
 
 import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { unifiedDiff } from "../../lib/diff/unifiedDiff";
+import { invoke } from "../../lib/ipcClient";
 
 export type CompareState = {
   status: "idle" | "loading" | "ready" | "error";
   diffText: string;
   error?: string;
+  /** The historical version's text content for display */
+  historicalText?: string;
+  /** The current document's text content for display */
+  currentText?: string;
 };
 
 /**
  * Hook to manage version comparison state and trigger compare mode.
+ *
+ * Uses version:read IPC to fetch actual historical version content
+ * and generates a unified diff against the current editor content.
  *
  * Usage:
  * ```tsx
  * const { compareState, startCompare, closeCompare } = useVersionCompare();
  *
  * // In VersionHistoryPanel:
- * onCompare={(versionId) => startCompare(versionId)}
+ * onCompare={(versionId) => startCompare(documentId, versionId)}
  *
  * // In AppShell when compareMode is true:
  * <DiffViewPanel
@@ -36,6 +40,7 @@ export type CompareState = {
 export function useVersionCompare() {
   const setCompareMode = useEditorStore((s) => s.setCompareMode);
   const editor = useEditorStore((s) => s.editor);
+  const documentId = useEditorStore((s) => s.documentId);
 
   const [compareState, setCompareState] = useState<CompareState>({
     status: "idle",
@@ -45,11 +50,11 @@ export function useVersionCompare() {
   /**
    * Start comparing a version against the current document.
    *
-   * TODO: Implement proper version:read IPC to fetch historical content.
-   * For now, generates a placeholder diff showing the comparison is active.
+   * Fetches the historical version content via version:read IPC,
+   * then generates a unified diff against the current editor content.
    */
   const startCompare = useCallback(
-    async (versionId: string) => {
+    async (docId: string, versionId: string) => {
       setCompareState({ status: "loading", diffText: "" });
       setCompareMode(true, versionId);
 
@@ -57,26 +62,36 @@ export function useVersionCompare() {
         // Get current editor content as the "after" version
         const currentText = editor?.getText() ?? "";
 
-        // TODO: Fetch historical version content via version:read IPC
-        // For now, use a placeholder that demonstrates the diff is working
-        const historicalText = `[版本 ${versionId} 的内容将在 version:read IPC 实现后显示]
+        // Fetch historical version content via version:read IPC
+        const res = await invoke("version:read", {
+          documentId: docId,
+          versionId,
+        });
 
-当前功能状态：
-- ✓ Compare 模式已激活
-- ✓ DiffView 面板已显示
-- ⏳ 等待 version:read IPC 实现
+        if (!res.ok) {
+          setCompareState({
+            status: "error",
+            diffText: "",
+            error: `${res.error.code}: ${res.error.message}`,
+          });
+          return;
+        }
 
-点击 Close 返回编辑器。`;
+        const historicalText = res.data.contentText;
 
         // Generate unified diff
         const diffText = unifiedDiff({
           oldText: historicalText,
-          newText: currentText || "[当前文档为空]",
+          newText: currentText || "",
+          oldLabel: `版本 (${new Date(res.data.createdAt).toLocaleString()})`,
+          newLabel: "当前",
         });
 
         setCompareState({
           status: "ready",
           diffText: diffText || "No differences found.",
+          historicalText,
+          currentText,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
@@ -102,5 +117,6 @@ export function useVersionCompare() {
     compareState,
     startCompare,
     closeCompare,
+    documentId,
   };
 }

--- a/apps/desktop/renderer/src/stores/versionStore.tsx
+++ b/apps/desktop/renderer/src/stores/versionStore.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import { create } from "zustand";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcRequest,
+} from "../../../../../packages/shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;
+
+/**
+ * Version list item from the backend.
+ */
+export type VersionListItem = {
+  versionId: string;
+  actor: "user" | "auto" | "ai";
+  reason: string;
+  contentHash: string;
+  createdAt: number;
+};
+
+/**
+ * Full version content from version:read.
+ */
+export type VersionContent = {
+  documentId: string;
+  projectId: string;
+  versionId: string;
+  actor: "user" | "auto" | "ai";
+  reason: string;
+  contentJson: string;
+  contentText: string;
+  contentMd: string;
+  contentHash: string;
+  createdAt: number;
+};
+
+export type VersionStoreState = {
+  /** Current document ID for version list */
+  documentId: string | null;
+  /** List fetch status */
+  listStatus: "idle" | "loading" | "ready" | "error";
+  /** Version list items */
+  items: VersionListItem[];
+  /** Last error */
+  lastError: IpcError | null;
+  /** Compare mode state */
+  compareVersionId: string | null;
+  compareStatus: "idle" | "loading" | "ready" | "error";
+  compareVersionContent: VersionContent | null;
+};
+
+export type VersionStoreActions = {
+  /**
+   * Fetch version list for a document.
+   */
+  fetchList: (documentId: string) => Promise<void>;
+  /**
+   * Read a specific version's content for comparison.
+   */
+  readVersion: (
+    documentId: string,
+    versionId: string,
+  ) => Promise<VersionContent | null>;
+  /**
+   * Start compare mode with a specific version.
+   */
+  startCompare: (documentId: string, versionId: string) => Promise<void>;
+  /**
+   * Exit compare mode.
+   */
+  exitCompare: () => void;
+  /**
+   * Restore a specific version.
+   */
+  restoreVersion: (
+    documentId: string,
+    versionId: string,
+  ) => Promise<{ ok: boolean; error?: IpcError }>;
+  /**
+   * Clear all state.
+   */
+  reset: () => void;
+};
+
+export type VersionStore = VersionStoreState & VersionStoreActions;
+
+export type UseVersionStore = ReturnType<typeof createVersionStore>;
+
+const VersionStoreContext = React.createContext<UseVersionStore | null>(null);
+
+const initialState: VersionStoreState = {
+  documentId: null,
+  listStatus: "idle",
+  items: [],
+  lastError: null,
+  compareVersionId: null,
+  compareStatus: "idle",
+  compareVersionContent: null,
+};
+
+/**
+ * Create a zustand store for version history state.
+ *
+ * Why: version list and compare state must be shared between Sidebar
+ * (VersionHistoryPanel) and AppShell (DiffViewPanel).
+ */
+export function createVersionStore(deps: { invoke: IpcInvoke }) {
+  return create<VersionStore>((set, get) => ({
+    ...initialState,
+
+    fetchList: async (documentId) => {
+      set({ documentId, listStatus: "loading", lastError: null });
+
+      const res = await deps.invoke("version:list", { documentId });
+      if (!res.ok) {
+        set({ listStatus: "error", lastError: res.error });
+        return;
+      }
+
+      set({
+        listStatus: "ready",
+        items: res.data.items,
+      });
+    },
+
+    readVersion: async (documentId, versionId) => {
+      const res = await deps.invoke("version:read", { documentId, versionId });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return null;
+      }
+      return res.data;
+    },
+
+    startCompare: async (documentId, versionId) => {
+      set({
+        compareVersionId: versionId,
+        compareStatus: "loading",
+        compareVersionContent: null,
+        lastError: null,
+      });
+
+      const res = await deps.invoke("version:read", { documentId, versionId });
+      if (!res.ok) {
+        set({ compareStatus: "error", lastError: res.error });
+        return;
+      }
+
+      set({
+        compareStatus: "ready",
+        compareVersionContent: res.data,
+      });
+    },
+
+    exitCompare: () => {
+      set({
+        compareVersionId: null,
+        compareStatus: "idle",
+        compareVersionContent: null,
+      });
+    },
+
+    restoreVersion: async (documentId, versionId) => {
+      const res = await deps.invoke("version:restore", {
+        documentId,
+        versionId,
+      });
+      if (!res.ok) {
+        set({ lastError: res.error });
+        return { ok: false, error: res.error };
+      }
+
+      // Refresh version list after restore
+      await get().fetchList(documentId);
+      return { ok: true };
+    },
+
+    reset: () => {
+      set(initialState);
+    },
+  }));
+}
+
+/**
+ * Provide a version store instance.
+ */
+export function VersionStoreProvider(props: {
+  store: UseVersionStore;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <VersionStoreContext.Provider value={props.store}>
+      {props.children}
+    </VersionStoreContext.Provider>
+  );
+}
+
+/**
+ * Read values from the injected version store.
+ */
+export function useVersionStore<T>(selector: (state: VersionStore) => T): T {
+  const store = React.useContext(VersionStoreContext);
+  if (!store) {
+    throw new Error("VersionStoreProvider is missing");
+  }
+  return store(selector);
+}

--- a/apps/desktop/tests/e2e/version-history.spec.ts
+++ b/apps/desktop/tests/e2e/version-history.spec.ts
@@ -1,0 +1,252 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E VersionHistory ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+test.describe("Version History IPC", () => {
+  test("version:read returns full version content", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+    const modKey = process.platform === "darwin" ? "Meta" : "Control";
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Version Test Project");
+    await page.getByTestId("create-project-submit").click();
+
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Type initial content
+    await page.getByTestId("tiptap-editor").click();
+    await page.keyboard.type("Initial content for version test");
+
+    // Wait for autosave
+    await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+      "data-status",
+      "saved",
+    );
+
+    // Manual save to create a user version
+    await page.keyboard.press(`${modKey}+S`);
+
+    // Get project and document IDs
+    const project = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:getCurrent", {});
+    });
+    expect(project.ok).toBe(true);
+    if (!project.ok) {
+      throw new Error(`Expected ok project, got: ${project.error.code}`);
+    }
+
+    const docs = await page.evaluate(async (projectId) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("file:document:list", { projectId });
+    }, project.data.projectId);
+    expect(docs.ok).toBe(true);
+    if (!docs.ok) {
+      throw new Error(`Expected ok document list, got: ${docs.error.code}`);
+    }
+    const documentId = docs.data.items[0]?.documentId;
+    expect(documentId).toBeTruthy();
+
+    // Get version list
+    const versions = await page.evaluate(async (docId) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("version:list", { documentId: docId });
+    }, documentId);
+    expect(versions.ok).toBe(true);
+    if (!versions.ok) {
+      throw new Error(`Expected ok version list, got: ${versions.error.code}`);
+    }
+    expect(versions.data.items.length).toBeGreaterThanOrEqual(1);
+
+    const versionId = versions.data.items[0]?.versionId;
+    expect(versionId).toBeTruthy();
+
+    // Test version:read
+    const versionContent = await page.evaluate(
+      async ({ docId, verId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("version:read", {
+          documentId: docId,
+          versionId: verId,
+        });
+      },
+      { docId: documentId, verId: versionId },
+    );
+
+    expect(versionContent.ok).toBe(true);
+    if (!versionContent.ok) {
+      throw new Error(
+        `Expected ok version read, got: ${versionContent.error.code}`,
+      );
+    }
+
+    // Verify version:read returns all expected fields
+    expect(versionContent.data.documentId).toBe(documentId);
+    expect(versionContent.data.versionId).toBe(versionId);
+    expect(versionContent.data.projectId).toBe(project.data.projectId);
+    expect(versionContent.data.contentJson).toBeTruthy();
+    expect(versionContent.data.contentText).toContain(
+      "Initial content for version test",
+    );
+    expect(versionContent.data.contentMd).toBeTruthy();
+    expect(versionContent.data.contentHash).toBeTruthy();
+    expect(versionContent.data.actor).toMatch(/^(user|auto|ai)$/);
+    expect(versionContent.data.reason).toBeTruthy();
+    expect(typeof versionContent.data.createdAt).toBe("number");
+
+    await electronApp.close();
+  });
+
+  test("version:read returns NOT_FOUND for invalid versionId", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Version Error Test");
+    await page.getByTestId("create-project-submit").click();
+
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Get document ID
+    const project = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("project:getCurrent", {});
+    });
+    expect(project.ok).toBe(true);
+    if (!project.ok) {
+      throw new Error(`Expected ok project, got: ${project.error.code}`);
+    }
+
+    const docs = await page.evaluate(async (projectId) => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("file:document:list", { projectId });
+    }, project.data.projectId);
+    expect(docs.ok).toBe(true);
+    if (!docs.ok) {
+      throw new Error(`Expected ok document list, got: ${docs.error.code}`);
+    }
+    const documentId = docs.data.items[0]?.documentId;
+    expect(documentId).toBeTruthy();
+
+    // Try to read non-existent version
+    const result = await page.evaluate(
+      async ({ docId }) => {
+        if (!window.creonow) {
+          throw new Error("Missing window.creonow bridge");
+        }
+        return await window.creonow.invoke("version:read", {
+          documentId: docId,
+          versionId: "non-existent-version-id",
+        });
+      },
+      { docId: documentId },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected error for non-existent version");
+    }
+    expect(result.error.code).toBe("NOT_FOUND");
+
+    await electronApp.close();
+  });
+
+  test("version:read returns INVALID_ARGUMENT for empty documentId", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Try to read with empty documentId
+    const result = await page.evaluate(async () => {
+      if (!window.creonow) {
+        throw new Error("Missing window.creonow bridge");
+      }
+      return await window.creonow.invoke("version:read", {
+        documentId: "",
+        versionId: "some-version",
+      });
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected error for empty documentId");
+    }
+    expect(result.error.code).toBe("INVALID_ARGUMENT");
+
+    await electronApp.close();
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-200.md
+++ b/openspec/_ops/task_runs/ISSUE-200.md
@@ -1,0 +1,19 @@
+# ISSUE-200
+
+- Issue: #200
+- Branch: task/200-version-history-read
+- PR: <fill-after-created>
+
+## Plan
+
+1. 新增 `version:read` IPC (contract + handler + documentService)
+2. 更新 renderer 侧 useVersionCompare 使用真实 IPC
+3. 更新 Sidebar/AppShell 接入真实版本数据
+4. 添加 E2E 测试
+
+## Runs
+
+### 2026-02-05 Initial Setup
+- Command: `gh issue create` + `agent_worktree_setup.sh`
+- Key output: Issue #200 created, worktree ready
+- Evidence: https://github.com/Leeky1017/CreoNow/issues/200

--- a/openspec/_ops/task_runs/ISSUE-200.md
+++ b/openspec/_ops/task_runs/ISSUE-200.md
@@ -2,7 +2,7 @@
 
 - Issue: #200
 - Branch: task/200-version-history-read
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/202
 
 ## Plan
 
@@ -17,3 +17,13 @@
 - Command: `gh issue create` + `agent_worktree_setup.sh`
 - Key output: Issue #200 created, worktree ready
 - Evidence: https://github.com/Leeky1017/CreoNow/issues/200
+
+### 2026-02-05 Implementation Complete
+- Command: `pnpm typecheck && pnpm lint && npx playwright test tests/e2e/version-history.spec.ts`
+- Key output:
+  - typecheck: passed
+  - lint: no new errors
+  - E2E: 3 passed (6.7s)
+- Evidence:
+  - PR: https://github.com/Leeky1017/CreoNow/pull/202
+  - Files changed: 13 files, +1008 -36 lines

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -114,6 +114,7 @@ export const IPC_CHANNELS = [
   "stats:getToday",
   "version:aiApply:logConflict",
   "version:list",
+  "version:read",
   "version:restore",
 ] as const;
 
@@ -1084,6 +1085,24 @@ export type IpcChannelSpec = {
         reason: string;
         versionId: string;
       }>;
+    };
+  };
+  "version:read": {
+    request: {
+      documentId: string;
+      versionId: string;
+    };
+    response: {
+      actor: "user" | "auto" | "ai";
+      contentHash: string;
+      contentJson: string;
+      contentMd: string;
+      contentText: string;
+      createdAt: number;
+      documentId: string;
+      projectId: string;
+      reason: string;
+      versionId: string;
     };
   };
   "version:restore": {


### PR DESCRIPTION
## Summary

- 新增 `version:read` IPC 通道，支持读取指定版本的完整内容
- 实现 documentService.readVersion 方法，从数据库获取版本内容
- 创建 versionStore 管理版本状态（列表、对比、恢复）
- 创建 VersionHistoryContainer，从后端获取真实版本数据并转换为 timeGroups 格式
- 更新 useVersionCompare 使用真实 IPC 代替占位实现
- 更新 AppShell/Sidebar 接入真实版本数据和 compare 模式
- 添加 E2E 测试覆盖 version:read IPC

## Changes

| 文件 | 变更 |
| --- | --- |
| `ipc-contract.ts` | 新增 version:read schema |
| `ipc-generated.ts` | codegen 输出 |
| `documentService.ts` | 新增 VersionRead 类型和 readVersion 方法 |
| `version.ts` | 实现 version:read handler |
| `versionStore.tsx` | 新增版本状态管理 store |
| `VersionHistoryContainer.tsx` | 新增版本历史容器组件 |
| `useVersionCompare.ts` | 改用真实 IPC |
| `AppShell.tsx` | 接入真实 diff 数据 |
| `Sidebar.tsx` | 使用 VersionHistoryContainer |
| `version-history.spec.ts` | 新增 E2E 测试 |

## Test plan

- [x] pnpm typecheck 通过
- [x] pnpm lint 无新增错误
- [x] E2E 测试通过 (version-history.spec.ts)
  - [x] version:read 返回完整版本内容
  - [x] version:read 对无效 versionId 返回 NOT_FOUND
  - [x] version:read 对空 documentId 返回 INVALID_ARGUMENT

Closes #200

Made with [Cursor](https://cursor.com)