### PR TITLE
feat(outline): derive outline from editor and enable navigation (#203)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { CharacterPanelContent } from "../../features/character/CharacterPanel";
 import { FileTreePanel } from "../../features/files/FileTreePanel";
 import { KnowledgeGraphPanel } from "../../features/kg/KnowledgeGraphPanel";
 import { MemoryPanel } from "../../features/memory/MemoryPanel";
-import { OutlinePanel } from "../../features/outline/OutlinePanel";
+import { OutlinePanelContainer } from "../../features/outline/OutlinePanelContainer";
 import { SearchPanel } from "../../features/search/SearchPanel";
 import { VersionHistoryContainer } from "../../features/version-history/VersionHistoryContainer";
 import { LAYOUT_DEFAULTS, type LeftPanelType } from "../../stores/layoutStore";
@@ -80,14 +80,7 @@ export function Sidebar(props: {
 
       case "outline":
         return props.projectId ? (
-          <OutlinePanel
-            items={[]}
-            activeId={null}
-            onNavigate={(id) => {
-              // TODO: Wire to editor scroll position
-              console.log("Navigate to outline item:", id);
-            }}
-          />
+          <OutlinePanelContainer />
         ) : (
           <div className="p-3 text-xs text-[var(--color-fg-muted)]">
             Open a document to view outline
@@ -143,9 +136,7 @@ export function Sidebar(props: {
       }}
     >
       <LeftPanelHeader title={PANEL_TITLES[props.activePanel]} />
-      <div className="flex-1 min-h-0 overflow-auto">
-        {renderPanelContent()}
-      </div>
+      <div className="flex-1 min-h-0 overflow-auto">{renderPanelContent()}</div>
     </aside>
   );
 }

--- a/apps/desktop/renderer/src/features/outline/OutlinePanelContainer.tsx
+++ b/apps/desktop/renderer/src/features/outline/OutlinePanelContainer.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { OutlinePanel } from "./OutlinePanel";
+import {
+  deriveOutline,
+  findActiveOutlineItem,
+  findHeadingPosition,
+} from "./deriveOutline";
+import { useEditorStore } from "../../stores/editorStore";
+
+/**
+ * Debounce helper to avoid excessive re-derivation on rapid editor updates.
+ */
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+/**
+ * OutlinePanelContainer connects the OutlinePanel to the editorStore.
+ *
+ * Responsibilities:
+ * - Derive outline items from the current editor document
+ * - Track active item based on cursor position
+ * - Handle navigation (scroll to heading in editor)
+ * - Debounce updates for performance
+ *
+ * This container pattern keeps OutlinePanel pure and testable.
+ */
+export function OutlinePanelContainer(): JSX.Element {
+  const editor = useEditorStore((s) => s.editor);
+  const documentId = useEditorStore((s) => s.documentId);
+  const bootstrapStatus = useEditorStore((s) => s.bootstrapStatus);
+
+  // Track document content changes
+  const [docJson, setDocJson] = React.useState<ReturnType<
+    NonNullable<typeof editor>["getJSON"]
+  > | null>(null);
+  const [cursorPos, setCursorPos] = React.useState<number>(0);
+
+  // Subscribe to editor updates
+  React.useEffect(() => {
+    if (!editor) {
+      setDocJson(null);
+      return;
+    }
+
+    // Initial state
+    setDocJson(editor.getJSON());
+    setCursorPos(editor.state.selection.anchor);
+
+    // Listen for document changes
+    const updateHandler = () => {
+      setDocJson(editor.getJSON());
+      setCursorPos(editor.state.selection.anchor);
+    };
+
+    editor.on("update", updateHandler);
+    editor.on("selectionUpdate", updateHandler);
+
+    return () => {
+      editor.off("update", updateHandler);
+      editor.off("selectionUpdate", updateHandler);
+    };
+  }, [editor]);
+
+  // Reset on document change
+  React.useEffect(() => {
+    if (editor) {
+      setDocJson(editor.getJSON());
+      setCursorPos(editor.state.selection.anchor);
+    }
+  }, [documentId, editor]);
+
+  // Debounce outline derivation for performance (50ms)
+  const debouncedDocJson = useDebouncedValue(docJson, 50);
+
+  // Derive outline items from document
+  const outlineItems = React.useMemo(() => {
+    return deriveOutline(debouncedDocJson);
+  }, [debouncedDocJson]);
+
+  // Find active item based on cursor position
+  const activeId = React.useMemo(() => {
+    return findActiveOutlineItem(debouncedDocJson, cursorPos);
+  }, [debouncedDocJson, cursorPos]);
+
+  /**
+   * Navigate to a heading in the editor.
+   *
+   * Finds the heading position and sets the editor selection there,
+   * which also scrolls the heading into view.
+   */
+  const handleNavigate = React.useCallback(
+    (itemId: string) => {
+      if (!editor || !debouncedDocJson) {
+        return;
+      }
+
+      const position = findHeadingPosition(
+        debouncedDocJson,
+        outlineItems,
+        itemId,
+      );
+      if (position === null) {
+        return;
+      }
+
+      try {
+        // Set selection to the heading position and focus editor
+        // Add 1 to position to move cursor inside the heading
+        const targetPos = Math.min(position + 1, editor.state.doc.content.size);
+        editor.chain().focus().setTextSelection(targetPos).run();
+
+        // Scroll the selection into view
+        // TipTap's scrollIntoView is automatic with setTextSelection + focus
+      } catch (err) {
+        // Position calculation might be slightly off - log but don't crash
+        console.warn("[OutlinePanelContainer] Navigation error:", err);
+      }
+    },
+    [editor, debouncedDocJson, outlineItems],
+  );
+
+  // Show empty state if no editor or document
+  if (bootstrapStatus !== "ready" || !editor) {
+    return <OutlinePanel items={[]} activeId={null} onNavigate={() => {}} />;
+  }
+
+  return (
+    <OutlinePanel
+      items={outlineItems}
+      activeId={activeId}
+      onNavigate={handleNavigate}
+      // Disable features that require IPC (rename/delete/reorder headings)
+      // These would need IPC to persist changes to the document
+      draggable={false}
+    />
+  );
+}

--- a/apps/desktop/renderer/src/features/outline/deriveOutline.test.ts
+++ b/apps/desktop/renderer/src/features/outline/deriveOutline.test.ts
@@ -1,0 +1,597 @@
+import { describe, it, expect } from "vitest";
+import type { JSONContent } from "@tiptap/react";
+import {
+  deriveOutline,
+  findActiveOutlineItem,
+  findHeadingPosition,
+} from "./deriveOutline";
+
+describe("deriveOutline", () => {
+  // ==========================================================================
+  // Empty/Null Document Cases
+  // ==========================================================================
+
+  it("returns empty array for null document", () => {
+    expect(deriveOutline(null)).toEqual([]);
+  });
+
+  it("returns empty array for undefined document", () => {
+    expect(deriveOutline(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty document", () => {
+    const doc: JSONContent = { type: "doc", content: [] };
+    expect(deriveOutline(doc)).toEqual([]);
+  });
+
+  it("returns empty array for document without content property", () => {
+    const doc = { type: "doc" } as JSONContent;
+    expect(deriveOutline(doc)).toEqual([]);
+  });
+
+  it("returns empty array for document with no headings", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Hello world" }] },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Another paragraph" }],
+        },
+      ],
+    };
+    expect(deriveOutline(doc)).toEqual([]);
+  });
+
+  // ==========================================================================
+  // Basic Heading Extraction
+  // ==========================================================================
+
+  it("extracts single H1 heading", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "My Title" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("My Title");
+    expect(result[0].level).toBe("h1");
+    expect(result[0].id).toBeDefined();
+  });
+
+  it("extracts H2 and H3 headings", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Section" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 3 },
+          content: [{ type: "text", text: "Subsection" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("Section");
+    expect(result[0].level).toBe("h2");
+    expect(result[1].title).toBe("Subsection");
+    expect(result[1].level).toBe("h3");
+  });
+
+  it("extracts multi-level headings in correct order", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Document Title" }],
+        },
+        { type: "paragraph", content: [{ type: "text", text: "Intro text" }] },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Chapter 1" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 3 },
+          content: [{ type: "text", text: "Section 1.1" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Chapter 2" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatchObject({ title: "Document Title", level: "h1" });
+    expect(result[1]).toMatchObject({ title: "Chapter 1", level: "h2" });
+    expect(result[2]).toMatchObject({ title: "Section 1.1", level: "h3" });
+    expect(result[3]).toMatchObject({ title: "Chapter 2", level: "h2" });
+  });
+
+  // ==========================================================================
+  // H4-H6 Exclusion
+  // ==========================================================================
+
+  it("ignores H4 headings", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 4 },
+          content: [{ type: "text", text: "H4 Heading" }],
+        },
+      ],
+    };
+
+    expect(deriveOutline(doc)).toEqual([]);
+  });
+
+  it("ignores H5 and H6 headings", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 5 },
+          content: [{ type: "text", text: "H5 Heading" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 6 },
+          content: [{ type: "text", text: "H6 Heading" }],
+        },
+      ],
+    };
+
+    expect(deriveOutline(doc)).toEqual([]);
+  });
+
+  it("extracts H1-H3 but ignores H4-H6", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 4 },
+          content: [{ type: "text", text: "Detail" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Section" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("Title");
+    expect(result[1].title).toBe("Section");
+  });
+
+  // ==========================================================================
+  // Edge Cases: Empty/Malformed Headings
+  // ==========================================================================
+
+  it("handles heading with empty content", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("(untitled heading)");
+  });
+
+  it("handles heading with no content property", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("(untitled heading)");
+  });
+
+  it("handles heading with whitespace-only text", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "   " }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("(untitled heading)");
+  });
+
+  it("handles heading without level attribute (defaults to h1)", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          content: [{ type: "text", text: "No Level" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("h1");
+  });
+
+  // ==========================================================================
+  // Special Characters
+  // ==========================================================================
+
+  it("handles headings with emoji", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "🚀 Getting Started" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "📖 Chapter 1 📚" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("🚀 Getting Started");
+    expect(result[1].title).toBe("📖 Chapter 1 📚");
+  });
+
+  it("handles headings with Chinese characters", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "第一章：序言" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "背景介绍" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("第一章：序言");
+    expect(result[1].title).toBe("背景介绍");
+  });
+
+  it("handles headings with special characters", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "C++ & JavaScript: A Comparison" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: 'Using "quotes" & <brackets>' }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("C++ & JavaScript: A Comparison");
+    expect(result[1].title).toBe('Using "quotes" & <brackets>');
+  });
+
+  // ==========================================================================
+  // Long Titles
+  // ==========================================================================
+
+  it("handles very long titles without truncation", () => {
+    const longTitle = "A".repeat(500);
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: longTitle }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe(longTitle);
+  });
+
+  // ==========================================================================
+  // Duplicate Titles - Unique IDs
+  // ==========================================================================
+
+  it("generates unique IDs for duplicate titles", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(3);
+    // All titles are the same
+    expect(result[0].title).toBe("Introduction");
+    expect(result[1].title).toBe("Introduction");
+    expect(result[2].title).toBe("Introduction");
+    // But IDs must be unique (they include position)
+    const ids = new Set(result.map((item) => item.id));
+    expect(ids.size).toBe(3);
+  });
+
+  // ==========================================================================
+  // ID Stability
+  // ==========================================================================
+
+  it("generates stable IDs for the same content", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "My Title" }],
+        },
+      ],
+    };
+
+    const result1 = deriveOutline(doc);
+    const result2 = deriveOutline(doc);
+
+    expect(result1[0].id).toBe(result2[0].id);
+  });
+
+  // ==========================================================================
+  // Complex Content within Headings
+  // ==========================================================================
+
+  it("concatenates multiple text nodes in a heading", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [
+            { type: "text", text: "Part " },
+            { type: "text", text: "One" },
+            { type: "text", text: ": Introduction" },
+          ],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Part One: Introduction");
+  });
+
+  it("ignores non-text nodes in heading content", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [
+            { type: "text", text: "Title with " },
+            { type: "hardBreak" }, // Non-text node
+            { type: "text", text: "break" },
+          ],
+        },
+      ],
+    };
+
+    const result = deriveOutline(doc);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Title with break");
+  });
+});
+
+describe("findActiveOutlineItem", () => {
+  it("returns null for empty document", () => {
+    expect(findActiveOutlineItem(null, 0)).toBeNull();
+    expect(findActiveOutlineItem({ type: "doc", content: [] }, 0)).toBeNull();
+  });
+
+  it("returns null for negative cursor position", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+      ],
+    };
+
+    expect(findActiveOutlineItem(doc, -1)).toBeNull();
+  });
+
+  it("returns null for document without headings", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Just text" }] },
+      ],
+    };
+
+    expect(findActiveOutlineItem(doc, 0)).toBeNull();
+  });
+
+  it("returns first heading ID when cursor is at start", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+        { type: "paragraph", content: [{ type: "text", text: "Text" }] },
+      ],
+    };
+
+    const items = deriveOutline(doc);
+    const activeId = findActiveOutlineItem(doc, 0);
+
+    expect(activeId).toBe(items[0].id);
+  });
+});
+
+describe("findHeadingPosition", () => {
+  it("returns null for empty document", () => {
+    expect(findHeadingPosition(null, [], "test-id")).toBeNull();
+  });
+
+  it("returns null for non-existent item ID", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+      ],
+    };
+    const items = deriveOutline(doc);
+
+    expect(findHeadingPosition(doc, items, "non-existent-id")).toBeNull();
+  });
+
+  it("returns position for first heading", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+      ],
+    };
+    const items = deriveOutline(doc);
+    const position = findHeadingPosition(doc, items, items[0].id);
+
+    expect(position).toBe(0);
+  });
+
+  it("returns position for second heading", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Title" }],
+        },
+        { type: "paragraph", content: [{ type: "text", text: "Text" }] },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Section" }],
+        },
+      ],
+    };
+    const items = deriveOutline(doc);
+    const position = findHeadingPosition(doc, items, items[1].id);
+
+    // Position should be after first heading + paragraph
+    expect(position).not.toBeNull();
+    expect(position).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/renderer/src/features/outline/deriveOutline.ts
+++ b/apps/desktop/renderer/src/features/outline/deriveOutline.ts
@@ -1,0 +1,251 @@
+import type { JSONContent } from "@tiptap/react";
+import type { OutlineItem, OutlineLevel } from "./OutlinePanel";
+
+/**
+ * Represents a heading node from the ProseMirror document.
+ */
+interface HeadingNode {
+  type: "heading";
+  attrs?: { level?: number };
+  content?: Array<{ type: string; text?: string }>;
+}
+
+/**
+ * Map heading level number (1-6) to OutlineLevel type.
+ * We only support H1-H3 for outline display.
+ */
+function mapLevelToOutlineLevel(level: number): OutlineLevel | null {
+  switch (level) {
+    case 1:
+      return "h1";
+    case 2:
+      return "h2";
+    case 3:
+      return "h3";
+    default:
+      // H4-H6 are not displayed in outline
+      return null;
+  }
+}
+
+/**
+ * Extract text content from a heading node.
+ * Handles nested text nodes and concatenates them.
+ */
+function extractHeadingText(node: HeadingNode): string {
+  if (!node.content || node.content.length === 0) {
+    return "(untitled heading)";
+  }
+
+  const text = node.content
+    .filter((child) => child.type === "text" && child.text)
+    .map((child) => child.text)
+    .join("");
+
+  return text.trim() || "(untitled heading)";
+}
+
+/**
+ * Generate a stable unique ID for a heading.
+ *
+ * Uses a combination of:
+ * - Heading level
+ * - Position (index) in the document
+ * - Hash of the title text (for stability when content changes)
+ *
+ * This ensures IDs don't change on re-render unless the heading itself changes.
+ */
+function generateHeadingId(
+  level: OutlineLevel,
+  position: number,
+  title: string,
+): string {
+  // Simple hash for title to help with stability
+  let hash = 0;
+  for (let i = 0; i < title.length; i++) {
+    const char = title.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  const hashStr = Math.abs(hash).toString(36).slice(0, 6);
+
+  return `${level}-${position}-${hashStr}`;
+}
+
+/**
+ * Derive outline items from a ProseMirror/TipTap document.
+ *
+ * Extracts all H1-H3 headings from the document and returns them as
+ * a flat array of OutlineItem objects suitable for the OutlinePanel.
+ *
+ * Features:
+ * - Stable IDs that don't change on re-render (unless content changes)
+ * - Position tracking for scroll-to-heading navigation
+ * - Graceful handling of empty/malformed headings
+ * - Support for emoji and non-ASCII characters
+ *
+ * @param doc - The TipTap/ProseMirror document JSON
+ * @returns Array of outline items, empty if no headings found
+ */
+export function deriveOutline(
+  doc: JSONContent | null | undefined,
+): OutlineItem[] {
+  if (!doc || !doc.content || !Array.isArray(doc.content)) {
+    return [];
+  }
+
+  const items: OutlineItem[] = [];
+  let headingIndex = 0;
+
+  for (let i = 0; i < doc.content.length; i++) {
+    const node = doc.content[i];
+
+    if (node.type !== "heading") {
+      continue;
+    }
+
+    const headingNode = node as unknown as HeadingNode;
+    const level = headingNode.attrs?.level ?? 1;
+    const outlineLevel = mapLevelToOutlineLevel(level);
+
+    // Skip H4-H6
+    if (!outlineLevel) {
+      continue;
+    }
+
+    const title = extractHeadingText(headingNode);
+    const id = generateHeadingId(outlineLevel, headingIndex, title);
+
+    items.push({
+      id,
+      title,
+      level: outlineLevel,
+    });
+
+    headingIndex++;
+  }
+
+  return items;
+}
+
+/**
+ * Find the outline item that should be active based on the current
+ * cursor position in the editor.
+ *
+ * Returns the ID of the heading that the cursor is currently under
+ * (i.e., the most recent heading before the cursor position).
+ *
+ * @param doc - The TipTap/ProseMirror document JSON
+ * @param cursorPos - The current cursor position in the document
+ * @returns The ID of the active outline item, or null if none
+ */
+export function findActiveOutlineItem(
+  doc: JSONContent | null | undefined,
+  cursorPos: number,
+): string | null {
+  if (!doc || !doc.content || !Array.isArray(doc.content) || cursorPos < 0) {
+    return null;
+  }
+
+  const items = deriveOutline(doc);
+  if (items.length === 0) {
+    return null;
+  }
+
+  // Calculate cumulative positions for each node
+  let currentPos = 0;
+  let headingIndex = 0;
+  let lastHeadingId: string | null = null;
+
+  for (const node of doc.content) {
+    if (node.type === "heading") {
+      const headingNode = node as unknown as HeadingNode;
+      const level = headingNode.attrs?.level ?? 1;
+      const outlineLevel = mapLevelToOutlineLevel(level);
+
+      if (outlineLevel && headingIndex < items.length) {
+        // If cursor is at or after this heading, update lastHeadingId
+        if (cursorPos >= currentPos) {
+          lastHeadingId = items[headingIndex].id;
+        }
+        headingIndex++;
+      }
+    }
+
+    // Estimate node size (simplified - actual ProseMirror uses nodeSize)
+    // Add 2 for the node boundaries
+    const nodeSize = estimateNodeSize(node);
+    currentPos += nodeSize;
+  }
+
+  return lastHeadingId;
+}
+
+/**
+ * Estimate the size of a node for position calculation.
+ * This is a simplified version - actual ProseMirror tracks this precisely.
+ */
+function estimateNodeSize(node: JSONContent): number {
+  if (!node.content || !Array.isArray(node.content)) {
+    // Empty node (like empty paragraph)
+    return 2; // Opening and closing boundaries
+  }
+
+  let size = 2; // Opening and closing boundaries
+  for (const child of node.content) {
+    if (child.type === "text" && child.text) {
+      size += child.text.length;
+    } else {
+      size += estimateNodeSize(child);
+    }
+  }
+
+  return size;
+}
+
+/**
+ * Find the document position of a heading by its outline item ID.
+ *
+ * Used for scroll-to-heading navigation.
+ *
+ * @param doc - The TipTap/ProseMirror document JSON
+ * @param outlineItems - The derived outline items
+ * @param itemId - The ID of the outline item to find
+ * @returns The document position of the heading, or null if not found
+ */
+export function findHeadingPosition(
+  doc: JSONContent | null | undefined,
+  outlineItems: OutlineItem[],
+  itemId: string,
+): number | null {
+  if (!doc || !doc.content || !Array.isArray(doc.content)) {
+    return null;
+  }
+
+  const targetIndex = outlineItems.findIndex((item) => item.id === itemId);
+  if (targetIndex === -1) {
+    return null;
+  }
+
+  let currentPos = 0;
+  let headingIndex = 0;
+
+  for (const node of doc.content) {
+    if (node.type === "heading") {
+      const headingNode = node as unknown as HeadingNode;
+      const level = headingNode.attrs?.level ?? 1;
+      const outlineLevel = mapLevelToOutlineLevel(level);
+
+      if (outlineLevel) {
+        if (headingIndex === targetIndex) {
+          return currentPos;
+        }
+        headingIndex++;
+      }
+    }
+
+    currentPos += estimateNodeSize(node);
+  }
+
+  return null;
+}

--- a/apps/desktop/renderer/src/features/outline/index.ts
+++ b/apps/desktop/renderer/src/features/outline/index.ts
@@ -4,3 +4,11 @@ export type {
   OutlineItem,
   OutlineLevel,
 } from "./OutlinePanel";
+
+export { OutlinePanelContainer } from "./OutlinePanelContainer";
+
+export {
+  deriveOutline,
+  findActiveOutlineItem,
+  findHeadingPosition,
+} from "./deriveOutline";

--- a/apps/desktop/tests/e2e/outline-panel.spec.ts
+++ b/apps/desktop/tests/e2e/outline-panel.spec.ts
@@ -1,0 +1,270 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E Outline ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+test.describe("OutlinePanel", () => {
+  test("derives outline from editor headings and navigates to them", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project to get an editor
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Outline Test Project");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor to be visible
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Type content with headings using TipTap's markdown-like shortcuts
+    // # at the start of a line followed by space creates H1
+    const editor = page.getByTestId("tiptap-editor");
+    await editor.click();
+
+    // Create H1: "Document Title"
+    await page.keyboard.type("# Document Title");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Some introduction text.");
+    await page.keyboard.press("Enter");
+
+    // Create H2: "Chapter One"
+    await page.keyboard.type("## Chapter One");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Content of chapter one.");
+    await page.keyboard.press("Enter");
+
+    // Create H3: "Section 1.1"
+    await page.keyboard.type("### Section 1.1");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Details of section 1.1.");
+    await page.keyboard.press("Enter");
+
+    // Create H2: "Chapter Two"
+    await page.keyboard.type("## Chapter Two");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Content of chapter two.");
+
+    // Wait for autosave to complete
+    await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+      "data-status",
+      "saved",
+      { timeout: 5000 },
+    );
+
+    // Open the Outline panel via IconBar
+    const outlineButton = page.getByTestId("iconbar-outline");
+    await outlineButton.click();
+
+    // Wait for outline panel to be visible
+    await expect(page.getByTestId("outline-panel")).toBeVisible();
+
+    // Verify headings appear in the outline
+    await expect(page.getByText("Document Title")).toBeVisible();
+    await expect(page.getByText("Chapter One")).toBeVisible();
+    await expect(page.getByText("Section 1.1")).toBeVisible();
+    await expect(page.getByText("Chapter Two")).toBeVisible();
+
+    // Click on "Chapter Two" in the outline to navigate
+    const chapterTwoOutlineItem = page
+      .locator('[data-testid="outline-panel"]')
+      .getByText("Chapter Two");
+    await chapterTwoOutlineItem.click();
+
+    // Verify the editor is focused (navigation happened)
+    // We can check by looking at aria-selected on the outline item
+    // The clicked item should become active
+    await expect(
+      page.locator('[data-testid^="outline-item-"]', {
+        hasText: "Chapter Two",
+      }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    await electronApp.close();
+  });
+
+  test("shows empty state when document has no headings", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Empty Outline Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Type content without any headings
+    const editor = page.getByTestId("tiptap-editor");
+    await editor.click();
+    await page.keyboard.type("Just some plain text without any headings.");
+
+    // Open the Outline panel
+    const outlineButton = page.getByTestId("iconbar-outline");
+    await outlineButton.click();
+
+    // Wait for outline panel
+    await expect(page.getByTestId("outline-panel")).toBeVisible();
+
+    // Verify empty state is shown
+    await expect(page.getByTestId("outline-empty-state")).toBeVisible();
+    await expect(page.getByText("No outline yet")).toBeVisible();
+
+    await electronApp.close();
+  });
+
+  test("updates outline when document content changes", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Dynamic Outline Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Open the Outline panel first
+    const outlineButton = page.getByTestId("iconbar-outline");
+    await outlineButton.click();
+    await expect(page.getByTestId("outline-panel")).toBeVisible();
+
+    // Initially should show empty state
+    await expect(page.getByTestId("outline-empty-state")).toBeVisible();
+
+    // Now add a heading in the editor
+    const editor = page.getByTestId("tiptap-editor");
+    await editor.click();
+    await page.keyboard.type("# New Heading Added");
+    await page.keyboard.press("Enter");
+
+    // Wait a bit for debounced update
+    await page.waitForTimeout(100);
+
+    // Verify the heading appears in the outline
+    await expect(page.getByText("New Heading Added")).toBeVisible();
+
+    // Empty state should no longer be visible
+    await expect(page.getByTestId("outline-empty-state")).not.toBeVisible();
+
+    await electronApp.close();
+  });
+
+  test("handles special characters and emoji in headings", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const appRoot = path.resolve(__dirname, "../..");
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project
+    await expect(page.getByTestId("welcome-screen")).toBeVisible();
+    await page.getByTestId("welcome-create-project").click();
+    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+    await page.getByTestId("create-project-name").fill("Special Chars Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Type content with special characters
+    const editor = page.getByTestId("tiptap-editor");
+    await editor.click();
+
+    // Create heading with Chinese characters
+    await page.keyboard.type("# 第一章：序言");
+    await page.keyboard.press("Enter");
+
+    // Create heading with emoji
+    await page.keyboard.type("## 🚀 Getting Started");
+    await page.keyboard.press("Enter");
+
+    // Open the Outline panel
+    const outlineButton = page.getByTestId("iconbar-outline");
+    await outlineButton.click();
+    await expect(page.getByTestId("outline-panel")).toBeVisible();
+
+    // Verify special characters render correctly
+    await expect(page.getByText("第一章：序言")).toBeVisible();
+    await expect(page.getByText("🚀 Getting Started")).toBeVisible();
+
+    await electronApp.close();
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-203.md
+++ b/openspec/_ops/task_runs/ISSUE-203.md
@@ -1,0 +1,46 @@
+# ISSUE-203
+
+- Issue: #203
+- Branch: task/203-outline-derive-navigate
+- PR: <fill-after-created>
+
+## Plan
+
+- 实现 `deriveOutline.ts` 纯函数从 ProseMirror 文档提取 H1-H3 标题
+- 实现 `OutlinePanelContainer.tsx` 连接 editorStore，提供 items/activeId/onNavigate
+- 更新 `Sidebar.tsx` 使用容器组件，移除占位代码
+- 添加单元测试和 E2E 测试
+
+## Runs
+
+### 2026-02-05 19:30 Implementation
+
+- Command: `pnpm test:run -- 'outline'`
+- Key output: `✓ renderer/src/features/outline/deriveOutline.test.ts (31 tests)`
+- Evidence: All 31 unit tests for deriveOutline passed
+
+### 2026-02-05 19:45 Full test suite
+
+- Command: `pnpm test:run`
+- Key output: `Test Files  58 passed (58), Tests  1209 passed (1209)`
+- Evidence: All project tests pass
+
+### 2026-02-05 19:50 TypeScript + Lint
+
+- Command: `pnpm typecheck && pnpm lint`
+- Key output: Both passed with no errors
+- Evidence: No type errors, only pre-existing warnings in unrelated files
+
+## Files Changed
+
+### Added
+
+- `apps/desktop/renderer/src/features/outline/deriveOutline.ts`
+- `apps/desktop/renderer/src/features/outline/deriveOutline.test.ts`
+- `apps/desktop/renderer/src/features/outline/OutlinePanelContainer.tsx`
+- `apps/desktop/tests/e2e/outline-panel.spec.ts`
+
+### Modified
+
+- `apps/desktop/renderer/src/components/layout/Sidebar.tsx`
+- `apps/desktop/renderer/src/features/outline/index.ts`

--- a/openspec/_ops/task_runs/ISSUE-203.md
+++ b/openspec/_ops/task_runs/ISSUE-203.md
@@ -2,7 +2,7 @@
 
 - Issue: #203
 - Branch: task/203-outline-derive-navigate
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/204
 
 ## Plan
 


### PR DESCRIPTION
Closes #203

## Summary

- Add `deriveOutline.ts`: pure function to extract H1-H3 headings from ProseMirror document
- Add `OutlinePanelContainer.tsx`: connects to editorStore, provides items/activeId/onNavigate with debouncing
- Update `Sidebar.tsx`: use container component, remove placeholder `items=[]` and `console.log`
- Add 31 unit tests for `deriveOutline` covering edge cases (empty docs, special chars, emoji, duplicates)
- Add E2E tests for outline panel functionality

## Test Plan

- [x] Unit tests: `pnpm test:run -- 'outline'` - 31 tests pass
- [x] Full test suite: `pnpm test:run` - 1209 tests pass
- [x] TypeScript: `pnpm typecheck` - no errors
- [x] Lint: `pnpm lint` - no new errors
- [x] Preflight: `scripts/agent_pr_preflight.sh` - pass

## Files Changed

### Added
- `apps/desktop/renderer/src/features/outline/deriveOutline.ts`
- `apps/desktop/renderer/src/features/outline/deriveOutline.test.ts`
- `apps/desktop/renderer/src/features/outline/OutlinePanelContainer.tsx`
- `apps/desktop/tests/e2e/outline-panel.spec.ts`
- `openspec/_ops/task_runs/ISSUE-203.md`

### Modified
- `apps/desktop/renderer/src/components/layout/Sidebar.tsx`
- `apps/desktop/renderer/src/features/outline/index.ts`

Made with [Cursor](https://cursor.com)