### PR TITLE
fix(e2e): correct testid for outline icon button (#205)

### DIFF
--- a/apps/desktop/tests/e2e/outline-panel.spec.ts
+++ b/apps/desktop/tests/e2e/outline-panel.spec.ts
@@ -82,7 +82,7 @@ test.describe("OutlinePanel", () => {
     );
 
     // Open the Outline panel via IconBar
-    const outlineButton = page.getByTestId("iconbar-outline");
+    const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
 
     // Wait for outline panel to be visible
@@ -147,7 +147,7 @@ test.describe("OutlinePanel", () => {
     await page.keyboard.type("Just some plain text without any headings.");
 
     // Open the Outline panel
-    const outlineButton = page.getByTestId("iconbar-outline");
+    const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
 
     // Wait for outline panel
@@ -190,7 +190,7 @@ test.describe("OutlinePanel", () => {
     await expect(page.getByTestId("tiptap-editor")).toBeVisible();
 
     // Open the Outline panel first
-    const outlineButton = page.getByTestId("iconbar-outline");
+    const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
     await expect(page.getByTestId("outline-panel")).toBeVisible();
 
@@ -257,7 +257,7 @@ test.describe("OutlinePanel", () => {
     await page.keyboard.press("Enter");
 
     // Open the Outline panel
-    const outlineButton = page.getByTestId("iconbar-outline");
+    const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
     await expect(page.getByTestId("outline-panel")).toBeVisible();
 

--- a/openspec/_ops/task_runs/ISSUE-205.md
+++ b/openspec/_ops/task_runs/ISSUE-205.md
@@ -1,0 +1,25 @@
+# RUN_LOG: Issue #205
+
+## Meta
+
+- **Issue**: https://github.com/Leeky1017/CreoNow/issues/205
+- **Branch**: `task/205-outline-e2e-testid-fix`
+- **PR**: https://github.com/Leeky1017/CreoNow/pull/206
+
+## Plan
+
+修复 E2E 测试中的 `data-testid` 不匹配问题：
+- E2E 测试使用了 `iconbar-outline`
+- 但 `IconBar.tsx` 组件定义的是 `icon-bar-outline`
+
+## Runs
+
+### Run 1: 2026-02-05
+
+**Goal**: 修复 testid 不匹配
+
+**Steps**:
+1. 将 `apps/desktop/tests/e2e/outline-panel.spec.ts` 中的 `iconbar-outline` 替换为 `icon-bar-outline`
+
+**Evidence**:
+- 修复已应用并提交


### PR DESCRIPTION
## Summary

修复 E2E 测试中的 `data-testid` 不匹配问题。

- E2E 测试使用了 `iconbar-outline`
- 但 `IconBar.tsx` 组件定义的是 `icon-bar-outline`

## 影响

此修复将解决 main 分支上 `windows-e2e` CI 失败的问题。

## 测试计划

- [ ] windows-e2e CI 通过

Closes #205

Made with [Cursor](https://cursor.com)