### PR TITLE
fix(e2e): scope assertions to outline panel (#207)

### DIFF
--- a/apps/desktop/tests/e2e/outline-panel.spec.ts
+++ b/apps/desktop/tests/e2e/outline-panel.spec.ts
@@ -86,13 +86,14 @@ test.describe("OutlinePanel", () => {
     await outlineButton.click();
 
     // Wait for outline panel to be visible
-    await expect(page.getByTestId("outline-panel")).toBeVisible();
+    const outlinePanel = page.getByTestId("outline-panel");
+    await expect(outlinePanel).toBeVisible();
 
-    // Verify headings appear in the outline
-    await expect(page.getByText("Document Title")).toBeVisible();
-    await expect(page.getByText("Chapter One")).toBeVisible();
-    await expect(page.getByText("Section 1.1")).toBeVisible();
-    await expect(page.getByText("Chapter Two")).toBeVisible();
+    // Verify headings appear in the outline (scoped to outline panel)
+    await expect(outlinePanel.getByText("Document Title")).toBeVisible();
+    await expect(outlinePanel.getByText("Chapter One")).toBeVisible();
+    await expect(outlinePanel.getByText("Section 1.1")).toBeVisible();
+    await expect(outlinePanel.getByText("Chapter Two")).toBeVisible();
 
     // Click on "Chapter Two" in the outline to navigate
     const chapterTwoOutlineItem = page
@@ -192,7 +193,8 @@ test.describe("OutlinePanel", () => {
     // Open the Outline panel first
     const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
-    await expect(page.getByTestId("outline-panel")).toBeVisible();
+    const outlinePanel = page.getByTestId("outline-panel");
+    await expect(outlinePanel).toBeVisible();
 
     // Initially should show empty state
     await expect(page.getByTestId("outline-empty-state")).toBeVisible();
@@ -206,8 +208,8 @@ test.describe("OutlinePanel", () => {
     // Wait a bit for debounced update
     await page.waitForTimeout(100);
 
-    // Verify the heading appears in the outline
-    await expect(page.getByText("New Heading Added")).toBeVisible();
+    // Verify the heading appears in the outline (scoped to outline panel)
+    await expect(outlinePanel.getByText("New Heading Added")).toBeVisible();
 
     // Empty state should no longer be visible
     await expect(page.getByTestId("outline-empty-state")).not.toBeVisible();
@@ -259,11 +261,12 @@ test.describe("OutlinePanel", () => {
     // Open the Outline panel
     const outlineButton = page.getByTestId("icon-bar-outline");
     await outlineButton.click();
-    await expect(page.getByTestId("outline-panel")).toBeVisible();
+    const outlinePanel = page.getByTestId("outline-panel");
+    await expect(outlinePanel).toBeVisible();
 
-    // Verify special characters render correctly
-    await expect(page.getByText("第一章：序言")).toBeVisible();
-    await expect(page.getByText("🚀 Getting Started")).toBeVisible();
+    // Verify special characters render correctly (scoped to outline panel)
+    await expect(outlinePanel.getByText("第一章：序言")).toBeVisible();
+    await expect(outlinePanel.getByText("🚀 Getting Started")).toBeVisible();
 
     await electronApp.close();
   });

--- a/openspec/_ops/task_runs/ISSUE-207.md
+++ b/openspec/_ops/task_runs/ISSUE-207.md
@@ -4,7 +4,7 @@
 
 - **Issue**: https://github.com/Leeky1017/CreoNow/issues/207
 - **Branch**: `task/207-e2e-scope-assertions`
-- **PR**: (待创建)
+- **PR**: https://github.com/Leeky1017/CreoNow/pull/208
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-207.md
+++ b/openspec/_ops/task_runs/ISSUE-207.md
@@ -1,0 +1,26 @@
+# RUN_LOG: Issue #207
+
+## Meta
+
+- **Issue**: https://github.com/Leeky1017/CreoNow/issues/207
+- **Branch**: `task/207-e2e-scope-assertions`
+- **PR**: (待创建)
+
+## Plan
+
+修复 E2E 测试中的 Playwright 严格模式违规：
+- 将 `page.getByText()` 断言限定在 `outlinePanel` 定位器范围内
+- 避免同时匹配编辑器和大纲面板中的相同文本
+
+## Runs
+
+### Run 1: 2026-02-05
+
+**Goal**: 修复严格模式违规
+
+**Steps**:
+1. 在每个测试中创建 `outlinePanel` 定位器
+2. 将所有 `getByText()` 断言改为 `outlinePanel.getByText()`
+
+**Evidence**:
+- 修复已应用


### PR DESCRIPTION
## Summary

修复 E2E 测试中的 Playwright 严格模式违规。

- E2E 测试使用 `page.getByText()` 匹配到编辑器和大纲面板中的相同文本
- 现在所有断言都限定在 `outlinePanel` 定位器范围内

## 影响

此修复将解决 main 分支上 `windows-e2e` CI 失败的问题。

## 测试计划

- [ ] windows-e2e CI 通过

Closes #207

Made with [Cursor](https://cursor.com)