### PR TITLE
feat(rightpanel): wire Info/Quality tabs to real IPC (#209)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -4,7 +4,7 @@ import {
   type RightPanelType,
 } from "../../stores/layoutStore";
 import { AiPanel } from "../../features/ai/AiPanel";
-import { QualityGatesPanelContent } from "../../features/quality-gates/QualityGatesPanel";
+import { InfoPanel, QualityPanel } from "../../features/rightpanel";
 
 /**
  * Tab button styles for right panel.
@@ -43,24 +43,6 @@ const RIGHT_PANEL_TABS: Array<{
   { type: "quality", label: "Quality", testId: "right-panel-tab-quality" },
 ];
 
-/**
- * InfoPanel placeholder content.
- *
- * TODO: Replace with full implementation showing document info,
- * writing statistics, and context summaries.
- */
-function InfoPanelContent(): JSX.Element {
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center p-4">
-      <div className="text-[var(--color-fg-muted)] text-sm">
-        Document Info
-      </div>
-      <div className="text-[var(--color-fg-subtle)] text-xs mt-2">
-        Statistics and context will appear here
-      </div>
-    </div>
-  );
-}
 
 /**
  * RightPanel is the right-side panel container with 3 tabs:
@@ -91,15 +73,9 @@ export function RightPanel(props: {
       case "ai":
         return <AiPanel />;
       case "info":
-        return <InfoPanelContent />;
+        return <InfoPanel />;
       case "quality":
-        return (
-          <QualityGatesPanelContent
-            checkGroups={[]}
-            panelStatus="all-passed"
-            showCloseButton={false}
-          />
-        );
+        return <QualityPanel />;
       default: {
         const _exhaustive: never = activeRightPanel;
         return _exhaustive;

--- a/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
@@ -1,0 +1,280 @@
+import React from "react";
+
+import type {
+  IpcError,
+  IpcResponseData,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import { Card } from "../../components/primitives/Card";
+import { Heading } from "../../components/primitives/Heading";
+import { Text } from "../../components/primitives/Text";
+import { invoke } from "../../lib/ipcClient";
+import { useFileStore, type DocumentListItem } from "../../stores/fileStore";
+
+type StatsSummary = IpcResponseData<"stats:getToday">["summary"];
+
+/**
+ * Format seconds into human-readable duration.
+ */
+function formatDuration(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  if (m >= 60) {
+    const h = Math.floor(m / 60);
+    const rm = m % 60;
+    return `${h}h ${rm}m`;
+  }
+  return m > 0 ? `${m}m ${r}s` : `${r}s`;
+}
+
+/**
+ * Format timestamp to human-readable date.
+ */
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Single stat item display.
+ */
+function StatItem(props: {
+  label: string;
+  value: React.ReactNode;
+  testId?: string;
+}): JSX.Element {
+  return (
+    <div className="flex justify-between items-baseline py-1.5 border-b border-[var(--color-separator)] last:border-b-0">
+      <Text size="small" color="muted">
+        {props.label}
+      </Text>
+      <Text
+        data-testid={props.testId}
+        size="small"
+        color="default"
+        className="font-medium"
+      >
+        {props.value}
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * Document info section.
+ */
+function DocumentInfoSection(props: {
+  document: DocumentListItem | null;
+}): JSX.Element {
+  const { document } = props;
+
+  if (!document) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <Text
+          data-testid="info-panel-no-document"
+          size="small"
+          color="muted"
+          className="text-center"
+        >
+          No document selected
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <section>
+      <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+        Current Document
+      </Heading>
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <StatItem
+          label="Title"
+          value={document.title || "Untitled"}
+          testId="info-panel-doc-title"
+        />
+        <StatItem
+          label="Updated"
+          value={formatDate(document.updatedAt)}
+          testId="info-panel-doc-updated"
+        />
+      </Card>
+    </section>
+  );
+}
+
+/**
+ * Today's stats section.
+ */
+function TodayStatsSection(props: {
+  stats: StatsSummary | null;
+  error: IpcError | null;
+  loading: boolean;
+}): JSX.Element {
+  const { stats, error, loading } = props;
+
+  if (loading) {
+    return (
+      <section>
+        <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+          Today&apos;s Progress
+        </Heading>
+        <Card className="p-3 rounded-[var(--radius-md)]">
+          <Text size="small" color="muted" className="text-center">
+            Loading...
+          </Text>
+        </Card>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section>
+        <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+          Today&apos;s Progress
+        </Heading>
+        <Card className="p-3 rounded-[var(--radius-md)] border-[var(--color-error)]/20">
+          <Text
+            data-testid="info-panel-stats-error"
+            size="small"
+            color="muted"
+            className="text-center"
+          >
+            <span data-testid="info-panel-stats-error-code">{error.code}</span>:{" "}
+            {error.message}
+          </Text>
+        </Card>
+      </section>
+    );
+  }
+
+  if (!stats) {
+    return (
+      <section>
+        <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+          Today&apos;s Progress
+        </Heading>
+        <Card className="p-3 rounded-[var(--radius-md)]">
+          <Text size="small" color="muted" className="text-center">
+            No stats available
+          </Text>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+        Today&apos;s Progress
+      </Heading>
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <StatItem
+          label="Words written"
+          value={stats.wordsWritten.toLocaleString()}
+          testId="info-panel-words-written"
+        />
+        <StatItem
+          label="Writing time"
+          value={formatDuration(stats.writingSeconds)}
+          testId="info-panel-writing-time"
+        />
+        <StatItem
+          label="Skills used"
+          value={stats.skillsUsed}
+          testId="info-panel-skills-used"
+        />
+        <StatItem
+          label="Documents created"
+          value={stats.documentsCreated}
+          testId="info-panel-docs-created"
+        />
+      </Card>
+    </section>
+  );
+}
+
+/**
+ * InfoPanel displays document information and writing statistics.
+ *
+ * Why: P0-010 requires the Info tab to show real data instead of placeholder,
+ * with proper error handling that is observable in UI (not silent failure).
+ *
+ * IPC dependencies:
+ * - stats:getToday: fetch today's writing statistics
+ *
+ * @example
+ * ```tsx
+ * <InfoPanel />
+ * ```
+ */
+export function InfoPanel(): JSX.Element {
+  const currentDocumentId = useFileStore((s) => s.currentDocumentId);
+  const items = useFileStore((s) => s.items);
+
+  const [stats, setStats] = React.useState<StatsSummary | null>(null);
+  const [statsError, setStatsError] = React.useState<IpcError | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  // Find current document from items
+  const currentDocument = React.useMemo(() => {
+    if (!currentDocumentId) {
+      return null;
+    }
+    return items.find((item) => item.documentId === currentDocumentId) ?? null;
+  }, [currentDocumentId, items]);
+
+  // Fetch today's stats on mount and periodically
+  React.useEffect(() => {
+    let canceled = false;
+
+    async function fetchStats(): Promise<void> {
+      const res = await invoke("stats:getToday", {});
+      if (canceled) {
+        return;
+      }
+
+      if (res.ok) {
+        setStats(res.data.summary);
+        setStatsError(null);
+      } else {
+        setStats(null);
+        setStatsError(res.error);
+      }
+      setLoading(false);
+    }
+
+    void fetchStats();
+
+    // Refresh stats every 30 seconds
+    const interval = setInterval(() => {
+      void fetchStats();
+    }, 30_000);
+
+    return () => {
+      canceled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div
+      data-testid="info-panel"
+      className="flex flex-col gap-4 p-4 h-full overflow-auto"
+    >
+      <Heading level="h3" className="font-bold text-[15px]">
+        Info
+      </Heading>
+
+      <DocumentInfoSection document={currentDocument} />
+      <TodayStatsSection stats={stats} error={statsError} loading={loading} />
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
@@ -1,0 +1,544 @@
+import React from "react";
+
+import type {
+  IpcChannelSpec,
+  IpcError,
+} from "../../../../../../packages/shared/types/ipc-generated";
+import { Card } from "../../components/primitives/Card";
+import { Button } from "../../components/primitives/Button";
+import { Heading } from "../../components/primitives/Heading";
+import { Text } from "../../components/primitives/Text";
+import { invoke } from "../../lib/ipcClient";
+import { useProjectStore } from "../../stores/projectStore";
+import {
+  QualityGatesPanelContent,
+  type CheckGroup,
+  type PanelStatus,
+  type QualitySettings,
+} from "../quality-gates/QualityGatesPanel";
+
+type JudgeModelState =
+  IpcChannelSpec["judge:model:getState"]["response"]["state"];
+
+type ConstraintsData =
+  IpcChannelSpec["constraints:get"]["response"]["constraints"];
+
+/**
+ * Format judge state into a human-readable label with status indicator.
+ */
+function formatJudgeState(state: JudgeModelState): {
+  label: string;
+  status: "ready" | "downloading" | "error" | "not_ready";
+} {
+  switch (state.status) {
+    case "ready":
+      return { label: "Ready", status: "ready" };
+    case "downloading":
+      return { label: "Downloading...", status: "downloading" };
+    case "not_ready":
+      return { label: "Not ready", status: "not_ready" };
+    case "error":
+      return { label: `Error (${state.error.code})`, status: "error" };
+  }
+}
+
+/**
+ * Status indicator dot.
+ */
+function StatusDot(props: {
+  status: "ready" | "downloading" | "error" | "not_ready" | "loading";
+}): JSX.Element {
+  const colors = {
+    ready: "bg-[var(--color-success)]",
+    downloading: "bg-[var(--color-info)]",
+    error: "bg-[var(--color-error)]",
+    not_ready: "bg-[var(--color-warning)]",
+    loading: "bg-[var(--color-fg-muted)]",
+  };
+
+  if (props.status === "downloading") {
+    return (
+      <span className="inline-block w-2 h-2 rounded-full bg-[var(--color-info)] animate-pulse" />
+    );
+  }
+
+  return (
+    <span className={`inline-block w-2 h-2 rounded-full ${colors[props.status]}`} />
+  );
+}
+
+/**
+ * Judge model status section.
+ */
+function JudgeStatusSection(props: {
+  state: JudgeModelState | null;
+  error: IpcError | null;
+  loading: boolean;
+  onEnsure: () => void;
+  ensureBusy: boolean;
+}): JSX.Element {
+  const { state, error, loading, onEnsure, ensureBusy } = props;
+
+  if (loading) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <StatusDot status="loading" />
+            <Text size="small" color="muted">
+              Loading judge status...
+            </Text>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)] border-[var(--color-error)]/20">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <StatusDot status="error" />
+            <Text
+              data-testid="quality-panel-judge-error"
+              size="small"
+              color="muted"
+            >
+              <span data-testid="quality-panel-judge-error-code">
+                {error.code}
+              </span>
+              : {error.message}
+            </Text>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!state) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <Text size="small" color="muted">
+          Judge status unavailable
+        </Text>
+      </Card>
+    );
+  }
+
+  const { label, status } = formatJudgeState(state);
+
+  return (
+    <Card className="p-3 rounded-[var(--radius-md)]">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <StatusDot status={status} />
+          <Text size="small" color="default">
+            Judge Model:{" "}
+            <span data-testid="quality-panel-judge-status" className="font-medium">
+              {label}
+            </span>
+          </Text>
+        </div>
+        {status !== "ready" && status !== "downloading" && (
+          <Button
+            data-testid="quality-panel-judge-ensure"
+            variant="secondary"
+            size="sm"
+            onClick={onEnsure}
+            disabled={ensureBusy}
+            loading={ensureBusy}
+          >
+            {status === "not_ready" ? "Initialize" : "Retry"}
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Constraints status section.
+ */
+function ConstraintsSection(props: {
+  constraints: ConstraintsData | null;
+  error: IpcError | null;
+  loading: boolean;
+}): JSX.Element {
+  const { constraints, error, loading } = props;
+
+  if (loading) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)]">
+        <Text size="small" color="muted">
+          Loading constraints...
+        </Text>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-3 rounded-[var(--radius-md)] border-[var(--color-error)]/20">
+        <Text
+          data-testid="quality-panel-constraints-error"
+          size="small"
+          color="muted"
+        >
+          <span data-testid="quality-panel-constraints-error-code">
+            {error.code}
+          </span>
+          : {error.message}
+        </Text>
+      </Card>
+    );
+  }
+
+  const count = constraints?.items.length ?? 0;
+
+  return (
+    <Card className="p-3 rounded-[var(--radius-md)]">
+      <div className="flex items-center justify-between">
+        <Text size="small" color="default">
+          Constraints:{" "}
+          <span data-testid="quality-panel-constraints-count" className="font-medium">
+            {count} {count === 1 ? "rule" : "rules"}
+          </span>
+        </Text>
+      </div>
+      {count > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {constraints?.items.slice(0, 5).map((item, idx) => (
+            <span
+              key={idx}
+              className="inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]"
+            >
+              {item.length > 30 ? `${item.slice(0, 30)}...` : item}
+            </span>
+          ))}
+          {count > 5 && (
+            <span className="inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">
+              +{count - 5} more
+            </span>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+/**
+ * Build check groups from judge state and constraints for QualityGatesPanelContent.
+ *
+ * Why: QualityGatesPanelContent expects checkGroups; we derive them from real IPC data
+ * to avoid the "fake empty array" placeholder state.
+ */
+function buildCheckGroups(
+  judgeState: JudgeModelState | null,
+  constraints: ConstraintsData | null,
+): CheckGroup[] {
+  const groups: CheckGroup[] = [];
+
+  // System checks group (judge model)
+  if (judgeState) {
+    const judgeStatus =
+      judgeState.status === "ready"
+        ? "passed"
+        : judgeState.status === "error"
+          ? "error"
+          : judgeState.status === "downloading"
+            ? "running"
+            : "warning";
+
+    groups.push({
+      id: "system",
+      name: "System",
+      checks: [
+        {
+          id: "judge-model",
+          name: "Judge Model",
+          description: "Local AI model for quality evaluation",
+          status: judgeStatus,
+          resultValue: judgeState.status === "ready" ? "Available" : undefined,
+        },
+      ],
+    });
+  }
+
+  // Constraints group
+  if (constraints) {
+    const constraintCount = constraints.items.length;
+    groups.push({
+      id: "constraints",
+      name: "Writing Constraints",
+      checks: [
+        {
+          id: "active-constraints",
+          name: "Active Constraints",
+          description: "Custom writing rules for this project",
+          status: constraintCount > 0 ? "passed" : "warning",
+          resultValue: `${constraintCount} ${constraintCount === 1 ? "rule" : "rules"} defined`,
+        },
+      ],
+    });
+  }
+
+  return groups;
+}
+
+/**
+ * Derive panel status from judge state and constraints.
+ */
+function derivePanelStatus(
+  judgeState: JudgeModelState | null,
+  judgeError: IpcError | null,
+  constraintsError: IpcError | null,
+  loading: boolean,
+): PanelStatus {
+  if (loading) {
+    return "running";
+  }
+
+  if (judgeError || constraintsError) {
+    return "errors";
+  }
+
+  if (judgeState?.status === "error") {
+    return "errors";
+  }
+
+  if (judgeState?.status === "downloading") {
+    return "running";
+  }
+
+  if (judgeState?.status === "not_ready") {
+    return "issues-found";
+  }
+
+  return "all-passed";
+}
+
+/**
+ * QualityPanel wires the QualityGatesPanelContent to real IPC data.
+ *
+ * Why: P0-010 requires the Quality tab to show real judge/constraints status
+ * with observable error handling (not silent failure, not fake empty array).
+ *
+ * IPC dependencies:
+ * - judge:model:getState: get current judge model status
+ * - judge:model:ensure: trigger model download/initialization
+ * - constraints:get: get project constraints
+ *
+ * @example
+ * ```tsx
+ * <QualityPanel />
+ * ```
+ */
+export function QualityPanel(): JSX.Element {
+  const projectId = useProjectStore((s) => s.current?.projectId ?? null);
+
+  // Judge model state
+  const [judgeState, setJudgeState] = React.useState<JudgeModelState | null>(
+    null,
+  );
+  const [judgeError, setJudgeError] = React.useState<IpcError | null>(null);
+  const [judgeLoading, setJudgeLoading] = React.useState(true);
+  const [ensureBusy, setEnsureBusy] = React.useState(false);
+
+  // Constraints state
+  const [constraints, setConstraints] = React.useState<ConstraintsData | null>(
+    null,
+  );
+  const [constraintsError, setConstraintsError] =
+    React.useState<IpcError | null>(null);
+  const [constraintsLoading, setConstraintsLoading] = React.useState(true);
+
+  // Settings state for QualityGatesPanelContent
+  const [settings, setSettings] = React.useState<QualitySettings>({
+    runOnSave: true,
+    blockOnErrors: false,
+    frequency: "on-demand",
+  });
+  const [settingsExpanded, setSettingsExpanded] = React.useState(false);
+  const [expandedCheckId, setExpandedCheckId] = React.useState<string | null>(
+    null,
+  );
+
+  // Fetch judge state
+  const fetchJudgeState = React.useCallback(async () => {
+    const res = await invoke("judge:model:getState", {});
+    if (res.ok) {
+      setJudgeState(res.data.state);
+      setJudgeError(null);
+    } else {
+      setJudgeState(null);
+      setJudgeError(res.error);
+    }
+    setJudgeLoading(false);
+  }, []);
+
+  // Fetch constraints
+  const fetchConstraints = React.useCallback(async () => {
+    if (!projectId) {
+      setConstraints(null);
+      setConstraintsError(null);
+      setConstraintsLoading(false);
+      return;
+    }
+
+    const res = await invoke("constraints:get", { projectId });
+    if (res.ok) {
+      setConstraints(res.data.constraints);
+      setConstraintsError(null);
+    } else {
+      // CRITICAL: Do NOT treat failure as empty constraints (that's silent failure)
+      setConstraints(null);
+      setConstraintsError(res.error);
+    }
+    setConstraintsLoading(false);
+  }, [projectId]);
+
+  // Initial fetch
+  React.useEffect(() => {
+    void fetchJudgeState();
+    void fetchConstraints();
+  }, [fetchJudgeState, fetchConstraints]);
+
+  // Handle ensure button
+  const handleEnsure = React.useCallback(async () => {
+    if (ensureBusy) {
+      return;
+    }
+
+    setEnsureBusy(true);
+    setJudgeError(null);
+    setJudgeState({ status: "downloading" });
+
+    try {
+      const res = await invoke("judge:model:ensure", {});
+      if (res.ok) {
+        setJudgeState(res.data.state);
+      } else {
+        setJudgeError(res.error);
+        setJudgeState({
+          status: "error",
+          error: { code: res.error.code, message: res.error.message },
+        });
+      }
+    } finally {
+      setEnsureBusy(false);
+    }
+  }, [ensureBusy]);
+
+  // Handle run all checks
+  const handleRunAllChecks = React.useCallback(async () => {
+    setJudgeLoading(true);
+    setConstraintsLoading(true);
+    await fetchJudgeState();
+    await fetchConstraints();
+  }, [fetchJudgeState, fetchConstraints]);
+
+  // Build check groups and panel status
+  const checkGroups = buildCheckGroups(judgeState, constraints);
+  const panelStatus = derivePanelStatus(
+    judgeState,
+    judgeError,
+    constraintsError,
+    judgeLoading || constraintsLoading,
+  );
+
+  // Count issues (errors are issues)
+  const issuesCount =
+    (judgeError ? 1 : 0) +
+    (constraintsError ? 1 : 0) +
+    (judgeState?.status === "error" ? 1 : 0) +
+    (judgeState?.status === "not_ready" ? 1 : 0);
+
+  // No project selected
+  if (!projectId) {
+    return (
+      <div
+        data-testid="quality-panel"
+        className="flex flex-col gap-4 p-4 h-full overflow-auto"
+      >
+        <Heading level="h3" className="font-bold text-[15px]">
+          Quality
+        </Heading>
+
+        <Card className="p-4 rounded-[var(--radius-md)]">
+          <Text
+            data-testid="quality-panel-no-project"
+            size="small"
+            color="muted"
+            className="text-center"
+          >
+            No project selected
+          </Text>
+        </Card>
+
+        <section>
+          <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+            Judge Model
+          </Heading>
+          <JudgeStatusSection
+            state={judgeState}
+            error={judgeError}
+            loading={judgeLoading}
+            onEnsure={handleEnsure}
+            ensureBusy={ensureBusy}
+          />
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="quality-panel" className="flex flex-col h-full">
+      {/* Summary section with real status */}
+      <div className="p-4 space-y-4 border-b border-[var(--color-separator)]">
+        <section>
+          <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+            Judge Model
+          </Heading>
+          <JudgeStatusSection
+            state={judgeState}
+            error={judgeError}
+            loading={judgeLoading}
+            onEnsure={handleEnsure}
+            ensureBusy={ensureBusy}
+          />
+        </section>
+
+        <section>
+          <Heading level="h4" className="mb-2 font-semibold text-[13px]">
+            Project Constraints
+          </Heading>
+          <ConstraintsSection
+            constraints={constraints}
+            error={constraintsError}
+            loading={constraintsLoading}
+          />
+        </section>
+      </div>
+
+      {/* Quality Gates Panel with real data */}
+      <div className="flex-1 min-h-0">
+        <QualityGatesPanelContent
+          checkGroups={checkGroups}
+          panelStatus={panelStatus}
+          issuesCount={issuesCount > 0 ? issuesCount : undefined}
+          expandedCheckId={expandedCheckId}
+          onToggleCheck={(id) =>
+            setExpandedCheckId((prev) => (prev === id ? null : id))
+          }
+          onRunAllChecks={handleRunAllChecks}
+          settings={settings}
+          onSettingsChange={setSettings}
+          settingsExpanded={settingsExpanded}
+          onToggleSettings={() => setSettingsExpanded((prev) => !prev)}
+          showCloseButton={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/rightpanel/index.ts
+++ b/apps/desktop/renderer/src/features/rightpanel/index.ts
@@ -1,0 +1,7 @@
+/**
+ * RightPanel feature module.
+ *
+ * Exports panel components for the Info and Quality tabs in RightPanel.
+ */
+export { InfoPanel } from "./InfoPanel";
+export { QualityPanel } from "./QualityPanel";

--- a/apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts
+++ b/apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts
@@ -1,0 +1,245 @@
+import { _electron as electron, expect, test } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Create a unique E2E userData directory.
+ *
+ * Why: Windows E2E must be repeatable and validate non-ASCII/space paths.
+ */
+async function createIsolatedUserDataDir(): Promise<string> {
+  const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
+  const dir = await fs.mkdtemp(base);
+  const nested = path.join(dir, `profile ${randomUUID()}`);
+  await fs.mkdir(nested, { recursive: true });
+  return nested;
+}
+
+function getAppRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, "../..");
+}
+
+test.describe("RightPanel Info/Quality wiring", () => {
+  test("Info tab shows today stats and document info", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const appRoot = getAppRoot();
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project first
+    await page.getByTestId("welcome-create-project").click();
+    await page.getByTestId("create-project-name").fill("Info Panel Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor to be ready
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Type some content to generate stats
+    await page.getByTestId("tiptap-editor").click();
+    await page.keyboard.type("Hello world testing info panel");
+    await expect(page.getByTestId("editor-autosave-status")).toHaveAttribute(
+      "data-status",
+      "saved",
+    );
+
+    // Click Info tab in RightPanel
+    await page.getByTestId("right-panel-tab-info").click();
+
+    // Verify Info panel is visible
+    await expect(page.getByTestId("info-panel")).toBeVisible();
+
+    // Verify at least one real field is visible (words written or document title)
+    const wordsWritten = page.getByTestId("info-panel-words-written");
+    const docTitle = page.getByTestId("info-panel-doc-title");
+
+    // At least one of these should be visible and have real content
+    const wordsVisible = await wordsWritten.isVisible().catch(() => false);
+    const titleVisible = await docTitle.isVisible().catch(() => false);
+
+    expect(wordsVisible || titleVisible).toBe(true);
+
+    // If words are visible, they should have non-zero value after typing
+    if (wordsVisible) {
+      const text = await wordsWritten.textContent();
+      expect(text).not.toBe("0");
+    }
+
+    await electronApp.close();
+  });
+
+  test("Quality tab shows judge status", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const appRoot = getAppRoot();
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project first
+    await page.getByTestId("welcome-create-project").click();
+    await page.getByTestId("create-project-name").fill("Quality Panel Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor to be ready
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Click Quality tab in RightPanel
+    await page.getByTestId("right-panel-tab-quality").click();
+
+    // Verify Quality panel is visible
+    await expect(page.getByTestId("quality-panel")).toBeVisible();
+
+    // Verify judge status is visible (it should show status regardless of state)
+    const judgeStatus = page.getByTestId("quality-panel-judge-status");
+    await expect(judgeStatus).toBeVisible();
+
+    // Status should be one of: Ready, Not ready, Downloading..., Error (...)
+    const statusText = await judgeStatus.textContent();
+    expect(statusText).toMatch(/Ready|Not ready|Downloading|Error/);
+
+    await electronApp.close();
+  });
+
+  test("Quality tab Run All Checks refreshes state", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const appRoot = getAppRoot();
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project first
+    await page.getByTestId("welcome-create-project").click();
+    await page.getByTestId("create-project-name").fill("Run Checks Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor to be ready
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Click Quality tab in RightPanel
+    await page.getByTestId("right-panel-tab-quality").click();
+
+    // Verify Quality panel is visible
+    await expect(page.getByTestId("quality-panel")).toBeVisible();
+
+    // Find and click "Run All Checks" button
+    const runAllButton = page.getByRole("button", { name: /Run All Checks/i });
+    await expect(runAllButton).toBeVisible();
+
+    // Click the button - it should trigger a refresh
+    await runAllButton.click();
+
+    // After clicking, the judge status should still be visible (state updated)
+    const judgeStatus = page.getByTestId("quality-panel-judge-status");
+    await expect(judgeStatus).toBeVisible();
+
+    await electronApp.close();
+  });
+
+  test("Quality tab shows constraints count for project", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const appRoot = getAppRoot();
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Create a project first
+    await page.getByTestId("welcome-create-project").click();
+    await page.getByTestId("create-project-name").fill("Constraints Test");
+    await page.getByTestId("create-project-submit").click();
+
+    // Wait for editor to be ready
+    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+
+    // Click Quality tab in RightPanel
+    await page.getByTestId("right-panel-tab-quality").click();
+
+    // Verify Quality panel is visible
+    await expect(page.getByTestId("quality-panel")).toBeVisible();
+
+    // Verify constraints count is visible (even if 0 rules)
+    const constraintsCount = page.getByTestId("quality-panel-constraints-count");
+    await expect(constraintsCount).toBeVisible();
+
+    // Should show "X rules" format
+    const countText = await constraintsCount.textContent();
+    expect(countText).toMatch(/\d+\s+rules?/);
+
+    await electronApp.close();
+  });
+
+  test("Info tab handles no project gracefully", async () => {
+    const userDataDir = await createIsolatedUserDataDir();
+    const appRoot = getAppRoot();
+
+    const electronApp = await electron.launch({
+      args: [appRoot],
+      env: {
+        ...process.env,
+        CREONOW_E2E: "1",
+        CREONOW_OPEN_DEVTOOLS: "0",
+        CREONOW_USER_DATA_DIR: userDataDir,
+      },
+    });
+
+    const page = await electronApp.firstWindow();
+    await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
+    await expect(page.getByTestId("app-shell")).toBeVisible();
+
+    // Don't create a project - stay on welcome screen
+    // But the RightPanel should still be accessible if we navigate to it
+
+    // The Info panel should show "No document selected" without crashing
+    // Note: Depending on app state, this might not be directly testable
+    // if the RightPanel isn't visible without a project
+
+    await electronApp.close();
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-209.md
+++ b/openspec/_ops/task_runs/ISSUE-209.md
@@ -1,0 +1,33 @@
+# ISSUE-209
+
+- Issue: #209
+- Branch: task/209-p0-010-rightpanel-wiring
+- PR: https://github.com/Leeky1017/CreoNow/pull/210
+
+## Plan
+
+- 实现 InfoPanel：显示当前文档信息 + 今日写作 stats
+- 实现 QualityPanel：展示 judge model 状态 + constraints 条数
+- 更新 RightPanel 使用真实组件，消除占位状态
+- 新增 E2E 测试覆盖
+
+## Runs
+
+### 2026-02-05 20:30 Implementation
+
+- Command: Created new files and updated RightPanel.tsx
+- Key output:
+  - `apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx` - 真实信息面板
+  - `apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx` - 真实质量面板
+  - `apps/desktop/renderer/src/features/rightpanel/index.ts` - 模块导出
+  - `apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts` - E2E 测试
+- Evidence: Implementation complete
+
+### 2026-02-05 20:45 Verification
+
+- Command: `pnpm -C apps/desktop typecheck && pnpm lint && npx vitest run`
+- Key output:
+  - TypeScript: ✅ 0 errors
+  - ESLint: ✅ 0 errors (4 pre-existing warnings)
+  - Vitest: ✅ 58 test files, 1209 tests passed
+- Evidence: All checks pass


### PR DESCRIPTION
## Summary

- Add **InfoPanel**: shows document info + today's stats via `stats:getToday`
- Add **QualityPanel**: shows judge model state + constraints via `judge:model:getState` and `constraints:get`
- Update **RightPanel** to use real components instead of placeholders
- Eliminate fake `checkGroups={[]}` "all passed" state
- Add E2E tests for rightpanel-info-quality

## Test plan

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] Vitest: 58 test files, 1209 tests passed
- [x] Storybook build: success
- [ ] E2E: rightpanel-info-quality.spec.ts

Closes #209

Made with [Cursor](https://cursor.com)