### PR TITLE
fix(e2e): CommandPalette keyboard navigation flaky on Windows CI

### DIFF
--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -253,6 +253,12 @@ test.describe("Command Palette + Shortcuts", () => {
     await page.keyboard.press(`${modKey}+p`);
     await expect(page.getByTestId("command-palette")).toBeVisible();
 
+    // Type and clear to force activeIndex reset via query change useEffect
+    // This is more reliable than relying on useLayoutEffect timing alone
+    const input = page.getByRole("textbox");
+    await input.fill("a");
+    await input.fill("");
+
     // Wait for the listbox to be rendered and have the initial active index set
     // Using data-active-index attribute for more reliable state detection
     const listbox = page.locator('[role="listbox"]');


### PR DESCRIPTION
## Summary

修复 Windows CI 上 CommandPalette 键盘导航 E2E 测试的 flaky 问题。

**问题**: 打开 Command Palette 时，`useLayoutEffect` 重置 `activeIndex` 到 0 的时机在 Windows 上不够稳定，导致测试断言时 `data-active-index` 可能不是预期的 0。

**修复**: 在测试开始时，先输入一个字符再清空，触发 `query` 变化的 `useEffect`，从而更可靠地重置 `activeIndex` 到 0。

## Test Plan

- [ ] CI checks (windows-e2e should pass)

Made with [Cursor](https://cursor.com)