### PR TITLE
fix(e2e): use specific textbox selector in CommandPalette test

### DIFF
--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -255,7 +255,7 @@ test.describe("Command Palette + Shortcuts", () => {
 
     // Type and clear to force activeIndex reset via query change useEffect
     // This is more reliable than relying on useLayoutEffect timing alone
-    const input = page.getByRole("textbox");
+    const input = page.getByRole("textbox", { name: "Search commands" });
     await input.fill("a");
     await input.fill("");
 


### PR DESCRIPTION
## Summary

修复 PR #215 合并后仍存在的 E2E 测试失败。

**问题**: `page.getByRole("textbox")` 匹配到了 2 个元素 (AI input + Command Palette search input)，导致 Playwright strict mode violation。

**修复**: 使用 `page.getByRole("textbox", { name: "Search commands" })` 精确定位 Command Palette 输入框。

## Test Plan

- [ ] CI checks (windows-e2e should pass)

Made with [Cursor](https://cursor.com)