### PR TITLE
[MVP-REMED] P0-005: CI add desktop vitest gate (#220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Integration tests
         run: pnpm test:integration
 
+      - name: Desktop vitest (renderer/store)
+        run: pnpm -C apps/desktop test:run
+
       - name: Storybook build check
         run: pnpm -C apps/desktop storybook:build
 

--- a/openspec/_ops/task_runs/ISSUE-220.md
+++ b/openspec/_ops/task_runs/ISSUE-220.md
@@ -2,7 +2,7 @@
 
 - Issue: #220
 - Branch: `task/220-p0-005-ci-desktop-vitest`
-- PR: <pending>
+- PR: https://github.com/Leeky1017/CreoNow/pull/221
 
 ## Goal
 
@@ -10,13 +10,13 @@
 
 ## Status
 
-- CURRENT: 门禁验证已通过，正在提交并创建 PR。
+- CURRENT: PR 已创建并回填，等待 checks + auto-merge。
 
 ## Next Actions
 
 - [x] 运行本 Issue 最小门禁（typecheck/lint/contract:check/test:unit）。
-- [ ] 提交 commit（message 含 `(#220)`）并推送。
-- [ ] 创建 PR（body 含 `Closes #220`），启用 auto-merge 并等待合并。
+- [x] 提交 commit（message 含 `(#220)`）并推送。
+- [ ] 监控 `ci`/`openspec-log-guard`/`merge-serial` 并确认 auto-merge 后 `mergedAt != null`。
 
 ## Decisions Made
 
@@ -28,6 +28,7 @@
 - 2026-02-06: `scripts/agent_controlplane_sync.sh` 在原工作区失败（控制面脏）。处理：切换到干净 clone 执行标准流程。
 - 2026-02-06: 首次 preflight 失败，`pnpm exec prettier` 不存在。处理：在 worktree 执行 `pnpm install --frozen-lockfile`。
 - 2026-02-06: 二次 preflight 失败，Prettier 检查未通过。处理：对改动文件执行 `pnpm exec prettier --write` 后重跑 preflight。
+- 2026-02-06: `gh pr create` 使用内联 body 时，反引号触发 shell 命令替换导致 PR body 污染。处理：改用 `--body-file` 并 `gh pr edit` 清理正文。
 
 ## Runs
 
@@ -105,3 +106,17 @@
   - `pnpm test:unit` passed.
 - Evidence:
   - `scripts/agent_pr_preflight.sh` output (latest run)
+
+### 2026-02-06 00:00 Commit, push, and PR creation
+
+- Command:
+  - `git commit -m "chore: normalize remediation design baseline and CI gate (#220)"`
+  - `git push -u origin HEAD`
+  - `gh pr create ...`
+  - `gh pr edit 221 --body-file /tmp/pr-220-clean.md`
+- Key output:
+  - Commit `ed4b2eb` created with required `(#220)` marker.
+  - Branch `task/220-p0-005-ci-desktop-vitest` pushed to origin.
+  - PR `#221` created and corrected with clean body including `Closes #220`.
+- Evidence:
+  - `https://github.com/Leeky1017/CreoNow/pull/221`

--- a/openspec/_ops/task_runs/ISSUE-220.md
+++ b/openspec/_ops/task_runs/ISSUE-220.md
@@ -1,0 +1,107 @@
+# ISSUE-220
+
+- Issue: #220
+- Branch: `task/220-p0-005-ci-desktop-vitest`
+- PR: <pending>
+
+## Goal
+
+- 完成 Preflight 设计路径统一，并在 CI `check` job 增加 desktop Vitest 门禁。
+
+## Status
+
+- CURRENT: 门禁验证已通过，正在提交并创建 PR。
+
+## Next Actions
+
+- [x] 运行本 Issue 最小门禁（typecheck/lint/contract:check/test:unit）。
+- [ ] 提交 commit（message 含 `(#220)`）并推送。
+- [ ] 创建 PR（body 含 `Closes #220`），启用 auto-merge 并等待合并。
+
+## Decisions Made
+
+- 2026-02-06: 采用独立干净 clone (`/home/leeky/work/CreoNow-delivery`) 作为控制面，避免污染用户已有脏工作区。
+- 2026-02-06: Preflight 路径统一改为 `design/system/README.md + design/system/01-tokens.css + design/DESIGN_DECISIONS.md`。
+
+## Errors Encountered
+
+- 2026-02-06: `scripts/agent_controlplane_sync.sh` 在原工作区失败（控制面脏）。处理：切换到干净 clone 执行标准流程。
+- 2026-02-06: 首次 preflight 失败，`pnpm exec prettier` 不存在。处理：在 worktree 执行 `pnpm install --frozen-lockfile`。
+- 2026-02-06: 二次 preflight 失败，Prettier 检查未通过。处理：对改动文件执行 `pnpm exec prettier --write` 后重跑 preflight。
+
+## Runs
+
+### 2026-02-06 00:00 Preflight auth and scripts
+
+- Command:
+  - `gh auth status`
+  - `git remote -v`
+  - `ls -1 scripts`
+- Key output:
+  - GitHub account `Leeky1017` authenticated.
+  - `origin` remote configured.
+  - Required delivery scripts are present.
+- Evidence:
+  - `scripts/agent_controlplane_sync.sh`
+  - `scripts/agent_worktree_setup.sh`
+
+### 2026-02-06 00:00 Issue and worktree bootstrap
+
+- Command:
+  - `gh issue create -t "[MVP-REMED] P0-005: CI add desktop vitest gate" ...`
+  - `scripts/agent_worktree_setup.sh 220 p0-005-ci-desktop-vitest`
+  - `rulebook task create issue-220-p0-005-ci-desktop-vitest`
+  - `rulebook task validate issue-220-p0-005-ci-desktop-vitest`
+- Key output:
+  - Created issue `#220`.
+  - Worktree created at `.worktrees/issue-220-p0-005-ci-desktop-vitest`.
+  - Rulebook task created and validated.
+- Evidence:
+  - `rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/`
+
+### 2026-02-06 00:00 Apply scoped file changes
+
+- Command:
+  - `cp` (from `/home/leeky/work/CreoNow`) into N1 worktree for 4 scoped files
+- Key output:
+  - Updated files:
+    - `.github/workflows/ci.yml`
+    - `openspec/specs/creonow-mvp-readiness-remediation/spec.md`
+    - `openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md`
+    - `openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md`
+- Evidence:
+  - `git status --short`
+
+### 2026-02-06 00:00 Resolve preflight blockers and verify
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+  - `pnpm install --frozen-lockfile || pnpm install`
+  - `pnpm exec prettier --write <changed files>`
+  - `scripts/agent_pr_preflight.sh`
+  - `rg -n "design/Variant/DESIGN_SPEC.md" openspec/specs/creonow-mvp-readiness-remediation/spec.md openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md || true`
+- Key output:
+  - First preflight failed due to missing `prettier` in workspace.
+  - Second preflight failed on formatting drift, then passed after formatting.
+  - Final preflight passed:
+    - `pnpm typecheck` passed
+    - `pnpm lint` passed (warnings only, no errors)
+    - `pnpm contract:check` passed
+    - `pnpm test:unit` passed
+  - `rg` returned no matches in remediation scope for `design/Variant/DESIGN_SPEC.md`.
+- Evidence:
+  - `openspec/_ops/task_runs/ISSUE-220.md`
+  - `rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/tasks.md`
+
+### 2026-02-06 00:00 Final preflight before commit
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+- Key output:
+  - Preflight passed end-to-end.
+  - `pnpm typecheck` passed.
+  - `pnpm lint` passed with 4 pre-existing warnings and 0 errors.
+  - `pnpm contract:check` passed.
+  - `pnpm test:unit` passed.
+- Evidence:
+  - `scripts/agent_pr_preflight.sh` output (latest run)

--- a/openspec/specs/creonow-mvp-readiness-remediation/spec.md
+++ b/openspec/specs/creonow-mvp-readiness-remediation/spec.md
@@ -8,7 +8,7 @@
 | 状态                    | Draft                                                                                                                                                                                       |
 | 更新日期                | 2026-02-05                                                                                                                                                                                  |
 | 目标                    | 基于 MVP 审评报告，把剩余阻塞项与关键短板**执行化**为可并行、可验收、可测试的任务卡：Phase 1（P0）把 MVP 就绪度从 ~85% 拉到 ≥95%；Phase 2/3（P1/P2）提供 1–2 周的质量/安全/性能加固施工图。 |
-| 上游依赖（硬约束）      | `AGENTS.md`、`design/Variant/DESIGN_SPEC.md`、`design/DESIGN_DECISIONS.md`                                                                                                                  |
+| 上游依赖（硬约束）      | `AGENTS.md`、`design/system/README.md`、`design/system/01-tokens.css`、`design/DESIGN_DECISIONS.md`                                                                                         |
 | 上游规格（关联）        | `openspec/specs/creonow-frontend-full-assembly/spec.md`（本 spec 为其“审评后 delta 执行化”，见 `design/01-delta-map.md`）                                                                   |
 | 参考输入（不作为 SSOT） | `/home/leeky/.cursor/plans/creonow_mvp审评报告_1a7946f4.plan.md`                                                                                                                            |
 | SSOT（本规范以此为准）  | 本 spec + `design/**` + `task_cards/**`（每张任务卡写死触碰文件、验收标准、测试与边界场景）                                                                                                 |
@@ -86,7 +86,7 @@
 ## Conformance（规范优先级）
 
 1. 仓库宪法：`AGENTS.md`（硬约束，尤其：IPC `{ ok: true|false }`、禁止 silent failure、必须有测试）。
-2. 设计规范：`design/Variant/DESIGN_SPEC.md` + `design/DESIGN_DECISIONS.md`（所有 UI/token/交互必须遵循）。
+2. 设计规范：`design/system/README.md` + `design/system/01-tokens.css` + `design/DESIGN_DECISIONS.md`（所有 UI/token/交互必须遵循）。
 3. 上游组装规范：`openspec/specs/creonow-frontend-full-assembly/spec.md`（本 spec 作为其审评后的 delta；冲突时以本 spec 的**显式决策**为准）。
 4. 本规范：`openspec/specs/creonow-mvp-readiness-remediation/spec.md`。
 5. 本规范配套设计：`openspec/specs/creonow-mvp-readiness-remediation/design/*.md`。

--- a/openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md
+++ b/openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md
@@ -9,7 +9,7 @@
 ## 全局约束（所有任务卡共用）
 
 - 宪法：`AGENTS.md`（IPC `{ ok: true|false }`、禁止 silent failure、必须有测试、显式依赖注入）。
-- 设计：`design/Variant/DESIGN_SPEC.md` + `design/DESIGN_DECISIONS.md`（token/间距/字体/交互不可偏移）。
+- 设计：`design/system/README.md` + `design/system/01-tokens.css` + `design/DESIGN_DECISIONS.md`（token/间距/字体/交互不可偏移）。
 - 关联规范：`openspec/specs/creonow-frontend-full-assembly/spec.md`（仅作为上游背景；本 spec 为 delta SSOT）。
 - IPC：任何新增/修改通道必须更新 codegen（`pnpm contract:generate`）且带最小测试覆盖。
 - 并行：`ipc-contract.ts` + `ipc-generated.ts` 必须串行（见 `design/09-parallel-execution-and-conflict-matrix.md`）。

--- a/openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md
+++ b/openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md
@@ -145,7 +145,7 @@ main.log 必须记录（info/error）：
 ## Manual QA (Storybook / App)
 
 - [ ] App 内实际点击 Dashboard menu：
-  - [ ] 对话框布局与 token 使用符合 `design/Variant/DESIGN_SPEC.md`
+  - [ ] 对话框布局与 token 使用符合 `design/system/README.md` 与 `design/system/01-tokens.css`
   - [ ] Disabled/loading/error 状态可感知且不抖动
 
 ## Completion

--- a/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/.metadata.json
+++ b/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-06T11:45:42.431Z",
+  "updatedAt": "2026-02-06T11:45:42.431Z"
+}

--- a/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/evidence/notes.md
+++ b/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/evidence/notes.md
@@ -1,0 +1,18 @@
+# Notes — issue-220-p0-005-ci-desktop-vitest
+
+## Scope
+
+- Preflight documentation path normalization for remediation spec/task cards.
+- CI gate enhancement for desktop renderer/store Vitest.
+
+## Decision
+
+- Keep this issue strictly scoped to docs + CI so subsequent P0 renderer issues inherit stronger gating without IPC conflicts.
+
+## Evidence Index
+
+- CI workflow: `.github/workflows/ci.yml`
+- Spec: `openspec/specs/creonow-mvp-readiness-remediation/spec.md`
+- Task index: `openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md`
+- P0-001 card: `openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md`
+- RUN_LOG: `openspec/_ops/task_runs/ISSUE-220.md`

--- a/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/proposal.md
+++ b/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: issue-220-p0-005-ci-desktop-vitest
+
+## Why
+
+MVP remediation documents referenced a non-existent design baseline path and CI lacked renderer/store Vitest gating. This causes execution ambiguity and allows regressions to merge without desktop component test enforcement.
+
+## What Changes
+
+- Normalize remediation spec/task-card design baseline references to existing paths:
+  - `design/system/README.md`
+  - `design/system/01-tokens.css`
+  - `design/DESIGN_DECISIONS.md`
+- Update CI `check` job to run `pnpm -C apps/desktop test:run` before Storybook build check.
+- Add issue run log and evidence records for org delivery.
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-mvp-readiness-remediation/spec.md`
+  - `openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md`
+  - `openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md`
+- Affected code:
+  - `.github/workflows/ci.yml`
+- Breaking change: NO
+- User benefit: Clear SSOT references and stronger CI gate for renderer/store regressions.

--- a/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/tasks.md
+++ b/rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Normalize remediation spec/task-card design baseline references to existing design system docs.
+- [x] 1.2 Add desktop Vitest gate (`pnpm -C apps/desktop test:run`) to CI `check` job.
+
+## 2. Testing
+
+- [x] 2.1 Run issue-scoped verification: `pnpm typecheck`, `pnpm lint`, `pnpm contract:check`, `pnpm test:unit`.
+- [x] 2.2 Verify `design/Variant/DESIGN_SPEC.md` is not referenced in remediation spec/task-card scope.
+
+## 3. Documentation and Delivery
+
+- [x] 3.1 Create/update `openspec/_ops/task_runs/ISSUE-220.md` with append-only `Runs`.
+- [x] 3.2 Add `rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/evidence/notes.md` and capture key evidence links.


### PR DESCRIPTION
Closes #220

## Summary
- normalize remediation spec/task-card design baseline to existing design system paths
- add desktop renderer/store Vitest gate to CI check job (`pnpm -C apps/desktop test:run`)
- add org delivery artifacts (`RUN_LOG`, rulebook task proposal/tasks/evidence)

## Test Plan
- `scripts/agent_pr_preflight.sh`
- `rg -n "design/Variant/DESIGN_SPEC.md" openspec/specs/creonow-mvp-readiness-remediation/spec.md openspec/specs/creonow-mvp-readiness-remediation/task_cards/index.md openspec/specs/creonow-mvp-readiness-remediation/task_cards/p0/P0-001-dashboard-project-actions-rename-duplicate-archive.md || true`

## Evidence
- `openspec/_ops/task_runs/ISSUE-220.md`
- `rulebook/tasks/issue-220-p0-005-ci-desktop-vitest/evidence/notes.md`
