### PR TITLE
[MVP-REMED] P0-002: Version Preview dialog real read-only (#222)

### DIFF
--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VersionHistoryContainer } from "./VersionHistoryContainer";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+const startCompareMock = vi.hoisted(() => vi.fn());
+const editorState = vi.hoisted(() => ({
+  documentId: "doc-1",
+}));
+
+vi.mock("../../lib/ipcClient", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("../../stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector: (state: typeof editorState) => unknown) =>
+    selector(editorState),
+  ),
+}));
+
+vi.mock("./useVersionCompare", () => ({
+  useVersionCompare: () => ({
+    startCompare: startCompareMock,
+  }),
+}));
+
+vi.mock("./VersionHistoryPanel", () => ({
+  VersionHistoryPanelContent: (props: {
+    onPreview?: (id: string) => void;
+    onRestore?: (id: string) => void;
+    onCompare?: (id: string) => void;
+  }) => (
+    <div data-testid="version-history-panel-content-mock">
+      <button
+        type="button"
+        data-testid="version-preview-trigger"
+        onClick={() => props.onPreview?.("v-1")}
+      >
+        Preview
+      </button>
+      <button
+        type="button"
+        data-testid="version-restore-trigger"
+        onClick={() => props.onRestore?.("v-1")}
+      >
+        Restore
+      </button>
+      <button
+        type="button"
+        data-testid="version-compare-trigger"
+        onClick={() => props.onCompare?.("v-1")}
+      >
+        Compare
+      </button>
+    </div>
+  ),
+}));
+
+/**
+ * Build a stable IPC mock implementation for version-history container tests.
+ */
+function installInvokeMock(args?: {
+  readVersionError?: { code: string; message: string };
+}): void {
+  invokeMock.mockImplementation(async (channel: string) => {
+    if (channel === "file:document:read") {
+      return {
+        ok: true,
+        data: {
+          documentId: "doc-1",
+          projectId: "project-1",
+          title: "Doc 1",
+          contentJson: '{"type":"doc"}',
+          contentText: "current",
+          contentMd: "current",
+          contentHash: "hash-current",
+          updatedAt: 100,
+        },
+      };
+    }
+
+    if (channel === "version:list") {
+      return {
+        ok: true,
+        data: {
+          items: [
+            {
+              versionId: "v-1",
+              actor: "user",
+              reason: "manual-save",
+              contentHash: "hash-old",
+              createdAt: 90,
+            },
+          ],
+        },
+      };
+    }
+
+    if (channel === "version:read") {
+      if (args?.readVersionError) {
+        return { ok: false, error: args.readVersionError };
+      }
+      return {
+        ok: true,
+        data: {
+          documentId: "doc-1",
+          projectId: "project-1",
+          versionId: "v-1",
+          actor: "user",
+          reason: "manual-save",
+          contentJson: '{"type":"doc"}',
+          contentText: "historical body",
+          contentMd: "historical body",
+          contentHash: "hash-old",
+          createdAt: 90,
+        },
+      };
+    }
+
+    if (channel === "version:restore") {
+      return { ok: true, data: { restored: true } };
+    }
+
+    return { ok: false, error: { code: "NOT_FOUND", message: "not found" } };
+  });
+}
+
+describe("VersionHistoryContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    editorState.documentId = "doc-1";
+    installInvokeMock();
+  });
+
+  it("opens preview dialog with read-only version content", async () => {
+    const user = userEvent.setup();
+
+    render(<VersionHistoryContainer projectId="project-1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("version-history-panel-content-mock"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("version-preview-trigger"));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("version:read", {
+        documentId: "doc-1",
+        versionId: "v-1",
+      });
+    });
+
+    const content = await screen.findByTestId("version-preview-content");
+    expect(content).toHaveAttribute("readonly");
+    expect(content).toHaveValue("historical body");
+  });
+
+  it("shows IPC error code/message when preview read fails", async () => {
+    const user = userEvent.setup();
+    installInvokeMock({
+      readVersionError: { code: "NOT_FOUND", message: "Version not found" },
+    });
+
+    render(<VersionHistoryContainer projectId="project-1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("version-history-panel-content-mock"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("version-preview-trigger"));
+
+    const error = await screen.findByTestId("version-preview-error");
+    expect(error).toHaveTextContent("NOT_FOUND: Version not found");
+  });
+});

--- a/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
@@ -1,0 +1,115 @@
+import { Dialog } from "../../components/primitives/Dialog";
+import { Button } from "../../components/primitives/Button";
+import { Textarea } from "../../components/primitives/Textarea";
+import { Text } from "../../components/primitives/Text";
+
+type PreviewVersion = {
+  versionId: string;
+  actor: "user" | "auto" | "ai";
+  reason: string;
+  createdAt: number;
+  contentText: string;
+};
+
+type VersionPreviewDialogProps = {
+  open: boolean;
+  loading: boolean;
+  data: PreviewVersion | null;
+  error: { code: string; message: string } | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * Convert actor value into dialog display text.
+ */
+function formatActor(actor: "user" | "auto" | "ai"): string {
+  if (actor === "user") return "User";
+  if (actor === "ai") return "AI";
+  return "Auto-save";
+}
+
+/**
+ * VersionPreviewDialog shows a read-only historical snapshot.
+ *
+ * Why: users need safe inspection before deciding whether to restore.
+ */
+export function VersionPreviewDialog(
+  props: VersionPreviewDialogProps,
+): JSX.Element {
+  const footer = (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={() => props.onOpenChange(false)}
+    >
+      Close
+    </Button>
+  );
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="Version Preview"
+      description="Read-only historical snapshot."
+      footer={footer}
+    >
+      <div data-testid="version-preview-dialog" className="space-y-3">
+        {props.loading ? (
+          <Text
+            data-testid="version-preview-loading"
+            size="small"
+            color="muted"
+          >
+            Loading version content...
+          </Text>
+        ) : null}
+
+        {!props.loading && props.error ? (
+          <div
+            data-testid="version-preview-error"
+            className="rounded-[var(--radius-sm)] border border-[var(--color-error)] bg-[var(--color-error-subtle)] p-3"
+          >
+            <Text size="small" className="text-[var(--color-error)]">
+              {props.error.code}: {props.error.message}
+            </Text>
+          </div>
+        ) : null}
+
+        {!props.loading && !props.error && props.data ? (
+          <>
+            <div className="grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-muted)]">
+              <div>
+                <span className="font-medium text-[var(--color-fg-default)]">
+                  Actor:
+                </span>{" "}
+                {formatActor(props.data.actor)}
+              </div>
+              <div>
+                <span className="font-medium text-[var(--color-fg-default)]">
+                  Timestamp:
+                </span>{" "}
+                {new Date(props.data.createdAt).toLocaleString()}
+              </div>
+              <div className="col-span-2">
+                <span className="font-medium text-[var(--color-fg-default)]">
+                  Reason:
+                </span>{" "}
+                {props.data.reason}
+              </div>
+            </div>
+            <Textarea
+              data-testid="version-preview-content"
+              value={props.data.contentText}
+              readOnly
+              rows={14}
+              fullWidth
+              className="resize-none"
+            />
+          </>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/openspec/_ops/task_runs/ISSUE-222.md
+++ b/openspec/_ops/task_runs/ISSUE-222.md
@@ -1,0 +1,89 @@
+# ISSUE-222
+
+- Issue: #222
+- Branch: `task/222-p0-002-version-preview-dialog`
+- PR: <pending>
+
+## Goal
+
+- 完成 P0-002：Version Preview 调 `version:read` 展示真实只读内容，并在失败时可见错误码+错误消息。
+
+## Status
+
+- CURRENT: preflight 已通过，准备提交并创建 PR。
+
+## Next Actions
+
+- [x] 运行 preflight（typecheck/lint/contract:check/test:unit）。
+- [ ] 提交并推送（commit message 含 `(#222)`）。
+- [ ] 创建 PR（body 含 `Closes #222`）并启用 auto-merge。
+
+## Decisions Made
+
+- 2026-02-06: N2 仅实现 Preview 闭环，不混入 Restore 确认逻辑（该逻辑在 N3 交付）。
+- 2026-02-06: Preview UI 使用独立 `VersionPreviewDialog`，避免 `VersionHistoryContainer` 过度膨胀。
+
+## Errors Encountered
+
+- 2026-02-06: 新 worktree 运行测试时报 `vitest: not found`。处理：执行 `pnpm install --frozen-lockfile`。
+- 2026-02-06: 首次 preflight `pnpm typecheck` 失败（TS6133: unused `React` imports）。处理：移除 `VersionHistoryContainer.test.tsx` 与 `VersionPreviewDialog.tsx` 的未使用导入后重跑。
+
+## Runs
+
+### 2026-02-06 00:00 Issue bootstrap
+
+- Command:
+  - `gh issue create -t "[MVP-REMED] P0-002: Version Preview dialog real read-only" ...`
+  - `scripts/agent_worktree_setup.sh 222 p0-002-version-preview-dialog`
+  - `rulebook task create issue-222-p0-002-version-preview-dialog`
+  - `rulebook task validate issue-222-p0-002-version-preview-dialog`
+- Key output:
+  - Issue `#222` created.
+  - Worktree created at `.worktrees/issue-222-p0-002-version-preview-dialog`.
+  - Rulebook task created and validated.
+- Evidence:
+  - `rulebook/tasks/issue-222-p0-002-version-preview-dialog/`
+
+### 2026-02-06 00:00 TDD red-green for preview
+
+- Command:
+  - `pnpm -C apps/desktop test:run renderer/src/features/version-history/VersionHistoryContainer.test.tsx` (RED)
+  - `pnpm install --frozen-lockfile`
+  - `pnpm -C apps/desktop test:run renderer/src/features/version-history/VersionHistoryContainer.test.tsx` (RED)
+  - Implement `VersionPreviewDialog` + `handlePreview(version:read)`
+  - `pnpm -C apps/desktop test:run renderer/src/features/version-history/VersionHistoryContainer.test.tsx` (GREEN)
+- Key output:
+  - RED: tests failed because `handlePreview` only logged and never called `version:read`.
+  - GREEN: `2 passed` in `VersionHistoryContainer.test.tsx`.
+- Evidence:
+  - `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx`
+  - `apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx`
+  - `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx`
+
+### 2026-02-06 00:00 Issue preflight verification
+
+- Command:
+  - `scripts/agent_pr_preflight.sh` (first run, failed)
+  - `scripts/agent_pr_preflight.sh` (second run, passed)
+- Key output:
+  - First run failed at `pnpm typecheck` with TS6133 in two new files.
+  - Second run passed end-to-end:
+    - `pnpm typecheck` passed
+    - `pnpm lint` passed (warnings only, no errors)
+    - `pnpm contract:check` passed
+    - `pnpm test:unit` passed
+- Evidence:
+  - `scripts/agent_pr_preflight.sh` output (latest run)
+
+### 2026-02-06 00:00 Final preflight before commit
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+- Key output:
+  - Preflight passed end-to-end after run-log updates.
+  - `pnpm typecheck` passed.
+  - `pnpm lint` passed with warnings only (0 errors).
+  - `pnpm contract:check` passed.
+  - `pnpm test:unit` passed.
+- Evidence:
+  - `scripts/agent_pr_preflight.sh` output (latest run)

--- a/openspec/_ops/task_runs/ISSUE-222.md
+++ b/openspec/_ops/task_runs/ISSUE-222.md
@@ -2,7 +2,7 @@
 
 - Issue: #222
 - Branch: `task/222-p0-002-version-preview-dialog`
-- PR: <pending>
+- PR: https://github.com/Leeky1017/CreoNow/pull/223
 
 ## Goal
 
@@ -10,13 +10,13 @@
 
 ## Status
 
-- CURRENT: preflight 已通过，准备提交并创建 PR。
+- CURRENT: PR 已创建并回填，等待 checks + auto-merge。
 
 ## Next Actions
 
 - [x] 运行 preflight（typecheck/lint/contract:check/test:unit）。
-- [ ] 提交并推送（commit message 含 `(#222)`）。
-- [ ] 创建 PR（body 含 `Closes #222`）并启用 auto-merge。
+- [x] 提交并推送（commit message 含 `(#222)`）。
+- [ ] 监控 `ci`/`openspec-log-guard`/`merge-serial` 并确认 `mergedAt != null`。
 
 ## Decisions Made
 
@@ -87,3 +87,15 @@
   - `pnpm test:unit` passed.
 - Evidence:
   - `scripts/agent_pr_preflight.sh` output (latest run)
+
+### 2026-02-06 00:00 Commit, push, and PR creation
+
+- Command:
+  - `git commit -m "feat: implement version preview read-only dialog (#222)"`
+  - `git push -u origin HEAD`
+  - `gh pr create --title "[MVP-REMED] P0-002: Version Preview dialog real read-only (#222)" ...`
+- Key output:
+  - Commit `e238283` created and pushed.
+  - PR `#223` created with `Closes #222` in body.
+- Evidence:
+  - `https://github.com/Leeky1017/CreoNow/pull/223`

--- a/rulebook/tasks/issue-222-p0-002-version-preview-dialog/.metadata.json
+++ b/rulebook/tasks/issue-222-p0-002-version-preview-dialog/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-06T11:55:16.899Z",
+  "updatedAt": "2026-02-06T11:55:16.899Z"
+}

--- a/rulebook/tasks/issue-222-p0-002-version-preview-dialog/evidence/notes.md
+++ b/rulebook/tasks/issue-222-p0-002-version-preview-dialog/evidence/notes.md
@@ -1,0 +1,17 @@
+# Notes — issue-222-p0-002-version-preview-dialog
+
+## Scope
+
+- Strictly implement P0-002 preview closure without bundling restore-confirm behavior.
+
+## TDD Evidence
+
+- RED: tests fail because preview path does not call `version:read`.
+- GREEN: tests pass after introducing `VersionPreviewDialog` and async preview read flow.
+
+## Artifacts
+
+- `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx`
+- `apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx`
+- `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx`
+- `openspec/_ops/task_runs/ISSUE-222.md`

--- a/rulebook/tasks/issue-222-p0-002-version-preview-dialog/proposal.md
+++ b/rulebook/tasks/issue-222-p0-002-version-preview-dialog/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: issue-222-p0-002-version-preview-dialog
+
+## Why
+
+Version History preview was a TODO with `console.log`, so users could not inspect historical content safely before restore decisions. This is a P0 closure item for MVP readiness.
+
+## What Changes
+
+- Add `VersionPreviewDialog` for read-only historical snapshot display.
+- Update `VersionHistoryContainer` preview handler to call `version:read` and wire loading/success/error states.
+- Add `VersionHistoryContainer` tests for:
+  - success path (reads and renders read-only content)
+  - error path (renders `error.code: error.message`)
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-mvp-readiness-remediation/spec.md` (CNMVP-REQ-002)
+- Affected code:
+  - `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx`
+  - `apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx`
+  - `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx`
+- Breaking change: NO
+- User benefit: Version preview becomes functional, read-only, and diagnosable on failure.

--- a/rulebook/tasks/issue-222-p0-002-version-preview-dialog/tasks.md
+++ b/rulebook/tasks/issue-222-p0-002-version-preview-dialog/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add `VersionPreviewDialog` with read-only content area and metadata fields.
+- [x] 1.2 Replace preview TODO/console in `VersionHistoryContainer` with `version:read` flow and dialog state handling.
+- [x] 1.3 Surface preview error as `error.code: error.message` in dialog.
+
+## 2. Testing
+
+- [x] 2.1 Add test: preview calls `version:read` and renders read-only content.
+- [x] 2.2 Add test: preview read failure shows `error.code + error.message`.
+- [x] 2.3 Run issue-scoped preflight verification.
+
+## 3. Documentation and Delivery
+
+- [x] 3.1 Add `openspec/_ops/task_runs/ISSUE-222.md` with append-only runs.
+- [x] 3.2 Capture evidence notes under `rulebook/tasks/issue-222-p0-002-version-preview-dialog/evidence/notes.md`.


### PR DESCRIPTION
Closes #222

## Summary
- add `VersionPreviewDialog` for read-only historical snapshot display
- wire `VersionHistoryContainer` preview action to call `version:read` and handle loading/success/error states
- add `VersionHistoryContainer` tests for preview success and failure paths
- add org delivery artifacts (`RUN_LOG`, rulebook task proposal/tasks/evidence)

## Test Plan
- `pnpm -C apps/desktop test:run renderer/src/features/version-history/VersionHistoryContainer.test.tsx`
- `scripts/agent_pr_preflight.sh`

## Evidence
- `openspec/_ops/task_runs/ISSUE-222.md`
- `rulebook/tasks/issue-222-p0-002-version-preview-dialog/evidence/notes.md`
