### PR TITLE
[MVP-REMED] P0-004: Global ErrorBoundary (#224)

### DIFF
--- a/apps/desktop/renderer/src/components/patterns/ErrorBoundary.test.tsx
+++ b/apps/desktop/renderer/src/components/patterns/ErrorBoundary.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import * as ErrorBoundaryModule from "./ErrorBoundary";
+
+function CrashyComponent(): JSX.Element {
+  throw new Error("boom-render");
+}
+
+describe("ErrorBoundary", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+    // suppress react error boundary noise in test output
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  it("renders fallback when child throws during render", () => {
+    render(
+      <ErrorBoundaryModule.ErrorBoundary>
+        <CrashyComponent />
+      </ErrorBoundaryModule.ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("app-error-boundary")).toBeInTheDocument();
+    expect(screen.getByText("App crashed")).toBeInTheDocument();
+    expect(screen.getByTestId("app-error-details")).toHaveTextContent(
+      "boom-render",
+    );
+  });
+
+  it("reload button triggers window reload", async () => {
+    const user = userEvent.setup();
+    const onReload = vi.fn();
+
+    render(
+      <ErrorBoundaryModule.ErrorBoundary onReload={onReload}>
+        <CrashyComponent />
+      </ErrorBoundaryModule.ErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reload App" }));
+
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+
+  it("copy button writes error details to clipboard", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ErrorBoundaryModule.ErrorBoundary>
+        <CrashyComponent />
+      </ErrorBoundaryModule.ErrorBoundary>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy error details" }),
+    );
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("app-error-copy-status")).toHaveTextContent(
+      "Error details copied.",
+    );
+  });
+});

--- a/apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx
+++ b/apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+
+import { Button } from "../primitives/Button";
+import { Text } from "../primitives/Text";
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+  onReload?: () => void;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  details: string;
+  copyStatus: "idle" | "copied" | "failed";
+};
+
+/**
+ * Reload the current renderer window.
+ *
+ * Why: exported helper is easy to assert in tests without mutating Location.
+ */
+export function reloadRendererWindow(): void {
+  window.location.reload();
+}
+
+/**
+ * ErrorBoundary catches render-time crashes and keeps the shell recoverable.
+ *
+ * Why: a single widget crash must not blank the whole renderer surface.
+ */
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  public constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, details: "", copyStatus: "idle" };
+  }
+
+  public static getDerivedStateFromError(): Partial<ErrorBoundaryState> {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    const componentStack =
+      info.componentStack?.trim() ?? "(no component stack)";
+    const details = [
+      `${error.name}: ${error.message}`,
+      "",
+      "Component stack:",
+      componentStack,
+    ].join("\n");
+    this.setState({ details, copyStatus: "idle" });
+  }
+
+  /**
+   * Reload the renderer to recover from an unrecoverable render crash.
+   */
+  private readonly handleReload = (): void => {
+    if (this.props.onReload) {
+      this.props.onReload();
+      return;
+    }
+    reloadRendererWindow();
+  };
+
+  /**
+   * Copy full error diagnostics so users can report actionable crash details.
+   */
+  private readonly handleCopyDetails = async (): Promise<void> => {
+    if (!navigator.clipboard?.writeText) {
+      this.setState({ copyStatus: "failed" });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(this.state.details);
+      this.setState({ copyStatus: "copied" });
+    } catch {
+      this.setState({ copyStatus: "failed" });
+    }
+  };
+
+  public render(): JSX.Element {
+    if (!this.state.hasError) {
+      return this.props.children as JSX.Element;
+    }
+
+    return (
+      <div
+        data-testid="app-error-boundary"
+        className="h-full w-full bg-[var(--color-bg-base)] p-6"
+      >
+        <div className="mx-auto max-w-2xl rounded-[var(--radius-lg)] border border-[var(--color-separator)] bg-[var(--color-bg-surface)] p-6 shadow-[var(--shadow-lg)]">
+          <h1 className="text-lg font-semibold text-[var(--color-fg-default)]">
+            App crashed
+          </h1>
+          <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
+            A render error occurred. You can reload the app or copy details for
+            diagnostics.
+          </p>
+
+          {this.state.details ? (
+            <pre
+              data-testid="app-error-details"
+              className="mt-4 max-h-60 overflow-auto rounded-[var(--radius-sm)] border border-[var(--color-separator)] bg-[var(--color-bg-hover)] p-3 text-xs text-[var(--color-fg-muted)]"
+            >
+              {this.state.details}
+            </pre>
+          ) : null}
+
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={this.handleReload}
+            >
+              Reload App
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => void this.handleCopyDetails()}
+            >
+              Copy error details
+            </Button>
+          </div>
+
+          {this.state.copyStatus === "copied" ? (
+            <Text
+              data-testid="app-error-copy-status"
+              size="small"
+              className="mt-3 text-[var(--color-success)]"
+            >
+              Error details copied.
+            </Text>
+          ) : null}
+          {this.state.copyStatus === "failed" ? (
+            <Text
+              data-testid="app-error-copy-status"
+              size="small"
+              className="mt-3 text-[var(--color-error)]"
+            >
+              Failed to copy error details.
+            </Text>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/desktop/renderer/src/components/patterns/index.ts
+++ b/apps/desktop/renderer/src/components/patterns/index.ts
@@ -48,3 +48,6 @@ export type {
   ErrorVariant,
   ErrorSeverity,
 } from "./ErrorState";
+
+// Error boundary
+export { ErrorBoundary } from "./ErrorBoundary";

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
+import { ErrorBoundary } from "./components/patterns";
 
 // Signal that React app has mounted
 if (typeof window.__CN_E2E__ !== "object") {
@@ -19,6 +20,8 @@ if (!rootEl) {
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/openspec/_ops/task_runs/ISSUE-224.md
+++ b/openspec/_ops/task_runs/ISSUE-224.md
@@ -2,7 +2,7 @@
 
 - Issue: #224
 - Branch: `task/224-p0-004-error-boundary`
-- PR: <pending>
+- PR: https://github.com/Leeky1017/CreoNow/pull/225
 
 ## Goal
 
@@ -10,13 +10,13 @@
 
 ## Status
 
-- CURRENT: preflight 已通过，准备提交并创建 PR。
+- CURRENT: PR 已创建并回填，等待 checks + auto-merge。
 
 ## Next Actions
 
 - [x] 运行 preflight（typecheck/lint/contract:check/test:unit）。
-- [ ] 提交并推送（commit message 含 `(#224)`）。
-- [ ] 创建 PR（body 含 `Closes #224`）并启用 auto-merge。
+- [x] 提交并推送（commit message 含 `(#224)`）。
+- [ ] 监控 `ci`/`openspec-log-guard`/`merge-serial` 并确认 `mergedAt != null`。
 
 ## Decisions Made
 
@@ -84,3 +84,15 @@
   - `pnpm test:unit` passed.
 - Evidence:
   - `scripts/agent_pr_preflight.sh` output (latest run)
+
+### 2026-02-06 00:00 Commit, push, and PR creation
+
+- Command:
+  - `git commit -m "feat: add global renderer error boundary (#224)"`
+  - `git push -u origin HEAD`
+  - `gh pr create --title "[MVP-REMED] P0-004: Global ErrorBoundary (#224)" ...`
+- Key output:
+  - Commit `349506b` created and pushed.
+  - PR `#225` created with `Closes #224`.
+- Evidence:
+  - `https://github.com/Leeky1017/CreoNow/pull/225`

--- a/openspec/_ops/task_runs/ISSUE-224.md
+++ b/openspec/_ops/task_runs/ISSUE-224.md
@@ -1,0 +1,86 @@
+# ISSUE-224
+
+- Issue: #224
+- Branch: `task/224-p0-004-error-boundary`
+- PR: <pending>
+
+## Goal
+
+- 完成 P0-004：新增全局 ErrorBoundary，避免渲染异常导致白屏，并提供 Reload / Copy details 恢复动作。
+
+## Status
+
+- CURRENT: preflight 已通过，准备提交并创建 PR。
+
+## Next Actions
+
+- [x] 运行 preflight（typecheck/lint/contract:check/test:unit）。
+- [ ] 提交并推送（commit message 含 `(#224)`）。
+- [ ] 创建 PR（body 含 `Closes #224`）并启用 auto-merge。
+
+## Decisions Made
+
+- 2026-02-06: 使用 class ErrorBoundary（含 `componentDidCatch`）满足 React render-crash 捕获语义。
+- 2026-02-06: `componentStack` 采用空值兜底，避免 secondary crash。
+
+## Errors Encountered
+
+- 2026-02-06: 新 worktree 运行测试时报 `vitest: not found`。处理：执行 `pnpm install --frozen-lockfile`。
+
+## Runs
+
+### 2026-02-06 00:00 Issue bootstrap
+
+- Command:
+  - `gh issue create -t "[MVP-REMED] P0-004: Global ErrorBoundary" ...`
+  - `scripts/agent_worktree_setup.sh 224 p0-004-error-boundary`
+  - `rulebook task create issue-224-p0-004-error-boundary`
+  - `rulebook task validate issue-224-p0-004-error-boundary`
+- Key output:
+  - Issue `#224` created.
+  - Worktree created at `.worktrees/issue-224-p0-004-error-boundary`.
+  - Rulebook task created and validated.
+- Evidence:
+  - `rulebook/tasks/issue-224-p0-004-error-boundary/`
+
+### 2026-02-06 00:00 TDD red-green for ErrorBoundary
+
+- Command:
+  - `pnpm -C apps/desktop test:run renderer/src/components/patterns/ErrorBoundary.test.tsx` (RED)
+  - `pnpm install --frozen-lockfile`
+  - `pnpm -C apps/desktop test:run renderer/src/components/patterns/ErrorBoundary.test.tsx` (RED)
+  - Implement ErrorBoundary + mount in `main.tsx`
+  - `pnpm -C apps/desktop test:run renderer/src/components/patterns/ErrorBoundary.test.tsx` (GREEN)
+- Key output:
+  - RED: import `./ErrorBoundary` unresolved (component missing).
+  - GREEN: `3 passed` in `ErrorBoundary.test.tsx`.
+- Evidence:
+  - `apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx`
+  - `apps/desktop/renderer/src/components/patterns/ErrorBoundary.test.tsx`
+  - `apps/desktop/renderer/src/main.tsx`
+
+### 2026-02-06 00:00 Issue preflight verification
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+- Key output:
+  - Preflight passed end-to-end:
+    - `pnpm typecheck` passed
+    - `pnpm lint` passed (warnings only, no errors)
+    - `pnpm contract:check` passed
+    - `pnpm test:unit` passed
+- Evidence:
+  - `scripts/agent_pr_preflight.sh` output (latest run)
+
+### 2026-02-06 00:00 Final preflight before commit
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+- Key output:
+  - Preflight passed after run-log updates.
+  - `pnpm typecheck` passed.
+  - `pnpm lint` passed with warnings only (0 errors).
+  - `pnpm contract:check` passed.
+  - `pnpm test:unit` passed.
+- Evidence:
+  - `scripts/agent_pr_preflight.sh` output (latest run)

--- a/rulebook/tasks/issue-224-p0-004-error-boundary/.metadata.json
+++ b/rulebook/tasks/issue-224-p0-004-error-boundary/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-06T12:06:01.205Z",
+  "updatedAt": "2026-02-06T12:06:01.205Z"
+}

--- a/rulebook/tasks/issue-224-p0-004-error-boundary/evidence/notes.md
+++ b/rulebook/tasks/issue-224-p0-004-error-boundary/evidence/notes.md
@@ -1,0 +1,18 @@
+# Notes — issue-224-p0-004-error-boundary
+
+## Scope
+
+- Implement global render crash containment via ErrorBoundary.
+
+## TDD Evidence
+
+- RED: test fails because `ErrorBoundary` module does not exist.
+- GREEN: tests pass after adding ErrorBoundary component and global mount.
+
+## Artifacts
+
+- `apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx`
+- `apps/desktop/renderer/src/components/patterns/ErrorBoundary.test.tsx`
+- `apps/desktop/renderer/src/components/patterns/index.ts`
+- `apps/desktop/renderer/src/main.tsx`
+- `openspec/_ops/task_runs/ISSUE-224.md`

--- a/rulebook/tasks/issue-224-p0-004-error-boundary/proposal.md
+++ b/rulebook/tasks/issue-224-p0-004-error-boundary/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: issue-224-p0-004-error-boundary
+
+## Why
+
+A render-time crash currently risks blanking the renderer surface. MVP readiness requires global crash containment and a recoverable fallback path.
+
+## What Changes
+
+- Add class-based `ErrorBoundary` with `componentDidCatch` diagnostics capture.
+- Provide fallback UI actions:
+  - `Reload App`
+  - `Copy error details`
+- Mount `ErrorBoundary` globally in `renderer/src/main.tsx`.
+- Export `ErrorBoundary` from patterns index.
+- Add `ErrorBoundary` tests covering fallback rendering and action buttons.
+
+## Impact
+
+- Affected specs:
+  - `openspec/specs/creonow-mvp-readiness-remediation/spec.md` (CNMVP-REQ-004)
+- Affected code:
+  - `apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx`
+  - `apps/desktop/renderer/src/components/patterns/ErrorBoundary.test.tsx`
+  - `apps/desktop/renderer/src/components/patterns/index.ts`
+  - `apps/desktop/renderer/src/main.tsx`
+- Breaking change: NO
+- User benefit: renderer no longer white-screens on render crashes; users can recover and report diagnostics.

--- a/rulebook/tasks/issue-224-p0-004-error-boundary/tasks.md
+++ b/rulebook/tasks/issue-224-p0-004-error-boundary/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Add class `ErrorBoundary` with `componentDidCatch` diagnostics capture.
+- [x] 1.2 Implement fallback UI with `Reload App` and `Copy error details` actions.
+- [x] 1.3 Mount `ErrorBoundary` globally in `renderer/src/main.tsx`.
+- [x] 1.4 Export `ErrorBoundary` via `components/patterns/index.ts`.
+
+## 2. Testing
+
+- [x] 2.1 Add fallback-render test for render crash scenario.
+- [x] 2.2 Add action tests for reload and copy details.
+- [x] 2.3 Run issue-scoped preflight verification.
+
+## 3. Documentation and Delivery
+
+- [x] 3.1 Add `openspec/_ops/task_runs/ISSUE-224.md` with append-only runs.
+- [x] 3.2 Capture evidence notes under `rulebook/tasks/issue-224-p0-004-error-boundary/evidence/notes.md`.


### PR DESCRIPTION
Closes #224

## Summary
- add class-based `ErrorBoundary` with `componentDidCatch` diagnostics capture
- add fallback actions `Reload App` and `Copy error details`
- mount `ErrorBoundary` globally in `renderer/src/main.tsx`
- export ErrorBoundary from patterns index
- add ErrorBoundary tests for crash fallback, reload, and copy actions
- add org delivery artifacts (`RUN_LOG`, rulebook task proposal/tasks/evidence)

## Test Plan
- `pnpm -C apps/desktop test:run renderer/src/components/patterns/ErrorBoundary.test.tsx`
- `scripts/agent_pr_preflight.sh`

## Evidence
- `openspec/_ops/task_runs/ISSUE-224.md`
- `rulebook/tasks/issue-224-p0-004-error-boundary/evidence/notes.md`
