### PR TITLE
docs: rewrite CNAUD 39-item OpenSpec package (#238)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-238.md
+++ b/openspec/_ops/task_runs/ISSUE-238.md
@@ -2,7 +2,7 @@
 
 - Issue: #238
 - Branch: task/238-cnaud-039-openspec-rewrite
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/239
 
 ## Plan
 
@@ -41,3 +41,9 @@
 - Command: scripts/agent_pr_preflight.sh
 - Key output: preflight fully passed; typecheck/lint/contract/unit-test all green (lint warning-only, 0 errors)
 - Evidence: scripts/agent_pr_preflight.sh output, apps/desktop/tests/unit/storybook-inventory.spec.ts output
+
+### 2026-02-07 01:24 pr-opened
+
+- Command: gh pr create / gh pr edit
+- Key output: PR #239 created and body normalized; includes `Closes #238`
+- Evidence: https://github.com/Leeky1017/CreoNow/pull/239

--- a/openspec/_ops/task_runs/ISSUE-238.md
+++ b/openspec/_ops/task_runs/ISSUE-238.md
@@ -1,0 +1,43 @@
+# ISSUE-238
+
+- Issue: #238
+- Branch: task/238-cnaud-039-openspec-rewrite
+- PR: <fill-after-created>
+
+## Plan
+
+- Rebuild audit remediation OpenSpec package from scratch.
+- Keep one-to-one mapping for #1..#39 with corrected P0/P1/P2 counts.
+- Deliver spec + 6 design docs + 39 task cards with verification_status.
+
+## Runs
+
+### 2026-02-06 23:59 initialize
+
+- Command: gh issue create / scripts/agent_worktree_setup.sh / rulebook task create+validate
+- Key output: issue #238 created; worktree and branch created; task validation passed
+- Evidence: openspec/specs/creonow-audit-remediation/, rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/
+
+### 2026-02-07 01:03 structure-audit
+
+- Command: find/rg counts for requirements, cards, priority buckets, verification_status
+- Key output: req_count=39; cards_total=39; p0=7; p1=17; p2=15; verified=32; needs-recheck=6; stale=1
+- Evidence: openspec/specs/creonow-audit-remediation/spec.md, openspec/specs/creonow-audit-remediation/task_cards/
+
+### 2026-02-07 01:08 workspace-verification
+
+- Command: pnpm typecheck; pnpm lint; pnpm contract:check; pnpm test:unit
+- Key output: typecheck pass; lint pass (4 warnings, 0 errors); contract check pass; unit tests pass
+- Evidence: scripts/agent_pr_preflight.sh output; apps/desktop/tests/unit/storybook-inventory.spec.ts output (56/56 mapped)
+
+### 2026-02-07 01:12 preflight-format-gate
+
+- Command: scripts/agent_pr_preflight.sh -> pnpm exec prettier --write -> scripts/agent_pr_preflight.sh
+- Key output: first preflight failed on prettier check; formatted files; second preflight passed all gates
+- Evidence: openspec/\_ops/task_runs/ISSUE-238.md, openspec/specs/creonow-audit-remediation/**, rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/**
+
+### 2026-02-07 01:18 final-preflight-before-commit
+
+- Command: scripts/agent_pr_preflight.sh
+- Key output: preflight fully passed; typecheck/lint/contract/unit-test all green (lint warning-only, 0 errors)
+- Evidence: scripts/agent_pr_preflight.sh output, apps/desktop/tests/unit/storybook-inventory.spec.ts output

--- a/openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+++ b/openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
@@ -1,0 +1,62 @@
+# Design 01 — AI Pipeline（AI 链路）
+
+## Scope
+
+- CNAUD-REQ-001
+- CNAUD-REQ-002
+- CNAUD-REQ-003
+- CNAUD-REQ-017
+- CNAUD-REQ-018
+- CNAUD-REQ-019
+- CNAUD-REQ-023
+- CNAUD-REQ-037
+- CNAUD-REQ-038
+
+## Current-State Evidence
+
+- aiService 仍存在 model: fake 与 Anthropic max_tokens: 256 硬编码。
+- ModelPicker/ModePicker 仅存在于 AiPanel 本地 state，未进入 store/IPC/service。
+- aiStore stream 流程没有 renderer watchdog，running 可能悬挂。
+- feedback 路径返回 recorded: true，但无持久化写入。
+- ChatHistory 与 SearchPanel 含 mock 数据和硬编码性能文案。
+- AiPanel 内嵌 style block。
+
+## Target Architecture
+
+1. AI Request Envelope SSOT
+   - ai:skill:run 请求必须支持 model 与 mode。
+   - aiStore 持有 selectedModel/selectedMode，而非 AiPanel 本地 state。
+
+2. Execution Safety
+   - main timeout 负责上游请求超时。
+   - renderer watchdog 负责流事件丢失兜底。
+
+3. Feedback Durability
+   - recorded=true 必须可落证据（DB/event log）。
+   - 写入失败必须返回稳定错误码（DB_ERROR）。
+
+4. Truthful UI
+   - 历史/搜索面板不得默认 mock fallback。
+   - 未实现能力必须显式 placeholder。
+
+5. Style Hygiene
+   - 动画与关键帧迁移到样式层。
+
+## Contract Changes
+
+- ai:skill:run.request 新增 model 与 mode。
+- ai:skill:run.response 保持 ok true/false envelope，不破坏已有调用方。
+
+## Failure Semantics
+
+- 无效模型：INVALID_ARGUMENT
+- 不支持 mode：UNSUPPORTED
+- stream watchdog 超时：TIMEOUT
+- feedback 写入失败：DB_ERROR
+
+## Verification Gates
+
+- unit: ai upstream payload 与错误映射。
+- integration: IPC schema 校验（request/response）。
+- ui: model/mode 选择可影响下游行为。
+- e2e: stream 异常下不会永久 running。

--- a/openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+++ b/openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
@@ -1,0 +1,45 @@
+# Design 02 — Editor / Zen Mode
+
+## Scope
+
+- CNAUD-REQ-005
+- CNAUD-REQ-008
+- CNAUD-REQ-009
+- CNAUD-REQ-014
+- CNAUD-REQ-024
+- CNAUD-REQ-039
+
+## Current-State Evidence
+
+- 编辑器扩展仍以 StarterKit 为主，缺少明确扩展基线分层。
+- 编辑器正文排版未显式绑定规范中的 editor typography token。
+- autosave 仍包含 cleanup fire-and-forget 与 setTimeout(..., 0) 时序路径。
+- Zen Mode 当前是提取后的只读展示，不是可编辑工作面。
+- Zen Mode 中存在大量硬编码颜色/inline style。
+- ZenModeOverlay 内容提取依赖 editor 引用，可能出现内容新鲜度问题。
+
+## Target Design
+
+1. Editor Extension Baseline
+   - 建立明确 extension 组合与分层（core + optional）。
+   - 所有扩展能力通过 typed config 注入。
+
+2. Typography Contract
+   - editor body 必须使用 font-family-body、text-editor-size、text-editor-line-height。
+
+3. Autosave State Machine
+   - 至少具备 idle -> queued -> saving -> saved|error。
+   - flush 路径必须可观测且可重试。
+
+4. Zen Mode as Real Surface
+   - 优先方案：Zen 复用同一 editor 实例（全屏化）。
+   - 备选方案：单独 editor surface，但同一 document SSOT、同一 autosave/undo 语义。
+
+5. Freshness Guarantee
+   - Zen 内容来源必须订阅编辑变化，不得仅依赖 editor 引用稳定性。
+
+## Verification Gates
+
+- unit: autosave 状态机与 flush 行为。
+- integration: Zen 打开/编辑/保存链路一致性。
+- ui: typography token 快照一致性。

--- a/openspec/specs/creonow-audit-remediation/design/03-data-migration.md
+++ b/openspec/specs/creonow-audit-remediation/design/03-data-migration.md
@@ -1,0 +1,34 @@
+# Design 03 — Data & Migration
+
+## Scope
+
+- CNAUD-REQ-004
+- CNAUD-REQ-006
+- CNAUD-REQ-035
+
+## Current-State Evidence
+
+- db/init.ts 中 migration 版本存在“可选迁移 + schema_version 前跳”风险。
+- DB 初始化失败后应用继续启动，但用户侧降级状态缺少统一可见语义。
+- document_versions 当前缺少 retention/prune 策略。
+
+## Target Design
+
+1. Migration Monotonicity
+   - 迁移版本必须严格单调回放。
+   - 能力可选不能通过“跳过版本号”实现。
+   - 能力开关落独立 capability 表，不污染 schema version 序列。
+
+2. Degraded Mode Contract
+   - DB 不可用时必须进入明确降级模式（只读/禁写/提示恢复）。
+   - 前后端错误呈现统一：错误码、用户提示、恢复动作。
+
+3. Version Retention
+   - 提供可配置策略：按条数保留与按时间保留。
+   - prune 行为需可审计（日志 + 统计）。
+
+## Verification Gates
+
+- migration roundtrip（含 sqlite-vec 可用/不可用两条路径）。
+- DB 初始化失败场景 UI 行为一致性测试。
+- version prune 触发与回归测试。

--- a/openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+++ b/openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
@@ -1,0 +1,41 @@
+# Design 04 — Design System & Tokens
+
+## Scope
+
+- CNAUD-REQ-007
+- CNAUD-REQ-012
+- CNAUD-REQ-013
+- CNAUD-REQ-031
+- CNAUD-REQ-032
+- CNAUD-REQ-036
+
+## Current-State Evidence
+
+- renderer tokens.css 与 design/system/01-tokens.css 存在双源。
+- renderer token 中缺失 --color-accent，但业务组件已消费该 token。
+- 业务界面仍存在大量硬编码色值与 arbitrary color classes。
+- ExportDialog 仍存在 important 样式。
+- accent 命名存在语义重叠与维护成本。
+
+## Target Design
+
+1. Token SSOT
+   - 以 design/system/01-tokens.css 为单一事实源。
+   - renderer token 文件改为导入或生成产物，禁止手工双写。
+
+2. Tailwind Mapping
+   - 在 theme 层建立语义色映射（bg/fg/border/accent）。
+   - 新增 lint 约束禁止新增非白名单 arbitrary color。
+
+3. Color Debt Burn-down
+   - 建立分批清理清单（P1/P2 分段）。
+   - 每批变更附带组件快照与视觉回归。
+
+4. Style Policy
+   - 禁止 important 作为常规样式策略。
+
+## Verification Gates
+
+- token 对齐检查（design vs renderer）。
+- 静态扫描：颜色字面量与 important 门禁。
+- Storybook 视觉回归快照。

--- a/openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
+++ b/openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
@@ -1,0 +1,39 @@
+# Design 05 — Testing & CI
+
+## Scope
+
+- CNAUD-REQ-020
+- CNAUD-REQ-021
+- CNAUD-REQ-028
+- CNAUD-REQ-029
+
+## Current-State Evidence
+
+- CNAUD-REQ-020 已在当前 CI 中落地，状态为 stale（审计项已过时）。
+- Toast 原语已实现，但应用根层仍缺统一 Provider/Viewport 接入与业务触发路径。
+- root test:unit 仍是手工串联 tsx 多文件执行。
+- features 测试分布不均，部分高频面板缺测试。
+
+## Target Design
+
+1. CI Gates as Contract
+   - 保持并强化 desktop vitest 门禁（防回退）。
+   - 对 stale 项采用“关闭证据卡”而非删除映射。
+
+2. Toast Integration
+   - 在根组件接入全局 Toast 容器。
+   - 统一 toast 调用 API 与错误展示策略。
+
+3. Runner Unification
+   - 保留 unit/integration/e2e 分层。
+   - 将手工串联逐步收敛为可维护 runner。
+
+4. Coverage Risk Matrix
+   - 按业务风险定义最低覆盖目标。
+   - 对“无测试高风险 feature”建立优先补测清单。
+
+## Verification Gates
+
+- CI required checks 不得缺失或降级。
+- toast 全链路测试（显示/关闭/并发）。
+- 覆盖率/分布报告纳入 RUN_LOG。

--- a/openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+++ b/openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
@@ -1,0 +1,56 @@
+# Design 06 — Architecture Consistency Refactoring
+
+## Scope
+
+- CNAUD-REQ-010
+- CNAUD-REQ-011
+- CNAUD-REQ-015
+- CNAUD-REQ-016
+- CNAUD-REQ-022
+- CNAUD-REQ-025
+- CNAUD-REQ-026
+- CNAUD-REQ-027
+- CNAUD-REQ-030
+- CNAUD-REQ-033
+- CNAUD-REQ-034
+
+## Current-State Evidence
+
+- IpcInvoke、ServiceResult、ipcError 在多处重复实现。
+- @shared 别名未建立，存在深层相对路径耦合。
+- templateStore 直接 localStorage，不走统一契约链路。
+- editorStore 与 fileStore bootstrap 逻辑重复。
+- packages/shared 承载能力不足。
+- AppShell、OutlinePanel 超大文件导致改动冲突高发。
+- 根组件 Provider 嵌套过深。
+- registerIpcHandlers 扁平注册。
+- 生产代码存在散落 console 调用。
+
+## Target Design
+
+1. Shared Core Types
+   - 抽取 IpcInvoke、ServiceResult、ipcError 到 shared 并统一导入。
+
+2. Import and Path Policy
+   - 引入 @shared alias 与 resolver。
+   - 禁止新增跨包深层相对路径。
+
+3. Store and Bootstrap Coordination
+   - 引入 bootstrap coordinator，避免多 store 重复 orchestration。
+   - template 数据链路迁移到 typed IPC + 持久层。
+
+4. Structural Decomposition
+   - AppShell/Outline 拆分为容器 + 纯视图 + hooks。
+   - IPC 注册改为分组注册器。
+
+5. Provider Composition
+   - 引入 provider composer，降低根树嵌套深度。
+
+6. Logging Policy
+   - 生产日志统一走 logger（renderer/main 统一策略）。
+
+## Verification Gates
+
+- typecheck/lint: 重构后类型与导入约束稳定。
+- unit: coordinator/registrar/adapter 可单测。
+- architecture audit: 体量阈值与重复定义扫描纳入门禁。

--- a/openspec/specs/creonow-audit-remediation/spec.md
+++ b/openspec/specs/creonow-audit-remediation/spec.md
@@ -1,0 +1,510 @@
+# CreoNow Audit Remediation 39 — OpenSpec
+
+## 元信息
+
+| 字段         | 值                                                                                       |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| 规范名称     | creonow-audit-remediation                                                                |
+| 状态         | Draft                                                                                    |
+| 更新日期     | 2026-02-06                                                                               |
+| 审计输入     | Opus审计完整版.md                                                                        |
+| 代码复核基线 | git@e1d65fb (main)                                                                       |
+| 目标         | 将审计 #1-#39 重写为可执行、可核验、可追踪的 OpenSpec（spec + 6 design + 39 task cards） |
+
+---
+
+## Purpose
+
+本规范用于把审计报告转化为可交付工程计划，并解决两个常见问题：
+
+- 只罗列问题但无法直接派发执行。
+- 报告与当前代码基线漂移，导致修复优先级失真。
+
+本次重写遵循：
+
+1. 一条审计问题对应一条 requirement（CNAUD-REQ-001..039）。
+2. 一条 requirement 对应一张 task card（39 张，不合并）。
+3. 每张卡强制包含 verification_status，避免把过期问题与当前问题混在一起。
+
+---
+
+## Scope
+
+### In scope
+
+- 39 条 requirement 的一对一重建。
+- 6 份按主题拆分的设计文档：
+  - AI Pipeline
+  - Editor / Zen Mode
+  - Data & Migration
+  - Design System & Tokens
+  - Testing & CI
+  - Architecture Consistency Refactoring
+- 39 张 task card，按 P0/P1/P2 分组。
+
+### Out of scope
+
+- 本规范不直接修改业务代码。
+- 本规范不替代 GitHub Issue/PR 流程，只定义执行蓝图与验收口径。
+
+---
+
+## Conformance
+
+1. 仓库治理：AGENTS.md
+2. 产品规格：openspec/specs/creonow-spec/spec.md
+3. 设计基线：design/Variant/DESIGN_SPEC.md + design/system/01-tokens.css
+4. 本规范：openspec/specs/creonow-audit-remediation/spec.md
+5. 本规范设计：openspec/specs/creonow-audit-remediation/design/\*.md
+6. 本规范任务卡：openspec/specs/creonow-audit-remediation/task\*cards/\*\*/\_.md
+
+---
+
+## Verification Method
+
+本规范中的 verification_status 来自“审计条目 + 代码复核”的交叉校验：
+
+- verified：在当前代码中确认问题仍成立。
+- stale：审计问题在当前代码中已不成立（或已完成门禁）。
+- needs-recheck：问题方向成立，但计数/范围/边界需二次复核后再开工。
+
+### 当前统计（39）
+
+- verified: 32
+- needs-recheck: 6
+- stale: 1
+
+### 优先级分布（纠偏后）
+
+- P0: 7
+- P1: 17
+- P2: 15
+- Total: 39
+
+---
+
+## Requirement Index
+
+| #   | Requirement   | Priority | verification_status | Source                               |
+| --- | ------------- | -------- | ------------------- | ------------------------------------ |
+| 01  | CNAUD-REQ-001 | P0       | verified            | Opus审计完整版.md §2.1               |
+| 02  | CNAUD-REQ-002 | P0       | verified            | Opus审计完整版.md §2.2               |
+| 03  | CNAUD-REQ-003 | P0       | verified            | Opus审计完整版.md §2.3               |
+| 04  | CNAUD-REQ-004 | P0       | verified            | Opus审计完整版.md §4.1               |
+| 05  | CNAUD-REQ-005 | P0       | verified            | Opus审计完整版.md §3.6               |
+| 06  | CNAUD-REQ-006 | P0       | needs-recheck       | Opus审计完整版.md §4.2 + §6.1        |
+| 07  | CNAUD-REQ-007 | P0       | verified            | Opus审计完整版.md §5.2               |
+| 08  | CNAUD-REQ-008 | P1       | verified            | Opus审计完整版.md §3.1               |
+| 09  | CNAUD-REQ-009 | P1       | verified            | Opus审计完整版.md §3.2               |
+| 10  | CNAUD-REQ-010 | P1       | verified            | Opus审计完整版.md §1.1               |
+| 11  | CNAUD-REQ-011 | P1       | verified            | Opus审计完整版.md §1.2 + §1.3        |
+| 12  | CNAUD-REQ-012 | P1       | needs-recheck       | Opus审计完整版.md §5.1               |
+| 13  | CNAUD-REQ-013 | P1       | needs-recheck       | Opus审计完整版.md §5.3               |
+| 14  | CNAUD-REQ-014 | P1       | needs-recheck       | Opus审计完整版.md §3.3 + §3.4 + §3.5 |
+| 15  | CNAUD-REQ-015 | P1       | verified            | Opus审计完整版.md §7.2               |
+| 16  | CNAUD-REQ-016 | P1       | verified            | Opus审计完整版.md §7.1               |
+| 17  | CNAUD-REQ-017 | P1       | verified            | Opus审计完整版.md §2.6               |
+| 18  | CNAUD-REQ-018 | P1       | verified            | Opus审计完整版.md §2.7               |
+| 19  | CNAUD-REQ-019 | P1       | verified            | Opus审计完整版.md §2.4               |
+| 20  | CNAUD-REQ-020 | P1       | stale               | Opus审计完整版.md §6.3               |
+| 21  | CNAUD-REQ-021 | P1       | verified            | Opus审计完整版.md §6.2               |
+| 22  | CNAUD-REQ-022 | P1       | verified            | Opus审计完整版.md §1.5               |
+| 23  | CNAUD-REQ-023 | P1       | verified            | Opus审计完整版.md §2.5               |
+| 24  | CNAUD-REQ-024 | P1       | verified            | Opus审计完整版.md §3.7               |
+| 25  | CNAUD-REQ-025 | P2       | verified            | Opus审计完整版.md §1.4               |
+| 26  | CNAUD-REQ-026 | P2       | verified            | Opus审计完整版.md §9.2               |
+| 27  | CNAUD-REQ-027 | P2       | verified            | Opus审计完整版.md §9.3               |
+| 28  | CNAUD-REQ-028 | P2       | verified            | Opus审计完整版.md §6.4               |
+| 29  | CNAUD-REQ-029 | P2       | needs-recheck       | Opus审计完整版.md §6.5               |
+| 30  | CNAUD-REQ-030 | P2       | verified            | Opus审计完整版.md §9.1               |
+| 31  | CNAUD-REQ-031 | P2       | verified            | Opus审计完整版.md §5.6               |
+| 32  | CNAUD-REQ-032 | P2       | needs-recheck       | Opus审计完整版.md §5.5               |
+| 33  | CNAUD-REQ-033 | P2       | verified            | Opus审计完整版.md §7.3               |
+| 34  | CNAUD-REQ-034 | P2       | verified            | Opus审计完整版.md §8.1               |
+| 35  | CNAUD-REQ-035 | P2       | verified            | Opus审计完整版.md §4.3               |
+| 36  | CNAUD-REQ-036 | P2       | verified            | Opus审计完整版.md §9.4               |
+| 37  | CNAUD-REQ-037 | P2       | verified            | Opus审计完整版.md §2.8               |
+| 38  | CNAUD-REQ-038 | P2       | verified            | Opus审计完整版.md §8.2 + §5.4        |
+| 39  | CNAUD-REQ-039 | P2       | verified            | Opus审计完整版.md §3.8               |
+
+---
+
+## Requirements
+
+每条 requirement 与审计问题编号 #1..#39 一一对应。
+
+### CNAUD-REQ-001
+
+- Audit issue: #1（AI model 参数硬编码为 fake）
+- Priority: P0
+- Source: Opus审计完整版.md §2.1
+- Requirement: AI 请求模型必须从调用参数显式传入，禁止在 service 层硬编码固定模型值。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-002
+
+- Audit issue: #2（Anthropic max_tokens 硬编码 256）
+- Priority: P0
+- Source: Opus审计完整版.md §2.2
+- Requirement: Anthropic 请求的 max_tokens 必须参数化并可审计配置，默认值需满足创作场景。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-003
+
+- Audit issue: #3（ModelPicker 与后端链路断线）
+- Priority: P0
+- Source: Opus审计完整版.md §2.3
+- Requirement: 模型选择必须贯通 renderer store、IPC contract 与 main service 的同一调用链路。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-004
+
+- Audit issue: #4（migration version 可跳跃导致缺失）
+- Priority: P0
+- Source: Opus审计完整版.md §4.1
+- Requirement: 迁移版本必须单调并可回放，禁止因可选扩展导致 schema_version 永久跨越未执行迁移。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/03-data-migration.md
+
+### CNAUD-REQ-005
+
+- Audit issue: #5（Zen Mode 不是可编辑链路）
+- Priority: P0
+- Source: Opus审计完整版.md §3.6
+- Requirement: Zen Mode 必须提供真实编辑能力或与主编辑器共享同一 SSOT 编辑链。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+### CNAUD-REQ-006
+
+- Audit issue: #6（DB 降级策略与错误边界不一致）
+- Priority: P0
+- Source: Opus审计完整版.md §4.2 + §6.1
+- Requirement: 数据库失败降级语义、错误呈现与恢复路径必须在 main 与 renderer 端一致可见。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/03-data-migration.md
+
+### CNAUD-REQ-007
+
+- Audit issue: #7（核心 --color-accent token 缺失）
+- Priority: P0
+- Source: Opus审计完整版.md §5.2
+- Requirement: 设计系统必须定义并统一消费 --color-accent 及派生 token。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-008
+
+- Audit issue: #8（编辑器仅使用 StarterKit）
+- Priority: P1
+- Source: Opus审计完整版.md §3.1
+- Requirement: 编辑器扩展能力必须达到最小可用基线（placeholder、统计、扩展入口）。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+### CNAUD-REQ-009
+
+- Audit issue: #9（编辑器排版未对齐设计 token）
+- Priority: P1
+- Source: Opus审计完整版.md §3.2
+- Requirement: 编辑器字体、字号、行高必须由 design token 驱动并与规范一致。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+### CNAUD-REQ-010
+
+- Audit issue: #10（IpcInvoke 在多个 store 重复定义）
+- Priority: P1
+- Source: Opus审计完整版.md §1.1
+- Requirement: IpcInvoke 类型必须单点定义并复用，禁止 store 本地重复声明。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-011
+
+- Audit issue: #11（ServiceResult/ipcError 重复实现）
+- Priority: P1
+- Source: Opus审计完整版.md §1.2 + §1.3
+- Requirement: ServiceResult 与 ipcError 必须集中到 shared，main/renderer 不得分散重复实现。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-012
+
+- Audit issue: #12（Tailwind 颜色映射缺失）
+- Priority: P1
+- Source: Opus审计完整版.md §5.1
+- Requirement: Tailwind 主题必须映射到 design token，禁止长期依赖 arbitrary color value。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-013
+
+- Audit issue: #13（业务 UI 存在大量硬编码颜色）
+- Priority: P1
+- Source: Opus审计完整版.md §5.3
+- Requirement: 业务界面颜色必须优先使用语义 token，逐步清理硬编码色值。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-014
+
+- Audit issue: #14（Autosave 状态与时序风险）
+- Priority: P1
+- Source: Opus审计完整版.md §3.3 + §3.4 + §3.5
+- Requirement: Autosave 必须具备可验证状态机与可靠 flush 语义，避免 cleanup fire-and-forget 和微任务时序依赖。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+### CNAUD-REQ-015
+
+- Audit issue: #15（editor/file bootstrap 协调缺口）
+- Priority: P1
+- Source: Opus审计完整版.md §7.2
+- Requirement: 多 store bootstrap 责任必须收敛到单协调链路，避免重复分叉流程。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-016
+
+- Audit issue: #16（templateStore 违反架构契约）
+- Priority: P1
+- Source: Opus审计完整版.md §7.1
+- Requirement: template 模块必须遵守显式依赖注入与 IPC/持久化契约，禁止裸 localStorage 双轨。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-017
+
+- Audit issue: #17（AI feedback 返回成功但未持久化）
+- Priority: P1
+- Source: Opus审计完整版.md §2.6
+- Requirement: 反馈 recorded=true 时必须有可审计落库证据与失败语义。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-018
+
+- Audit issue: #18（AI stream 缺 renderer 客户端超时）
+- Priority: P1
+- Source: Opus审计完整版.md §2.7
+- Requirement: renderer 必须具备 stream watchdog，防止 IPC 丢事件后永久 running。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-019
+
+- Audit issue: #19（ModePicker 仅装饰无语义分发）
+- Priority: P1
+- Source: Opus审计完整版.md §2.4
+- Requirement: ModePicker 必须驱动真实 mode 语义，或显式下线避免误导。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-020
+
+- Audit issue: #20（CI 未运行 desktop vitest 门禁）
+- Priority: P1
+- Source: Opus审计完整版.md §6.3
+- Requirement: CI 必须包含 renderer/store vitest 门禁并阻止失败合并。
+- verification_status: stale
+- Design: openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
+
+### CNAUD-REQ-021
+
+- Audit issue: #21（Toast 组件存在但未全局接入）
+- Priority: P1
+- Source: Opus审计完整版.md §6.2
+- Requirement: Toast Provider/Viewport 与统一触发路径必须在应用根层接入。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
+
+### CNAUD-REQ-022
+
+- Audit issue: #22（缺少 @shared 等路径别名）
+- Priority: P1
+- Source: Opus审计完整版.md §1.5
+- Requirement: 必须建立跨包 alias，替换深层相对路径并统一 import 约束。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-023
+
+- Audit issue: #23（ChatHistory 使用 mock 历史）
+- Priority: P1
+- Source: Opus审计完整版.md §2.5
+- Requirement: ChatHistory 必须接入真实数据源或明确 placeholder 状态。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-024
+
+- Audit issue: #24（Zen Mode 存在硬编码样式）
+- Priority: P1
+- Source: Opus审计完整版.md §3.7
+- Requirement: Zen Mode 样式必须 token 化并避免组件内动态 style 拼装。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+### CNAUD-REQ-025
+
+- Audit issue: #25（packages/shared 利用率不足）
+- Priority: P2
+- Source: Opus审计完整版.md §1.4
+- Requirement: shared 包必须承载跨进程复用类型与工具，避免 monorepo 空壳化。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-026
+
+- Audit issue: #26（AppShell 文件过大职责过多）
+- Priority: P2
+- Source: Opus审计完整版.md §9.2
+- Requirement: AppShell 必须按路由、布局、命令、副作用拆分为可测试模块。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-027
+
+- Audit issue: #27（OutlinePanel 文件过大）
+- Priority: P2
+- Source: Opus审计完整版.md §9.3
+- Requirement: OutlinePanel 必须按图标、列表项、搜索与容器职责拆分。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-028
+
+- Audit issue: #28（测试运行入口碎片化）
+- Priority: P2
+- Source: Opus审计完整版.md §6.4
+- Requirement: 测试入口必须可组合且可维护，避免 root test:unit 的手工串联脚本膨胀。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
+
+### CNAUD-REQ-029
+
+- Audit issue: #29（features 测试覆盖分布不均）
+- Priority: P2
+- Source: Opus审计完整版.md §6.5
+- Requirement: 测试覆盖应按风险分布，关键 feature 不得长期无测试。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/05-testing-ci.md
+
+### CNAUD-REQ-030
+
+- Audit issue: #30（生产代码散落 console 调用）
+- Priority: P2
+- Source: Opus审计完整版.md §9.1
+- Requirement: 生产代码日志必须收敛到统一 logger/telemetry，禁止散落 console.\*。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-031
+
+- Audit issue: #31（token 存在双源漂移）
+- Priority: P2
+- Source: Opus审计完整版.md §5.6
+- Requirement: token 来源必须单一 SSOT，避免 design 与 renderer 双源漂移。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-032
+
+- Audit issue: #32（accent token 命名重叠冗余）
+- Priority: P2
+- Source: Opus审计完整版.md §5.5
+- Requirement: accent 系列 token 必须形成可维护命名层级，避免语义重复。
+- verification_status: needs-recheck
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-033
+
+- Audit issue: #33（Provider 嵌套层级过深）
+- Priority: P2
+- Source: Opus审计完整版.md §7.3
+- Requirement: Provider 组合需压缩并引入组合器模式，降低根组件复杂度。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-034
+
+- Audit issue: #34（registerIpcHandlers 扁平臃肿）
+- Priority: P2
+- Source: Opus审计完整版.md §8.1
+- Requirement: IPC 注册入口需模块化分组，降低单函数复杂度与冲突面。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/06-architecture-consistency.md
+
+### CNAUD-REQ-035
+
+- Audit issue: #35（document_versions 缺修剪策略）
+- Priority: P2
+- Source: Opus审计完整版.md §4.3
+- Requirement: 版本历史必须提供 retention/prune 策略与可配置参数。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/03-data-migration.md
+
+### CNAUD-REQ-036
+
+- Audit issue: #36（ExportDialog 使用 !important）
+- Priority: P2
+- Source: Opus审计完整版.md §9.4
+- Requirement: UI 样式禁止依赖 !important 兜底，需回归 token 化样式层。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/04-design-system-tokens.md
+
+### CNAUD-REQ-037
+
+- Audit issue: #37（AiPanel 内嵌 style 标签）
+- Priority: P2
+- Source: Opus审计完整版.md §2.8
+- Requirement: AiPanel 动画样式需迁移到样式层，禁止组件内嵌 style block。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-038
+
+- Audit issue: #38（SearchPanel mock 与假性能文案）
+- Priority: P2
+- Source: Opus审计完整版.md §8.2 + §5.4
+- Requirement: SearchPanel 必须移除 mock fallback 与硬编码耗时文案，接入真实指标。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/01-ai-pipeline.md
+
+### CNAUD-REQ-039
+
+- Audit issue: #39（ZenModeOverlay memo 依赖导致内容过时）
+- Priority: P2
+- Source: Opus审计完整版.md §3.8
+- Requirement: Zen 模式内容提取必须对编辑器内容变化保持新鲜性，不得仅依赖 editor 引用。
+- verification_status: verified
+- Design: openspec/specs/creonow-audit-remediation/design/02-editor-zen-mode.md
+
+## Execution Waves
+
+### Wave 1 — P0（先修“能用”）
+
+- #1 #2 #3：AI 模型参数链路打通（model/max_tokens/model-picker）。
+- #4：修复 migration version 跳跃与回放一致性。
+- #5：Zen Mode 回到真实编辑链路。
+- #6：DB 降级与错误呈现一致化。
+- #7：补齐核心 accent token。
+
+### Wave 2 — P1（补齐“好用”）
+
+- Editor/Autosave：#8 #9 #14 #24。
+- 复用与架构一致性：#10 #11 #15 #16 #22。
+- AI 可信度：#17 #18 #19 #23。
+- CI/UX 基础：#20 #21。
+- 设计系统治理：#12 #13。
+
+### Wave 3 — P2（工程质量收敛）
+
+- 架构拆分：#25 #26 #27 #33 #34。
+- 测试体系与覆盖：#28 #29。
+- 样式与 token 收敛：#31 #32 #36 #37 #38。
+- 运维与可观测：#30 #35 #39。

--- a/openspec/specs/creonow-audit-remediation/task_cards/index.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/index.md
@@ -1,0 +1,61 @@
+# Task Cards Index — CreoNow Audit Remediation 39
+
+Spec: openspec/specs/creonow-audit-remediation/spec.md
+
+## Summary
+
+- Total cards: 39
+- P0: 7
+- P1: 17
+- P2: 15
+- 每张卡必须包含 verification_status（verified / stale / needs-recheck）。
+
+## Card List
+
+### P0
+
+- P0-001 #1 AI model 参数硬编码为 fake — task_cards/p0/P0-001-ai-model-hardcoded-fake.md
+- P0-002 #2 Anthropic max_tokens 硬编码 256 — task_cards/p0/P0-002-anthropic-max-tokens-hardcoded.md
+- P0-003 #3 ModelPicker 与后端链路断线 — task_cards/p0/P0-003-modelpicker-disconnected.md
+- P0-004 #4 migration version 可跳跃导致缺失 — task_cards/p0/P0-004-migration-version-gap.md
+- P0-005 #5 Zen Mode 不是可编辑链路 — task_cards/p0/P0-005-zen-mode-not-editable.md
+- P0-006 #6 DB 降级策略与错误边界不一致 — task_cards/p0/P0-006-db-degrade-and-error-boundary.md
+- P0-007 #7 核心 --color-accent token 缺失 — task_cards/p0/P0-007-accent-token-missing.md
+
+### P1
+
+- P1-001 #8 编辑器仅使用 StarterKit — task_cards/p1/P1-001-editor-starterkit-only.md
+- P1-002 #9 编辑器排版未对齐设计 token — task_cards/p1/P1-002-editor-typography-token-mismatch.md
+- P1-003 #10 IpcInvoke 在多个 store 重复定义 — task_cards/p1/P1-003-ipcinvoke-duplication.md
+- P1-004 #11 ServiceResult/ipcError 重复实现 — task_cards/p1/P1-004-service-result-ipcerror-duplication.md
+- P1-005 #12 Tailwind 颜色映射缺失 — task_cards/p1/P1-005-tailwind-color-mapping-missing.md
+- P1-006 #13 业务 UI 存在大量硬编码颜色 — task_cards/p1/P1-006-hardcoded-color-literals.md
+- P1-007 #14 Autosave 状态与时序风险 — task_cards/p1/P1-007-autosave-race-and-status.md
+- P1-008 #15 editor/file bootstrap 协调缺口 — task_cards/p1/P1-008-store-bootstrap-coordination-gap.md
+- P1-009 #16 templateStore 违反架构契约 — task_cards/p1/P1-009-template-store-contract-violation.md
+- P1-010 #17 AI feedback 返回成功但未持久化 — task_cards/p1/P1-010-ai-feedback-not-persisted.md
+- P1-011 #18 AI stream 缺 renderer 客户端超时 — task_cards/p1/P1-011-ai-stream-client-timeout-missing.md
+- P1-012 #19 ModePicker 仅装饰无语义分发 — task_cards/p1/P1-012-modepicker-decorative-only.md
+- P1-013 #20 CI 未运行 desktop vitest 门禁 — task_cards/p1/P1-013-ci-vitest-gate.md
+- P1-014 #21 Toast 组件存在但未全局接入 — task_cards/p1/P1-014-toast-global-integration-missing.md
+- P1-015 #22 缺少 @shared 等路径别名 — task_cards/p1/P1-015-path-alias-missing.md
+- P1-016 #23 ChatHistory 使用 mock 历史 — task_cards/p1/P1-016-chat-history-mock-data.md
+- P1-017 #24 Zen Mode 存在硬编码样式 — task_cards/p1/P1-017-zen-mode-hardcoded-style.md
+
+### P2
+
+- P2-001 #25 packages/shared 利用率不足 — task_cards/p2/P2-001-shared-package-underused.md
+- P2-002 #26 AppShell 文件过大职责过多 — task_cards/p2/P2-002-appshell-oversized.md
+- P2-003 #27 OutlinePanel 文件过大 — task_cards/p2/P2-003-outlinepanel-oversized.md
+- P2-004 #28 测试运行入口碎片化 — task_cards/p2/P2-004-fragmented-test-runners.md
+- P2-005 #29 features 测试覆盖分布不均 — task_cards/p2/P2-005-uneven-feature-test-coverage.md
+- P2-006 #30 生产代码散落 console 调用 — task_cards/p2/P2-006-production-console-usage.md
+- P2-007 #31 token 存在双源漂移 — task_cards/p2/P2-007-token-dual-source.md
+- P2-008 #32 accent token 命名重叠冗余 — task_cards/p2/P2-008-redundant-accent-tokens.md
+- P2-009 #33 Provider 嵌套层级过深 — task_cards/p2/P2-009-deep-provider-nesting.md
+- P2-010 #34 registerIpcHandlers 扁平臃肿 — task_cards/p2/P2-010-flat-ipc-registrar.md
+- P2-011 #35 document_versions 缺修剪策略 — task_cards/p2/P2-011-version-retention-missing.md
+- P2-012 #36 ExportDialog 使用 !important — task_cards/p2/P2-012-exportdialog-important-style.md
+- P2-013 #37 AiPanel 内嵌 style 标签 — task_cards/p2/P2-013-aipanel-inline-style-tag.md
+- P2-014 #38 SearchPanel mock 与假性能文案 — task_cards/p2/P2-014-searchpanel-mock-and-fake-metrics.md
+- P2-015 #39 ZenModeOverlay memo 依赖导致内容过时 — task_cards/p2/P2-015-zenmodeoverlay-stale-memo-deps.md

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-001-ai-model-hardcoded-fake.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-001-ai-model-hardcoded-fake.md
@@ -1,0 +1,51 @@
+# P0-001: AI model 参数硬编码为 fake
+
+Status: todo
+verification_status: verified
+audit_issue: #1
+requirement: CNAUD-REQ-001
+source: Opus审计完整版.md §2.1
+priority: P0
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #1 执行化为可验收改造，满足 CNAUD-REQ-001，并保证失败路径可观测。
+
+## Requirement
+
+AI 请求模型必须从调用参数显式传入，禁止在 service 层硬编码固定模型值。
+
+## Assets in Scope
+
+- apps/desktop/main/src/services/ai/aiService.ts
+- apps/desktop/main/src/ipc/ai.ts
+- apps/desktop/renderer/src/stores/aiStore.ts
+- apps/desktop/main/src/ipc/contract/ipc-contract.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-001 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-002-anthropic-max-tokens-hardcoded.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-002-anthropic-max-tokens-hardcoded.md
@@ -1,0 +1,49 @@
+# P0-002: Anthropic max_tokens 硬编码 256
+
+Status: todo
+verification_status: verified
+audit_issue: #2
+requirement: CNAUD-REQ-002
+source: Opus审计完整版.md §2.2
+priority: P0
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #2 执行化为可验收改造，满足 CNAUD-REQ-002，并保证失败路径可观测。
+
+## Requirement
+
+Anthropic 请求的 max_tokens 必须参数化并可审计配置，默认值需满足创作场景。
+
+## Assets in Scope
+
+- apps/desktop/main/src/services/ai/aiService.ts
+- apps/desktop/main/src/services/ai/aiProxySettingsService.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-002 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-003-modelpicker-disconnected.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-003-modelpicker-disconnected.md
@@ -1,0 +1,51 @@
+# P0-003: ModelPicker 与后端链路断线
+
+Status: todo
+verification_status: verified
+audit_issue: #3
+requirement: CNAUD-REQ-003
+source: Opus审计完整版.md §2.3
+priority: P0
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #3 执行化为可验收改造，满足 CNAUD-REQ-003，并保证失败路径可观测。
+
+## Requirement
+
+模型选择必须贯通 renderer store、IPC contract 与 main service 的同一调用链路。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/ai/AiPanel.tsx
+- apps/desktop/renderer/src/features/ai/ModelPicker.tsx
+- apps/desktop/renderer/src/stores/aiStore.ts
+- apps/desktop/main/src/ipc/contract/ipc-contract.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-003 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-004-migration-version-gap.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-004-migration-version-gap.md
@@ -1,0 +1,49 @@
+# P0-004: migration version 可跳跃导致缺失
+
+Status: todo
+verification_status: verified
+audit_issue: #4
+requirement: CNAUD-REQ-004
+source: Opus审计完整版.md §4.1
+priority: P0
+design: ../../design/03-data-migration.md
+
+## Goal
+
+将审计问题 #4 执行化为可验收改造，满足 CNAUD-REQ-004，并保证失败路径可观测。
+
+## Requirement
+
+迁移版本必须单调并可回放，禁止因可选扩展导致 schema_version 永久跨越未执行迁移。
+
+## Assets in Scope
+
+- apps/desktop/main/src/db/init.ts
+- apps/desktop/main/src/db/migrations/0008_user_memory_vec.sql
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-004 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-005-zen-mode-not-editable.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-005-zen-mode-not-editable.md
@@ -1,0 +1,50 @@
+# P0-005: Zen Mode 不是可编辑链路
+
+Status: todo
+verification_status: verified
+audit_issue: #5
+requirement: CNAUD-REQ-005
+source: Opus审计完整版.md §3.6
+priority: P0
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #5 执行化为可验收改造，满足 CNAUD-REQ-005，并保证失败路径可观测。
+
+## Requirement
+
+Zen Mode 必须提供真实编辑能力或与主编辑器共享同一 SSOT 编辑链。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/zen-mode/ZenMode.tsx
+- apps/desktop/renderer/src/components/layout/AppShell.tsx
+- apps/desktop/renderer/src/features/editor/EditorPane.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-005 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-006-db-degrade-and-error-boundary.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-006-db-degrade-and-error-boundary.md
@@ -1,0 +1,52 @@
+# P0-006: DB 降级策略与错误边界不一致
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #6
+requirement: CNAUD-REQ-006
+source: Opus审计完整版.md §4.2 + §6.1
+priority: P0
+design: ../../design/03-data-migration.md
+
+## Goal
+
+将审计问题 #6 执行化为可验收改造，满足 CNAUD-REQ-006，并保证失败路径可观测。
+
+## Requirement
+
+数据库失败降级语义、错误呈现与恢复路径必须在 main 与 renderer 端一致可见。
+
+## Assets in Scope
+
+- apps/desktop/main/src/index.ts
+- apps/desktop/main/src/db/init.ts
+- apps/desktop/renderer/src/main.tsx
+- apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-006 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-007-accent-token-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p0/P0-007-accent-token-missing.md
@@ -1,0 +1,50 @@
+# P0-007: 核心 --color-accent token 缺失
+
+Status: todo
+verification_status: verified
+audit_issue: #7
+requirement: CNAUD-REQ-007
+source: Opus审计完整版.md §5.2
+priority: P0
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #7 执行化为可验收改造，满足 CNAUD-REQ-007，并保证失败路径可观测。
+
+## Requirement
+
+设计系统必须定义并统一消费 --color-accent 及派生 token。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/styles/tokens.css
+- design/system/01-tokens.css
+- apps/desktop/renderer/src/features/ai/AiPanel.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-007 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-001-editor-starterkit-only.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-001-editor-starterkit-only.md
@@ -1,0 +1,49 @@
+# P1-001: 编辑器仅使用 StarterKit
+
+Status: todo
+verification_status: verified
+audit_issue: #8
+requirement: CNAUD-REQ-008
+source: Opus审计完整版.md §3.1
+priority: P1
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #8 执行化为可验收改造，满足 CNAUD-REQ-008，并保证失败路径可观测。
+
+## Requirement
+
+编辑器扩展能力必须达到最小可用基线（placeholder、统计、扩展入口）。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/editor/EditorPane.tsx
+- apps/desktop/renderer/src/features/editor/EditorToolbar.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-008 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-002-editor-typography-token-mismatch.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-002-editor-typography-token-mismatch.md
@@ -1,0 +1,50 @@
+# P1-002: 编辑器排版未对齐设计 token
+
+Status: todo
+verification_status: verified
+audit_issue: #9
+requirement: CNAUD-REQ-009
+source: Opus审计完整版.md §3.2
+priority: P1
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #9 执行化为可验收改造，满足 CNAUD-REQ-009，并保证失败路径可观测。
+
+## Requirement
+
+编辑器字体、字号、行高必须由 design token 驱动并与规范一致。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/editor/EditorPane.tsx
+- design/system/01-tokens.css
+- apps/desktop/renderer/src/styles/fonts.css
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-009 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-003-ipcinvoke-duplication.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-003-ipcinvoke-duplication.md
@@ -1,0 +1,50 @@
+# P1-003: IpcInvoke 在多个 store 重复定义
+
+Status: todo
+verification_status: verified
+audit_issue: #10
+requirement: CNAUD-REQ-010
+source: Opus审计完整版.md §1.1
+priority: P1
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #10 执行化为可验收改造，满足 CNAUD-REQ-010，并保证失败路径可观测。
+
+## Requirement
+
+IpcInvoke 类型必须单点定义并复用，禁止 store 本地重复声明。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/stores/aiStore.ts
+- apps/desktop/renderer/src/stores/editorStore.tsx
+- apps/desktop/renderer/src/lib/ipcClient.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-010 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-004-service-result-ipcerror-duplication.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-004-service-result-ipcerror-duplication.md
@@ -1,0 +1,51 @@
+# P1-004: ServiceResult/ipcError 重复实现
+
+Status: todo
+verification_status: verified
+audit_issue: #11
+requirement: CNAUD-REQ-011
+source: Opus审计完整版.md §1.2 + §1.3
+priority: P1
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #11 执行化为可验收改造，满足 CNAUD-REQ-011，并保证失败路径可观测。
+
+## Requirement
+
+ServiceResult 与 ipcError 必须集中到 shared，main/renderer 不得分散重复实现。
+
+## Assets in Scope
+
+- apps/desktop/main/src/services
+- apps/desktop/main/src/ipc
+- apps/desktop/main/src/db/init.ts
+- packages/shared/types
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-011 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-005-tailwind-color-mapping-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-005-tailwind-color-mapping-missing.md
@@ -1,0 +1,50 @@
+# P1-005: Tailwind 颜色映射缺失
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #12
+requirement: CNAUD-REQ-012
+source: Opus审计完整版.md §5.1
+priority: P1
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #12 执行化为可验收改造，满足 CNAUD-REQ-012，并保证失败路径可观测。
+
+## Requirement
+
+Tailwind 主题必须映射到 design token，禁止长期依赖 arbitrary color value。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/styles/main.css
+- apps/desktop/renderer/src/features/search/SearchPanel.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-012 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-006-hardcoded-color-literals.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-006-hardcoded-color-literals.md
@@ -1,0 +1,51 @@
+# P1-006: 业务 UI 存在大量硬编码颜色
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #13
+requirement: CNAUD-REQ-013
+source: Opus审计完整版.md §5.3
+priority: P1
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #13 执行化为可验收改造，满足 CNAUD-REQ-013，并保证失败路径可观测。
+
+## Requirement
+
+业务界面颜色必须优先使用语义 token，逐步清理硬编码色值。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/search/SearchPanel.tsx
+- apps/desktop/renderer/src/features/zen-mode/ZenMode.tsx
+- apps/desktop/renderer/src/features/export/ExportDialog.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-013 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-007-autosave-race-and-status.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-007-autosave-race-and-status.md
@@ -1,0 +1,51 @@
+# P1-007: Autosave 状态与时序风险
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #14
+requirement: CNAUD-REQ-014
+source: Opus审计完整版.md §3.3 + §3.4 + §3.5
+priority: P1
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #14 执行化为可验收改造，满足 CNAUD-REQ-014，并保证失败路径可观测。
+
+## Requirement
+
+Autosave 必须具备可验证状态机与可靠 flush 语义，避免 cleanup fire-and-forget 和微任务时序依赖。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/editor/useAutosave.ts
+- apps/desktop/renderer/src/features/editor/EditorPane.tsx
+- apps/desktop/renderer/src/stores/editorStore.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-014 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-008-store-bootstrap-coordination-gap.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-008-store-bootstrap-coordination-gap.md
@@ -1,0 +1,50 @@
+# P1-008: editor/file bootstrap 协调缺口
+
+Status: todo
+verification_status: verified
+audit_issue: #15
+requirement: CNAUD-REQ-015
+source: Opus审计完整版.md §7.2
+priority: P1
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #15 执行化为可验收改造，满足 CNAUD-REQ-015，并保证失败路径可观测。
+
+## Requirement
+
+多 store bootstrap 责任必须收敛到单协调链路，避免重复分叉流程。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/stores/editorStore.tsx
+- apps/desktop/renderer/src/stores/fileStore.ts
+- apps/desktop/renderer/src/components/layout/AppShell.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-015 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-009-template-store-contract-violation.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-009-template-store-contract-violation.md
@@ -1,0 +1,49 @@
+# P1-009: templateStore 违反架构契约
+
+Status: todo
+verification_status: verified
+audit_issue: #16
+requirement: CNAUD-REQ-016
+source: Opus审计完整版.md §7.1
+priority: P1
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #16 执行化为可验收改造，满足 CNAUD-REQ-016，并保证失败路径可观测。
+
+## Requirement
+
+template 模块必须遵守显式依赖注入与 IPC/持久化契约，禁止裸 localStorage 双轨。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/stores/templateStore.ts
+- apps/desktop/main/src/ipc
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-016 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-010-ai-feedback-not-persisted.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-010-ai-feedback-not-persisted.md
@@ -1,0 +1,50 @@
+# P1-010: AI feedback 返回成功但未持久化
+
+Status: todo
+verification_status: verified
+audit_issue: #17
+requirement: CNAUD-REQ-017
+source: Opus审计完整版.md §2.6
+priority: P1
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #17 执行化为可验收改造，满足 CNAUD-REQ-017，并保证失败路径可观测。
+
+## Requirement
+
+反馈 recorded=true 时必须有可审计落库证据与失败语义。
+
+## Assets in Scope
+
+- apps/desktop/main/src/services/ai/aiService.ts
+- apps/desktop/main/src/services/memory/preferenceLearning.ts
+- apps/desktop/main/src/db/migrations
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-017 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-011-ai-stream-client-timeout-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-011-ai-stream-client-timeout-missing.md
@@ -1,0 +1,49 @@
+# P1-011: AI stream 缺 renderer 客户端超时
+
+Status: todo
+verification_status: verified
+audit_issue: #18
+requirement: CNAUD-REQ-018
+source: Opus审计完整版.md §2.7
+priority: P1
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #18 执行化为可验收改造，满足 CNAUD-REQ-018，并保证失败路径可观测。
+
+## Requirement
+
+renderer 必须具备 stream watchdog，防止 IPC 丢事件后永久 running。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/stores/aiStore.ts
+- apps/desktop/renderer/src/features/ai/useAiStream.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-018 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-012-modepicker-decorative-only.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-012-modepicker-decorative-only.md
@@ -1,0 +1,50 @@
+# P1-012: ModePicker 仅装饰无语义分发
+
+Status: todo
+verification_status: verified
+audit_issue: #19
+requirement: CNAUD-REQ-019
+source: Opus审计完整版.md §2.4
+priority: P1
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #19 执行化为可验收改造，满足 CNAUD-REQ-019，并保证失败路径可观测。
+
+## Requirement
+
+ModePicker 必须驱动真实 mode 语义，或显式下线避免误导。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/ai/ModePicker.tsx
+- apps/desktop/renderer/src/features/ai/AiPanel.tsx
+- apps/desktop/renderer/src/stores/aiStore.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-019 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-013-ci-vitest-gate.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-013-ci-vitest-gate.md
@@ -1,0 +1,50 @@
+# P1-013: CI 未运行 desktop vitest 门禁
+
+Status: todo
+verification_status: stale
+audit_issue: #20
+requirement: CNAUD-REQ-020
+source: Opus审计完整版.md §6.3
+priority: P1
+design: ../../design/05-testing-ci.md
+
+## Goal
+
+将审计问题 #20 执行化为可验收改造，满足 CNAUD-REQ-020，并保证失败路径可观测。
+
+## Requirement
+
+CI 必须包含 renderer/store vitest 门禁并阻止失败合并。
+
+## Assets in Scope
+
+- .github/workflows/ci.yml
+- apps/desktop/package.json
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-020 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 以关闭证据卡完成：补充已修复证据与回归防线。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-014-toast-global-integration-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-014-toast-global-integration-missing.md
@@ -1,0 +1,50 @@
+# P1-014: Toast 组件存在但未全局接入
+
+Status: todo
+verification_status: verified
+audit_issue: #21
+requirement: CNAUD-REQ-021
+source: Opus审计完整版.md §6.2
+priority: P1
+design: ../../design/05-testing-ci.md
+
+## Goal
+
+将审计问题 #21 执行化为可验收改造，满足 CNAUD-REQ-021，并保证失败路径可观测。
+
+## Requirement
+
+Toast Provider/Viewport 与统一触发路径必须在应用根层接入。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/components/primitives/Toast.tsx
+- apps/desktop/renderer/src/App.tsx
+- apps/desktop/renderer/src/main.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-021 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-015-path-alias-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-015-path-alias-missing.md
@@ -1,0 +1,50 @@
+# P1-015: 缺少 @shared 等路径别名
+
+Status: todo
+verification_status: verified
+audit_issue: #22
+requirement: CNAUD-REQ-022
+source: Opus审计完整版.md §1.5
+priority: P1
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #22 执行化为可验收改造，满足 CNAUD-REQ-022，并保证失败路径可观测。
+
+## Requirement
+
+必须建立跨包 alias，替换深层相对路径并统一 import 约束。
+
+## Assets in Scope
+
+- tsconfig.base.json
+- apps/desktop/tsconfig.json
+- apps/desktop/electron.vite.config.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-022 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-016-chat-history-mock-data.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-016-chat-history-mock-data.md
@@ -1,0 +1,49 @@
+# P1-016: ChatHistory 使用 mock 历史
+
+Status: todo
+verification_status: verified
+audit_issue: #23
+requirement: CNAUD-REQ-023
+source: Opus审计完整版.md §2.5
+priority: P1
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #23 执行化为可验收改造，满足 CNAUD-REQ-023，并保证失败路径可观测。
+
+## Requirement
+
+ChatHistory 必须接入真实数据源或明确 placeholder 状态。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/ai/ChatHistory.tsx
+- apps/desktop/renderer/src/stores/aiStore.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-023 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-017-zen-mode-hardcoded-style.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p1/P1-017-zen-mode-hardcoded-style.md
@@ -1,0 +1,49 @@
+# P1-017: Zen Mode 存在硬编码样式
+
+Status: todo
+verification_status: verified
+audit_issue: #24
+requirement: CNAUD-REQ-024
+source: Opus审计完整版.md §3.7
+priority: P1
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #24 执行化为可验收改造，满足 CNAUD-REQ-024，并保证失败路径可观测。
+
+## Requirement
+
+Zen Mode 样式必须 token 化并避免组件内动态 style 拼装。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/zen-mode/ZenMode.tsx
+- apps/desktop/renderer/src/features/zen-mode/ZenModeStatus.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-024 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-001-shared-package-underused.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-001-shared-package-underused.md
@@ -1,0 +1,50 @@
+# P2-001: packages/shared 利用率不足
+
+Status: todo
+verification_status: verified
+audit_issue: #25
+requirement: CNAUD-REQ-025
+source: Opus审计完整版.md §1.4
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #25 执行化为可验收改造，满足 CNAUD-REQ-025，并保证失败路径可观测。
+
+## Requirement
+
+shared 包必须承载跨进程复用类型与工具，避免 monorepo 空壳化。
+
+## Assets in Scope
+
+- packages/shared/types
+- apps/desktop/main/src
+- apps/desktop/renderer/src
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-025 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-002-appshell-oversized.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-002-appshell-oversized.md
@@ -1,0 +1,48 @@
+# P2-002: AppShell 文件过大职责过多
+
+Status: todo
+verification_status: verified
+audit_issue: #26
+requirement: CNAUD-REQ-026
+source: Opus审计完整版.md §9.2
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #26 执行化为可验收改造，满足 CNAUD-REQ-026，并保证失败路径可观测。
+
+## Requirement
+
+AppShell 必须按路由、布局、命令、副作用拆分为可测试模块。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/components/layout/AppShell.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-026 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-003-outlinepanel-oversized.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-003-outlinepanel-oversized.md
@@ -1,0 +1,48 @@
+# P2-003: OutlinePanel 文件过大
+
+Status: todo
+verification_status: verified
+audit_issue: #27
+requirement: CNAUD-REQ-027
+source: Opus审计完整版.md §9.3
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #27 执行化为可验收改造，满足 CNAUD-REQ-027，并保证失败路径可观测。
+
+## Requirement
+
+OutlinePanel 必须按图标、列表项、搜索与容器职责拆分。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/outline/OutlinePanel.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-027 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-004-fragmented-test-runners.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-004-fragmented-test-runners.md
@@ -1,0 +1,50 @@
+# P2-004: 测试运行入口碎片化
+
+Status: todo
+verification_status: verified
+audit_issue: #28
+requirement: CNAUD-REQ-028
+source: Opus审计完整版.md §6.4
+priority: P2
+design: ../../design/05-testing-ci.md
+
+## Goal
+
+将审计问题 #28 执行化为可验收改造，满足 CNAUD-REQ-028，并保证失败路径可观测。
+
+## Requirement
+
+测试入口必须可组合且可维护，避免 root test:unit 的手工串联脚本膨胀。
+
+## Assets in Scope
+
+- package.json
+- apps/desktop/package.json
+- apps/desktop/tests
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-028 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-005-uneven-feature-test-coverage.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-005-uneven-feature-test-coverage.md
@@ -1,0 +1,50 @@
+# P2-005: features 测试覆盖分布不均
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #29
+requirement: CNAUD-REQ-029
+source: Opus审计完整版.md §6.5
+priority: P2
+design: ../../design/05-testing-ci.md
+
+## Goal
+
+将审计问题 #29 执行化为可验收改造，满足 CNAUD-REQ-029，并保证失败路径可观测。
+
+## Requirement
+
+测试覆盖应按风险分布，关键 feature 不得长期无测试。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features
+- apps/desktop/renderer/src/features/_/_.test.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-029 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-006-production-console-usage.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-006-production-console-usage.md
@@ -1,0 +1,50 @@
+# P2-006: 生产代码散落 console 调用
+
+Status: todo
+verification_status: verified
+audit_issue: #30
+requirement: CNAUD-REQ-030
+source: Opus审计完整版.md §9.1
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #30 执行化为可验收改造，满足 CNAUD-REQ-030，并保证失败路径可观测。
+
+## Requirement
+
+生产代码日志必须收敛到统一 logger/telemetry，禁止散落 console.\*。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/stores/templateStore.ts
+- apps/desktop/renderer/src/lib/preferences.ts
+- apps/desktop/main/src/logging/logger.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-030 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-007-token-dual-source.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-007-token-dual-source.md
@@ -1,0 +1,49 @@
+# P2-007: token 存在双源漂移
+
+Status: todo
+verification_status: verified
+audit_issue: #31
+requirement: CNAUD-REQ-031
+source: Opus审计完整版.md §5.6
+priority: P2
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #31 执行化为可验收改造，满足 CNAUD-REQ-031，并保证失败路径可观测。
+
+## Requirement
+
+token 来源必须单一 SSOT，避免 design 与 renderer 双源漂移。
+
+## Assets in Scope
+
+- design/system/01-tokens.css
+- apps/desktop/renderer/src/styles/tokens.css
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-031 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-008-redundant-accent-tokens.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-008-redundant-accent-tokens.md
@@ -1,0 +1,50 @@
+# P2-008: accent token 命名重叠冗余
+
+Status: todo
+verification_status: needs-recheck
+audit_issue: #32
+requirement: CNAUD-REQ-032
+source: Opus审计完整版.md §5.5
+priority: P2
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #32 执行化为可验收改造，满足 CNAUD-REQ-032，并保证失败路径可观测。
+
+## Requirement
+
+accent 系列 token 必须形成可维护命名层级，避免语义重复。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/styles/tokens.css
+- design/system/01-tokens.css
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-032 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+- [ ] 先完成范围与计数复核，再进入实现。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-009-deep-provider-nesting.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-009-deep-provider-nesting.md
@@ -1,0 +1,48 @@
+# P2-009: Provider 嵌套层级过深
+
+Status: todo
+verification_status: verified
+audit_issue: #33
+requirement: CNAUD-REQ-033
+source: Opus审计完整版.md §7.3
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #33 执行化为可验收改造，满足 CNAUD-REQ-033，并保证失败路径可观测。
+
+## Requirement
+
+Provider 组合需压缩并引入组合器模式，降低根组件复杂度。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/App.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-033 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-010-flat-ipc-registrar.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-010-flat-ipc-registrar.md
@@ -1,0 +1,48 @@
+# P2-010: registerIpcHandlers 扁平臃肿
+
+Status: todo
+verification_status: verified
+audit_issue: #34
+requirement: CNAUD-REQ-034
+source: Opus审计完整版.md §8.1
+priority: P2
+design: ../../design/06-architecture-consistency.md
+
+## Goal
+
+将审计问题 #34 执行化为可验收改造，满足 CNAUD-REQ-034，并保证失败路径可观测。
+
+## Requirement
+
+IPC 注册入口需模块化分组，降低单函数复杂度与冲突面。
+
+## Assets in Scope
+
+- apps/desktop/main/src/index.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-034 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-011-version-retention-missing.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-011-version-retention-missing.md
@@ -1,0 +1,49 @@
+# P2-011: document_versions 缺修剪策略
+
+Status: todo
+verification_status: verified
+audit_issue: #35
+requirement: CNAUD-REQ-035
+source: Opus审计完整版.md §4.3
+priority: P2
+design: ../../design/03-data-migration.md
+
+## Goal
+
+将审计问题 #35 执行化为可验收改造，满足 CNAUD-REQ-035，并保证失败路径可观测。
+
+## Requirement
+
+版本历史必须提供 retention/prune 策略与可配置参数。
+
+## Assets in Scope
+
+- apps/desktop/main/src/services/documents/documentService.ts
+- apps/desktop/main/src/db/migrations/0002_documents_versioning.sql
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-035 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-012-exportdialog-important-style.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-012-exportdialog-important-style.md
@@ -1,0 +1,48 @@
+# P2-012: ExportDialog 使用 !important
+
+Status: todo
+verification_status: verified
+audit_issue: #36
+requirement: CNAUD-REQ-036
+source: Opus审计完整版.md §9.4
+priority: P2
+design: ../../design/04-design-system-tokens.md
+
+## Goal
+
+将审计问题 #36 执行化为可验收改造，满足 CNAUD-REQ-036，并保证失败路径可观测。
+
+## Requirement
+
+UI 样式禁止依赖 !important 兜底，需回归 token 化样式层。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/export/ExportDialog.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-036 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-013-aipanel-inline-style-tag.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-013-aipanel-inline-style-tag.md
@@ -1,0 +1,49 @@
+# P2-013: AiPanel 内嵌 style 标签
+
+Status: todo
+verification_status: verified
+audit_issue: #37
+requirement: CNAUD-REQ-037
+source: Opus审计完整版.md §2.8
+priority: P2
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #37 执行化为可验收改造，满足 CNAUD-REQ-037，并保证失败路径可观测。
+
+## Requirement
+
+AiPanel 动画样式需迁移到样式层，禁止组件内嵌 style block。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/ai/AiPanel.tsx
+- apps/desktop/renderer/src/styles/main.css
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-037 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-014-searchpanel-mock-and-fake-metrics.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-014-searchpanel-mock-and-fake-metrics.md
@@ -1,0 +1,49 @@
+# P2-014: SearchPanel mock 与假性能文案
+
+Status: todo
+verification_status: verified
+audit_issue: #38
+requirement: CNAUD-REQ-038
+source: Opus审计完整版.md §8.2 + §5.4
+priority: P2
+design: ../../design/01-ai-pipeline.md
+
+## Goal
+
+将审计问题 #38 执行化为可验收改造，满足 CNAUD-REQ-038，并保证失败路径可观测。
+
+## Requirement
+
+SearchPanel 必须移除 mock fallback 与硬编码耗时文案，接入真实指标。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/features/search/SearchPanel.tsx
+- apps/desktop/renderer/src/stores/searchStore.ts
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-038 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-015-zenmodeoverlay-stale-memo-deps.md
+++ b/openspec/specs/creonow-audit-remediation/task_cards/p2/P2-015-zenmodeoverlay-stale-memo-deps.md
@@ -1,0 +1,49 @@
+# P2-015: ZenModeOverlay memo 依赖导致内容过时
+
+Status: todo
+verification_status: verified
+audit_issue: #39
+requirement: CNAUD-REQ-039
+source: Opus审计完整版.md §3.8
+priority: P2
+design: ../../design/02-editor-zen-mode.md
+
+## Goal
+
+将审计问题 #39 执行化为可验收改造，满足 CNAUD-REQ-039，并保证失败路径可观测。
+
+## Requirement
+
+Zen 模式内容提取必须对编辑器内容变化保持新鲜性，不得仅依赖 editor 引用。
+
+## Assets in Scope
+
+- apps/desktop/renderer/src/components/layout/AppShell.tsx
+- apps/desktop/renderer/src/stores/editorStore.tsx
+
+## Implementation Notes
+
+- 先复核当前代码证据与该卡 verification_status 是否仍成立。
+- 变更必须沿单链路收敛，避免引入并行实现或 silent fallback。
+- 若涉及 IPC/DB/schema，必须同步更新契约、调用方和测试。
+
+## Acceptance Checklist
+
+- [ ] 根因修复与 CNAUD-REQ-039 保持一致。
+- [ ] 关键失败路径返回可判定结果（ok true/false + 稳定错误码）。
+- [ ] 相关测试（unit/integration/vitest/e2e）覆盖新增或变更行为。
+- [ ] RUN_LOG 记录关键命令、关键输出与证据路径。
+
+## Verification
+
+- [ ] pnpm typecheck
+- [ ] pnpm lint
+- [ ] pnpm contract:check（涉及 IPC contract 时必跑）
+- [ ] pnpm test:unit
+- [ ] pnpm test:integration（涉及 main/data 链路时必跑）
+- [ ] pnpm -C apps/desktop test:run（涉及 renderer/store 时必跑）
+
+## Notes
+
+- GitHub 执行阶段需保持 1 卡对应 1 Issue（Issue 号作为任务唯一 ID）。
+- Commit message 必须包含 (#N)，PR body 必须包含 Closes #N。

--- a/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/.metadata.json
+++ b/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-06T17:02:13.656Z",
+  "updatedAt": "2026-02-06T17:02:13.656Z"
+}

--- a/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/proposal.md
+++ b/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/proposal.md
@@ -1,0 +1,19 @@
+# Proposal: issue-238-cnaud-039-openspec-rewrite
+
+## Why
+
+现有审计重构稿已被明确判定为无效，需要基于当前代码实际状态重写为可执行 OpenSpec 资产，并确保 39 条问题映射、优先级分布和验证状态可追踪。
+
+## What Changes
+
+- 全量重写 `openspec/specs/creonow-audit-remediation/`。
+- 重建 `CNAUD-REQ-001..039` 与审计 #1..#39 的一对一映射。
+- 新增 6 份主题设计文档与 39 张任务卡（含 `verification_status`）。
+- 纠正优先级分布为 P0=7、P1=17、P2=15。
+
+## Impact
+
+- Affected specs: `openspec/specs/creonow-audit-remediation/**`
+- Affected code: 无业务代码改动（文档交付）
+- Breaking change: NO
+- User benefit: 获得可直接派发执行的标准化审计治理包，并明确哪些问题已过时或需复核。

--- a/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/specs/creonow-audit-remediation/spec.md
+++ b/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/specs/creonow-audit-remediation/spec.md
@@ -1,0 +1,43 @@
+# Delta Spec — creonow-audit-remediation
+
+## Added Requirements
+
+### DELTA-REQ-001: Full Rewrite Required
+
+系统 MUST 将 `openspec/specs/creonow-audit-remediation/` 作为全量重写交付，不可复用旧稿内容。
+
+#### Scenario: User-invalidated draft
+
+- GIVEN 当前仓库存在历史审计重构稿
+- WHEN 用户明确声明“原有内容不作数，全部重写”
+- THEN 交付 MUST 为全新生成的 spec/design/task_cards 资产，且旧稿不作为来源。
+
+### DELTA-REQ-002: One-to-one Mapping Integrity
+
+重写结果 MUST 保持审计 #1..#39 与 requirements、task cards 的一对一关系。
+
+#### Scenario: Mapping audit to cards
+
+- GIVEN 审计问题列表 #1..#39 已确定
+- WHEN 生成 requirement 和任务卡
+- THEN 每个审计问题 MUST 对应唯一 `CNAUD-REQ-xxx` 与唯一任务卡。
+
+### DELTA-REQ-003: Verification Status Governance
+
+每张任务卡 MUST 包含 `verification_status` 字段，并使用 `verified|stale|needs-recheck` 之一。
+
+#### Scenario: Status distribution validation
+
+- GIVEN 39 张任务卡已生成
+- WHEN 完成交付前校验
+- THEN 任务卡中的状态统计 MUST 与 spec 中汇总一致。
+
+### DELTA-REQ-004: Priority Distribution Correction
+
+交付 MUST 采用修正后的优先级分布：P0=7、P1=17、P2=15。
+
+#### Scenario: Index consistency
+
+- GIVEN 所有任务卡按优先级归类
+- WHEN 生成 task_cards/index.md
+- THEN P0/P1/P2 分组计数 MUST 与 spec 声明一致。

--- a/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/tasks.md
+++ b/rulebook/tasks/issue-238-cnaud-039-openspec-rewrite/tasks.md
@@ -1,0 +1,22 @@
+## 1. Audit Mapping
+
+- [x] 1.1 从 `Opus审计完整版.md` 提取并锁定 #1..#39 映射。
+- [x] 1.2 建立 requirement 编号 `CNAUD-REQ-001..039`。
+- [x] 1.3 校正优先级分布（P0=7, P1=17, P2=15）。
+
+## 2. Code Verification
+
+- [x] 2.1 逐类复核 AI/Editor/Data/Design/CI/Architecture 相关代码。
+- [x] 2.2 为每条映射写入 `verification_status`（verified/stale/needs-recheck）。
+
+## 3. OpenSpec Rewrite
+
+- [x] 3.1 重写 spec 文档（含 requirements 与 execution waves）。
+- [x] 3.2 重写 6 份主题 design 文档。
+- [x] 3.3 重写 39 张 task cards 与索引。
+
+## 4. Delivery Hygiene
+
+- [x] 4.1 创建 `openspec/_ops/task_runs/ISSUE-238.md`。
+- [ ] 4.2 执行 preflight（typecheck/lint/contract/test:unit）。
+- [ ] 4.3 提交 PR 并启用 auto-merge。


### PR DESCRIPTION
Closes #238

## Summary
- rewrite `openspec/specs/creonow-audit-remediation/spec.md` with CNAUD-REQ-001..039 one-to-one mapping
- add 6 themed design docs under `openspec/specs/creonow-audit-remediation/design/`
- add 39 task cards with corrected priority buckets (P0=7, P1=17, P2=15) and `verification_status`
- add Rulebook task assets and run log evidence for this delivery

## Verification
- scripts/agent_pr_preflight.sh
- pnpm typecheck
- pnpm lint
- pnpm contract:check
- pnpm test:unit
