### PR TITLE
fix: stabilize windows-e2e theme spec and artifact upload paths (#240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
         with:
           name: playwright-artifacts-windows
           path: |
-            apps/desktop/playwright-report/
-            apps/desktop/test-results/
+            apps/desktop/tests/e2e/playwright-report/
+            apps/desktop/tests/e2e/test-results/
 
   windows-build:
     runs-on: windows-latest

--- a/apps/desktop/tests/e2e/theme.spec.ts
+++ b/apps/desktop/tests/e2e/theme.spec.ts
@@ -47,6 +47,8 @@ test("theme: switch to light + persist across restart", async () => {
   // Open SettingsDialog (single-path settings surface)
   await first.page.getByTestId("icon-bar-settings").click();
   await expect(first.page.getByTestId("settings-dialog")).toBeVisible();
+  await first.page.getByTestId("settings-nav-appearance").click();
+  await expect(first.page.getByTestId("theme-mode-light")).toBeVisible();
 
   await first.page.getByTestId("theme-mode-light").click();
   await expect(first.page.locator("html")).toHaveAttribute(

--- a/openspec/_ops/task_runs/ISSUE-240.md
+++ b/openspec/_ops/task_runs/ISSUE-240.md
@@ -2,7 +2,7 @@
 
 - Issue: #240
 - Branch: task/240-windows-e2e-theme-fix
-- PR: <pending>
+- PR: https://github.com/Leeky1017/CreoNow/pull/241
 
 ## Plan
 
@@ -64,4 +64,16 @@
 
 - Command: `scripts/agent_pr_preflight.sh`
 - Key output: failed at `pnpm test:unit` with `ERR_DLOPEN_FAILED` for `better_sqlite3.node`: compiled with `NODE_MODULE_VERSION 143` while runtime expects `115`; rerun after `pnpm rebuild better-sqlite3` still fails with same ABI mismatch.
+- Evidence: local shell output
+
+### 2026-02-07 01:47 CST publish PR
+
+- Command: `git push -u origin HEAD` + `gh pr create --title ... --body ...`
+- Key output: branch pushed to `origin/task/240-windows-e2e-theme-fix`; PR created: `https://github.com/Leeky1017/CreoNow/pull/241`.
+- Evidence: local shell output
+
+### 2026-02-07 01:47 CST fix PR body quoting
+
+- Command: `gh pr edit 241 --body-file /tmp/pr-241-body.md`
+- Key output: PR body corrected and retains `Closes #240`.
 - Evidence: local shell output

--- a/openspec/_ops/task_runs/ISSUE-240.md
+++ b/openspec/_ops/task_runs/ISSUE-240.md
@@ -1,0 +1,67 @@
+# ISSUE-240
+
+- Issue: #240
+- Branch: task/240-windows-e2e-theme-fix
+- PR: <pending>
+
+## Plan
+
+- Reproduce `tests/e2e/theme.spec.ts` failure and confirm the failing UI precondition.
+- Apply minimal fix in `theme.spec.ts` (navigate to Appearance tab + explicit visibility assertion) and correct CI artifact paths.
+- Run required E2E specs and `scripts/agent_pr_preflight.sh`, then submit PR with auto-merge.
+
+## Runs
+
+### 2026-02-07 01:41 CST setup
+
+- Command: `scripts/agent_worktree_setup.sh 240 windows-e2e-theme-fix`
+- Key output: `Worktree created: .worktrees/issue-240-windows-e2e-theme-fix`, `Branch: task/240-windows-e2e-theme-fix`
+- Evidence: local shell output
+
+### 2026-02-07 01:41 CST baseline inspection
+
+- Command: `sed -n ... apps/desktop/tests/e2e/theme.spec.ts apps/desktop/tests/e2e/settings-dialog.spec.ts apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx .github/workflows/ci.yml`
+- Key output: `theme.spec.ts` clicks `theme-mode-light` directly; `SettingsDialog` default tab is `general`; `settings-dialog.spec.ts` clicks `settings-nav-appearance` first; CI artifact path currently points to `apps/desktop/playwright-report/` and `apps/desktop/test-results/`.
+- Evidence: inspected source files in worktree
+
+### 2026-02-07 01:42 CST reproduce failure (`theme.spec.ts`)
+
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/theme.spec.ts`
+- Key output: `TimeoutError: locator.click: Timeout 30000ms exceeded`, `waiting for getByTestId('theme-mode-light')` at `apps/desktop/tests/e2e/theme.spec.ts:51`.
+- Evidence: local shell output
+
+### 2026-02-07 01:42 CST control comparison (`settings-dialog.spec.ts`)
+
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/settings-dialog.spec.ts`
+- Key output: `1 passed`.
+- Evidence: local shell output
+
+### 2026-02-07 01:42 CST workspace bootstrap
+
+- Command: `pnpm install`
+- Key output: `Packages: +962`, install completed successfully.
+- Evidence: local shell output
+
+### 2026-02-07 01:45 CST apply fix
+
+- Command: `apply_patch (theme.spec.ts, .github/workflows/ci.yml)`
+- Key output: inserted `settings-nav-appearance` click + `theme-mode-light` visibility assertion before click; updated artifact paths to `apps/desktop/tests/e2e/playwright-report/` and `apps/desktop/tests/e2e/test-results/`.
+- Evidence: git diff for modified files
+
+### 2026-02-07 01:45 CST required verification (`theme.spec.ts`)
+
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/theme.spec.ts`
+- Key output: `1 passed`.
+- Evidence: local shell output
+
+### 2026-02-07 01:45 CST required verification (`settings-dialog.spec.ts`)
+
+- Command: `pnpm -C apps/desktop test:e2e -- tests/e2e/settings-dialog.spec.ts`
+- Key output: `1 passed`.
+- Evidence: local shell output
+
+### 2026-02-07 01:45 CST preflight
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: failed at `pnpm test:unit` with `ERR_DLOPEN_FAILED` for `better_sqlite3.node`: compiled with `NODE_MODULE_VERSION 143` while runtime expects `115`; rerun after `pnpm rebuild better-sqlite3` still fails with same ABI mismatch.
+- Evidence: local shell output


### PR DESCRIPTION
Closes #240

## Summary
- update `apps/desktop/tests/e2e/theme.spec.ts` to navigate to the Appearance tab before clicking `theme-mode-light`
- add explicit visibility assertion for `theme-mode-light` before click to reduce flake
- fix CI Windows Playwright artifact upload paths to match `apps/desktop/tests/e2e/playwright.config.ts` output directories
- add `openspec/_ops/task_runs/ISSUE-240.md` run log with reproduction and verification evidence

## Verification
- `pnpm -C apps/desktop test:e2e -- tests/e2e/theme.spec.ts`
- `pnpm -C apps/desktop test:e2e -- tests/e2e/settings-dialog.spec.ts`
- `scripts/agent_pr_preflight.sh` (fails in this workspace due better-sqlite3 ABI mismatch after Electron rebuild; details in RUN_LOG)
