### PR TITLE
Align CN delivery skill v2 governance and gates (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,18 @@ jobs:
           name: creonow-windows-build
           path: |
             apps/desktop/dist-electron/
+
+  ci:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs:
+      - lint-and-typecheck
+      - unit-test
+      - integration-test
+      - contract-check
+      - storybook-build
+      - windows-e2e
+    timeout-minutes: 2
+    steps:
+      - name: CI gate
+        run: echo "All required CI jobs passed."

--- a/.github/workflows/merge-serial.yml
+++ b/.github/workflows/merge-serial.yml
@@ -2,6 +2,7 @@ name: Merge Serial
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -9,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  merge-gate:
+  merge-serial:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -5,13 +5,15 @@ on:
     branches: [main]
 
 jobs:
-  log-guard:
+  openspec-log-guard:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check RUN_LOG exists and validate format
+      - name: Validate RUN_LOG or Skip-Reason
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           BRANCH="${{ github.head_ref }}"
 
@@ -41,6 +43,10 @@ jobs:
             echo "✅ RUN_LOG format validated"
 
           else
-            echo "⚠️ Branch '$BRANCH' does not match task/<N>-<slug> pattern"
-            echo "Non-task branches must explain skip reason in PR body."
+            if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then
+              echo "✅ Non-task branch with required Skip-Reason"
+            else
+              echo "❌ Non-task branch '$BRANCH' must include 'Skip-Reason:' in PR body"
+              exit 1
+            fi
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,72 +6,72 @@
 
 ## 索引
 
-| §   | 章节           | 内容                                   |
-| --- | -------------- | -------------------------------------- |
-| 一  | 规范导航       | 文档路径速查                           |
-| 二  | 架构           | 四层架构 + 12 模块 Spec 路径           |
-| 三  | 不可违反的规则  | Spec-First、TDD、证据落盘、门禁、变更流程 |
-| 四  | 禁止行为清单   | 14 条硬禁                              |
-| 五  | 工作流程       | 接任务、开发阶段、命名约定              |
-| 六  | Spec 与代码关系 | GIVEN/WHEN/THEN → AAA → 实现           |
-| 七  | 测试要求速查   | 分层、覆盖率、编写规范                  |
-| 八  | 技术选型约束   | 锁定技术列表                           |
-| 九  | 工具链         | 包管理、构建、测试、Mock 工具           |
-| 十  | 设计规范       | Design Token 引用                      |
-| 十一 | 异常处理      | 遇到问题的「必须做」和「禁止做」        |
-| 十二 | 代码原则      | 显式注入、JSDoc、类型完备               |
-| 十三 | 文件组织      | 源码、测试、OpenSpec 目录结构           |
+| §    | 章节            | 内容                                      |
+| ---- | --------------- | ----------------------------------------- |
+| 一   | 规范导航        | 文档路径速查                              |
+| 二   | 架构            | 四层架构 + 12 模块 Spec 路径              |
+| 三   | 不可违反的规则  | Spec-First、TDD、证据落盘、门禁、变更流程 |
+| 四   | 禁止行为清单    | 14 条硬禁                                 |
+| 五   | 工作流程        | 接任务、开发阶段、命名约定                |
+| 六   | Spec 与代码关系 | GIVEN/WHEN/THEN → AAA → 实现              |
+| 七   | 测试要求速查    | 分层、覆盖率、编写规范                    |
+| 八   | 技术选型约束    | 锁定技术列表                              |
+| 九   | 工具链          | 包管理、构建、测试、Mock 工具             |
+| 十   | 设计规范        | Design Token 引用                         |
+| 十一 | 异常处理        | 遇到问题的「必须做」和「禁止做」          |
+| 十二 | 代码原则        | 显式注入、JSDoc、类型完备                 |
+| 十三 | 文件组织        | 源码、测试、OpenSpec 目录结构             |
 
 ---
 
 ## 一、规范导航
 
-| #  | 文档               | 路径                                    |
-| -- | ------------------ | --------------------------------------- |
-| 1  | 本文件（Agent 宪法）| `AGENTS.md`                            |
-| 2  | 项目概述           | `openspec/project.md`                   |
-| 3  | 模块行为规范       | `openspec/specs/<module>/spec.md`       |
-| 4  | 交付规则（SKILL）   | `docs/delivery-skill.md`               |
-| 5  | 设计规范           | `design/DESIGN_DECISIONS.md`            |
-| 6  | 任务运行日志       | `openspec/_ops/task_runs/ISSUE-N.md`    |
+| #   | 文档                 | 路径                                 |
+| --- | -------------------- | ------------------------------------ |
+| 1   | 本文件（Agent 宪法） | `AGENTS.md`                          |
+| 2   | 项目概述             | `openspec/project.md`                |
+| 3   | 模块行为规范         | `openspec/specs/<module>/spec.md`    |
+| 4   | 交付规则（SKILL）    | `docs/delivery-skill.md`             |
+| 5   | 设计规范             | `design/DESIGN_DECISIONS.md`         |
+| 6   | 任务运行日志         | `openspec/_ops/task_runs/ISSUE-N.md` |
 
 ---
 
 ## 二、架构
 
-| 架构层         | 路径                      | 运行环境          | 包含内容                                          |
-| -------------- | ------------------------- | ----------------- | ------------------------------------------------- |
-| 前端（渲染层） | `apps/desktop/renderer/`  | Electron 渲染进程 | React 组件、TipTap 编辑器、Zustand store、UI 交互  |
-| Preload        | `apps/desktop/preload/`   | Electron Preload  | contextBridge，安全暴露 IPC API                     |
-| 后端（业务层） | `apps/desktop/main/`      | Electron 主进程   | 上下文引擎、知识图谱、记忆系统、技能系统、SQLite DAO、LLM 调用 |
-| 共享层         | `packages/shared/`        | 跨进程            | IPC 类型定义、共享常量                              |
+| 架构层         | 路径                     | 运行环境          | 包含内容                                                       |
+| -------------- | ------------------------ | ----------------- | -------------------------------------------------------------- |
+| 前端（渲染层） | `apps/desktop/renderer/` | Electron 渲染进程 | React 组件、TipTap 编辑器、Zustand store、UI 交互              |
+| Preload        | `apps/desktop/preload/`  | Electron Preload  | contextBridge，安全暴露 IPC API                                |
+| 后端（业务层） | `apps/desktop/main/`     | Electron 主进程   | 上下文引擎、知识图谱、记忆系统、技能系统、SQLite DAO、LLM 调用 |
+| 共享层         | `packages/shared/`       | 跨进程            | IPC 类型定义、共享常量                                         |
 
 ### 核心引擎（后端为主）
 
 | 模块               | 职责                                    | Spec 路径                                     |
 | ------------------ | --------------------------------------- | --------------------------------------------- |
-| Context Engine     | 分层上下文管理、Token 预算、Constraints  | `openspec/specs/context-engine/spec.md`        |
-| Knowledge Graph    | 实体与关系管理、语义检索、角色管理系统    | `openspec/specs/knowledge-graph/spec.md`       |
-| Memory System      | 写作偏好学习、记忆存储与衰减             | `openspec/specs/memory-system/spec.md`         |
-| Skill System       | AI 技能抽象、三级作用域、技能执行         | `openspec/specs/skill-system/spec.md`          |
-| AI Service         | LLM 代理调用、流式响应、AI 面板、Judge   | `openspec/specs/ai-service/spec.md`            |
-| Search & Retrieval | 全文检索、RAG、向量嵌入、语义搜索        | `openspec/specs/search-and-retrieval/spec.md`  |
+| Context Engine     | 分层上下文管理、Token 预算、Constraints | `openspec/specs/context-engine/spec.md`       |
+| Knowledge Graph    | 实体与关系管理、语义检索、角色管理系统  | `openspec/specs/knowledge-graph/spec.md`      |
+| Memory System      | 写作偏好学习、记忆存储与衰减            | `openspec/specs/memory-system/spec.md`        |
+| Skill System       | AI 技能抽象、三级作用域、技能执行       | `openspec/specs/skill-system/spec.md`         |
+| AI Service         | LLM 代理调用、流式响应、AI 面板、Judge  | `openspec/specs/ai-service/spec.md`           |
+| Search & Retrieval | 全文检索、RAG、向量嵌入、语义搜索       | `openspec/specs/search-and-retrieval/spec.md` |
 
 ### 用户界面（前端为主）
 
-| 模块               | 职责                                    | Spec 路径                                     |
-| ------------------ | --------------------------------------- | --------------------------------------------- |
-| Editor             | TipTap 编辑器、大纲、Diff 对比、禅模式   | `openspec/specs/editor/spec.md`                |
-| Workbench          | UI 外壳、布局、Surface、命令面板、设置    | `openspec/specs/workbench/spec.md`             |
-| Document Mgmt      | 文档 CRUD、文件树、导出                  | `openspec/specs/document-management/spec.md`   |
-| Project Mgmt       | 项目生命周期、仪表盘、模板、引导         | `openspec/specs/project-management/spec.md`    |
+| 模块          | 职责                                   | Spec 路径                                    |
+| ------------- | -------------------------------------- | -------------------------------------------- |
+| Editor        | TipTap 编辑器、大纲、Diff 对比、禅模式 | `openspec/specs/editor/spec.md`              |
+| Workbench     | UI 外壳、布局、Surface、命令面板、设置 | `openspec/specs/workbench/spec.md`           |
+| Document Mgmt | 文档 CRUD、文件树、导出                | `openspec/specs/document-management/spec.md` |
+| Project Mgmt  | 项目生命周期、仪表盘、模板、引导       | `openspec/specs/project-management/spec.md`  |
 
 ### 基础设施
 
-| 模块               | 职责                                    | Spec 路径                                     |
-| ------------------ | --------------------------------------- | --------------------------------------------- |
-| IPC                | 前后端通信契约、契约自动生成与校验        | `openspec/specs/ipc/spec.md`                   |
-| Version Control    | 快照、AI 修改标记、Diff、版本恢复        | `openspec/specs/version-control/spec.md`       |
+| 模块            | 职责                               | Spec 路径                                |
+| --------------- | ---------------------------------- | ---------------------------------------- |
+| IPC             | 前后端通信契约、契约自动生成与校验 | `openspec/specs/ipc/spec.md`             |
+| Version Control | 快照、AI 修改标记、Diff、版本恢复  | `openspec/specs/version-control/spec.md` |
 
 ---
 
@@ -104,6 +104,7 @@
 - PR 必须通过三个 required checks：`ci`、`openspec-log-guard`、`merge-serial`
 - 所有 PR 必须启用 auto-merge，禁止手动合并
 - CI 失败后必须修复再 push，不得「先合并再修」
+- 交付规则文档与 GitHub branch protection 的 required checks 必须一致，不一致时必须阻断并升级
 
 ### 3.5 变更流程
 
@@ -132,6 +133,8 @@
 12. 禁止 `pnpm install` 不带 `--frozen-lockfile`
 13. 禁止 RUN_LOG 的 PR 字段留占位符（必须回填真实链接）
 14. 禁止 silent abandonment（遇到 blocker 必须记录并通知，不得静默放弃）
+15. 禁止在 Rulebook task 不存在或 validate 失败时继续实现
+16. 禁止在 required checks 与交付规则文档不一致时宣称「门禁全绿」
 
 ---
 
@@ -149,25 +152,25 @@
 
 ### 5.2 开发流程
 
-| 阶段             | 完成条件                                                       |
-| ---------------- | -------------------------------------------------------------- |
-| 1. 任务准入       | Issue 已创建或认领，N 和 SLUG 已确定                            |
-| 2. 规格制定       | spec 已编写或更新；delta spec 已提交 Owner 审阅（如需要）        |
-| 3. 环境隔离       | Worktree 已创建，工作目录已切换                                  |
-| 4. 实现与测试     | 按 TDD 循环实现；所有测试通过；RUN_LOG 已记录                    |
-| 5. 提交与合并     | PR 已创建；auto-merge 已开启；三个 checks 全绿；PR 已确认合并    |
-| 6. 收口与归档     | 控制面已同步；worktree 已清理                                    |
+| 阶段          | 完成条件                                                                                       |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| 1. 任务准入   | Issue 已创建或认领，N 和 SLUG 已确定                                                           |
+| 2. 规格制定   | spec 已编写或更新；Rulebook task 已创建并通过 validate；delta spec 已提交 Owner 审阅（如需要） |
+| 3. 环境隔离   | Worktree 已创建，工作目录已切换                                                                |
+| 4. 实现与测试 | 按 TDD 循环实现；所有测试通过；RUN_LOG 已记录                                                  |
+| 5. 提交与合并 | PR 已创建；auto-merge 已开启；三个 checks 全绿；PR 已确认合并                                  |
+| 6. 收口与归档 | 控制面已同步；worktree 已清理；Rulebook task 已归档                                            |
 
 ### 5.3 命名约定
 
-| 实体      | 格式                                     | 示例                              |
-| --------- | ---------------------------------------- | --------------------------------- |
-| Branch    | `task/<N>-<slug>`                        | `task/42-memory-decay`            |
-| Commit    | `<type>: <summary> (#<N>)`               | `feat: add memory decay (#42)`    |
-| PR title  | `<title> (#<N>)`                         | `Add memory decay (#42)`          |
-| PR body   | 必须包含 `Closes #<N>`                   | `Closes #42`                      |
-| RUN_LOG   | `openspec/_ops/task_runs/ISSUE-<N>.md`   | `ISSUE-42.md`                     |
-| Worktree  | `.worktrees/issue-<N>-<slug>`            | `.worktrees/issue-42-memory-decay`|
+| 实体     | 格式                                   | 示例                               |
+| -------- | -------------------------------------- | ---------------------------------- |
+| Branch   | `task/<N>-<slug>`                      | `task/42-memory-decay`             |
+| Commit   | `<type>: <summary> (#<N>)`             | `feat: add memory decay (#42)`     |
+| PR title | `<title> (#<N>)`                       | `Add memory decay (#42)`           |
+| PR body  | 必须包含 `Closes #<N>`                 | `Closes #42`                       |
+| RUN_LOG  | `openspec/_ops/task_runs/ISSUE-<N>.md` | `ISSUE-42.md`                      |
+| Worktree | `.worktrees/issue-<N>-<slug>`          | `.worktrees/issue-42-memory-decay` |
 
 Commit type 可选值：`feat`、`fix`、`refactor`、`test`、`docs`、`chore`、`ci`
 
@@ -184,6 +187,7 @@ THEN（期望结果）       →  Assert（验证）        →  被测模块的
 ```
 
 同步规则：
+
 - Spec 新增 Scenario → 必须新增对应测试
 - Spec 修改 Scenario → 必须同步修改对应测试
 - Spec 删除 Scenario → 必须同步删除对应测试
@@ -195,20 +199,20 @@ THEN（期望结果）       →  Assert（验证）        →  被测模块的
 
 ### 7.1 测试分层
 
-| 层级       | 运行时机   | 速度要求      | 外部依赖                  |
-| ---------- | ---------- | ------------- | ------------------------- |
-| 单元测试   | 每次保存   | 全套 30 秒内  | 全部 mock                 |
-| 集成测试   | 每次提交   | 全套 2 分钟内 | SQLite 内存 OK，LLM 必须 mock |
-| E2E 测试   | 每次合并   | 全套 10 分钟内| LLM 用 mock server        |
-| AI Eval    | Prompt 变更| 取决于 API    | 真实 LLM，手动触发         |
+| 层级     | 运行时机    | 速度要求       | 外部依赖                      |
+| -------- | ----------- | -------------- | ----------------------------- |
+| 单元测试 | 每次保存    | 全套 30 秒内   | 全部 mock                     |
+| 集成测试 | 每次提交    | 全套 2 分钟内  | SQLite 内存 OK，LLM 必须 mock |
+| E2E 测试 | 每次合并    | 全套 10 分钟内 | LLM 用 mock server            |
+| AI Eval  | Prompt 变更 | 取决于 API     | 真实 LLM，手动触发            |
 
 ### 7.2 覆盖率要求
 
-| 模块类别                              | 最低覆盖率 |
-| ------------------------------------- | ---------- |
-| 核心业务逻辑（Context Engine、KG、Memory） | 90%       |
-| 一般业务模块（DAO、Skill、Version）      | 80%       |
-| UI 组件和胶水代码                        | 60%       |
+| 模块类别                                   | 最低覆盖率 |
+| ------------------------------------------ | ---------- |
+| 核心业务逻辑（Context Engine、KG、Memory） | 90%        |
+| 一般业务模块（DAO、Skill、Version）        | 80%        |
+| UI 组件和胶水代码                          | 60%        |
 
 ### 7.3 测试编写规范
 
@@ -242,17 +246,17 @@ THEN（期望结果）       →  Assert（验证）        →  被测模块的
 
 ## 九、工具链
 
-| 用途       | 工具                           | 说明                          |
-| ---------- | ------------------------------ | ----------------------------- |
-| 包管理     | pnpm 8                        | 必须使用 `--frozen-lockfile`  |
-| 构建       | Vite（via electron-vite）      | —                             |
-| 测试框架   | Vitest                         | 兼容 Jest API                 |
-| 组件测试   | React Testing Library          | 测试行为而非实现               |
-| E2E        | Playwright                     | 支持 Electron                 |
-| Mock       | Vitest 内置（vi.mock / vi.fn） | —                             |
-| 样式       | Tailwind CSS 4                 | 原子化 CSS                    |
-| 状态管理   | Zustand                        | —                             |
-| 本地存储   | SQLite                         | 测试中使用 `:memory:`         |
+| 用途     | 工具                           | 说明                         |
+| -------- | ------------------------------ | ---------------------------- |
+| 包管理   | pnpm 8                         | 必须使用 `--frozen-lockfile` |
+| 构建     | Vite（via electron-vite）      | —                            |
+| 测试框架 | Vitest                         | 兼容 Jest API                |
+| 组件测试 | React Testing Library          | 测试行为而非实现             |
+| E2E      | Playwright                     | 支持 Electron                |
+| Mock     | Vitest 内置（vi.mock / vi.fn） | —                            |
+| 样式     | Tailwind CSS 4                 | 原子化 CSS                   |
+| 状态管理 | Zustand                        | —                            |
+| 本地存储 | SQLite                         | 测试中使用 `:memory:`        |
 
 ---
 
@@ -266,14 +270,17 @@ THEN（期望结果）       →  Assert（验证）        →  被测模块的
 
 ## 十一、异常处理
 
-| 遇到的情况                 | 必须做                                           | 禁止做                   |
-| -------------------------- | ------------------------------------------------ | ------------------------ |
-| Spec 不存在或不完整         | 通知 Owner，请求补充 spec                         | 根据猜测直接写代码        |
-| 开发中发现 spec 遗漏场景    | 写 delta spec 补充 → 通知 Owner → 等确认          | 只写测试不更新 spec       |
-| `gh` 命令超时               | 重试 3 次（间隔 10s），仍失败 → 记录 RUN_LOG → 升级| 静默忽略                 |
-| PR 需要 review              | 记录 blocker → 通知 reviewer → 等待               | 静默放弃                 |
-| CI 失败                     | 修复 → push → 再次 watch → 写入 RUN_LOG           | 先合并再修               |
-| 任务超出 spec 范围          | 先补 spec → 经 Owner 确认后再做                    | 超范围自由发挥            |
+| 遇到的情况                           | 必须做                                              | 禁止做                     |
+| ------------------------------------ | --------------------------------------------------- | -------------------------- |
+| Spec 不存在或不完整                  | 通知 Owner，请求补充 spec                           | 根据猜测直接写代码         |
+| 开发中发现 spec 遗漏场景             | 写 delta spec 补充 → 通知 Owner → 等确认            | 只写测试不更新 spec        |
+| `gh` 命令超时                        | 重试 3 次（间隔 10s），仍失败 → 记录 RUN_LOG → 升级 | 静默忽略                   |
+| PR 需要 review                       | 记录 blocker → 通知 reviewer → 等待                 | 静默放弃                   |
+| CI 失败                              | 修复 → push → 再次 watch → 写入 RUN_LOG             | 先合并再修                 |
+| Rulebook task 不存在或 validate 失败 | 阻断交付，先修复 Rulebook 再继续                    | 跳过 Rulebook 直接实现     |
+| 非 `task/*` 分支提交 PR              | PR body 必须包含 `Skip-Reason:`                     | 不说明原因直接跳过 RUN_LOG |
+| required checks 与交付规则文档不一致 | 阻断交付并升级治理，先完成对齐                      | 继续宣称门禁全绿           |
+| 任务超出 spec 范围                   | 先补 spec → 经 Owner 确认后再做                     | 超范围自由发挥             |
 
 ---
 

--- a/docs/delivery-rule-mapping.md
+++ b/docs/delivery-rule-mapping.md
@@ -1,0 +1,22 @@
+# Delivery Rule Mapping Matrix (CN Skill v2)
+
+本表用于审计“规则声明 -> 仓库门禁 -> 脚本校验”是否一致。
+
+| 规则项                             | 外部 Skill                                       | 仓库规则主源                        | 宪法入口               | Workflow / Script                                      |
+| ---------------------------------- | ------------------------------------------------ | ----------------------------------- | ---------------------- | ------------------------------------------------------ |
+| 身份锚点：Issue / Branch / RUN_LOG | `openspec-rulebook-github-delivery/SKILL.md` §一 | `docs/delivery-skill.md` §一        | `AGENTS.md` §5.3       | `openspec-log-guard.yml`, `agent_pr_preflight.py`      |
+| Spec-first + Rulebook-first        | 外部 Skill §二 规则 1                            | `docs/delivery-skill.md` §二 规则 1 | `AGENTS.md` §3.1, §5.2 | `agent_pr_preflight.py`（Rulebook validate 强制）      |
+| 红灯先行（TDD）                    | 外部 Skill §二 规则 2                            | `docs/delivery-skill.md` §二 规则 2 | `AGENTS.md` §3.2       | CI `unit-test`, `integration-test`                     |
+| 证据落盘（RUN_LOG）                | 外部 Skill §二 规则 3                            | `docs/delivery-skill.md` §二 规则 3 | `AGENTS.md` §3.3       | `openspec-log-guard.yml`                               |
+| 门禁一致（文档=远端）              | 外部 Skill §二 规则 4                            | `docs/delivery-skill.md` §二 规则 4 | `AGENTS.md` §3.4, §11  | branch protection required checks                      |
+| 门禁全绿 + auto-merge              | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5 | `AGENTS.md` §3.4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml` |
+| 非 task 分支必须 Skip-Reason       | 外部 Skill §四                                   | `docs/delivery-skill.md` §四        | `AGENTS.md` §11        | `openspec-log-guard.yml`                               |
+| gh 超时 3 次 + 升级                | 外部 Skill §四                                   | `docs/delivery-skill.md` §四        | `AGENTS.md` §11        | 执行规范（RUN_LOG 记录）                               |
+
+## Canonical Checks
+
+- `ci`
+- `openspec-log-guard`
+- `merge-serial`
+
+若 GitHub branch protection 与上面三项不一致，按 blocker 处理，不得宣称“门禁全绿”。

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -1,59 +1,62 @@
 # OpenSpec + Rulebook + GitHub 交付规则
 
-本文件是 Agent 的交付指令（SKILL），定义约束条件和质量标准。不定义具体命令和脚本路径。
+本文件是 CreoNow 的交付规则主源（Source of Truth）。
+本文件只定义约束条件和验收标准，不定义具体命令和脚本参数。
 
-具体命令参见 `scripts/README.md`。
+命令与脚本用法参见 `scripts/README.md`。
 
 ---
 
 ## 一、命名约定
 
-| 实体      | 格式                                     | 示例                              |
-| --------- | ---------------------------------------- | --------------------------------- |
-| Issue     | GitHub Issue，自动分配编号 N              | `#42`                             |
-| Branch    | `task/<N>-<slug>`                        | `task/42-memory-decay`            |
-| Commit    | `<type>: <summary> (#<N>)`               | `feat: add memory decay (#42)`    |
-| PR title  | `<summary> (#<N>)`                       | `Add memory decay (#42)`          |
-| PR body   | 必须包含 `Closes #<N>`                   | `Closes #42`                      |
-| RUN_LOG   | `openspec/_ops/task_runs/ISSUE-<N>.md`   | `ISSUE-42.md`                     |
-| Worktree  | `.worktrees/issue-<N>-<slug>`            | `.worktrees/issue-42-memory-decay`|
+| 实体     | 格式                                   | 示例                               |
+| -------- | -------------------------------------- | ---------------------------------- |
+| Issue    | GitHub Issue，自动分配编号 `N`         | `#42`                              |
+| Branch   | `task/<N>-<slug>`                      | `task/42-memory-decay`             |
+| Commit   | `<type>: <summary> (#<N>)`             | `feat: add memory decay (#42)`     |
+| PR title | `<summary> (#<N>)`                     | `Add memory decay (#42)`           |
+| PR body  | 必须包含 `Closes #<N>`                 | `Closes #42`                       |
+| RUN_LOG  | `openspec/_ops/task_runs/ISSUE-<N>.md` | `ISSUE-42.md`                      |
+| Worktree | `.worktrees/issue-<N>-<slug>`          | `.worktrees/issue-42-memory-decay` |
 
 Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 
 ---
 
-## 二、交付规则
+## 二、交付规则（硬约束）
 
-1. **Spec-first** — 任何功能变更必须先有 OpenSpec spec，再写代码
-2. **红灯先行** — 测试必须先失败再通过（Red → Green → Refactor），禁止先写实现再补测试
-3. **证据落盘** — 关键命令的输入输出必须写入 RUN_LOG，禁止 silent failure
-4. **门禁全绿** — PR 必须通过 `ci`、`openspec-log-guard`、`merge-serial` 三个 required checks
-5. **串行合并** — 所有 PR 通过 auto-merge 串行化，禁止手动合并
+1. **Spec-first + Rulebook-first**：任何功能变更必须先有 OpenSpec spec，并且 Rulebook task 必须存在且通过 `validate`。
+2. **红灯先行**：测试必须先失败再通过（Red → Green → Refactor），禁止先写实现再补测试。
+3. **证据落盘**：关键命令输入输出必须写入 RUN_LOG，禁止 silent failure。
+4. **门禁一致**：文档契约与 GitHub required checks 必须一致；不一致时必须阻断并升级。
+5. **门禁全绿 + 串行合并**：PR 必须通过 `ci`、`openspec-log-guard`、`merge-serial`，并启用 auto-merge。
 
 ---
 
 ## 三、工作流阶段
 
-| 阶段             | 完成条件                                                       |
-| ---------------- | -------------------------------------------------------------- |
-| 1. 任务准入       | Issue 已创建或认领，N 和 SLUG 已确定                            |
-| 2. 规格制定       | OpenSpec spec 已编写或更新；delta spec 已提交 Owner 审阅（如需要）|
-| 3. 环境隔离       | Worktree 已创建，工作目录已切换                                  |
-| 4. 实现与测试     | 按 TDD 循环实现；所有测试通过；RUN_LOG 已记录                    |
-| 5. 提交与合并     | PR 已创建；auto-merge 已开启；三个 checks 全绿；PR 已确认合并    |
-| 6. 收口与归档     | 控制面已同步；worktree 已清理                                    |
+| 阶段          | 完成条件                                                        |
+| ------------- | --------------------------------------------------------------- |
+| 1. 任务准入   | Issue 已创建或认领，`N` 和 `SLUG` 已确定                        |
+| 2. 规格制定   | OpenSpec spec 已编写或更新；Rulebook task 已创建并通过 validate |
+| 3. 环境隔离   | Worktree 已创建，工作目录已切换                                 |
+| 4. 实现与测试 | 按 TDD 循环实现；所有测试通过；RUN_LOG 已记录                   |
+| 5. 提交与合并 | PR 已创建；auto-merge 已开启；三个 checks 全绿；PR 已确认合并   |
+| 6. 收口与归档 | 控制面已同步；worktree 已清理；Rulebook task 已归档             |
 
 ---
 
 ## 四、异常处理规则
 
-| 情况                       | 规则                                                 |
-| -------------------------- | ---------------------------------------------------- |
-| `gh` 命令超时               | 最多重试 3 次（间隔 10s），仍失败 → 记录 RUN_LOG → 升级 |
-| PR 需要 review              | 记录 blocker → 通知 reviewer → 等待，禁止 silent abandonment |
-| checks 失败                 | 修复 → push → 再次 watch → 失败原因写入 RUN_LOG       |
-| Spec 不存在或不完整          | 通知 Owner 请求补充 spec，禁止猜测着写代码              |
-| 任务超出 spec 范围           | 先补 delta spec → 经 Owner 确认后再做                  |
+| 情况                                 | 规则                                                           |
+| ------------------------------------ | -------------------------------------------------------------- |
+| `gh` 命令超时                        | 最多重试 3 次（间隔 10s），仍失败必须记录 RUN_LOG 并升级       |
+| PR 需要 review                       | 记录 blocker，通知 reviewer，等待处理，禁止 silent abandonment |
+| checks 失败                          | 修复后重新 push，重跑并记录失败原因和修复证据                  |
+| Spec 不存在或不完整                  | 必须先补 spec 并确认，禁止猜测实现                             |
+| Rulebook task 不存在或 validate 失败 | 阻断交付，先修复 Rulebook 再继续                               |
+| 非 `task/*` 分支提交 PR              | 可跳过 RUN_LOG，但 PR body 必须包含 `Skip-Reason:`             |
+| required checks 与本文件不一致       | 阻断交付并升级治理，禁止宣称“门禁全绿”                         |
 
 ---
 
@@ -61,13 +64,11 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 
 ```
 OpenSpec（做什么）     Rulebook（怎么做）     GitHub（怎么验收）
-specs/                tasks/               .github/
-project.md            evidence/            scripts/
-changes/                                   ci.yml
+openspec/             rulebook/tasks/        .github/workflows/
 ```
 
-- **OpenSpec** 定义行为和约束 → Agent 写代码前读
-- **Rulebook** 记录执行步骤和证据 → Agent 执行中写
-- **GitHub** 自动验收（CI checks + PR review）→ CI 自动运行
+- **OpenSpec**：定义行为和约束，Agent 实现前必须阅读。
+- **Rulebook**：记录任务拆解、执行与验证证据，交付前必须可验证。
+- **GitHub**：以 required checks 和 auto-merge 作为最终验收门禁。
 
-Agent 读 AGENTS.md 理解宪法 → 读 spec 理解行为 → 按本文件的规则交付。
+规则冲突时，以本文件为主源；`AGENTS.md` 与外部 Skill 必须保持一致。

--- a/openspec/_ops/task_runs/ISSUE-242.md
+++ b/openspec/_ops/task_runs/ISSUE-242.md
@@ -2,7 +2,7 @@
 
 - Issue: #242
 - Branch: task/242-cn-delivery-skill-v2-migration
-- PR: <pending>
+- PR: https://github.com/Leeky1017/CreoNow/pull/243
 
 ## Plan
 
@@ -74,3 +74,10 @@
 - Key output: issue body normalized with explicit Scope/Acceptance and canonical check names
 - Result: ✅ 通过
 - Evidence: `https://github.com/Leeky1017/CreoNow/issues/242`
+
+### 2026-02-07 16:15 pr-opened
+
+- Command: `gh pr create --base main --head task/242-cn-delivery-skill-v2-migration ...`
+- Key output: PR #243 created with `Closes #242`
+- Result: ✅ 通过
+- Evidence: `https://github.com/Leeky1017/CreoNow/pull/243`

--- a/openspec/_ops/task_runs/ISSUE-242.md
+++ b/openspec/_ops/task_runs/ISSUE-242.md
@@ -1,0 +1,76 @@
+# ISSUE-242
+
+- Issue: #242
+- Branch: task/242-cn-delivery-skill-v2-migration
+- PR: <pending>
+
+## Plan
+
+- 对齐外部 Skill、`docs/delivery-skill.md`、`AGENTS.md` 三份交付规则口径。
+- 产出并验证 canonical checks：`ci`、`openspec-log-guard`、`merge-serial`。
+- 强化 preflight 的 Rulebook 强制校验并完成 PR 交付合并。
+
+## Runs
+
+### 2026-02-07 15:55 baseline
+
+- Command: `git status --short && gh auth status && gh api .../branches/main/protection`
+- Key output: worktree 有待提交改动；GitHub 鉴权正常；required checks 为 `openspec-log-guard/ci/merge-serial`
+- Result: ✅ 通过
+- Evidence: `.github/workflows/*`, `docs/delivery-skill.md`, `AGENTS.md`
+
+### 2026-02-07 15:58 issue-and-branch
+
+- Command: `gh issue create` + `git checkout -b task/242-cn-delivery-skill-v2-migration`
+- Key output: issue `#242` 创建成功；分支已切换到 `task/242-cn-delivery-skill-v2-migration`
+- Result: ✅ 通过（issue 创建命令中存在 shell 转义噪音，不影响 issue 创建）
+- Evidence: `https://github.com/Leeky1017/CreoNow/issues/242`
+
+### 2026-02-07 16:00 rulebook-init
+
+- Command: `rulebook task create issue-242-cn-delivery-skill-v2-migration` + `rulebook task validate ...`
+- Key output: task 创建并校验通过（仅提示无 spec 文件 warning）
+- Result: ✅ 通过
+- Evidence: `rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/`
+
+### 2026-02-07 16:01 implementation
+
+- Command: update skill/docs/workflows/preflight + add mapping doc
+- Key output: 已完成外部 Skill 声明式重写；规则主源和宪法对齐；workflow job 名与 checks 对齐；preflight 改为 Rulebook 强制
+- Result: ✅ 通过
+- Evidence: `/home/leeky/.codex/skills/openspec-rulebook-github-delivery/SKILL.md`, `docs/delivery-skill.md`, `AGENTS.md`, `.github/workflows/ci.yml`, `.github/workflows/openspec-log-guard.yml`, `.github/workflows/merge-serial.yml`, `scripts/agent_pr_preflight.py`, `docs/delivery-rule-mapping.md`
+
+### 2026-02-07 16:04 validation
+
+- Command: `python3 -m py_compile scripts/agent_pr_preflight.py`; `python yaml parse`; `pnpm exec prettier --check ...`; `gh api .../protection`
+- Key output: Python/YAML/Prettier 校验通过；branch protection required checks 回读为 `openspec-log-guard/ci/merge-serial`
+- Result: ✅ 通过
+- Evidence: `.github/workflows/*`, `scripts/agent_pr_preflight.py`
+
+### 2026-02-07 16:07 preflight-format-failure
+
+- Command: `scripts/agent_pr_preflight.sh`
+- Key output: preflight failed at prettier check on Rulebook new files
+- Result: ❌ 失败
+- Evidence: `rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/{.metadata.json,proposal.md,tasks.md}`
+
+### 2026-02-07 16:08 format-fix
+
+- Command: `pnpm exec prettier --write ...` + `scripts/agent_pr_preflight.sh`
+- Key output: formatting fixed; second run failed at `pnpm test:unit` due `better-sqlite3` Node ABI mismatch (`143` vs `115`)
+- Result: ⚠️ 需关注
+- Evidence: `scripts/agent_pr_preflight.sh` output
+
+### 2026-02-07 16:10 native-rebuild-and-preflight-pass
+
+- Command: `npm rebuild --build-from-source` (in `better-sqlite3`) + `scripts/agent_pr_preflight.sh`
+- Key output: native rebuild succeeded; preflight fully passed (typecheck/lint/contract/unit green, lint warning-only)
+- Result: ✅ 通过
+- Evidence: `scripts/agent_pr_preflight.sh` output
+
+### 2026-02-07 16:12 issue-body-normalization
+
+- Command: `gh issue edit 242 --body-file -`
+- Key output: issue body normalized with explicit Scope/Acceptance and canonical check names
+- Result: ✅ 通过
+- Evidence: `https://github.com/Leeky1017/CreoNow/issues/242`

--- a/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/.metadata.json
+++ b/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-07T08:00:58.016Z",
+  "updatedAt": "2026-02-07T08:00:58.016Z"
+}

--- a/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/proposal.md
+++ b/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/proposal.md
@@ -1,0 +1,21 @@
+# Proposal: issue-242-cn-delivery-skill-v2-migration
+
+## Why
+
+CreoNow 交付规则、外部 Skill、CI 门禁上下文存在历史漂移，导致“文档口径”和“实际 required checks”不一致，影响自动化交付稳定性与审计一致性。
+
+## What Changes
+
+- 将 `docs/delivery-skill.md` 固化为交付规则主源
+- 重写外部 Skill 为 CN 声明式规则，移除旧模板残留与命令手册内容
+- 对齐 `AGENTS.md` 的交付与异常处理条款
+- 落地 canonical checks：`ci`、`openspec-log-guard`、`merge-serial`
+- 强化 `agent_pr_preflight.py`：Rulebook task 缺失或校验失败即阻断
+- 新增规则映射矩阵文档便于审计回归
+
+## Impact
+
+- Affected specs: N/A（流程治理与交付规则文档升级）
+- Affected code: `.github/workflows/**`, `scripts/agent_pr_preflight.py`, `docs/**`, `AGENTS.md`
+- Breaking change: YES（流程门禁收紧，旧流程将被阻断）
+- User benefit: 交付规则单一真相源、门禁命名统一、审计与执行可追溯

--- a/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/tasks.md
+++ b/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/tasks.md
@@ -1,0 +1,21 @@
+## 1. Implementation
+
+- [x] 1.1 重写外部 Skill 为 CN 声明式规则
+- [x] 1.2 更新 `docs/delivery-skill.md` 为唯一主源
+- [x] 1.3 同步 `AGENTS.md` 相关条款
+- [x] 1.4 更新 workflow 产出 canonical checks
+- [x] 1.5 强化 `scripts/agent_pr_preflight.py` 的 Rulebook 校验
+- [x] 1.6 新增规则映射矩阵文档
+
+## 2. Validation
+
+- [x] 2.1 workflow YAML 可解析
+- [x] 2.2 目标文件 Prettier 校验通过
+- [x] 2.3 branch protection required checks 回读验证
+- [ ] 2.4 PR checks 全绿并确认 mergedAt
+
+## 3. Delivery
+
+- [ ] 3.1 创建 PR（包含 `Closes #242`）
+- [ ] 3.2 开启 auto-merge 并 watch checks
+- [ ] 3.3 回填 RUN_LOG PR 链接与最终结果

--- a/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/tasks.md
+++ b/rulebook/tasks/issue-242-cn-delivery-skill-v2-migration/tasks.md
@@ -16,6 +16,6 @@
 
 ## 3. Delivery
 
-- [ ] 3.1 创建 PR（包含 `Closes #242`）
+- [x] 3.1 创建 PR（包含 `Closes #242`）
 - [ ] 3.2 开启 auto-merge 并 watch checks
 - [ ] 3.3 回填 RUN_LOG PR 链接与最终结果

--- a/scripts/agent_pr_preflight.py
+++ b/scripts/agent_pr_preflight.py
@@ -53,7 +53,7 @@ def current_branch(repo_root: str) -> str:
 
 def require_file(path: str) -> None:
     if not os.path.isfile(path):
-        raise RuntimeError(f"required file missing: {path}")
+        raise RuntimeError(f"[RUN_LOG] required file missing: {path}")
 
 
 def main() -> int:
@@ -62,7 +62,7 @@ def main() -> int:
         branch = current_branch(repo)
         m = re.match(r"^task/(?P<n>[0-9]+)-(?P<slug>[a-z0-9-]+)$", branch)
         if not m:
-            raise RuntimeError(f"branch must be task/<N>-<slug>, got: {branch}")
+            raise RuntimeError(f"[CONTRACT] branch must be task/<N>-<slug>, got: {branch}")
 
         issue_number = m.group("n")
         slug = m.group("slug")
@@ -75,10 +75,9 @@ def main() -> int:
         print("\n== Rulebook checks ==")
         task_id = f"issue-{issue_number}-{slug}"
         task_dir = os.path.join(repo, "rulebook", "tasks", task_id)
-        if os.path.isdir(task_dir):
-            must_run(["rulebook", "task", "validate", task_id], cwd=repo)
-        else:
-            print(f"(skip) rulebook task dir not found: {task_dir}")
+        if not os.path.isdir(task_dir):
+            raise RuntimeError(f"[RULEBOOK] required task dir missing: {task_dir}")
+        must_run(["rulebook", "task", "validate", task_id], cwd=repo)
 
         print("\n== Workspace checks ==")
         # Keep preflight OS-agnostic; Windows-only build/E2E are enforced in CI.
@@ -132,4 +131,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
Closes #242

## Summary
- promote `docs/delivery-skill.md` as CN delivery source-of-truth and align `AGENTS.md`
- rewrite external skill to CN declarative governance rules
- enforce canonical checks in workflows: `ci`, `openspec-log-guard`, `merge-serial`
- strengthen `agent_pr_preflight.py` to require Rulebook task presence/validation
- add delivery rule mapping matrix and task evidence (`RUN_LOG`, Rulebook task)

## Test Plan
- `rulebook task validate issue-242-cn-delivery-skill-v2-migration`
- `scripts/agent_pr_preflight.sh`
- `pnpm exec prettier --check AGENTS.md docs/delivery-skill.md docs/delivery-rule-mapping.md .github/workflows/ci.yml .github/workflows/openspec-log-guard.yml .github/workflows/merge-serial.yml`
- `gh api repos/Leeky1017/CreoNow/branches/main/protection --jq '.required_status_checks.contexts'`

## Notes
- local preflight initially failed due better-sqlite3 ABI mismatch; fixed by native rebuild and reran preflight green.
