### PR TITLE
Stabilize Windows E2E startup readiness (#273)

### DIFF
--- a/apps/desktop/tests/e2e/_helpers/projectReadiness.ts
+++ b/apps/desktop/tests/e2e/_helpers/projectReadiness.ts
@@ -1,0 +1,175 @@
+import { expect, type Page } from "@playwright/test";
+
+const DEFAULT_EDITOR_READY_TIMEOUT_MS = 30_000;
+
+/**
+ * Wait until project IPC endpoints are ready to serve requests.
+ */
+export async function waitForProjectIpcReady(args: {
+  page: Page;
+  timeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_EDITOR_READY_TIMEOUT_MS;
+  await expect
+    .poll(
+      async () =>
+        await args.page.evaluate(async () => {
+          if (!window.creonow) {
+            return "BRIDGE_MISSING";
+          }
+          const result = await window.creonow.invoke("project:project:list", {
+            includeArchived: true,
+          });
+          if (result.ok) {
+            return "READY";
+          }
+          return result.error.code;
+        }),
+      { timeout: timeoutMs },
+    )
+    .toBe("READY");
+}
+
+/**
+ * Wait until at least one "create project" entry point is visible.
+ */
+export async function waitForCreateProjectEntry(args: {
+  page: Page;
+  timeoutMs?: number;
+}): Promise<"welcome" | "dashboard-empty" | "dashboard"> {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_EDITOR_READY_TIMEOUT_MS;
+  const welcomeCreate = args.page.getByTestId("welcome-create-project");
+  const dashboardCreateFirst = args.page.getByTestId("dashboard-create-first");
+  const dashboardCreateNew = args.page.getByTestId("dashboard-create-new");
+
+  await expect
+    .poll(
+      async (): Promise<"welcome" | "dashboard-empty" | "dashboard" | ""> => {
+        if (await welcomeCreate.isVisible()) {
+          return "welcome";
+        }
+        if (await dashboardCreateFirst.isVisible()) {
+          return "dashboard-empty";
+        }
+        if (await dashboardCreateNew.isVisible()) {
+          return "dashboard";
+        }
+        return "";
+      },
+      { timeout: timeoutMs },
+    )
+    .not.toBe("");
+
+  if (await welcomeCreate.isVisible()) {
+    return "welcome";
+  }
+  if (await dashboardCreateFirst.isVisible()) {
+    return "dashboard-empty";
+  }
+  return "dashboard";
+}
+
+/**
+ * Wait until project creation fully transitions into an editable editor state.
+ *
+ * Why: Windows CI startup timing is variable; tests must wait on observable
+ * conditions instead of fixed sleeps.
+ */
+export async function waitForEditorReady(args: {
+  page: Page;
+  timeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_EDITOR_READY_TIMEOUT_MS;
+
+  const createDialog = args.page.getByTestId("create-project-dialog");
+  await expect(createDialog).toBeHidden({ timeout: timeoutMs });
+
+  const editorPane = args.page.getByTestId("editor-pane");
+  await expect(editorPane).toBeVisible({ timeout: timeoutMs });
+
+  await expect
+    .poll(
+      async () => {
+        const documentId = await editorPane.getAttribute("data-document-id");
+        return documentId?.trim().length ?? 0;
+      },
+      { timeout: timeoutMs },
+    )
+    .toBeGreaterThan(0);
+
+  await expect(args.page.getByTestId("tiptap-editor")).toBeVisible({
+    timeout: timeoutMs,
+  });
+}
+
+/**
+ * Create a project from Welcome screen and wait until editor is interactive.
+ */
+export async function createProjectViaWelcomeAndWaitForEditor(args: {
+  page: Page;
+  projectName: string;
+  clickEditor?: boolean;
+  timeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = args.timeoutMs ?? DEFAULT_EDITOR_READY_TIMEOUT_MS;
+  await waitForProjectIpcReady({ page: args.page, timeoutMs });
+  const createEntry = await waitForCreateProjectEntry({
+    page: args.page,
+    timeoutMs,
+  });
+
+  if (createEntry === "welcome") {
+    await args.page.getByTestId("welcome-create-project").click();
+  } else if (createEntry === "dashboard-empty") {
+    await args.page.getByTestId("dashboard-create-first").click();
+  } else {
+    await args.page.getByTestId("dashboard-create-new").click();
+  }
+
+  await expect(args.page.getByTestId("create-project-dialog")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await args.page.getByTestId("create-project-name").fill(args.projectName);
+  await args.page.getByTestId("create-project-submit").click();
+
+  await waitForEditorReady({ page: args.page, timeoutMs });
+
+  if (args.clickEditor) {
+    await args.page.getByTestId("tiptap-editor").click();
+  }
+}
+
+/**
+ * Close known modal surfaces to prevent state leakage across tests.
+ */
+export async function ensureWorkbenchDialogsClosed(args: {
+  page: Page;
+}): Promise<void> {
+  const dialogLocators = [
+    args.page.getByTestId("command-palette"),
+    args.page.getByTestId("settings-dialog"),
+    args.page.getByTestId("export-dialog"),
+    args.page.getByTestId("create-project-dialog"),
+  ];
+
+  for (let i = 0; i < 6; i += 1) {
+    let hasOpenDialog = false;
+
+    for (const dialog of dialogLocators) {
+      if (await dialog.isVisible()) {
+        hasOpenDialog = true;
+        break;
+      }
+    }
+
+    if (!hasOpenDialog) {
+      break;
+    }
+
+    await args.page.keyboard.press("Escape");
+  }
+
+  for (const dialog of dialogLocators) {
+    await expect(dialog).not.toBeVisible();
+  }
+}

--- a/apps/desktop/tests/e2e/ai-apply.spec.ts
+++ b/apps/desktop/tests/e2e/ai-apply.spec.ts
@@ -10,6 +10,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 const MOD_KEY = process.platform === "darwin" ? "Meta" : "Control";
 
 /**
@@ -57,14 +59,11 @@ async function launchApp(userDataDir: string) {
 async function createProjectAndFocusEditor(args: {
   page: Page;
 }): Promise<void> {
-  const page = args.page;
-  await expect(page.getByTestId("welcome-screen")).toBeVisible();
-  await page.getByTestId("welcome-create-project").click();
-  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-  await page.getByTestId("create-project-name").fill("Demo Project");
-  await page.getByTestId("create-project-submit").click();
-  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
-  await page.getByTestId("tiptap-editor").click();
+  await createProjectViaWelcomeAndWaitForEditor({
+    page: args.page,
+    projectName: "Demo Project",
+    clickEditor: true,
+  });
 }
 
 async function selectLastWord(args: { page: Page }) {

--- a/apps/desktop/tests/e2e/analytics.spec.ts
+++ b/apps/desktop/tests/e2e/analytics.spec.ts
@@ -10,6 +10,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 type IpcOk<T> = { ok: true; data: T };
 type IpcErr = { ok: false; error: { code: string; message: string } };
 type IpcEnvelope<T> = IpcOk<T> | IpcErr;
@@ -82,9 +84,10 @@ test("analytics: wordsWritten + skillsUsed increment and are visible", async () 
   await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
   await expect(page.getByTestId("app-shell")).toBeVisible();
 
-  await page.getByTestId("welcome-create-project").click();
-  await page.getByTestId("create-project-name").fill("Analytics Project");
-  await page.getByTestId("create-project-submit").click();
+  await createProjectViaWelcomeAndWaitForEditor({
+    page,
+    projectName: "Analytics Project",
+  });
 
   const before = await ipcInvoke<{ date: string; summary: StatsSummary }>(
     page,

--- a/apps/desktop/tests/e2e/editor-autosave.spec.ts
+++ b/apps/desktop/tests/e2e/editor-autosave.spec.ts
@@ -5,6 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  createProjectViaWelcomeAndWaitForEditor,
+  waitForEditorReady,
+} from "./_helpers/projectReadiness";
+
 /**
  * Create a unique E2E userData directory.
  *
@@ -41,13 +46,10 @@ test("editor autosave: typing persists across restart (actor=auto)", async () =>
   await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
   await expect(page.getByTestId("app-shell")).toBeVisible();
 
-  await expect(page.getByTestId("welcome-screen")).toBeVisible();
-  await page.getByTestId("welcome-create-project").click();
-  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-  await page.getByTestId("create-project-name").fill("Demo Project");
-  await page.getByTestId("create-project-submit").click();
-
-  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+  await createProjectViaWelcomeAndWaitForEditor({
+    page,
+    projectName: "Demo Project",
+  });
 
   await page.getByTestId("tiptap-editor").click();
   await page.keyboard.type("Hello autosave");
@@ -159,7 +161,7 @@ test("editor autosave: typing persists across restart (actor=auto)", async () =>
   const page2 = await electronApp2.firstWindow();
   await page2.waitForFunction(() => window.__CN_E2E__?.ready === true);
   await expect(page2.getByTestId("app-shell")).toBeVisible();
-  await expect(page2.getByTestId("tiptap-editor")).toBeVisible();
+  await waitForEditorReady({ page: page2 });
   await expect(page2.getByTestId("tiptap-editor")).toContainText(
     "Hello autosave",
   );

--- a/apps/desktop/tests/e2e/export-markdown.spec.ts
+++ b/apps/desktop/tests/e2e/export-markdown.spec.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 async function createIsolatedUserDataDir(): Promise<string> {
   const base = path.join(os.tmpdir(), "CreoNow E2E 世界 ");
   const dir = await fs.mkdtemp(base);
@@ -45,9 +47,10 @@ test("export: markdown writes deterministic file under userData exports", async 
   await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
   await expect(page.getByTestId("app-shell")).toBeVisible();
 
-  await page.getByTestId("welcome-create-project").click();
-  await page.getByTestId("create-project-name").fill("Export Project");
-  await page.getByTestId("create-project-submit").click();
+  await createProjectViaWelcomeAndWaitForEditor({
+    page,
+    projectName: "Export Project",
+  });
 
   const current = await page.evaluate(async () => {
     if (!window.creonow) {

--- a/apps/desktop/tests/e2e/knowledge-graph.spec.ts
+++ b/apps/desktop/tests/e2e/knowledge-graph.spec.ts
@@ -10,6 +10,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 /**
  * Create a unique E2E userData directory.
  *
@@ -53,12 +55,10 @@ async function launchApp(args: { userDataDir: string }) {
 }
 
 async function createProjectViaUi(page: Page): Promise<void> {
-  await expect(page.getByTestId("welcome-screen")).toBeVisible();
-  await page.getByTestId("welcome-create-project").click();
-  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-  await page.getByTestId("create-project-name").fill("Demo Project");
-  await page.getByTestId("create-project-submit").click();
-  await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+  await createProjectViaWelcomeAndWaitForEditor({
+    page,
+    projectName: "Demo Project",
+  });
 }
 
 test("knowledge graph: sidebar CRUD + context viewer injection (skill gated)", async () => {

--- a/apps/desktop/tests/e2e/outline-panel.spec.ts
+++ b/apps/desktop/tests/e2e/outline-panel.spec.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 /**
  * Create a unique E2E userData directory.
  */
@@ -36,15 +38,10 @@ test.describe("OutlinePanel", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project to get an editor
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Outline Test Project");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor to be visible
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Outline Test Project",
+    });
 
     // Type content with headings using TipTap's markdown-like shortcuts
     // # at the start of a line followed by space creates H1
@@ -132,15 +129,10 @@ test.describe("OutlinePanel", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Empty Outline Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Empty Outline Test",
+    });
 
     // Type content without any headings
     const editor = page.getByTestId("tiptap-editor");
@@ -180,15 +172,10 @@ test.describe("OutlinePanel", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Dynamic Outline Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Dynamic Outline Test",
+    });
 
     // Open the Outline panel first
     const outlineButton = page.getByTestId("icon-bar-outline");
@@ -236,15 +223,10 @@ test.describe("OutlinePanel", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Special Chars Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Special Chars Test",
+    });
 
     // Type content with special characters
     const editor = page.getByTestId("tiptap-editor");

--- a/apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts
+++ b/apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createProjectViaWelcomeAndWaitForEditor } from "./_helpers/projectReadiness";
+
 /**
  * Create a unique E2E userData directory.
  *
@@ -42,13 +44,10 @@ test.describe("RightPanel Info/Quality wiring", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project first
-    await page.getByTestId("welcome-create-project").click();
-    await page.getByTestId("create-project-name").fill("Info Panel Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor to be ready
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Info Panel Test",
+    });
 
     // Type some content to generate stats
     await page.getByTestId("tiptap-editor").click();
@@ -101,13 +100,10 @@ test.describe("RightPanel Info/Quality wiring", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project first
-    await page.getByTestId("welcome-create-project").click();
-    await page.getByTestId("create-project-name").fill("Quality Panel Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor to be ready
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Quality Panel Test",
+    });
 
     // Click Quality tab in RightPanel
     await page.getByTestId("right-panel-tab-quality").click();
@@ -144,13 +140,10 @@ test.describe("RightPanel Info/Quality wiring", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project first
-    await page.getByTestId("welcome-create-project").click();
-    await page.getByTestId("create-project-name").fill("Run Checks Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor to be ready
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Run Checks Test",
+    });
 
     // Click Quality tab in RightPanel
     await page.getByTestId("right-panel-tab-quality").click();
@@ -190,13 +183,10 @@ test.describe("RightPanel Info/Quality wiring", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project first
-    await page.getByTestId("welcome-create-project").click();
-    await page.getByTestId("create-project-name").fill("Constraints Test");
-    await page.getByTestId("create-project-submit").click();
-
-    // Wait for editor to be ready
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Constraints Test",
+    });
 
     // Click Quality tab in RightPanel
     await page.getByTestId("right-panel-tab-quality").click();
@@ -205,7 +195,9 @@ test.describe("RightPanel Info/Quality wiring", () => {
     await expect(page.getByTestId("quality-panel")).toBeVisible();
 
     // Verify constraints count is visible (even if 0 rules)
-    const constraintsCount = page.getByTestId("quality-panel-constraints-count");
+    const constraintsCount = page.getByTestId(
+      "quality-panel-constraints-count",
+    );
     await expect(constraintsCount).toBeVisible();
 
     // Should show "X rules" format

--- a/apps/desktop/tests/e2e/version-history.spec.ts
+++ b/apps/desktop/tests/e2e/version-history.spec.ts
@@ -5,6 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  createProjectViaWelcomeAndWaitForEditor,
+  waitForProjectIpcReady,
+} from "./_helpers/projectReadiness";
+
 /**
  * Create a unique E2E userData directory.
  */
@@ -36,14 +41,10 @@ test.describe("Version History IPC", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Version Test Project");
-    await page.getByTestId("create-project-submit").click();
-
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Version Test Project",
+    });
 
     // Type initial content
     await page.getByTestId("tiptap-editor").click();
@@ -157,14 +158,10 @@ test.describe("Version History IPC", () => {
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
 
-    // Create a project
-    await expect(page.getByTestId("welcome-screen")).toBeVisible();
-    await page.getByTestId("welcome-create-project").click();
-    await expect(page.getByTestId("create-project-dialog")).toBeVisible();
-    await page.getByTestId("create-project-name").fill("Version Error Test");
-    await page.getByTestId("create-project-submit").click();
-
-    await expect(page.getByTestId("tiptap-editor")).toBeVisible();
+    await createProjectViaWelcomeAndWaitForEditor({
+      page,
+      projectName: "Version Error Test",
+    });
 
     // Get document ID
     const project = await page.evaluate(async () => {
@@ -231,6 +228,7 @@ test.describe("Version History IPC", () => {
     const page = await electronApp.firstWindow();
     await page.waitForFunction(() => window.__CN_E2E__?.ready === true);
     await expect(page.getByTestId("app-shell")).toBeVisible();
+    await waitForProjectIpcReady({ page });
 
     // Try to read with empty documentId
     const result = await page.evaluate(async () => {

--- a/openspec/_ops/task_runs/ISSUE-273.md
+++ b/openspec/_ops/task_runs/ISSUE-273.md
@@ -1,0 +1,187 @@
+# ISSUE-273
+
+- Issue: #273
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/273
+- Branch: `task/273-windows-e2e-startup-readiness`
+- PR: TBD
+- Scope: 修复 Windows E2E 启动就绪竞态与命令面板跨用例状态泄漏（Spec-first + TDD）
+- Out of Scope: 业务功能扩展、主 spec 直接修改、非本次失败链路的 UI/后端重构
+
+## Goal
+
+- 建立 `windows-e2e-startup-readiness` change（proposal/tasks/delta spec）。
+- 通过 Red→Green 修复以下失败模式：
+  - 创建项目后 `tiptap-editor` 不可见超时（多文件复现）
+  - 命令面板 `Search commands` 输入框偶发不可定位（弹窗残留）
+  - 文档 IPC 响应契约失败：`parent_id = NULL` 导致响应校验报错
+- 完成 required checks 并合并收口到控制面 `main`。
+
+## Status
+
+- CURRENT: `IN_PROGRESS`（实现与本地验证完成，待 PR + required checks + merge）
+
+## Plan
+
+- 提交当前变更并推送分支。
+- 创建 PR（`Closes #273`）并开启 auto-merge。
+- 等待 `ci` / `openspec-log-guard` / `merge-serial` 全绿后收口 `main`。
+
+## Runs
+
+### 2026-02-08 14:58 +0800 issue bootstrap
+
+- Command:
+  - `gh issue create --title "[Windows E2E] Startup readiness + command palette test isolation" --body-file ...`
+- Exit code: `0`
+- Key output:
+  - `https://github.com/Leeky1017/CreoNow/issues/273`
+
+### 2026-02-08 14:59 +0800 worktree bootstrap
+
+- Command:
+  - `scripts/agent_worktree_setup.sh 273 windows-e2e-startup-readiness`
+- Exit code: `0`
+- Key output:
+  - `Worktree created: .worktrees/issue-273-windows-e2e-startup-readiness`
+  - `Branch: task/273-windows-e2e-startup-readiness`
+
+### 2026-02-08 15:00 +0800 rulebook bootstrap
+
+- Command:
+  - `rulebook task create issue-273-windows-e2e-startup-readiness`
+  - `rulebook task validate issue-273-windows-e2e-startup-readiness`
+- Exit code: `0`
+- Key output:
+  - `✅ Task issue-273-windows-e2e-startup-readiness is valid`
+  - `⚠️ Warnings: No spec files found (specs/*/spec.md)`
+
+### 2026-02-08 15:05 +0800 historical failure evidence collection
+
+- Command:
+  - `gh run view 21793667176 --repo Leeky1017/CreoNow --log-failed`
+- Exit code: `0`
+- Key output:
+  - `windows-e2e` job: `18 failed`, `1 flaky`, `31 passed`
+  - 失败主链路：`getByTestId('tiptap-editor')` 在创建项目后超时
+  - flaky：`command-palette.spec.ts` 中 `Search commands` 输入框 `fill` 超时
+
+### 2026-02-08 15:07 +0800 change apply (spec docs)
+
+- Command:
+  - `mkdir -p openspec/changes/windows-e2e-startup-readiness/specs/{project-management,workbench}`
+  - `cat > openspec/changes/windows-e2e-startup-readiness/{proposal.md,tasks.md}`
+  - `cat > openspec/changes/windows-e2e-startup-readiness/specs/project-management/spec.md`
+  - `cat > openspec/changes/windows-e2e-startup-readiness/specs/workbench/spec.md`
+- Exit code: `0`
+- Key output:
+  - change 文档创建完成，Requirement 数量控制在 2（<=3）
+
+### 2026-02-08 15:10 +0800 Red reproduction (current branch)
+
+- Command:
+  - `pnpm -C apps/desktop exec playwright test tests/e2e/documents-filetree.spec.ts tests/e2e/system-dialog.spec.ts --config tests/e2e/playwright.config.ts`
+- Exit code: `1`
+- Key output:
+  - `documents-filetree.spec.ts` 超时：等待 `file-actions-<docId>`
+  - `system-dialog.spec.ts` 超时：等待 `file-row-<docId> ... file-actions-*`
+
+### 2026-02-08 15:15 +0800 root cause capture
+
+- Evidence:
+  - 文档服务日志显示 IPC 契约失败：`ipc_response_validation_failed`（`file:document:list` / `file:document:read`）
+  - 根因 1：数据库 `parent_id` 为 `NULL`，IPC 契约要求 `string | undefined`，导致 contract validation 失败。
+  - 根因 2：`file-create` 后新文档默认进入 inline rename 模式，该行不渲染 `file-actions-*`，测试直接点 actions 触发超时。
+
+### 2026-02-08 15:20 +0800 Green implementation
+
+- Changes:
+  - `apps/desktop/main/src/services/documents/documentService.ts`
+    - 增加 `normalizeParentId`，`list/read` 将 `null` 归一化为 `undefined`。
+  - `apps/desktop/tests/unit/documentService.lifecycle.test.ts`
+    - 新增回归断言：`list/read` 对 `parentId` 返回 `undefined`。
+  - `apps/desktop/tests/e2e/_helpers/projectReadiness.ts`
+    - 新增共享就绪 helper：`waitForProjectIpcReady` / `waitForEditorReady` / `createProjectViaWelcomeAndWaitForEditor` / `ensureWorkbenchDialogsClosed`。
+  - 多个 E2E 用例迁移到共享 helper，命令面板加入前后置弹窗清理。
+  - `documents-filetree.spec.ts` / `system-dialog.spec.ts`
+    - 新建文档后先处理 inline rename，再执行删除路径。
+    - 文件行操作改用更稳的 context-menu 路径。
+
+### 2026-02-08 15:30 +0800 targeted E2E verification
+
+- Command:
+  - `pnpm -C apps/desktop exec playwright test tests/e2e/documents-filetree.spec.ts tests/e2e/system-dialog.spec.ts --config tests/e2e/playwright.config.ts`
+- Exit code: `0`
+- Key output:
+  - `2 passed`
+
+### 2026-02-08 15:33 +0800 touched E2E suite verification
+
+- Command:
+  - `pnpm -C apps/desktop exec playwright test tests/e2e/ai-apply.spec.ts tests/e2e/analytics.spec.ts tests/e2e/command-palette.spec.ts tests/e2e/documents-filetree.spec.ts tests/e2e/editor-autosave.spec.ts tests/e2e/export-markdown.spec.ts tests/e2e/knowledge-graph.spec.ts tests/e2e/outline-panel.spec.ts tests/e2e/rightpanel-info-quality.spec.ts tests/e2e/system-dialog.spec.ts tests/e2e/version-history.spec.ts --config tests/e2e/playwright.config.ts`
+- Exit code: `0`
+- Key output:
+  - `29 passed`, `1 skipped`
+
+### 2026-02-08 15:35 +0800 unit/integration/static verification
+
+- Commands:
+  - `pnpm test:unit`
+  - `pnpm test:integration`
+  - `pnpm -C apps/desktop test:run`
+  - `pnpm typecheck`
+  - `pnpm lint`
+  - `pnpm contract:check`
+- Exit code:
+  - `test:unit` 初次失败（native ABI mismatch）
+  - 其余命令最终成功
+- Key output:
+  - 失败原因：`better-sqlite3.node` ABI `143`（Electron）与 Node ABI `115` 不匹配
+  - 修复命令：`pnpm -C apps/desktop exec npm rebuild better-sqlite3 --build-from-source`
+  - 修复后：`test:unit` 全绿
+
+### 2026-02-08 15:41 +0800 rulebook re-validate
+
+- Command:
+  - `rulebook task validate issue-273-windows-e2e-startup-readiness`
+- Exit code: `0`
+- Key output:
+  - `✅ Task issue-273-windows-e2e-startup-readiness is valid`
+  - `⚠️ Warnings: No spec files found (specs/*/spec.md)`
+
+### 2026-02-08 15:44 +0800 formatting + ABI switching evidence
+
+- Commands:
+  - `pnpm exec prettier --write apps/desktop/tests/e2e/documents-filetree.spec.ts apps/desktop/tests/e2e/rightpanel-info-quality.spec.ts apps/desktop/tests/e2e/system-dialog.spec.ts`
+  - `pnpm -C apps/desktop exec playwright test tests/e2e/documents-filetree.spec.ts tests/e2e/system-dialog.spec.ts tests/e2e/rightpanel-info-quality.spec.ts --config tests/e2e/playwright.config.ts`
+- Exit code:
+  - `prettier --write`: `0`
+  - `playwright subset`: `1`
+- Key output:
+  - 失败原因不是业务回归，而是 native ABI 切换后 Electron 运行期数据库加载失败，`waitForProjectIpcReady` 轮询结果持续为 `DB_ERROR`。
+
+### 2026-02-08 15:47 +0800 ABI recover + final local green
+
+- Commands:
+  - `pnpm -C apps/desktop rebuild:native`
+  - `pnpm -C apps/desktop exec playwright test tests/e2e/documents-filetree.spec.ts tests/e2e/system-dialog.spec.ts tests/e2e/rightpanel-info-quality.spec.ts --config tests/e2e/playwright.config.ts`
+  - `pnpm -C apps/desktop exec npm rebuild better-sqlite3 --build-from-source`
+  - `pnpm test:unit`
+  - `pnpm exec prettier --check $(git diff --name-only --diff-filter=ACMR)`
+  - `pnpm lint`
+- Exit code: `0`
+- Key output:
+  - E2E 子集：`7 passed`
+  - Unit：全绿
+  - Prettier：`All matched files use Prettier code style!`
+  - Lint：仅历史 warning，无 error
+
+## Blockers
+
+- NONE（当前无技术阻塞）
+
+## Next
+
+- 提交并推送分支。
+- 创建 PR + auto-merge，回填本 RUN_LOG 的 `PR` 字段。
+- 执行 `scripts/agent_pr_preflight.sh` 并记录输出。
+- 等待 required checks 全绿后合并收口 `main`，归档 change 与 Rulebook task。

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,22 +1,22 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-08 13:01
+更新时间：2026-02-08 15:41
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 0。
-- 执行模式：无待执行变更。
+- 当前活跃 change 数量为 1。
+- 执行模式：串行（单 change 直接执行）。
 
 ## 执行顺序
 
-- 当前无活跃 change。
+1. `windows-e2e-startup-readiness`（当前进行中）
 
 ## 依赖说明
 
-- `ipc-p0-envelope-ok-and-preload-security-evidence` 已完成并归档到 `openspec/changes/archive/`。
-- 历史 IPC changes 已归档在 `openspec/changes/archive/`，作为后续审计基线输入。
+- `windows-e2e-startup-readiness` 依赖现有主 spec 能力，无前置活跃 change 依赖。
+- 历史 changes 已归档在 `openspec/changes/archive/`，作为审计基线输入。
 
 ## 维护规则
 

--- a/openspec/changes/windows-e2e-startup-readiness/proposal.md
+++ b/openspec/changes/windows-e2e-startup-readiness/proposal.md
@@ -1,0 +1,36 @@
+# 提案：windows-e2e-startup-readiness
+
+## 背景
+
+PR #272 的 `windows-e2e` 任务在 2026-02-08 触发 18 个失败与 1 个 flaky。失败主因集中在两类：
+
+- 多个 E2E 用例在「创建项目 → 进入编辑器」后 5 秒内找不到 `tiptap-editor`，表现为启动就绪竞态。
+- `command-palette.spec.ts` 在复用同一页面执行多用例时出现弹窗残留，导致搜索输入框偶发不可用。
+
+## 变更内容
+
+- 在 `project-management` delta spec 中明确「创建项目后的编辑器就绪」可观察条件，并要求 E2E 使用条件等待，不使用固定 sleep。
+- 在 `workbench` delta spec 中明确命令面板命令执行后的弹窗焦点与面板关闭时序，并要求快捷键用例之间无残留弹窗状态。
+- 通过 TDD 修复 Windows E2E 稳定性：先记录 Red 失败证据，再以最小改动引入共享等待 helper 与命令面板测试隔离。
+
+## 受影响模块
+
+- OpenSpec:
+  - `openspec/changes/windows-e2e-startup-readiness/**`
+- E2E 测试：
+  - `apps/desktop/tests/e2e/**/*.spec.ts`（仅涉及创建项目后编辑器就绪路径）
+  - `apps/desktop/tests/e2e/command-palette.spec.ts`
+  - `apps/desktop/tests/e2e/_helpers/*.ts`（新增共享 helper）
+- 运行证据：
+  - `openspec/_ops/task_runs/ISSUE-273.md`
+
+## 不做什么
+
+- 不修改主 spec：`openspec/specs/**`。
+- 不改变业务功能语义（项目创建、命令面板功能本身不扩展）。
+- 不在本 change 中引入新技术栈或跨模块架构重写。
+
+## 审阅状态
+
+- Owner 审阅：`APPROVED`
+- Apply 状态：`IN_PROGRESS`

--- a/openspec/changes/windows-e2e-startup-readiness/specs/project-management/spec.md
+++ b/openspec/changes/windows-e2e-startup-readiness/specs/project-management/spec.md
@@ -1,0 +1,28 @@
+# Project Management Specification Delta
+
+## Change: windows-e2e-startup-readiness
+
+### Requirement: 项目创建 [MODIFIED]
+
+在 Windows CI 场景下，项目创建流程必须提供可稳定等待的「编辑器就绪」外显状态，避免 E2E 在创建完成后对内部异步时序做猜测。
+
+E2E 允许的就绪判定应基于可观察 UI 状态组合：
+
+- 创建项目对话框关闭
+- `editor-pane` 可见且存在有效 `data-document-id`
+- `tiptap-editor` 可见并可聚焦
+
+#### Scenario: 创建项目后进入可编辑状态具备可等待就绪信号 [MODIFIED]
+
+- **假设** 用户在欢迎页点击「Create project」并提交表单
+- **当** 主进程完成项目创建与当前项目切换
+- **则** 渲染层最终进入可编辑状态（`editor-pane + tiptap-editor` 均可见）
+- **并且** E2E 测试可基于该可观察状态稳定等待，不依赖固定时间
+
+#### Scenario: E2E 创建流程使用条件等待而非固定 sleep [ADDED]
+
+- **假设** 平台为 Windows CI，渲染线程与 IPC 初始化速度存在抖动
+- **当** 测试执行「创建项目 → 等待编辑器」流程
+- **则** 等待策略必须使用条件轮询（可观察状态）
+- **并且** 测试中不得通过固定 sleep 掩盖时序问题
+

--- a/openspec/changes/windows-e2e-startup-readiness/specs/workbench/spec.md
+++ b/openspec/changes/windows-e2e-startup-readiness/specs/workbench/spec.md
@@ -1,0 +1,22 @@
+# Workbench Specification Delta
+
+## Change: windows-e2e-startup-readiness
+
+### Requirement: 命令面板（Command Palette） [MODIFIED]
+
+命令面板执行命令后，必须在测试可观察层面满足「目标对话框可见且命令面板已关闭」的顺序一致性，避免跨测试残留状态导致后续快捷键用例误判。
+
+#### Scenario: 命令执行后焦点落在目标对话框且命令面板已关闭 [MODIFIED]
+
+- **假设** 用户通过 `Cmd/Ctrl+P` 打开命令面板
+- **当** 用户执行 `Settings` 或 `Export` 命令
+- **则** 命令面板关闭
+- **并且** 目标对话框可见并接收后续键盘输入
+
+#### Scenario: 快捷键用例间无残留弹窗状态 [ADDED]
+
+- **假设** 同一测试文件内连续执行多个快捷键用例
+- **当** 进入下一条用例前执行状态清理
+- **则** `settings-dialog`、`export-dialog`、`create-project-dialog` 均关闭
+- **并且** 下一条用例打开命令面板时可稳定定位 `Search commands` 输入框
+

--- a/openspec/changes/windows-e2e-startup-readiness/tasks.md
+++ b/openspec/changes/windows-e2e-startup-readiness/tasks.md
@@ -1,0 +1,54 @@
+## 1. Specification
+
+- [x] 1.1 限定本 change 仅覆盖 2 个 requirement：`项目创建` 与 `命令面板` 的 Windows E2E 就绪稳定性
+- [x] 1.2 确认仅通过 delta spec 表达变更，不修改任何主 spec
+- [x] 1.3 明确 out-of-scope：不修改业务语义与产品能力范围
+
+## 2. TDD Mapping（先测前提）
+
+- [x] 2.1 将 delta spec 每个 Scenario 映射到至少一个失败测试
+- [x] 2.2 建立 Scenario ID → 测试文件/用例映射，保证可追踪
+- [x] 2.3 设定门禁：未记录 Red 失败证据不得进入 Green
+- [x] 2.4 未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+- [x] PM-WIN-S1 `创建项目后进入可编辑状态具备可等待就绪信号 [MODIFIED]`
+  - 目标测试：`apps/desktop/tests/e2e/ai-apply.spec.ts`
+  - 目标测试：`apps/desktop/tests/e2e/version-history.spec.ts`
+  - 目标测试：`apps/desktop/tests/e2e/documents-filetree.spec.ts`
+  - 用例：创建项目后通过共享 helper 等待 `editor-pane + tiptap-editor` 就绪
+- [x] PM-WIN-S2 `E2E 创建流程使用条件等待而非固定 sleep [ADDED]`
+  - 目标测试：`apps/desktop/tests/e2e/_helpers/projectReadiness.ts`（新增）
+  - 用例：`waitForEditorReady` 仅基于可观察状态（dialog 关闭、editor 可见、documentId 可用）
+- [x] WB-WIN-S1 `命令执行后焦点落在目标对话框且命令面板已关闭 [MODIFIED]`
+  - 目标测试：`apps/desktop/tests/e2e/command-palette.spec.ts`
+  - 用例：`Settings`/`Export` 路径在继续交互前显式断言命令面板关闭
+- [x] WB-WIN-S2 `快捷键用例间无残留弹窗状态 [ADDED]`
+  - 目标测试：`apps/desktop/tests/e2e/command-palette.spec.ts`
+  - 用例：每个测试开始前执行弹窗清理并断言 `settings/export/create-project` 均关闭
+
+## 3. Red（先写失败测试）
+
+- [x] 3.1 在共享 helper 引入前，记录 Windows 失败证据（`tiptap-editor` 不可见 + `Search commands` fill 超时）
+- [x] 3.2 针对 PM-WIN-S1/PM-WIN-S2 先编写或调整失败测试，证明现有等待策略不稳
+- [x] 3.3 针对 WB-WIN-S1/WB-WIN-S2 先编写或调整失败测试，证明残留弹窗会污染后续用例
+- [x] 3.4 Red 证据写入 `openspec/_ops/task_runs/ISSUE-273.md`
+
+## 4. Green（最小实现通过）
+
+- [x] 4.1 新增最小共享 helper，统一创建项目后的条件等待
+- [x] 4.2 将失败集中的 E2E 用例迁移到共享 helper，去除脆弱等待点
+- [x] 4.3 调整命令面板用例隔离策略，确保无弹窗残留
+- [x] 4.4 执行最小验证集并记录 Green 证据
+
+## 5. Refactor（保持绿灯）
+
+- [x] 5.1 合并重复创建项目逻辑，减少跨文件重复步骤
+- [x] 5.2 保持行为不变前提下整理测试可读性并持续绿灯
+
+## 6. Evidence
+
+- [ ] 6.1 RUN_LOG 记录完整（Issue/PR/关键命令输入输出/失败与修复轨迹）
+- [x] 6.2 记录规则校验：`rulebook task validate issue-273-windows-e2e-startup-readiness`
+- [ ] 6.3 记录门禁状态：`ci`、`openspec-log-guard`、`merge-serial`

--- a/rulebook/tasks/issue-273-windows-e2e-startup-readiness/.metadata.json
+++ b/rulebook/tasks/issue-273-windows-e2e-startup-readiness/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "in-progress",
+  "createdAt": "2026-02-08T06:58:47.837Z",
+  "updatedAt": "2026-02-08T07:26:00.000Z"
+}

--- a/rulebook/tasks/issue-273-windows-e2e-startup-readiness/proposal.md
+++ b/rulebook/tasks/issue-273-windows-e2e-startup-readiness/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: issue-273-windows-e2e-startup-readiness
+
+## Why
+Windows CI 的 `windows-e2e` 在 PR #272 中出现 18 例失败与 1 例 flaky，失败集中在创建项目后的编辑器就绪等待与命令面板跨用例状态泄漏，必须通过 Spec-first + TDD 修复稳定性。
+
+## What Changes
+- 新增 OpenSpec change：`windows-e2e-startup-readiness`
+- 引入共享 E2E helper，统一「创建项目后等待编辑器就绪」条件等待
+- 修复 `command-palette.spec.ts` 用例隔离，确保无残留弹窗污染
+- 完整记录 Red/Green 证据到 RUN_LOG
+
+## Impact
+- Affected specs:
+  - `openspec/changes/windows-e2e-startup-readiness/specs/project-management/spec.md`
+  - `openspec/changes/windows-e2e-startup-readiness/specs/workbench/spec.md`
+- Affected code:
+  - `apps/desktop/tests/e2e/**/*.spec.ts`（创建项目就绪路径）
+  - `apps/desktop/tests/e2e/_helpers/*.ts`（新增）
+- Breaking change: NO
+- User benefit: Windows E2E 稳定通过，降低 CI 偶发失败与返工

--- a/rulebook/tasks/issue-273-windows-e2e-startup-readiness/tasks.md
+++ b/rulebook/tasks/issue-273-windows-e2e-startup-readiness/tasks.md
@@ -1,0 +1,20 @@
+## 1. Specification
+- [x] 1.1 建立 change：`windows-e2e-startup-readiness`
+- [x] 1.2 编写 proposal/tasks/delta spec（project-management + workbench）
+- [x] 1.3 Rulebook validate 通过并记录
+
+## 2. TDD
+- [x] 2.1 记录 Windows E2E Red 失败证据
+- [x] 2.2 先调整失败测试（等待策略 + 命令面板隔离）
+- [x] 2.3 再做最小实现使其通过
+
+## 3. Verification
+- [x] 3.1 执行 targeted E2E（command-palette/version-history/ai-apply）
+- [ ] 3.2 执行 preflight（unit/integration/typecheck/lint + guard）
+- [ ] 3.3 RUN_LOG 回填完整证据
+
+## 4. Delivery
+- [ ] 4.1 提交并推送分支
+- [ ] 4.2 创建 PR（Closes #273）并启用 auto-merge
+- [ ] 4.3 等待 `ci` / `openspec-log-guard` / `merge-serial` 全绿
+- [ ] 4.4 合并后收口到控制面 `main`，归档 change 与 rulebook task


### PR DESCRIPTION
## Summary
- add OpenSpec + Rulebook change for Windows E2E startup readiness and command palette isolation
- normalize document parentId responses (null -> undefined) to satisfy IPC contract validation
- introduce shared E2E readiness helpers and migrate affected specs to condition-based waits
- harden file-tree/system-dialog tests for inline-rename state and flaky row actions

## Validation
- pnpm -C apps/desktop exec playwright test tests/e2e/ai-apply.spec.ts tests/e2e/analytics.spec.ts tests/e2e/command-palette.spec.ts tests/e2e/documents-filetree.spec.ts tests/e2e/editor-autosave.spec.ts tests/e2e/export-markdown.spec.ts tests/e2e/knowledge-graph.spec.ts tests/e2e/outline-panel.spec.ts tests/e2e/rightpanel-info-quality.spec.ts tests/e2e/system-dialog.spec.ts tests/e2e/version-history.spec.ts --config tests/e2e/playwright.config.ts
- pnpm -C apps/desktop exec playwright test tests/e2e/documents-filetree.spec.ts tests/e2e/system-dialog.spec.ts tests/e2e/rightpanel-info-quality.spec.ts --config tests/e2e/playwright.config.ts
- pnpm test:unit
- pnpm -C apps/desktop test:run
- pnpm test:integration
- pnpm typecheck
- pnpm lint
- pnpm contract:check

Closes #273
