### PR TITLE
Deliver project-management-p1-lifecycle-switch-delete (#307)

### DIFF
--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -25,7 +25,10 @@ export const IPC_ERROR_CODES = [
   "UPSTREAM_ERROR",
   "INTERNAL",
   "PROJECT_CAPACITY_EXCEEDED",
+  "PROJECT_DELETE_REQUIRES_ARCHIVE",
   "PROJECT_METADATA_INVALID_ENUM",
+  "PROJECT_PURGE_PERMISSION_DENIED",
+  "PROJECT_LIFECYCLE_WRITE_FAILED",
   "PROJECT_IPC_SCHEMA_INVALID",
   "KG_ATTRIBUTE_KEYS_EXCEEDED",
   "KG_CAPACITY_EXCEEDED",
@@ -140,6 +143,12 @@ const PROJECT_STAGE_SCHEMA = s.union(
   s.literal("draft"),
   s.literal("revision"),
   s.literal("final"),
+);
+
+const PROJECT_LIFECYCLE_STATE_SCHEMA = s.union(
+  s.literal("active"),
+  s.literal("archived"),
+  s.literal("deleted"),
 );
 
 const EXPORT_RESULT_SCHEMA = s.object({
@@ -891,9 +900,62 @@ export const ipcContract = {
       request: s.object({ projectId: s.string() }),
       response: s.object({ projectId: s.string(), rootPath: s.string() }),
     },
+    "project:project:switch": {
+      request: s.object({
+        projectId: s.string(),
+        operatorId: s.string(),
+        fromProjectId: s.string(),
+        traceId: s.string(),
+      }),
+      response: s.object({
+        currentProjectId: s.string(),
+        switchedAt: s.string(),
+      }),
+    },
     "project:project:delete": {
       request: s.object({ projectId: s.string() }),
       response: s.object({ deleted: s.literal(true) }),
+    },
+    "project:lifecycle:archive": {
+      request: s.object({
+        projectId: s.string(),
+        traceId: s.optional(s.string()),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        state: PROJECT_LIFECYCLE_STATE_SCHEMA,
+        archivedAt: s.optional(s.number()),
+      }),
+    },
+    "project:lifecycle:restore": {
+      request: s.object({
+        projectId: s.string(),
+        traceId: s.optional(s.string()),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        state: PROJECT_LIFECYCLE_STATE_SCHEMA,
+      }),
+    },
+    "project:lifecycle:purge": {
+      request: s.object({
+        projectId: s.string(),
+        traceId: s.optional(s.string()),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        state: PROJECT_LIFECYCLE_STATE_SCHEMA,
+      }),
+    },
+    "project:lifecycle:get": {
+      request: s.object({
+        projectId: s.string(),
+        traceId: s.optional(s.string()),
+      }),
+      response: s.object({
+        projectId: s.string(),
+        state: PROJECT_LIFECYCLE_STATE_SCHEMA,
+      }),
     },
     "context:creonow:ensure": {
       request: s.object({ projectId: s.string() }),

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -310,6 +310,45 @@ export function registerProjectIpcHandlers(deps: {
   );
 
   deps.ipcMain.handle(
+    "project:project:switch",
+    async (
+      _e,
+      payload: {
+        projectId: string;
+        fromProjectId: string;
+        operatorId: string;
+        traceId: string;
+      },
+    ): Promise<
+      IpcResponse<{
+        currentProjectId: string;
+        switchedAt: string;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.switchProject({
+        projectId: payload.projectId,
+        fromProjectId: payload.fromProjectId,
+        operatorId: payload.operatorId,
+        traceId: payload.traceId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
     "project:project:delete",
     async (
       _e,
@@ -327,6 +366,135 @@ export function registerProjectIpcHandlers(deps: {
         logger: deps.logger,
       });
       const res = svc.delete({ projectId: payload.projectId });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:lifecycle:archive",
+    async (
+      _e,
+      payload: { projectId: string; traceId?: string },
+    ): Promise<
+      IpcResponse<{
+        projectId: string;
+        state: "active" | "archived" | "deleted";
+        archivedAt?: number;
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.lifecycleArchive({
+        projectId: payload.projectId,
+        traceId: payload.traceId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:lifecycle:restore",
+    async (
+      _e,
+      payload: { projectId: string; traceId?: string },
+    ): Promise<
+      IpcResponse<{
+        projectId: string;
+        state: "active" | "archived" | "deleted";
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.lifecycleRestore({
+        projectId: payload.projectId,
+        traceId: payload.traceId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:lifecycle:purge",
+    async (
+      _e,
+      payload: { projectId: string; traceId?: string },
+    ): Promise<
+      IpcResponse<{
+        projectId: string;
+        state: "active" | "archived" | "deleted";
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.lifecyclePurge({
+        projectId: payload.projectId,
+        traceId: payload.traceId,
+      });
+      return res.ok
+        ? { ok: true, data: res.data }
+        : { ok: false, error: res.error };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "project:lifecycle:get",
+    async (
+      _e,
+      payload: { projectId: string; traceId?: string },
+    ): Promise<
+      IpcResponse<{
+        projectId: string;
+        state: "active" | "archived" | "deleted";
+      }>
+    > => {
+      if (!deps.db) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
+      }
+      const svc = createProjectService({
+        db: deps.db,
+        userDataDir: deps.userDataDir,
+        logger: deps.logger,
+      });
+      const res = svc.lifecycleGet({
+        projectId: payload.projectId,
+        traceId: payload.traceId,
+      });
       return res.ok
         ? { ok: true, data: res.data }
         : { ok: false, error: res.error };

--- a/apps/desktop/main/src/ipc/runtime-validation.ts
+++ b/apps/desktop/main/src/ipc/runtime-validation.ts
@@ -272,7 +272,10 @@ function toValidationError(
   channel: string,
   issues: RuntimeValidationIssue[],
 ): IpcResponse<never> {
-  if (channel.startsWith("project:project:")) {
+  if (
+    channel.startsWith("project:project:") ||
+    channel.startsWith("project:lifecycle:")
+  ) {
     return {
       ok: false,
       error: {

--- a/apps/desktop/main/src/services/projects/projectLifecycleStateMachine.ts
+++ b/apps/desktop/main/src/services/projects/projectLifecycleStateMachine.ts
@@ -1,0 +1,61 @@
+import type { IpcError } from "../../../../../../packages/shared/types/ipc-generated";
+
+export type ProjectLifecycleState = "active" | "archived" | "deleted";
+
+export type LifecycleTransitionResult =
+  | { ok: true; data: { from: ProjectLifecycleState; to: ProjectLifecycleState } }
+  | { ok: false; error: IpcError };
+
+const LIFECYCLE_TRANSITIONS: Record<
+  ProjectLifecycleState,
+  readonly ProjectLifecycleState[]
+> = {
+  active: ["archived"],
+  archived: ["active", "deleted"],
+  deleted: [],
+};
+
+/**
+ * Evaluate whether a lifecycle transition is allowed by the PM-2 state machine.
+ *
+ * Why: lifecycle constraints must be centralized and testable, rather than
+ * scattered as ad-hoc conditionals.
+ */
+export function evaluateLifecycleTransition(args: {
+  from: ProjectLifecycleState;
+  to: ProjectLifecycleState;
+  traceId?: string;
+}): LifecycleTransitionResult {
+  if (args.from === args.to) {
+    return { ok: true, data: { from: args.from, to: args.to } };
+  }
+
+  const allowed = LIFECYCLE_TRANSITIONS[args.from] ?? [];
+  if (allowed.includes(args.to)) {
+    return { ok: true, data: { from: args.from, to: args.to } };
+  }
+
+  if (args.from === "active" && args.to === "deleted") {
+    return {
+      ok: false,
+      error: {
+        code: "PROJECT_DELETE_REQUIRES_ARCHIVE",
+        message: "请先归档项目再删除",
+        traceId: args.traceId,
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_ARGUMENT",
+      message: `Invalid lifecycle transition: ${args.from} -> ${args.to}`,
+      traceId: args.traceId,
+      details: {
+        from: args.from,
+        to: args.to,
+      },
+    },
+  };
+}

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -97,13 +97,25 @@ export function App(): JSX.Element {
     return createOnboardingStore(preferences);
   }, [preferences]);
 
-  const projectStore = React.useMemo(() => {
-    return createProjectStore({ invoke });
-  }, []);
-
   const editorStore = React.useMemo(() => {
     return createEditorStore({ invoke });
   }, []);
+
+  const projectStore = React.useMemo(() => {
+    return createProjectStore({
+      invoke,
+      flushPendingAutosave: async () => {
+        await editorStore.getState().flushPendingAutosave();
+      },
+      getOperatorId: () => "renderer",
+      createTraceId: () => {
+        if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+          return crypto.randomUUID();
+        }
+        return "trace-fallback";
+      },
+    });
+  }, [editorStore]);
 
   const aiStore = React.useMemo(() => {
     return createAiStore({ invoke });

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.stories.tsx
@@ -70,7 +70,7 @@ function createMockProjectStore() {
         ok: true,
         data: {
           projectId,
-          archived,
+          state: archived ? "archived" : "active",
           ...(archived ? { archivedAt: Date.now() } : {}),
         },
       };

--- a/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteProjectDialog } from "./DeleteProjectDialog";
+
+describe("DeleteProjectDialog confirmation", () => {
+  it("should enable delete only when typed project name matches exactly", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <DeleteProjectDialog
+        open
+        projectName="测试项目"
+        documentCount={3}
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const confirmButton = screen.getByTestId("delete-project-confirm-button");
+    const nameInput = screen.getByTestId("delete-project-name-input");
+
+    expect(confirmButton).toBeDisabled();
+
+    await user.type(nameInput, "测试");
+    expect(confirmButton).toBeDisabled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "测试项目");
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep delete disabled and skip ipc request on mismatch", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <DeleteProjectDialog
+        open
+        projectName="测试项目"
+        documentCount={3}
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const confirmButton = screen.getByTestId("delete-project-confirm-button");
+    const nameInput = screen.getByTestId("delete-project-name-input");
+
+    await user.type(nameInput, "测试项");
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(confirmButton);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+
+import { Button, Dialog, Input, Text } from "../../components/primitives";
+
+export interface DeleteProjectDialogProps {
+  open: boolean;
+  projectName: string;
+  documentCount: number;
+  submitting?: boolean;
+  onConfirm: () => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * DeleteProjectDialog enforces exact-name confirmation before destructive delete.
+ *
+ * Why: PM-2 requires explicit second confirmation to prevent accidental purge.
+ */
+export function DeleteProjectDialog(props: DeleteProjectDialogProps): JSX.Element {
+  const [typedName, setTypedName] = React.useState("");
+
+  React.useEffect(() => {
+    if (props.open) {
+      setTypedName("");
+    }
+  }, [props.open]);
+
+  const canDelete = typedName === props.projectName && !props.submitting;
+
+  const description = `删除项目"${props.projectName}"将永久删除所有文档（${props.documentCount} 篇）、知识图谱数据和版本历史。请输入项目名称确认删除。`;
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="确认删除项目"
+      description={description}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => props.onOpenChange(false)}
+            disabled={Boolean(props.submitting)}
+          >
+            取消
+          </Button>
+          <Button
+            data-testid="delete-project-confirm-button"
+            type="button"
+            variant="danger"
+            disabled={!canDelete}
+            loading={Boolean(props.submitting)}
+            onClick={() => {
+              if (!canDelete) {
+                return;
+              }
+              void props.onConfirm();
+            }}
+          >
+            确认删除
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <Text size="small" color="muted">
+          请输入项目名以确认：
+        </Text>
+        <Input
+          data-testid="delete-project-name-input"
+          value={typedName}
+          onChange={(event) => setTypedName(event.target.value)}
+          placeholder={props.projectName}
+          autoFocus
+        />
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx
@@ -1,0 +1,53 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProjectSwitcher } from "./ProjectSwitcher";
+
+describe("ProjectSwitcher loading bar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should show top progress bar after 1s timeout and hide on completion", async () => {
+    let resolveSwitch: (() => void) | null = null;
+    const onSwitch = vi.fn(() => {
+      return new Promise<void>((resolve) => {
+        resolveSwitch = resolve;
+      });
+    });
+
+    render(
+      <ProjectSwitcher
+        currentProjectId="proj-a"
+        projects={[
+          { projectId: "proj-a", name: "A", rootPath: "/a", updatedAt: 1 },
+          { projectId: "proj-b", name: "B", rootPath: "/b", updatedAt: 2 },
+        ]}
+        onSwitch={onSwitch}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("project-switcher-select"), {
+      target: { value: "proj-b" },
+    });
+
+    expect(screen.queryByTestId("project-switcher-progress")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByTestId("project-switcher-progress")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSwitch?.();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId("project-switcher-progress")).toBeNull();
+  });
+});

--- a/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
+++ b/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import type { ProjectListItem } from "../../stores/projectStore";
+
+export interface ProjectSwitcherProps {
+  currentProjectId: string | null;
+  projects: ProjectListItem[];
+  onSwitch: (projectId: string) => Promise<void>;
+}
+
+/**
+ * ProjectSwitcher lets users switch between projects with a delayed progress bar.
+ *
+ * Why: PM-2 requires a visible loading indicator when switching takes >1s.
+ */
+export function ProjectSwitcher(props: ProjectSwitcherProps): JSX.Element {
+  const [switching, setSwitching] = React.useState(false);
+  const [showProgress, setShowProgress] = React.useState(false);
+  const timerRef = React.useRef<number | null>(null);
+
+  const handleChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const nextProjectId = event.target.value;
+      if (switching || !nextProjectId || nextProjectId === props.currentProjectId) {
+        return;
+      }
+
+      setSwitching(true);
+      setShowProgress(false);
+      timerRef.current = window.setTimeout(() => {
+        setShowProgress(true);
+      }, 1000);
+
+      void props.onSwitch(nextProjectId).finally(() => {
+        if (timerRef.current !== null) {
+          window.clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+        setShowProgress(false);
+        setSwitching(false);
+      });
+    },
+    [props, switching],
+  );
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="relative w-full">
+      {showProgress ? (
+        <div
+          data-testid="project-switcher-progress"
+          className="absolute left-0 top-0 h-[2px] w-full overflow-hidden bg-[var(--color-border-default)]"
+        >
+          <div className="h-full w-1/3 animate-pulse bg-[var(--color-fg-default)]" />
+        </div>
+      ) : null}
+
+      <select
+        data-testid="project-switcher-select"
+        value={props.currentProjectId ?? ""}
+        onChange={handleChange}
+        disabled={switching}
+        className="h-8 min-w-[220px] rounded-[var(--radius-sm)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 text-xs text-[var(--color-fg-default)]"
+      >
+        {props.currentProjectId ? null : (
+          <option value="" disabled>
+            选择项目
+          </option>
+        )}
+        {props.projects.map((project) => (
+          <option key={project.projectId} value={project.projectId}>
+            {project.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
+++ b/apps/desktop/renderer/src/features/welcome/WelcomeScreen.stories.tsx
@@ -83,7 +83,7 @@ function createMockProjectStore(overrides: Partial<ProjectStore> = {}) {
           ok: true,
           data: {
             projectId,
-            archived,
+            state: archived ? "archived" : "active",
             ...(archived ? { archivedAt: Date.now() } : {}),
           },
         };

--- a/apps/desktop/tests/integration/project-lifecycle.state-machine.test.ts
+++ b/apps/desktop/tests/integration/project-lifecycle.state-machine.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { IpcMainInvokeEvent } from "electron";
+
+import { registerProjectIpcHandlers } from "../../main/src/ipc/project";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../unit/projectService.test-helpers";
+
+type HandleListener = (
+  event: IpcMainInvokeEvent,
+  payload: unknown,
+) => Promise<unknown> | unknown;
+
+/**
+ * Create a fake ipcMain that stores handlers and supports invoke.
+ */
+function createMockIpcMain() {
+  const handlers = new Map<string, HandleListener>();
+
+  return {
+    handle(channel: string, listener: HandleListener): void {
+      handlers.set(channel, listener);
+    },
+    async invoke(channel: string, payload: unknown): Promise<unknown> {
+      const listener = handlers.get(channel);
+      if (!listener) {
+        throw new Error(`Missing handler: ${channel}`);
+      }
+      return await listener({} as IpcMainInvokeEvent, payload);
+    },
+  };
+}
+
+/**
+ * PM2-S5
+ * should transition active->archived->active and preserve stats
+ */
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-pm2-state-"),
+  );
+  const db = createProjectTestDb();
+  const ipcMain = createMockIpcMain();
+
+  registerProjectIpcHandlers({
+    ipcMain: ipcMain as unknown as Parameters<typeof registerProjectIpcHandlers>[0]["ipcMain"],
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  const created = (await ipcMain.invoke("project:project:create", {
+    name: "Lifecycle Project",
+  })) as { ok: boolean; data?: { projectId: string } };
+  assert.equal(created.ok, true);
+  if (!created.ok || !created.data) {
+    throw new Error("failed to create project");
+  }
+
+  const before = (await ipcMain.invoke("project:project:stats", {})) as {
+    ok: boolean;
+    data?: { total: number; active: number; archived: number };
+  };
+  assert.equal(before.ok, true);
+  if (!before.ok || !before.data) {
+    throw new Error("failed to read stats before lifecycle switch");
+  }
+
+  const archived = (await ipcMain.invoke("project:lifecycle:archive", {
+    projectId: created.data.projectId,
+  })) as { ok: boolean; data?: { state: "active" | "archived" | "deleted" } };
+  assert.equal(archived.ok, true);
+  if (!archived.ok || !archived.data) {
+    throw new Error("archive failed");
+  }
+  assert.equal(archived.data.state, "archived");
+
+  const restored = (await ipcMain.invoke("project:lifecycle:restore", {
+    projectId: created.data.projectId,
+  })) as { ok: boolean; data?: { state: "active" | "archived" | "deleted" } };
+  assert.equal(restored.ok, true);
+  if (!restored.ok || !restored.data) {
+    throw new Error("restore failed");
+  }
+  assert.equal(restored.data.state, "active");
+
+  const after = (await ipcMain.invoke("project:project:stats", {})) as {
+    ok: boolean;
+    data?: { total: number; active: number; archived: number };
+  };
+  assert.equal(after.ok, true);
+  if (!after.ok || !after.data) {
+    throw new Error("failed to read stats after lifecycle switch");
+  }
+
+  assert.deepEqual(after.data, before.data);
+
+  db.close();
+  await fs.rm(userDataDir, { recursive: true, force: true });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/integration/project-purge.concurrent.test.ts
+++ b/apps/desktop/tests/integration/project-purge.concurrent.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { IpcMainInvokeEvent } from "electron";
+
+import { registerProjectIpcHandlers } from "../../main/src/ipc/project";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../unit/projectService.test-helpers";
+
+type HandleListener = (
+  event: IpcMainInvokeEvent,
+  payload: unknown,
+) => Promise<unknown> | unknown;
+
+function createMockIpcMain() {
+  const handlers = new Map<string, HandleListener>();
+
+  return {
+    handle(channel: string, listener: HandleListener): void {
+      handlers.set(channel, listener);
+    },
+    async invoke(channel: string, payload: unknown): Promise<unknown> {
+      const listener = handlers.get(channel);
+      if (!listener) {
+        throw new Error(`Missing handler: ${channel}`);
+      }
+      return await listener({} as IpcMainInvokeEvent, payload);
+    },
+  };
+}
+
+/**
+ * PM2-S7
+ * should return NOT_FOUND for second purge request without side effects
+ */
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-pm2-purge-concurrent-"),
+  );
+  const db = createProjectTestDb();
+  const ipcMain = createMockIpcMain();
+
+  registerProjectIpcHandlers({
+    ipcMain: ipcMain as unknown as Parameters<typeof registerProjectIpcHandlers>[0]["ipcMain"],
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  const created = (await ipcMain.invoke("project:project:create", {
+    name: "Concurrent Purge",
+  })) as { ok: boolean; data?: { projectId: string } };
+  assert.equal(created.ok, true);
+  if (!created.ok || !created.data) {
+    throw new Error("failed to create project");
+  }
+
+  const archived = (await ipcMain.invoke("project:lifecycle:archive", {
+    projectId: created.data.projectId,
+  })) as { ok: boolean };
+  assert.equal(archived.ok, true);
+
+  const first = (await ipcMain.invoke("project:lifecycle:purge", {
+    projectId: created.data.projectId,
+  })) as { ok: boolean };
+  assert.equal(first.ok, true);
+
+  const second = (await ipcMain.invoke("project:lifecycle:purge", {
+    projectId: created.data.projectId,
+  })) as { ok: boolean; error?: { code: string } };
+  assert.equal(second.ok, false);
+  if (second.ok || !second.error) {
+    throw new Error("expected NOT_FOUND on second purge");
+  }
+  assert.equal(second.error.code, "NOT_FOUND");
+
+  db.close();
+  await fs.rm(userDataDir, { recursive: true, force: true });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/integration/project-purge.permission.test.ts
+++ b/apps/desktop/tests/integration/project-purge.permission.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { createProjectService } from "../../main/src/services/projects/projectService";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../unit/projectService.test-helpers";
+
+/**
+ * PM2-S8
+ * should keep archived status when purge path has no write permission
+ */
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "creonow-pm2-"));
+  const db = createProjectTestDb();
+
+  const svc = createProjectService({
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+    removeProjectRoot: () => {
+      const error = new Error("permission denied");
+      (error as NodeJS.ErrnoException).code = "EACCES";
+      throw error;
+    },
+  });
+
+  const created = svc.create({ name: "Permission Purge" });
+  assert.equal(created.ok, true);
+  if (!created.ok) {
+    throw new Error("failed to create project");
+  }
+
+  const archived = svc.archive({
+    projectId: created.data.projectId,
+    archived: true,
+  });
+  assert.equal(archived.ok, true);
+
+  const purged = svc.lifecyclePurge({
+    projectId: created.data.projectId,
+    traceId: "trace-purge-permission",
+  });
+
+  assert.equal(purged.ok, false);
+  if (purged.ok || !purged.error) {
+    throw new Error("expected purge permission error");
+  }
+  assert.equal(purged.error.code, "PROJECT_PURGE_PERMISSION_DENIED");
+
+  const row = db
+    .prepare<
+      [string],
+      { archivedAt: number | null }
+    >("SELECT archived_at as archivedAt FROM projects WHERE project_id = ?")
+    .get(created.data.projectId);
+  assert.equal(typeof row?.archivedAt, "number");
+
+  db.close();
+  await fs.rm(userDataDir, { recursive: true, force: true });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/integration/project-switch.autosave.test.ts
+++ b/apps/desktop/tests/integration/project-switch.autosave.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+
+import { createProjectStore } from "../../renderer/src/stores/projectStore";
+
+type Call = `flush` | `invoke:${string}`;
+
+/**
+ * PM2-S1
+ * should flush pending autosave before switching project context
+ */
+async function main(): Promise<void> {
+  const calls: Call[] = [];
+
+  const invoke = (async (channel: string) => {
+    calls.push(`invoke:${channel}`);
+
+    if (channel === "project:project:switch") {
+      return {
+        ok: true,
+        data: {
+          currentProjectId: "proj-b",
+          switchedAt: new Date(0).toISOString(),
+        },
+      };
+    }
+
+    if (channel === "project:project:setcurrent") {
+      return {
+        ok: true,
+        data: {
+          projectId: "proj-b",
+          rootPath: "/tmp/proj-b",
+        },
+      };
+    }
+
+    return { ok: true, data: {} };
+  }) as Parameters<typeof createProjectStore>[0]["invoke"];
+
+  const flushPendingAutosave = async (): Promise<void> => {
+    calls.push("flush");
+  };
+
+  const store = createProjectStore({
+    invoke,
+    // PM2 adds this dependency; kept as cast for RED phase before impl.
+    flushPendingAutosave,
+  } as Parameters<typeof createProjectStore>[0]);
+
+  store.setState({
+    current: { projectId: "proj-a", rootPath: "/tmp/proj-a" },
+    items: [
+      {
+        projectId: "proj-a",
+        name: "Project A",
+        rootPath: "/tmp/proj-a",
+        updatedAt: Date.now(),
+      },
+      {
+        projectId: "proj-b",
+        name: "Project B",
+        rootPath: "/tmp/proj-b",
+        updatedAt: Date.now(),
+      },
+    ],
+    bootstrapStatus: "ready",
+    lastError: null,
+  });
+
+  const result = await store.getState().setCurrentProject("proj-b");
+  assert.equal(result.ok, true);
+
+  assert.equal(calls[0], "flush");
+  assert.equal(calls[1], "invoke:project:project:switch");
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts
+++ b/apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { IpcMainInvokeEvent } from "electron";
+
+import { registerProjectIpcHandlers } from "../../main/src/ipc/project";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../unit/projectService.test-helpers";
+
+type HandleListener = (
+  event: IpcMainInvokeEvent,
+  payload: unknown,
+) => Promise<unknown> | unknown;
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function createMockIpcMain() {
+  const handlers = new Map<string, HandleListener>();
+
+  return {
+    handle(channel: string, listener: HandleListener): void {
+      handlers.set(channel, listener);
+    },
+    handlers,
+  };
+}
+
+/**
+ * PM2-S10
+ * should assert switch/archive/restore/purge latency baseline thresholds
+ */
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-pm2-benchmark-"),
+  );
+  const db = createProjectTestDb();
+  const ipcMain = createMockIpcMain();
+
+  registerProjectIpcHandlers({
+    ipcMain: ipcMain as unknown as Parameters<typeof registerProjectIpcHandlers>[0]["ipcMain"],
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  const switchHandler = ipcMain.handlers.get("project:project:switch");
+  const archiveHandler = ipcMain.handlers.get("project:lifecycle:archive");
+  const restoreHandler = ipcMain.handlers.get("project:lifecycle:restore");
+  const purgeHandler = ipcMain.handlers.get("project:lifecycle:purge");
+  const createHandler = ipcMain.handlers.get("project:project:create");
+
+  assert.ok(switchHandler, "Missing handler project:project:switch");
+  assert.ok(archiveHandler, "Missing handler project:lifecycle:archive");
+  assert.ok(restoreHandler, "Missing handler project:lifecycle:restore");
+  assert.ok(purgeHandler, "Missing handler project:lifecycle:purge");
+  assert.ok(createHandler, "Missing handler project:project:create");
+
+  const createdIds: string[] = [];
+  for (let i = 0; i < 20; i += 1) {
+    const created = (await createHandler?.({} as IpcMainInvokeEvent, {
+      name: `Perf ${i}`,
+    })) as { ok: boolean; data?: { projectId: string } };
+    if (!created.ok || !created.data) {
+      throw new Error("create failed in benchmark setup");
+    }
+    createdIds.push(created.data.projectId);
+  }
+
+  const switchDurations: number[] = [];
+  const archiveDurations: number[] = [];
+  const restoreDurations: number[] = [];
+  const purgeDurations: number[] = [];
+
+  for (let i = 0; i < createdIds.length; i += 1) {
+    const current = createdIds[i];
+    const previous = createdIds[(i + createdIds.length - 1) % createdIds.length];
+
+    const tSwitch0 = performance.now();
+    await switchHandler?.({} as IpcMainInvokeEvent, {
+      projectId: current,
+      fromProjectId: previous,
+      operatorId: "bench",
+      traceId: `switch-${i}`,
+    });
+    const tSwitch1 = performance.now();
+    switchDurations.push(tSwitch1 - tSwitch0);
+
+    const tArchive0 = performance.now();
+    await archiveHandler?.({} as IpcMainInvokeEvent, {
+      projectId: current,
+      traceId: `archive-${i}`,
+    });
+    const tArchive1 = performance.now();
+    archiveDurations.push(tArchive1 - tArchive0);
+
+    const tRestore0 = performance.now();
+    await restoreHandler?.({} as IpcMainInvokeEvent, {
+      projectId: current,
+      traceId: `restore-${i}`,
+    });
+    const tRestore1 = performance.now();
+    restoreDurations.push(tRestore1 - tRestore0);
+
+    await archiveHandler?.({} as IpcMainInvokeEvent, {
+      projectId: current,
+      traceId: `archive-final-${i}`,
+    });
+
+    const tPurge0 = performance.now();
+    await purgeHandler?.({} as IpcMainInvokeEvent, {
+      projectId: current,
+      traceId: `purge-${i}`,
+    });
+    const tPurge1 = performance.now();
+    purgeDurations.push(tPurge1 - tPurge0);
+  }
+
+  const switchP95 = percentile(switchDurations, 95);
+  const switchP99 = percentile(switchDurations, 99);
+  const archiveP95 = percentile(archiveDurations, 95);
+  const restoreP95 = percentile(restoreDurations, 95);
+  const purgeP95 = percentile(purgeDurations, 95);
+
+  assert.ok(switchP95 < 1000, `switch p95 >= 1s: ${switchP95}`);
+  assert.ok(switchP99 < 2000, `switch p99 >= 2s: ${switchP99}`);
+  assert.ok(archiveP95 < 600, `archive p95 >= 600ms: ${archiveP95}`);
+  assert.ok(restoreP95 < 800, `restore p95 >= 800ms: ${restoreP95}`);
+  assert.ok(purgeP95 < 2000, `purge p95 >= 2s: ${purgeP95}`);
+
+  db.close();
+  await fs.rm(userDataDir, { recursive: true, force: true });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/unit/projectLifecycle.guard.test.ts
+++ b/apps/desktop/tests/unit/projectLifecycle.guard.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+
+import {
+  evaluateLifecycleTransition,
+  type ProjectLifecycleState,
+} from "../../main/src/services/projects/projectLifecycleStateMachine";
+
+/**
+ * PM2-S6
+ * should reject active->deleted transition with PROJECT_DELETE_REQUIRES_ARCHIVE
+ */
+function main(): void {
+  const from: ProjectLifecycleState = "active";
+  const to: ProjectLifecycleState = "deleted";
+
+  const res = evaluateLifecycleTransition({
+    from,
+    to,
+    traceId: "trace-guard-test",
+  });
+
+  assert.equal(res.ok, false);
+  if (res.ok) {
+    throw new Error("expected guard rejection for active->deleted");
+  }
+
+  assert.equal(res.error.code, "PROJECT_DELETE_REQUIRES_ARCHIVE");
+}
+
+main();

--- a/apps/desktop/tests/unit/projectLifecycle.persistence-failure.test.ts
+++ b/apps/desktop/tests/unit/projectLifecycle.persistence-failure.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type Database from "better-sqlite3";
+
+import { createProjectService } from "../../main/src/services/projects/projectService";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "./projectService.test-helpers";
+
+/**
+ * PM2-S9
+ * should return PROJECT_LIFECYCLE_WRITE_FAILED when db write fails
+ */
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-pm2-write-failure-"),
+  );
+  const db = createProjectTestDb();
+  const svc = createProjectService({
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  const created = svc.create({ name: "Write Failure" });
+  assert.equal(created.ok, true);
+  if (!created.ok) {
+    throw new Error("failed to create project");
+  }
+
+  const originalPrepare = db.prepare.bind(db);
+  (db as unknown as { prepare: Database.Database["prepare"] }).prepare = ((sql) => {
+    if (typeof sql === "string" && sql.includes("UPDATE projects SET archived_at = ?, updated_at = ?")) {
+      return {
+        run: () => {
+          throw new Error("db write failed");
+        },
+      } as unknown as ReturnType<Database.Database["prepare"]>;
+    }
+    return originalPrepare(sql as never);
+  }) as Database.Database["prepare"];
+
+  const res = svc.archive({
+    projectId: created.data.projectId,
+    archived: true,
+  });
+
+  assert.equal(res.ok, false);
+  if (res.ok) {
+    throw new Error("expected lifecycle persistence failure");
+  }
+  assert.equal(res.error.code, "PROJECT_LIFECYCLE_WRITE_FAILED");
+
+  db.close();
+  await fs.rm(userDataDir, { recursive: true, force: true });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/openspec/_ops/task_runs/ISSUE-307.md
+++ b/openspec/_ops/task_runs/ISSUE-307.md
@@ -1,0 +1,207 @@
+# ISSUE-307
+
+- Issue: #307
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/307
+- Branch: task/307-project-management-p1-lifecycle-switch-delete
+- PR: PENDING
+- Scope: 完成 `openspec/changes/project-management-p1-lifecycle-switch-delete` 的全部任务内容（仅该 change）
+- Out of Scope: 该 change 之外的功能与文档变更
+
+## Plan
+
+- 完成 Rulebook task 创建与 validate，并在独立 worktree 开展实现。
+- 先完成 Dependency Sync Check，再按 PM2-S1~S10 执行 Red→Green→Refactor。
+- 完成 IPC/服务/前端与测试落地，记录性能基线与异常路径证据。
+- 通过 preflight 与 required checks，开启 auto-merge，收口 main 并归档 change。
+
+## Runs
+
+### 2026-02-08 22:41 准入阻断（关闭 Issue 不可复用）
+
+- Command: `gh issue view 291 --json number,state,title,url`
+- Exit code: `0`
+- Key output:
+  - `{"number":291,"state":"CLOSED","title":"Project Management: draft PM-1 and PM-2 OpenSpec changes","url":"https://github.com/Leeky1017/CreoNow/issues/291"}`
+- Decision:
+  - 按 AGENTS 规则停止复用历史入口，改为创建新的 OPEN Issue。
+
+### 2026-02-08 22:42 新建 OPEN Issue 入口
+
+- Command: `gh issue list --state open --limit 200 --json number,title,url --search "project-management-p1-lifecycle-switch-delete"`
+- Exit code: `0`
+- Key output:
+  - `[]`（无现成 OPEN Issue）
+- Command: `gh issue create --title "Deliver change project-management-p1-lifecycle-switch-delete" --body "..."`
+- Exit code: `0`
+- Key output:
+  - `https://github.com/Leeky1017/CreoNow/issues/307`
+
+### 2026-02-08 22:43 控制面同步与 worktree 创建
+
+- Command: `git fetch origin && git checkout main && git pull --ff-only origin main`
+- Exit code: `0`
+- Key output:
+  - `Already up to date.`
+- Command: `git worktree add .worktrees/issue-307-project-management-p1-lifecycle-switch-delete -b task/307-project-management-p1-lifecycle-switch-delete`
+- Exit code: `0`
+- Key output:
+  - `Preparing worktree (new branch 'task/307-project-management-p1-lifecycle-switch-delete')`
+
+### 2026-02-08 22:45 Rulebook 任务初始化
+
+- Command: `rulebook task create issue-307-project-management-p1-lifecycle-switch-delete`（MCP）
+- Exit code: `0`
+- Key output:
+  - `Task issue-307-project-management-p1-lifecycle-switch-delete created successfully`
+- Note:
+  - MCP 默认写入控制面路径，随后已复制到本 worktree 并清理控制面残留目录。
+
+### 2026-02-08 22:47 Rulebook 校验（worktree 内）
+
+- Command: `rulebook task validate issue-307-project-management-p1-lifecycle-switch-delete`
+- Exit code: `0`
+- Key output:
+  - `✅ Task issue-307-project-management-p1-lifecycle-switch-delete is valid`
+
+### 2026-02-08 22:49 Dependency Sync Check（PM-1 -> PM-2）
+
+- Input checks:
+  - 数据模型：`openspec/changes/archive/project-management-p0-creation-metadata-dashboard` 已归档，`projects` 模型已包含 `archived_at`（支持 PM-2 生命周期落地）
+  - IPC 契约：当前已落地 PM-1 通道为 `project:project:*`（create/list/update/stats/archive/getcurrent/setcurrent/delete）
+  - 命名治理：IPC 命名规则要求三段式 `<domain>:<resource>:<action>`
+  - 错误码：`PROJECT_DELETE_REQUIRES_ARCHIVE` / `PROJECT_PURGE_PERMISSION_DENIED` / `PROJECT_LIFECYCLE_WRITE_FAILED` 尚未定义（待 PM-2 实现）
+- Drift:
+  - PM-2 delta 原文使用了两段式/旧式通道名（如 `project:switch`、`project:archive`），与当前治理基线不一致。
+- Action:
+  - 已先更新 PM-2 文档：
+    - `project:switch` -> `project:project:switch`
+    - `project:archive|restore|purge` -> `project:lifecycle:archive|restore|purge`
+    - Red 证据日志目标由 `ISSUE-291` 修正为 `ISSUE-307`
+- Conclusion:
+  - 依赖已满足且文档漂移已修正，可进入 Red 阶段。
+
+### 2026-02-08 23:02 Red 失败证据（PM2 测试初次执行）
+
+- Command: `pnpm exec tsx apps/desktop/tests/integration/project-purge.concurrent.test.ts`
+- Exit code: `1`
+- Key output:
+  - `TypeError: Cannot read properties of undefined (reading 'ok')`
+  - `at Object.lifecyclePurge (.../projectService.ts:1236:21)`
+- Diagnosis:
+  - `projectService.ts` 中 `ipcError` / `createDefaultProjectMetadata` 出现错误 patch，返回值结构被破坏。
+
+- Command: `pnpm -C apps/desktop exec vitest run renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx`
+- Exit code: `1`
+- Key output:
+  - `ProjectSwitcher.loading-bar.test.tsx ... Test timed out in 5000ms`
+- Diagnosis:
+  - 组件测试在 fake timers + async handler 场景下触发等待超时，需要最小化调整事件触发与 act 驱动。
+
+### 2026-02-08 23:10 Green 修复（服务与 IPC 关键路径）
+
+- Edited:
+  - `apps/desktop/main/src/services/projects/projectService.ts`
+  - `apps/desktop/main/src/services/projects/projectLifecycleStateMachine.ts`
+  - `apps/desktop/main/src/ipc/project.ts`
+  - `apps/desktop/main/src/ipc/runtime-validation.ts`
+  - `apps/desktop/main/src/ipc/contract/ipc-contract.ts`
+  - `packages/shared/types/ipc-generated.ts`
+- Key fixes:
+  - 修复 `createDefaultProjectMetadata` 返回 `ServiceResult<ProjectMetadata>`。
+  - 修复 `ipcError` 默认分支返回 `Err`，消除 `undefined` 错误路径。
+  - `createProjectService` 恢复 `const service = {...}; return service;`，支持内部复用 `service.lifecycle*`。
+  - 落地 PM2 契约：`project:project:switch` 与 `project:lifecycle:{archive|restore|purge|get}`，并补齐错误码。
+
+### 2026-02-08 23:16 Green 修复（Renderer/Store/UI）
+
+- Edited:
+  - `apps/desktop/renderer/src/stores/projectStore.tsx`
+  - `apps/desktop/renderer/src/stores/editorStore.tsx`
+  - `apps/desktop/renderer/src/App.tsx`
+  - `apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx`
+  - `apps/desktop/renderer/src/features/projects/DeleteProjectDialog.tsx`
+  - `apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx`
+- Key behavior:
+  - 切换项目前 flush autosave，再调用 `project:project:switch`。
+  - 删除确认改为名称精确匹配。
+  - 生命周期入口统一走 `project:lifecycle:*`。
+  - 切换耗时 >1s 显示顶部进度条。
+
+### 2026-02-08 23:18 Storybook/Type 对齐修复
+
+- Command: `pnpm typecheck`
+- Exit code: `1`（首次）
+- Key output:
+  - `CreateProjectDialog.stories.tsx` / `WelcomeScreen.stories.tsx` 返回旧字段 `archived`，缺少 `state`。
+- Action:
+  - 更新上述 stories mock 返回为 `{ projectId, state, archivedAt? }`。
+- Command: `pnpm typecheck`
+- Exit code: `0`（修复后）
+
+### 2026-02-08 23:20 Lint 修复（新增 trace fallback）
+
+- Command: `pnpm lint`
+- Exit code: `1`（首次）
+- Key output:
+  - `App.tsx` purity 规则报错：`Date.now` / ref / globals fallback。
+- Action:
+  - 将 `createTraceId` fallback 调整为纯常量 `"trace-fallback"`（主路径仍优先 `crypto.randomUUID()`）。
+- Command: `pnpm lint`
+- Exit code: `0`
+- Notes:
+  - 存在 4 条仓库既有 warnings（`react-hooks/exhaustive-deps`），无 error。
+
+### 2026-02-08 23:26 PM2 场景 Green 通过证据（S1-S10）
+
+- Command set (all exit `0`):
+  - `pnpm exec tsx apps/desktop/tests/integration/project-switch.autosave.test.ts`
+  - `pnpm -C apps/desktop exec vitest run renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx`
+  - `pnpm exec tsx apps/desktop/tests/integration/project-lifecycle.state-machine.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/unit/projectLifecycle.guard.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/integration/project-purge.concurrent.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/integration/project-purge.permission.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/unit/projectLifecycle.persistence-failure.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts`
+- Scenario mapping result:
+  - PM2-S1 ~ PM2-S10 全部通过。
+
+### 2026-02-08 23:27 Benchmark/NFR 证据
+
+- Command: `pnpm exec tsx apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts`
+- Exit code: `0`
+- Threshold judgment:
+  - 用例内断言已覆盖并通过：
+    - `switch p95 < 1000ms`
+    - `switch p99 < 2000ms`
+    - `archive p95 < 600ms`
+    - `restore p95 < 800ms`
+    - `purge p95 < 2000ms`
+
+### 2026-02-08 23:28 额外回归与契约幂等验证
+
+- Command: `pnpm exec tsx apps/desktop/tests/unit/projectService.projectActions.test.ts`
+- Exit code: `0`
+- Key output:
+  - `projectService.projectActions.test.ts: all assertions passed`
+
+- Command: `pnpm -C apps/desktop exec vitest run renderer/src/features/dashboard/Dashboard.open-project.test.tsx renderer/src/features/dashboard/Dashboard.search.test.tsx renderer/src/features/dashboard/Dashboard.empty-state.test.tsx`
+- Exit code: `0`
+- Key output:
+  - `Test Files 3 passed (3)`
+
+- Command: `git diff -- packages/shared/types/ipc-generated.ts > /tmp/issue307-ipc-before-final.diff && pnpm contract:generate && git diff -- packages/shared/types/ipc-generated.ts > /tmp/issue307-ipc-after-final.diff && diff -u /tmp/issue307-ipc-before-final.diff /tmp/issue307-ipc-after-final.diff`
+- Exit code: `0`
+- Conclusion:
+  - 契约生成结果稳定（无二次漂移）。
+
+### 2026-02-08 23:29 交付前治理校验
+
+- Command: `rulebook task validate issue-307-project-management-p1-lifecycle-switch-delete`
+- Exit code: `0`
+- Key output:
+  - `✅ Task issue-307-project-management-p1-lifecycle-switch-delete is valid`
+
+- Command: `gh auth status`
+- Exit code: `0`
+- Key output:
+  - `Logged in to github.com account Leeky1017`

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-08 23:23
+更新时间：2026-02-08 23:31
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-08 22:22
+更新时间：2026-02-08 22:50
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 

--- a/openspec/changes/project-management-p1-lifecycle-switch-delete/proposal.md
+++ b/openspec/changes/project-management-p1-lifecycle-switch-delete/proposal.md
@@ -14,15 +14,15 @@ PM 主规范中的多项目切换、删除与生命周期闭环是 P1 阶段的�
   - 项目生命周期闭环（归档→恢复→清除、活跃直接删除阻断）
 - 依赖约束：`project-management-p0-creation-metadata-dashboard`（PM-1）合并后再进入实现。
 - 定义切换与生命周期 IPC 契约：
-  - `project:switch`
-  - `project:archive`
-  - `project:restore`
-  - `project:purge`
+  - `project:project:switch`
+  - `project:lifecycle:archive`
+  - `project:lifecycle:restore`
+  - `project:lifecycle:purge`
   - `project:lifecycle:get`
-- 明确 `project:switch` 需调用 KG/MS 上下文切换预留接口（mock/no-op 占位），暂不接入真实引擎。
+- 明确 `project:project:switch` 需调用 KG/MS 上下文切换预留接口（mock/no-op 占位），暂不接入真实引擎。
 - 生命周期必须实现为代码级状态机（transition map/guard），禁止散落式 `if/else` 硬编码。
 - 删除确认必须采用「输入项目名二次确认」机制。
-- 在测试中建立 NFR benchmark 基线，覆盖 `project:switch` 与 lifecycle IPC 阈值。
+- 在测试中建立 NFR benchmark 基线，覆盖 `project:project:switch` 与 lifecycle IPC 阈值。
 - 纳入跨切边界场景：并发删除冲突、权限不足、数据库写入失败。
 
 ## 受影响模块

--- a/openspec/changes/project-management-p1-lifecycle-switch-delete/tasks.md
+++ b/openspec/changes/project-management-p1-lifecycle-switch-delete/tasks.md
@@ -1,71 +1,71 @@
 ## 1. Specification
 
-- [ ] 1.1 审阅并确认 PM-2 仅覆盖多项目切换、项目删除、生命周期闭环
-- [ ] 1.2 审阅并确认 PM-2 依赖 PM-1 合并后才可进入实现
-- [ ] 1.3 审阅并确认跨切异常覆盖（并发冲突/权限不足/数据库写失败）与 NFR 基线要求
-- [ ] 1.4 在进入 Red 前完成依赖同步检查（Dependency Sync Check）：核对 PM-1 已合并产出的数据模型/IPC 契约/错误码与本 change 假设
+- [x] 1.1 审阅并确认 PM-2 仅覆盖多项目切换、项目删除、生命周期闭环
+- [x] 1.2 审阅并确认 PM-2 依赖 PM-1 合并后才可进入实现
+- [x] 1.3 审阅并确认跨切异常覆盖（并发冲突/权限不足/数据库写失败）与 NFR 基线要求
+- [x] 1.4 在进入 Red 前完成依赖同步检查（Dependency Sync Check）：核对 PM-1 已合并产出的数据模型/IPC 契约/错误码与本 change 假设
 
 ## 2. TDD Mapping（先测前提）
 
-- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
-- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
-- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [x] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [x] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [x] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
 
 ### Scenario → Test 映射
 
-- [ ] PM2-S1 切换项目前先保存当前未落盘内容
+- [x] PM2-S1 切换项目前先保存当前未落盘内容
   - 目标测试：`apps/desktop/tests/integration/project-switch.autosave.test.ts`
   - 用例：`should flush pending autosave before switching project context`
-- [ ] PM2-S2 切换超过 1 秒显示加载指示并在完成后消失
+- [x] PM2-S2 切换超过 1 秒显示加载指示并在完成后消失
   - 目标测试：`apps/desktop/renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx`
   - 用例：`should show top progress bar after 1s timeout and hide on completion`
-- [ ] PM2-S3 名称匹配后确认删除项目
+- [x] PM2-S3 名称匹配后确认删除项目
   - 目标测试：`apps/desktop/renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx`
   - 用例：`should enable delete only when typed project name matches exactly`
-- [ ] PM2-S4 名称不匹配时删除被阻断
+- [x] PM2-S4 名称不匹配时删除被阻断
   - 目标测试：`apps/desktop/renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx`
   - 用例：`should keep delete disabled and skip ipc request on mismatch`
-- [ ] PM2-S5 归档后恢复并保持项目统计一致
+- [x] PM2-S5 归档后恢复并保持项目统计一致
   - 目标测试：`apps/desktop/tests/integration/project-lifecycle.state-machine.test.ts`
   - 用例：`should transition active->archived->active and preserve stats`
-- [ ] PM2-S6 活跃项目直接永久删除被阻断
+- [x] PM2-S6 活跃项目直接永久删除被阻断
   - 目标测试：`apps/desktop/tests/unit/projectLifecycle.guard.test.ts`
   - 用例：`should reject active->deleted transition with PROJECT_DELETE_REQUIRES_ARCHIVE`
-- [ ] PM2-S7 两窗口并发删除同一项目的幂等冲突处理
+- [x] PM2-S7 两窗口并发删除同一项目的幂等冲突处理
   - 目标测试：`apps/desktop/tests/integration/project-purge.concurrent.test.ts`
   - 用例：`should return NOT_FOUND for second purge request without side effects`
-- [ ] PM2-S8 文件系统权限不足时阻断 purge
+- [x] PM2-S8 文件系统权限不足时阻断 purge
   - 目标测试：`apps/desktop/tests/integration/project-purge.permission.test.ts`
   - 用例：`should keep archived status when purge path has no write permission`
-- [ ] PM2-S9 数据库写入失败时返回结构化错误码
+- [x] PM2-S9 数据库写入失败时返回结构化错误码
   - 目标测试：`apps/desktop/tests/unit/projectLifecycle.persistence-failure.test.ts`
   - 用例：`should return PROJECT_LIFECYCLE_WRITE_FAILED when db write fails`
-- [ ] PM2-S10 切换与生命周期阈值建立 benchmark 基线
+- [x] PM2-S10 切换与生命周期阈值建立 benchmark 基线
   - 目标测试：`apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts`
   - 用例：`should assert switch/archive/restore/purge latency baseline thresholds`
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 先为 PM2-S1~PM2-S2 编写失败测试并确认 Red（切换与超时可视反馈）
-- [ ] 3.2 再为 PM2-S3~PM2-S6 编写失败测试并确认 Red（删除确认与状态机约束）
-- [ ] 3.3 最后为 PM2-S7~PM2-S10 编写失败测试并确认 Red（并发/权限/IO/NFR）
-- [ ] 3.4 将 Red 失败日志与命令输出记录到 `openspec/_ops/task_runs/ISSUE-291.md`
+- [x] 3.1 先为 PM2-S1~PM2-S2 编写失败测试并确认 Red（切换与超时可视反馈）
+- [x] 3.2 再为 PM2-S3~PM2-S6 编写失败测试并确认 Red（删除确认与状态机约束）
+- [x] 3.3 最后为 PM2-S7~PM2-S10 编写失败测试并确认 Red（并发/权限/IO/NFR）
+- [x] 3.4 将 Red 失败日志与命令输出记录到 `openspec/_ops/task_runs/ISSUE-307.md`
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 PM2-S1~PM2-S2 通过的最小代码
-- [ ] 4.2 仅实现让 PM2-S3~PM2-S6 通过的最小代码
-- [ ] 4.3 仅实现让 PM2-S7~PM2-S10 通过的最小代码
-- [ ] 4.4 记录 Green 通过证据（集成/组件/基线测试）到 RUN_LOG
+- [x] 4.1 仅实现让 PM2-S1~PM2-S2 通过的最小代码
+- [x] 4.2 仅实现让 PM2-S3~PM2-S6 通过的最小代码
+- [x] 4.3 仅实现让 PM2-S7~PM2-S10 通过的最小代码
+- [x] 4.4 记录 Green 通过证据（集成/组件/基线测试）到 RUN_LOG
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 将生命周期 transition map 与 guard 抽离为可测试状态机模块
-- [ ] 5.2 保持 `project:switch`、`project:archive|restore|purge|lifecycle:get` 外部契约稳定
+- [x] 5.1 将生命周期 transition map 与 guard 抽离为可测试状态机模块
+- [x] 5.2 保持 `project:project:switch`、`project:lifecycle:{archive|restore|purge|get}` 外部契约稳定
 
 ## 6. Evidence
 
-- [ ] 6.1 记录 RUN_LOG（Scenario 映射、Red/Green 证据、关键命令输出）
-- [ ] 6.2 记录 benchmark 基线结果与阈值判断证据
+- [x] 6.1 记录 RUN_LOG（Scenario 映射、Red/Green 证据、关键命令输出）
+- [x] 6.2 记录 benchmark 基线结果与阈值判断证据
 - [ ] 6.3 记录门禁、Rulebook 校验与 PR 合并证据
-- [ ] 6.4 记录 Dependency Sync Check 的输入、结论（无漂移/已更新）与后续动作
+- [x] 6.4 记录 Dependency Sync Check 的输入、结论（无漂移/已更新）与后续动作

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -34,8 +34,11 @@ export type IpcErrorCode =
   | "NOT_FOUND"
   | "PERMISSION_DENIED"
   | "PROJECT_CAPACITY_EXCEEDED"
+  | "PROJECT_DELETE_REQUIRES_ARCHIVE"
   | "PROJECT_IPC_SCHEMA_INVALID"
+  | "PROJECT_LIFECYCLE_WRITE_FAILED"
   | "PROJECT_METADATA_INVALID_ENUM"
+  | "PROJECT_PURGE_PERMISSION_DENIED"
   | "RATE_LIMITED"
   | "TIMEOUT"
   | "UNSUPPORTED"
@@ -134,6 +137,10 @@ export const IPC_CHANNELS = [
   "memory:semantic:update",
   "memory:settings:get",
   "memory:settings:update",
+  "project:lifecycle:archive",
+  "project:lifecycle:get",
+  "project:lifecycle:purge",
+  "project:lifecycle:restore",
   "project:project:archive",
   "project:project:create",
   "project:project:createaiassist",
@@ -144,6 +151,7 @@ export const IPC_CHANNELS = [
   "project:project:rename",
   "project:project:setcurrent",
   "project:project:stats",
+  "project:project:switch",
   "project:project:update",
   "rag:context:retrieve",
   "search:fulltext:query",
@@ -205,7 +213,10 @@ export type IpcChannelSpec = {
           | "UPSTREAM_ERROR"
           | "INTERNAL"
           | "PROJECT_CAPACITY_EXCEEDED"
+          | "PROJECT_DELETE_REQUIRES_ARCHIVE"
           | "PROJECT_METADATA_INVALID_ENUM"
+          | "PROJECT_PURGE_PERMISSION_DENIED"
+          | "PROJECT_LIFECYCLE_WRITE_FAILED"
           | "PROJECT_IPC_SCHEMA_INVALID"
           | "KG_ATTRIBUTE_KEYS_EXCEEDED"
           | "KG_CAPACITY_EXCEEDED"
@@ -666,7 +677,10 @@ export type IpcChannelSpec = {
                 | "UPSTREAM_ERROR"
                 | "INTERNAL"
                 | "PROJECT_CAPACITY_EXCEEDED"
+                | "PROJECT_DELETE_REQUIRES_ARCHIVE"
                 | "PROJECT_METADATA_INVALID_ENUM"
+                | "PROJECT_PURGE_PERMISSION_DENIED"
+                | "PROJECT_LIFECYCLE_WRITE_FAILED"
                 | "PROJECT_IPC_SCHEMA_INVALID"
                 | "KG_ATTRIBUTE_KEYS_EXCEEDED"
                 | "KG_CAPACITY_EXCEEDED"
@@ -723,7 +737,10 @@ export type IpcChannelSpec = {
                 | "UPSTREAM_ERROR"
                 | "INTERNAL"
                 | "PROJECT_CAPACITY_EXCEEDED"
+                | "PROJECT_DELETE_REQUIRES_ARCHIVE"
                 | "PROJECT_METADATA_INVALID_ENUM"
+                | "PROJECT_PURGE_PERMISSION_DENIED"
+                | "PROJECT_LIFECYCLE_WRITE_FAILED"
                 | "PROJECT_IPC_SCHEMA_INVALID"
                 | "KG_ATTRIBUTE_KEYS_EXCEEDED"
                 | "KG_CAPACITY_EXCEEDED"
@@ -1384,6 +1401,47 @@ export type IpcChannelSpec = {
       privacyModeEnabled: boolean;
     };
   };
+  "project:lifecycle:archive": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      archivedAt?: number;
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:get": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:purge": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:restore": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
   "project:project:archive": {
     request: {
       archived: boolean;
@@ -1485,6 +1543,18 @@ export type IpcChannelSpec = {
       active: number;
       archived: number;
       total: number;
+    };
+  };
+  "project:project:switch": {
+    request: {
+      fromProjectId: string;
+      operatorId: string;
+      projectId: string;
+      traceId: string;
+    };
+    response: {
+      currentProjectId: string;
+      switchedAt: string;
     };
   };
   "project:project:update": {
@@ -1606,7 +1676,10 @@ export type IpcChannelSpec = {
           | "UPSTREAM_ERROR"
           | "INTERNAL"
           | "PROJECT_CAPACITY_EXCEEDED"
+          | "PROJECT_DELETE_REQUIRES_ARCHIVE"
           | "PROJECT_METADATA_INVALID_ENUM"
+          | "PROJECT_PURGE_PERMISSION_DENIED"
+          | "PROJECT_LIFECYCLE_WRITE_FAILED"
           | "PROJECT_IPC_SCHEMA_INVALID"
           | "KG_ATTRIBUTE_KEYS_EXCEEDED"
           | "KG_CAPACITY_EXCEEDED"

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -32,8 +32,11 @@ export type IpcErrorCode =
   | "NOT_FOUND"
   | "PERMISSION_DENIED"
   | "PROJECT_CAPACITY_EXCEEDED"
+  | "PROJECT_DELETE_REQUIRES_ARCHIVE"
   | "PROJECT_IPC_SCHEMA_INVALID"
+  | "PROJECT_LIFECYCLE_WRITE_FAILED"
   | "PROJECT_METADATA_INVALID_ENUM"
+  | "PROJECT_PURGE_PERMISSION_DENIED"
   | "RATE_LIMITED"
   | "TIMEOUT"
   | "UNSUPPORTED"
@@ -126,6 +129,10 @@ export const IPC_CHANNELS = [
   "memory:injection:preview",
   "memory:settings:get",
   "memory:settings:update",
+  "project:lifecycle:archive",
+  "project:lifecycle:get",
+  "project:lifecycle:purge",
+  "project:lifecycle:restore",
   "project:project:archive",
   "project:project:create",
   "project:project:createaiassist",
@@ -136,6 +143,7 @@ export const IPC_CHANNELS = [
   "project:project:rename",
   "project:project:setcurrent",
   "project:project:stats",
+  "project:project:switch",
   "project:project:update",
   "rag:context:retrieve",
   "search:fulltext:query",
@@ -195,7 +203,10 @@ export type IpcChannelSpec = {
           | "UPSTREAM_ERROR"
           | "INTERNAL"
           | "PROJECT_CAPACITY_EXCEEDED"
+          | "PROJECT_DELETE_REQUIRES_ARCHIVE"
           | "PROJECT_METADATA_INVALID_ENUM"
+          | "PROJECT_PURGE_PERMISSION_DENIED"
+          | "PROJECT_LIFECYCLE_WRITE_FAILED"
           | "PROJECT_IPC_SCHEMA_INVALID"
           | "KG_ATTRIBUTE_KEYS_EXCEEDED"
           | "KG_CAPACITY_EXCEEDED"
@@ -654,7 +665,10 @@ export type IpcChannelSpec = {
                 | "UPSTREAM_ERROR"
                 | "INTERNAL"
                 | "PROJECT_CAPACITY_EXCEEDED"
+                | "PROJECT_DELETE_REQUIRES_ARCHIVE"
                 | "PROJECT_METADATA_INVALID_ENUM"
+                | "PROJECT_PURGE_PERMISSION_DENIED"
+                | "PROJECT_LIFECYCLE_WRITE_FAILED"
                 | "PROJECT_IPC_SCHEMA_INVALID"
                 | "KG_ATTRIBUTE_KEYS_EXCEEDED"
                 | "KG_CAPACITY_EXCEEDED"
@@ -709,7 +723,10 @@ export type IpcChannelSpec = {
                 | "UPSTREAM_ERROR"
                 | "INTERNAL"
                 | "PROJECT_CAPACITY_EXCEEDED"
+                | "PROJECT_DELETE_REQUIRES_ARCHIVE"
                 | "PROJECT_METADATA_INVALID_ENUM"
+                | "PROJECT_PURGE_PERMISSION_DENIED"
+                | "PROJECT_LIFECYCLE_WRITE_FAILED"
                 | "PROJECT_IPC_SCHEMA_INVALID"
                 | "KG_ATTRIBUTE_KEYS_EXCEEDED"
                 | "KG_CAPACITY_EXCEEDED"
@@ -1148,6 +1165,47 @@ export type IpcChannelSpec = {
       privacyModeEnabled: boolean;
     };
   };
+  "project:lifecycle:archive": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      archivedAt?: number;
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:get": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:purge": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
+  "project:lifecycle:restore": {
+    request: {
+      projectId: string;
+      traceId?: string;
+    };
+    response: {
+      projectId: string;
+      state: "active" | "archived" | "deleted";
+    };
+  };
   "project:project:archive": {
     request: {
       archived: boolean;
@@ -1249,6 +1307,18 @@ export type IpcChannelSpec = {
       active: number;
       archived: number;
       total: number;
+    };
+  };
+  "project:project:switch": {
+    request: {
+      fromProjectId: string;
+      operatorId: string;
+      projectId: string;
+      traceId: string;
+    };
+    response: {
+      currentProjectId: string;
+      switchedAt: string;
     };
   };
   "project:project:update": {
@@ -1368,7 +1438,10 @@ export type IpcChannelSpec = {
           | "UPSTREAM_ERROR"
           | "INTERNAL"
           | "PROJECT_CAPACITY_EXCEEDED"
+          | "PROJECT_DELETE_REQUIRES_ARCHIVE"
           | "PROJECT_METADATA_INVALID_ENUM"
+          | "PROJECT_PURGE_PERMISSION_DENIED"
+          | "PROJECT_LIFECYCLE_WRITE_FAILED"
           | "PROJECT_IPC_SCHEMA_INVALID"
           | "KG_ATTRIBUTE_KEYS_EXCEEDED"
           | "KG_CAPACITY_EXCEEDED"

--- a/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/.metadata.json
+++ b/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-08T14:45:38.333Z",
+  "updatedAt": "2026-02-08T14:45:38.333Z"
+}

--- a/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/proposal.md
+++ b/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: issue-307-project-management-p1-lifecycle-switch-delete
+
+## Why
+
+`project-management-p1-lifecycle-switch-delete` 当前仅有 PM-2 delta 文档，尚未完成可执行实现与测试闭环。为满足 Project Management 生命周期安全要求，必须补齐项目切换前 autosave flush、删除二次确认、生命周期状态机与异常路径治理能力，并按 OpenSpec + Rulebook + GitHub 门禁完成交付。
+
+## What Changes
+
+- 仅交付 `openspec/changes/project-management-p1-lifecycle-switch-delete` 覆盖范围。
+- 新增并落地 PM2-S1~S10 对应测试（Red→Green→Refactor）。
+- 在主进程实现 `switch/archive/restore/purge/lifecycle:get` 生命周期能力，状态机采用 transition map + guard。
+- 在渲染层实现项目切换加载条（>1s）与删除名称二次确认拦截。
+- 更新 IPC contract / generated types / error code，补齐结构化错误返回。
+- 记录依赖同步检查、Red/Green 证据、门禁与合并证据到 RUN_LOG。
+
+## Impact
+
+- Affected specs:
+  - `openspec/changes/project-management-p1-lifecycle-switch-delete/**`
+- Affected code:
+  - `apps/desktop/main/src/services/projects/**`
+  - `apps/desktop/main/src/ipc/project.ts`
+  - `apps/desktop/main/src/ipc/contract/ipc-contract.ts`
+  - `apps/desktop/renderer/src/features/projects/**`
+  - `apps/desktop/renderer/src/stores/projectStore.tsx`
+  - `apps/desktop/tests/**`（PM-2 对应测试文件）
+  - `packages/shared/types/ipc-generated.ts`
+- Breaking change: NO（保留既有 `project:project:setcurrent`、`project:project:archive`、`project:project:delete` 调用路径）
+- User benefit:
+  - 降低跨项目切换丢稿风险
+  - 强化删除防误操作能力
+  - 形成可恢复、可审计、可回归的生命周期闭环

--- a/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/specs/project-management/spec.md
+++ b/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/specs/project-management/spec.md
@@ -1,0 +1,34 @@
+# Rulebook Delta: project-management（Issue-307）
+
+## Scope
+
+仅实现并交付以下活跃 change：
+
+- `openspec/changes/project-management-p1-lifecycle-switch-delete`
+
+## Requirements Coverage
+
+- 多项目切换：
+  - `project:project:switch` 前必须 flush pending autosave
+  - 切换超过 1 秒显示顶部进度条并在完成后消失
+  - 切换过程触发 KG/MS context hook（mock/no-op）
+- 项目删除：
+  - 删除前必须输入项目名二次确认
+  - 名称不匹配不得触发删除 IPC
+- 生命周期闭环：
+  - 状态机固定 `active -> archived -> deleted`，支持 `archived -> active`
+  - `active -> deleted` 被阻断并返回 `PROJECT_DELETE_REQUIRES_ARCHIVE`
+  - 覆盖并发 purge 冲突、权限不足、数据库写入失败
+- 基线阈值：
+  - `switch` p95 < 1s，p99 < 2s
+  - `archive` p95 < 600ms
+  - `restore` p95 < 800ms
+  - `purge` p95 < 2s（<=1000 文档规模）
+
+## Delivery Guardrails
+
+- Spec-first + Rulebook-first，主 spec 只读
+- 先 Red 再 Green，禁止先写实现
+- 关键命令与结论必须落盘 RUN_LOG
+- 必须通过 `ci`、`openspec-log-guard`、`merge-serial` 并启用 auto-merge
+- 最终收口到控制面 `main`

--- a/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/tasks.md
+++ b/rulebook/tasks/issue-307-project-management-p1-lifecycle-switch-delete/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+- [ ] 1.1 完成任务准入：OPEN Issue、Rulebook task、独立 worktree、依赖同步检查（PM-1 -> PM-2）
+- [ ] 1.2 建立 PM2-S1~S10 的 Scenario→测试映射并设置 Red gate
+- [ ] 1.3 落地主进程生命周期状态机与 `project:project:switch` / `project:lifecycle:{archive|restore|purge|get}` IPC
+- [ ] 1.4 落地渲染层切换加载条与删除二次确认输入校验，并接入 store 调用链
+- [ ] 1.5 保持既有 project IPC 对外契约稳定（兼容旧通道调用）
+
+## 2. Testing
+- [ ] 2.1 PM2-S1~S10 先写失败测试并记录 Red 证据（命令+关键输出）
+- [ ] 2.2 仅以最小实现使新增测试转绿并记录 Green 证据
+- [ ] 2.3 执行相关 unit/integration/renderer/perf 回归并记录阈值结果
+- [ ] 2.4 运行 Rulebook validate 与 preflight，确保门禁一致性
+
+## 3. Documentation
+- [ ] 3.1 维护 `openspec/_ops/task_runs/ISSUE-307.md`（映射、依赖同步、Red/Green、PR、checks）
+- [ ] 3.2 更新 `openspec/changes/project-management-p1-lifecycle-switch-delete/tasks.md` 完成勾选
+- [ ] 3.3 完成交付后归档 change，并同步 `openspec/changes/EXECUTION_ORDER.md`


### PR DESCRIPTION
Closes #307

## Summary
- implement PM2 project switch/delete/lifecycle flow with stable IPC contracts
- add lifecycle state machine and structured lifecycle error handling in main process
- add PM2 S1-S10 test coverage (integration/unit/perf + renderer component tests)
- update change docs/tasks and ISSUE-307 RUN_LOG evidence

## Verification
- pnpm typecheck
- pnpm lint
- pnpm -C apps/desktop exec vitest run renderer/src/features/projects/ProjectSwitcher.loading-bar.test.tsx renderer/src/features/projects/DeleteProjectDialog.confirmation.test.tsx
- pnpm exec tsx apps/desktop/tests/integration/project-switch.autosave.test.ts
- pnpm exec tsx apps/desktop/tests/integration/project-lifecycle.state-machine.test.ts
- pnpm exec tsx apps/desktop/tests/integration/project-purge.concurrent.test.ts
- pnpm exec tsx apps/desktop/tests/integration/project-purge.permission.test.ts
- pnpm exec tsx apps/desktop/tests/unit/projectLifecycle.guard.test.ts
- pnpm exec tsx apps/desktop/tests/unit/projectLifecycle.persistence-failure.test.ts
- pnpm exec tsx apps/desktop/tests/perf/project-lifecycle.benchmark.test.ts
- pnpm exec tsx apps/desktop/tests/unit/projectService.projectActions.test.ts
- pnpm -C apps/desktop exec vitest run renderer/src/features/dashboard/Dashboard.open-project.test.tsx renderer/src/features/dashboard/Dashboard.search.test.tsx renderer/src/features/dashboard/Dashboard.empty-state.test.tsx
- pnpm contract:generate