### PR TITLE
fix: add debounce wait to E2E shortcut toggle tests (#451)

### DIFF
--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -141,6 +141,9 @@ test.describe("Command Palette + Shortcuts", () => {
       await expect(sidebar).toBeVisible();
     }
 
+    // Wait for debounce window (300ms) to expire before toggling back
+    await page.waitForTimeout(350);
+
     // Toggle back
     await page.keyboard.press(`${modKey}+\\`);
 
@@ -168,6 +171,9 @@ test.describe("Command Palette + Shortcuts", () => {
     } else {
       await expect(panel).toBeVisible();
     }
+
+    // Wait for debounce window (300ms) to expire before toggling back
+    await page.waitForTimeout(350);
 
     // Toggle back
     await page.keyboard.press(`${modKey}+l`);


### PR DESCRIPTION
Follow-up to #452 (merged).

Skip-Reason: E2E-only fix for debounce wait introduced in #452. No spec change, no new behavior — only adds waitForTimeout to existing E2E tests.

The 300ms keyboard shortcut debounce introduced in #452 causes E2E tests `Cmd/Ctrl+\` and `Cmd/Ctrl+L` to fail because the toggle-back press fires within the debounce window.

**Fix**: Add `await page.waitForTimeout(350)` between the two toggle presses in `command-palette.spec.ts`.