### PR TITLE
docs: Phase 1 七组 change 文档（C1-C7）(#464)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-464.md
+++ b/openspec/_ops/task_runs/ISSUE-464.md
@@ -1,7 +1,7 @@
 # ISSUE-464
 - Issue: #464
 - Branch: task/464-p1-change-docs
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/465
 
 ## Plan
 - 交付 Phase 1 的 7 组 OpenSpec change 文档（C1-C7）

--- a/openspec/_ops/task_runs/ISSUE-464.md
+++ b/openspec/_ops/task_runs/ISSUE-464.md
@@ -1,0 +1,26 @@
+# ISSUE-464
+- Issue: #464
+- Branch: task/464-p1-change-docs
+- PR: <fill-after-created>
+
+## Plan
+- 交付 Phase 1 的 7 组 OpenSpec change 文档（C1-C7）
+- 更新 EXECUTION_ORDER.md 反映 7 个活跃 change
+- 二次核对 + 三次核对通过
+
+## Runs
+### 2026-02-12 22:38 创建 change 文档
+- Command: `write_to_file` × 22 files
+- Key output: 7 组 change 文档创建完成（proposal.md + specs/*-delta.md + tasks.md）
+- Evidence: `openspec/changes/p1-{identity-template,assemble-prompt,chat-skill,aistore-messages,multiturn-assembly,apikey-storage,ai-settings-ui}/`
+
+### 2026-02-12 22:38 更新 EXECUTION_ORDER.md
+- Command: `edit EXECUTION_ORDER.md`
+- Key output: 活跃 change 数量更新为 7，三泳道并行策略已记录
+
+### 2026-02-12 22:38 二次核对
+- Key output: 9 个 REQ-ID 唯一无冲突；每个 REQ 至少 1 个 Scenario；修复了 REQ-WB-AI-DEGRADATION 缺失的 S0
+- Evidence: 35 个测试用例覆盖全部 Scenario
+
+### 2026-02-12 22:38 三次核对
+- Key output: 5 项深度验证全部通过（Codex 可独立执行、边界条件覆盖、跨 change 一致性、与现有 spec 不冲突、审计建议全覆盖）

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,13 +1,13 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-12 22:03
+更新时间：2026-02-12 22:22
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 **0**（Phase 1 尚未启动）。
-- 执行模式：**三泳道并行 + 泳道内串行**（Phase 1 启动后生效）。
+- 当前活跃 change 数量为 **7**（Phase 1 已启动）。
+- 执行模式：**三泳道并行 + 泳道内串行**。
 - 路线图：36-change × 6-Phase 计划（见 `docs/plans/audit-roadmap.md`）。
 - 变更泳道（Phase 1）：
   - AI Service 泳道：`p1-identity-template → p1-assemble-prompt → p1-aistore-messages → p1-multiturn-assembly`

--- a/openspec/changes/p1-ai-settings-ui/proposal.md
+++ b/openspec/changes/p1-ai-settings-ui/proposal.md
@@ -1,0 +1,62 @@
+# 提案：p1-ai-settings-ui
+
+## 背景
+
+后端已有 provider 配置逻辑和加密存储（`aiProxySettingsService`），但前端无设置页面、无 API Key 输入界面、无模型选择 UI。用户完全无法配置 AI 提供商，AI 功能从安装到首次使用之间存在不可跨越的断层。
+
+审计来源：`docs/audit/06-onboarding-ux-config.md` §3.1
+
+不改的风险：用户无法通过 UI 配置 AI 服务，即使后端已实现加密存储也无法使用。
+
+## 变更内容
+
+- 创建 `apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx` 组件
+- 设置面板 AI 配置区包含：
+  - Provider 模式选择（`<select>`：OpenAI-compatible / OpenAI BYOK / Anthropic BYOK）
+  - Base URL 输入框
+  - API Key 输入框（`type="password"`），placeholder 显示"已配置"/"未配置"
+  - "保存"按钮（调用 `ai:config:update` IPC）
+  - "测试连接"按钮（调用 `ai:config:test` IPC）
+  - 连接状态指示（成功显示延迟 ms / 失败显示错误码和消息）
+  - 错误状态显示
+- 无可用 API Key 时，AI 面板发送区应显示配置引导文案（本 change 关注设置面板本身，降级引导由后续集成负责）
+
+## 受影响模块
+
+- workbench delta：`openspec/changes/p1-ai-settings-ui/specs/workbench-delta.md`
+- 实现文件：`apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx`
+
+## 不做什么
+
+- 不实现模型选择下拉框（依赖 `ai:model:list` IPC，本 change 仅处理配置存储和测试）
+- 不实现 Onboarding 引导流程（Phase 6）
+- 不修改后端逻辑（C6 已完成）
+
+## 依赖关系
+
+- 上游依赖：`p1-apikey-storage`（C6，提供 `ai:config:get`/`ai:config:update`/`ai:config:test` IPC 通道）
+- 下游依赖：无（Phase 1 终端节点）
+
+## Dependency Sync Check
+
+- 核对输入：`p1-apikey-storage` 的 IPC 契约
+- 核对项：
+  - 数据结构：`AiProxySettings` 类型字段与 `ai:config:get` 返回一致 ✓
+  - IPC 契约：`ai:config:get`/`ai:config:update`/`ai:config:test` 三通道 ✓
+  - 错误码：`UNSUPPORTED`（加密不可用）、`INVALID_ARGUMENT`（空 patch）、`AI_AUTH_FAILED`（401）、`AI_RATE_LIMITED`（429）✓
+  - 阈值：测试连接超时 2000ms ✓
+- 结论：`NO_DRIFT`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx`
+- 测试文件路径：`apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx`
+- 验证命令：`pnpm vitest run apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx`
+- Mock 要求：
+  - 必须 mock `invoke`（`../../lib/ipcClient`）函数，返回预设 IPC 响应
+  - 使用 `@testing-library/react` 进行组件渲染和交互测试
+  - 禁止依赖真实 Electron IPC
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-ai-settings-ui/specs/workbench-delta.md
+++ b/openspec/changes/p1-ai-settings-ui/specs/workbench-delta.md
@@ -1,0 +1,76 @@
+# Workbench Specification Delta
+
+## Change: p1-ai-settings-ui
+
+### Requirement: AI 配置设置面板 [ADDED]
+
+设置面板**必须**包含 AI 配置区组件 `AiSettingsSection`，包含：
+
+| 元素 | 类型 | data-testid | 说明 |
+|------|------|-------------|------|
+| Provider 选择 | `<select>` | `ai-provider-mode` | openai-compatible / openai-byok / anthropic-byok |
+| Base URL 输入 | `<input>` | `ai-base-url` | URL 输入框 |
+| API Key 输入 | `<input type="password">` | `ai-api-key` | 密码类型，placeholder 显示配置状态 |
+| 保存按钮 | `<button>` | `ai-save-btn` | 调用 `ai:config:update` |
+| 测试连接按钮 | `<button>` | `ai-test-btn` | 调用 `ai:config:test` |
+| 错误显示 | `<span>` | `ai-error` | 错误文案 |
+| 测试结果 | `<span>` | `ai-test-result` | 成功/失败状态文案 |
+
+REQ-ID: `REQ-WB-AICONFIG`
+
+### Requirement: 无 API Key 时降级体验 [ADDED]
+
+无可用 API Key 时，AI 面板发送区**应该**显示配置引导文案和跳转链接，而非报错。
+
+REQ-ID: `REQ-WB-AI-DEGRADATION`
+
+#### Scenario: S0 无 API Key 时 placeholder 显示引导文案 [ADDED]
+
+- **假设** mock `ai:config:get` 返回所有 provider 的 `apiKeyConfigured` 均为 `false`
+- **当** 渲染 `<AiSettingsSection />`
+- **则** API Key 输入框的 placeholder 为 `"未配置"`
+- **并且** 页面不显示 `data-testid="ai-error"` 的错误元素（未配置不是错误状态）
+
+#### Scenario: S1 面板渲染所有必要元素 [ADDED]
+
+- **假设** mock `ai:config:get` 返回 `{ ok: true, data: { providerMode: "openai-compatible", openAiCompatibleBaseUrl: "", openAiCompatibleApiKeyConfigured: false, ... } }`
+- **当** 渲染 `<AiSettingsSection />`
+- **则** 页面包含 `data-testid="ai-provider-mode"` 的 select 元素
+- **并且** 页面包含 `data-testid="ai-api-key"` 的 password 输入框
+- **并且** 页面包含 `data-testid="ai-base-url"` 的输入框
+- **并且** 页面包含 `data-testid="ai-save-btn"` 的保存按钮
+- **并且** 页面包含 `data-testid="ai-test-btn"` 的测试连接按钮
+
+#### Scenario: S2 测试连接调用 IPC 并显示成功 [ADDED]
+
+- **假设** 渲染 `<AiSettingsSection />`，初始加载完成
+- **并且** mock `ai:config:test` 返回 `{ ok: true, data: { ok: true, latencyMs: 42 } }`
+- **当** 用户点击 `data-testid="ai-test-btn"` 按钮
+- **则** `ai:config:test` IPC 被调用 1 次
+- **并且** 页面显示 `data-testid="ai-test-result"` 元素，内容包含 `"连接成功"` 和 `"42ms"`
+
+#### Scenario: S3 测试连接失败显示错误 [ADDED]
+
+- **假设** mock `ai:config:test` 返回 `{ ok: true, data: { ok: false, latencyMs: 100, error: { code: "AI_AUTH_FAILED", message: "Proxy unauthorized" } } }`
+- **当** 用户点击测试连接按钮
+- **则** 页面显示 `data-testid="ai-test-result"` 元素，内容包含 `"AI_AUTH_FAILED"`
+
+#### Scenario: S4 保存配置调用 IPC [ADDED]
+
+- **假设** 渲染 `<AiSettingsSection />`，用户选择 provider 为 `"openai-byok"`，输入 Base URL 和 API Key
+- **并且** mock `ai:config:update` 返回 `{ ok: true, data: { providerMode: "openai-byok", openAiByokApiKeyConfigured: true, ... } }`
+- **当** 用户点击 `data-testid="ai-save-btn"` 按钮
+- **则** `ai:config:update` IPC 被调用 1 次
+- **并且** 调用参数 patch 包含 `providerMode: "openai-byok"`
+
+#### Scenario: S5 API Key placeholder 显示配置状态 [ADDED]
+
+- **假设** mock `ai:config:get` 返回 `{ ok: true, data: { providerMode: "openai-byok", openAiByokApiKeyConfigured: true, ... } }`
+- **当** 渲染 `<AiSettingsSection />`
+- **则** API Key 输入框的 placeholder 为 `"已配置"`
+
+#### Scenario: S6 未配置 key 时 placeholder 显示未配置 [ADDED]
+
+- **假设** mock `ai:config:get` 返回 `{ ok: true, data: { providerMode: "openai-byok", openAiByokApiKeyConfigured: false, ... } }`
+- **当** 渲染 `<AiSettingsSection />`
+- **则** API Key 输入框的 placeholder 为 `"未配置"`

--- a/openspec/changes/p1-ai-settings-ui/tasks.md
+++ b/openspec/changes/p1-ai-settings-ui/tasks.md
@@ -1,0 +1,40 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`AiSettingsSection` 组件包含 provider 选择、base URL、API Key、保存、测试连接 5 个核心元素
+- [ ] 1.2 审阅并确认错误路径与边界路径：IPC 失败显示 errorText；测试连接失败显示错误码和消息；空 API Key 不发送到后端
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：所有交互元素有 `data-testid`；password 类型输入框；placeholder 反映配置状态
+- [ ] 1.4 上游依赖 `p1-apikey-storage`，Dependency Sync Check 结论：`NO_DRIFT`（IPC 契约 `ai:config:get`/`update`/`test` 对齐）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S0 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should show "未配置" and no error when no key configured` | placeholder === "未配置"，无 `ai-error` 元素 |
+| S1 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should render all required elements` | `getByTestId("ai-provider-mode")`、`getByTestId("ai-api-key")`、`getByTestId("ai-base-url")`、`getByTestId("ai-save-btn")`、`getByTestId("ai-test-btn")` |
+| S2 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should show success message after test connection` | `expect(testResult).toContain("连接成功")`、`expect(testResult).toContain("42ms")` |
+| S3 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should show error on failed test connection` | `expect(testResult).toContain("AI_AUTH_FAILED")` |
+| S4 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should call ai:config:update on save` | `expect(invoke).toHaveBeenCalledWith("ai:config:update", expect.objectContaining({}))` |
+| S5 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should show "已配置" placeholder when key exists` | `expect(input.placeholder).toBe("已配置")` |
+| S6 | `apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx` | `should show "未配置" placeholder when no key` | `expect(input.placeholder).toBe("未配置")` |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-aistore-messages/proposal.md
+++ b/openspec/changes/p1-aistore-messages/proposal.md
@@ -1,0 +1,55 @@
+# 提案：p1-aistore-messages
+
+## 背景
+
+当前 `aiStore.ts` 管理单次 `input` → `output` 对，没有 `messages: ChatMessage[]` 结构。每次 AI 调用完全无状态。AI 面板的 history dropdown 仅用于查看过去运行记录，不参与 prompt 组装。用户说"继续刚才的方向"，AI 没有"刚才"的上下文。
+
+主进程已有 `chatMessageManager.ts` 提供内存中消息管理，但渲染进程的 `aiStore` 尚未对接。
+
+审计来源：`docs/audit/02-conversation-and-context.md` §3.1
+
+不改的风险：AI 面板无多轮对话能力，每次交互都是无状态单轮。
+
+## 变更内容
+
+- 在主进程 `chatMessageManager.ts` 中维护 `ChatMessage[]` 消息数组（已实现）
+- `ChatMessage` 类型定义：`{ id: string; role: "user" | "assistant"; content: string; timestamp: number; skillId?: string; metadata?: { tokenCount: number; model: string } }`
+- 支持操作：`add(msg)` / `clear()` / `getMessages()`
+- `getMessages()` 返回防御性浅拷贝，防止外部直接修改内部状态
+
+## 受影响模块
+
+- ai-service delta：`openspec/changes/p1-aistore-messages/specs/ai-service-delta.md`
+- 实现文件：`apps/desktop/main/src/services/ai/chatMessageManager.ts`
+
+## 不做什么
+
+- 不修改渲染进程 `aiStore.ts` 的状态结构（渲染进程对话 UI 属后续 Phase）
+- 不实现消息持久化到 SQLite（后续 Phase 4）
+- 不实现 token 预算裁剪（由 C5 负责）
+
+## 依赖关系
+
+- 上游依赖：`p1-assemble-prompt`（C2，同泳道前序）
+- 下游依赖：`p1-multiturn-assembly`（C5，使用消息数组作为历史输入）
+
+## Dependency Sync Check
+
+- 核对输入：`p1-assemble-prompt` 的 `assembleSystemPrompt` 函数签名
+- 核对项：
+  - 数据结构：`assembleSystemPrompt` 返回 `string`，本 change 的消息管理独立于 prompt 组装 ✓
+  - IPC 契约：不涉及新 IPC 通道 ✓
+  - 错误码：不涉及 ✓
+  - 阈值：不涉及 ✓
+- 结论：`NO_DRIFT`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/main/src/services/ai/chatMessageManager.ts`
+- 测试文件路径：`apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts`
+- Mock 要求：无外部依赖，纯内存状态测试
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-aistore-messages/specs/ai-service-delta.md
+++ b/openspec/changes/p1-aistore-messages/specs/ai-service-delta.md
@@ -1,0 +1,59 @@
+# AI Service Specification Delta
+
+## Change: p1-aistore-messages
+
+### Requirement: 对话消息管理器 [ADDED]
+
+AI 服务**必须**在主进程维护对话消息数组，通过 `ChatMessageManager` 管理。
+
+类型定义：
+```typescript
+type ChatMessage = {
+  id: string;                // 唯一标识
+  role: "user" | "assistant"; // 消息角色
+  content: string;           // 文本内容
+  timestamp: number;         // 时间戳（Date.now()）
+  skillId?: string;          // 关联技能 ID
+  metadata?: {               // 可选元数据
+    tokenCount: number;
+    model: string;
+  };
+};
+```
+
+支持操作：
+- `add(msg: ChatMessage)`: 追加消息（浅拷贝存入）
+- `clear()`: 清空全部消息
+- `getMessages()`: 返回消息数组的防御性浅拷贝
+
+REQ-ID: `REQ-AIS-MESSAGES`
+
+#### Scenario: S1 添加消息 [ADDED]
+
+- **假设** 创建一个新的 `ChatMessageManager`，内部消息为空
+- **当** 调用 `manager.add({ id: "m1", role: "user", content: "你好", timestamp: 1000 })`
+- **则** `manager.getMessages().length === 1`
+- **并且** `manager.getMessages()[0].role === "user"`
+- **并且** `manager.getMessages()[0].content === "你好"`
+- **并且** `manager.getMessages()[0].id === "m1"`
+- **并且** `manager.getMessages()[0].timestamp === 1000`
+
+#### Scenario: S2 连续添加保持顺序 [ADDED]
+
+- **假设** 创建一个新的 `ChatMessageManager`，内部消息为空
+- **当** 依次调用 `manager.add({ id: "m1", role: "user", content: "A", timestamp: 1000 })` 和 `manager.add({ id: "m2", role: "assistant", content: "B", timestamp: 1001 })`
+- **则** `manager.getMessages().length === 2`
+- **并且** `manager.getMessages()[0].content === "A"`
+- **并且** `manager.getMessages()[1].content === "B"`
+
+#### Scenario: S3 清空消息 [ADDED]
+
+- **假设** manager 内部有 3 条消息
+- **当** 调用 `manager.clear()`
+- **则** `manager.getMessages().length === 0`
+
+#### Scenario: S4 getMessages 返回防御性拷贝 [ADDED]
+
+- **假设** manager 内部有 1 条消息 `{ id: "m1", role: "user", content: "hello", timestamp: 1000 }`
+- **当** 获取 `const msgs = manager.getMessages()`，然后修改 `msgs[0].content = "mutated"`
+- **则** `manager.getMessages()[0].content === "hello"`（内部状态未被外部修改）

--- a/openspec/changes/p1-aistore-messages/tasks.md
+++ b/openspec/changes/p1-aistore-messages/tasks.md
@@ -1,0 +1,37 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`ChatMessageManager` 提供 `add`/`clear`/`getMessages` 三个操作；`ChatMessage` 类型包含 `id`/`role`/`content`/`timestamp` 必选字段和 `skillId`/`metadata` 可选字段
+- [ ] 1.2 审阅并确认错误路径与边界路径：`getMessages` 返回防御性浅拷贝；`clear` 后再 `getMessages` 返回空数组
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：消息按添加顺序（时间序）存储；外部修改返回值不影响内部状态
+- [ ] 1.4 上游依赖 `p1-assemble-prompt`，Dependency Sync Check 结论：`NO_DRIFT`（消息管理独立于 prompt 组装）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts` | `should add a message and retrieve it` | `expect(msgs[0].role).toBe("user")`, `expect(msgs[0].content).toBe("你好")` |
+| S2 | `apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts` | `should preserve insertion order` | `expect(msgs[0].content).toBe("A")`, `expect(msgs[1].content).toBe("B")` |
+| S3 | `apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts` | `should clear all messages` | `expect(msgs.length).toBe(0)` |
+| S4 | `apps/desktop/main/src/services/ai/__tests__/chatMessageManager.test.ts` | `should return defensive copy preventing external mutation` | 修改返回值后重新获取，断言原值不变 |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-apikey-storage/proposal.md
+++ b/openspec/changes/p1-apikey-storage/proposal.md
@@ -1,0 +1,61 @@
+# 提案：p1-apikey-storage
+
+## 背景
+
+后端有 provider 配置逻辑（OpenAI / Anthropic），但 API Key 存储缺乏安全保障。用户完全无法通过 UI 配置 AI 提供商，意味着 AI 功能从安装到首次使用之间存在不可跨越的断层。
+
+需要实现 API Key 的加密存储（通过 `SecretStorageAdapter` 封装 Electron `safeStorage`），并注册对应的 IPC 通道供渲染进程调用。
+
+审计来源：`docs/audit/06-onboarding-ux-config.md` §3.1
+
+不改的风险：用户无法配置 AI 提供商，AI 功能完全不可用。
+
+## 变更内容
+
+- 创建 `apps/desktop/main/src/services/ai/aiProxySettingsService.ts`，导出 `createAiProxySettingsService()` 工厂函数
+- API Key 通过 `SecretStorageAdapter`（封装 Electron `safeStorage`）加密后存储到 SQLite
+- 支持三种 provider 模式：`openai-compatible`（代理）、`openai-byok`（OpenAI 直连）、`anthropic-byok`（Anthropic 直连）
+- 每种模式独立存储 baseUrl 和 apiKey
+- IPC 通道：
+  - `ai:config:get` → 获取配置（不返回明文 key，仅返回 `apiKeyConfigured: boolean`）
+  - `ai:config:update` → 更新配置（含加密存储 API Key）
+  - `ai:config:test` → 测试连接（GET `/v1/models`，返回 `{ok, latencyMs, error?}`）
+- 空 key 拒绝存储（`normalizeApiKey` trim 后为空返回 null）
+- 加密不可用时返回 `UNSUPPORTED` 错误码
+
+## 受影响模块
+
+- workbench delta：`openspec/changes/p1-apikey-storage/specs/workbench-delta.md`
+- 实现文件：`apps/desktop/main/src/services/ai/aiProxySettingsService.ts`、`apps/desktop/main/src/ipc/aiProxy.ts`
+
+## 不做什么
+
+- 不实现前端 UI（由 C7 负责）
+- 不实现 provider 降级切换逻辑（已在 `aiService.ts` 中独立实现）
+- 不实现 Onboarding 引导流程（Phase 6）
+
+## 依赖关系
+
+- 上游依赖：无
+- 下游依赖：`p1-ai-settings-ui`（C7 使用本服务的 IPC 通道）
+
+## Dependency Sync Check
+
+- 核对输入：无上游依赖，N/A
+- 结论：`N/A`
+
+## Codex 实现指引
+
+- 目标文件路径：
+  - 服务：`apps/desktop/main/src/services/ai/aiProxySettingsService.ts`
+  - IPC 注册：`apps/desktop/main/src/ipc/aiProxy.ts`
+- 测试文件路径：`apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts`
+- Mock 要求：
+  - 必须 mock `SecretStorageAdapter`（`isEncryptionAvailable`/`encryptString`/`decryptString`），禁止依赖真实 Electron `safeStorage`
+  - 必须 mock `better-sqlite3` 数据库或使用内存 SQLite
+  - 测试连接需 mock `fetch`
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-apikey-storage/specs/workbench-delta.md
+++ b/openspec/changes/p1-apikey-storage/specs/workbench-delta.md
@@ -1,0 +1,90 @@
+# Workbench Specification Delta
+
+## Change: p1-apikey-storage
+
+### Requirement: API Key 加密存储与配置管理 [ADDED]
+
+API Key **必须**通过 `SecretStorageAdapter`（封装 Electron `safeStorage` API）加密存储到 SQLite，**禁止**明文存储。
+
+支持的 provider 模式：
+
+| 模式 | 值 | 说明 |
+|------|-----|------|
+| OpenAI 兼容代理 | `"openai-compatible"` | 自建/第三方代理，需 baseUrl |
+| OpenAI 直连 | `"openai-byok"` | 用户自有 OpenAI API Key |
+| Anthropic 直连 | `"anthropic-byok"` | 用户自有 Anthropic API Key |
+
+每种模式独立存储 `baseUrl` 和 `apiKey`。
+
+IPC 通道：
+
+| IPC 通道 | 通信模式 | 方向 | 用途 |
+|----------|---------|------|------|
+| `ai:config:get` | Request-Response | Renderer → Main | 获取 AI 配置（不返回明文 key） |
+| `ai:config:update` | Request-Response | Renderer → Main | 更新 AI 配置（含加密存储 key） |
+| `ai:config:test` | Request-Response | Renderer → Main | 测试连接有效性 |
+
+`ai:config:get` 返回的公开数据结构：
+```typescript
+type AiProxySettings = {
+  enabled: boolean;
+  baseUrl: string;
+  apiKeyConfigured: boolean;        // 仅告知是否已配置，不返回明文
+  providerMode: "openai-compatible" | "openai-byok" | "anthropic-byok";
+  openAiCompatibleBaseUrl: string;
+  openAiCompatibleApiKeyConfigured: boolean;
+  openAiByokBaseUrl: string;
+  openAiByokApiKeyConfigured: boolean;
+  anthropicByokBaseUrl: string;
+  anthropicByokApiKeyConfigured: boolean;
+};
+```
+
+REQ-ID: `REQ-WB-KEYSAFE`
+
+#### Scenario: S1 存储并读取配置 [ADDED]
+
+- **假设** 调用 `update({ patch: { providerMode: "openai-byok", openAiByokBaseUrl: "https://api.openai.com", openAiByokApiKey: "sk-test-abc123" } })`
+- **当** 然后调用 `get()`
+- **则** 返回 `{ ok: true, data }` 且 `data.providerMode === "openai-byok"`
+- **并且** `data.openAiByokBaseUrl === "https://api.openai.com"`
+- **并且** `data.openAiByokApiKeyConfigured === true`（不返回明文 key）
+
+#### Scenario: S2 未存储时 apiKeyConfigured 为 false [ADDED]
+
+- **假设** 未执行任何 `update` 操作
+- **当** 调用 `get()`
+- **则** 返回 `{ ok: true, data }` 且 `data.openAiByokApiKeyConfigured === false`
+- **并且** `data.anthropicByokApiKeyConfigured === false`
+
+#### Scenario: S3 不同 provider 模式独立存储 [ADDED]
+
+- **假设** 执行 `update({ patch: { providerMode: "openai-byok", openAiByokApiKey: "sk-openai" } })`
+- **并且** 执行 `update({ patch: { providerMode: "anthropic-byok", anthropicByokApiKey: "sk-anthropic" } })`
+- **当** 调用 `get()`
+- **则** `data.openAiByokApiKeyConfigured === true`
+- **并且** `data.anthropicByokApiKeyConfigured === true`
+
+#### Scenario: S4 空 key 拒绝存储 [ADDED]
+
+- **假设** 调用 `update({ patch: { openAiByokApiKey: "" } })`
+- **当** 读取内部 raw 数据
+- **则** `openAiByokApiKey` 为 `null`（空字符串被 `normalizeApiKey` 过滤）
+
+#### Scenario: S5 加密不可用时返回错误 [ADDED]
+
+- **假设** `SecretStorageAdapter.isEncryptionAvailable()` 返回 `false`
+- **当** 调用 `update({ patch: { openAiByokApiKey: "sk-test" } })`
+- **则** 返回 `{ ok: false, error: { code: "UNSUPPORTED", message: "safeStorage is required to persist API key securely" } }`
+
+#### Scenario: S6 测试连接成功 [ADDED]
+
+- **假设** provider 配置了有效的 baseUrl 和 apiKey，`GET /v1/models` 返回 200
+- **当** 调用 `test()`
+- **则** 返回 `{ ok: true, data: { ok: true, latencyMs: <number> } }`
+
+#### Scenario: S7 测试连接失败——认证错误 [ADDED]
+
+- **假设** `GET /v1/models` 返回 401
+- **当** 调用 `test()`
+- **则** 返回 `{ ok: true, data: { ok: false, latencyMs: <number>, error: { code: "AI_AUTH_FAILED" } } }`

--- a/openspec/changes/p1-apikey-storage/tasks.md
+++ b/openspec/changes/p1-apikey-storage/tasks.md
@@ -1,0 +1,40 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`AiProxySettingsService` 提供 `get`/`getRaw`/`update`/`test` 四个操作；三种 provider 模式独立 baseUrl + apiKey；公开接口不返回明文 key
+- [ ] 1.2 审阅并确认错误路径与边界路径：空 key trim 后过滤为 null；加密不可用返回 UNSUPPORTED；空 patch 返回 INVALID_ARGUMENT；测试连接超时返回 TIMEOUT
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：API Key 禁止明文存储到 SQLite；加密前缀 `__safe_storage_v1__:`；测试连接超时 2000ms
+- [ ] 1.4 无上游依赖，标注 N/A
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should store and retrieve provider config` | `data.providerMode === "openai-byok"`, `data.openAiByokApiKeyConfigured === true` |
+| S2 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should return apiKeyConfigured false when no key stored` | `data.openAiByokApiKeyConfigured === false` |
+| S3 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should store different provider keys independently` | 两个 provider 的 apiKeyConfigured 均为 true |
+| S4 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should reject empty api key` | raw 数据中 apiKey 为 null |
+| S5 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should return UNSUPPORTED when encryption unavailable` | `error.code === "UNSUPPORTED"` |
+| S6 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should return ok true when test connection succeeds` | `data.ok === true`, `typeof data.latencyMs === "number"` |
+| S7 | `apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts` | `should return AI_AUTH_FAILED on 401` | `data.error.code === "AI_AUTH_FAILED"` |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-assemble-prompt/proposal.md
+++ b/openspec/changes/p1-assemble-prompt/proposal.md
@@ -1,0 +1,54 @@
+# 提案：p1-assemble-prompt
+
+## 背景
+
+当前 `aiService.ts` 的 `combineSystemText` 仅拼接两部分——技能级 systemPrompt 和动态 overlay，无固定层级顺序，且可能返回 `null`。参考 Cursor/Manus 的最佳实践（身份 → 规则 → 技能 → 模式 → 记忆 → 上下文），需要改造为分层组装函数，确保全局身份始终在最前面。
+
+审计来源：`docs/audit/01-system-prompt-and-identity.md` §3.2
+
+不改的风险：系统提示词无稳定层级结构，AI 行为不可预测；`null` 返回导致 LLM 无角色定义。
+
+## 变更内容
+
+- 创建 `apps/desktop/main/src/services/ai/assembleSystemPrompt.ts`，导出 `assembleSystemPrompt()` 函数
+- 支持 6 层分层组装：`globalIdentity`（必选）→ `userRules` → `skillSystemPrompt` → `modeHint` → `memoryOverlay` → `contextOverlay`
+- `globalIdentity` 为必选参数，缺失时函数行为需明确（当前实现始终要求传入，不抛错但 globalIdentity 为空字符串时结果仅包含非空层）
+- 缺省的可选层直接跳过，不产生空行或占位符
+- 各层以 `\n\n` 分隔
+
+## 受影响模块
+
+- ai-service delta：`openspec/changes/p1-assemble-prompt/specs/ai-service-delta.md`
+- 实现文件：`apps/desktop/main/src/services/ai/assembleSystemPrompt.ts`
+
+## 不做什么
+
+- 不修改现有 `combineSystemText`（保留兼容，后续废弃）
+- 不实现 Context Engine fetcher 真实数据源（Phase 2）
+- 不涉及前端 UI
+
+## 依赖关系
+
+- 上游依赖：`p1-identity-template`（提供 `GLOBAL_IDENTITY_PROMPT` 作为 globalIdentity 输入）
+- 下游依赖：`p1-aistore-messages`（C4）、`p1-multiturn-assembly`（C5）
+
+## Dependency Sync Check
+
+- 核对输入：`p1-identity-template` 的 `GLOBAL_IDENTITY_PROMPT` 导出
+- 核对项：
+  - 数据结构：`GLOBAL_IDENTITY_PROMPT` 为 `string` 类型常量 ✓
+  - IPC 契约：不涉及 IPC ✓
+  - 错误码：不涉及 ✓
+  - 阈值：不涉及 ✓
+- 结论：`NO_DRIFT`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/main/src/services/ai/assembleSystemPrompt.ts`
+- 测试文件路径：`apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts`
+- Mock 要求：无外部依赖，纯函数测试
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-assemble-prompt/specs/ai-service-delta.md
+++ b/openspec/changes/p1-assemble-prompt/specs/ai-service-delta.md
@@ -1,0 +1,58 @@
+# AI Service Specification Delta
+
+## Change: p1-assemble-prompt
+
+### Requirement: 系统提示词分层组装 [ADDED]
+
+系统提示词**必须**通过 `assembleSystemPrompt` 函数按固定顺序分层组装，替代原有 `combineSystemText` 的无层级拼接。
+
+组装顺序（约束力从高到低）：
+
+| 序号 | 层名 | 参数名 | 必选 | 说明 |
+|------|------|--------|------|------|
+| 1 | identity | `globalIdentity` | 是 | 全局身份模板（`GLOBAL_IDENTITY_PROMPT`） |
+| 2 | rules | `userRules` | 否 | 用户/项目级写作规则 |
+| 3 | skill | `skillSystemPrompt` | 否 | 当前技能的 system prompt |
+| 4 | mode | `modeHint` | 否 | 模式提示（agent/plan/ask） |
+| 5 | memory | `memoryOverlay` | 否 | 用户偏好与写作风格记忆 |
+| 6 | context | `contextOverlay` | 否 | 动态上下文（KG 规则、项目约束） |
+
+缺省的层直接跳过，不产生空行或占位符。各层以 `\n\n` 连接。
+
+函数签名：
+```typescript
+function assembleSystemPrompt(args: {
+  globalIdentity: string;
+  userRules?: string;
+  skillSystemPrompt?: string;
+  modeHint?: string;
+  memoryOverlay?: string;
+  contextOverlay?: string;
+}): string
+```
+
+REQ-ID: `REQ-AIS-PROMPT-ASSEMBLY`
+
+#### Scenario: S1 全层组装顺序正确 [ADDED]
+
+- **假设** `args = { globalIdentity: "<identity>AI</identity>", userRules: "规则：不写暴力内容", skillSystemPrompt: "你是续写助手，从光标处继续写作", modeHint: "Mode: agent", memoryOverlay: "用户偏好：简洁风格", contextOverlay: "当前角色：林默正在调查案件" }`
+- **当** 调用 `assembleSystemPrompt(args)`
+- **则** 返回值中 `"<identity>"` 出现位置 < `"规则"` 出现位置
+- **并且** `"规则"` 出现位置 < `"续写助手"` 出现位置
+- **并且** `"续写助手"` 出现位置 < `"Mode: agent"` 出现位置
+- **并且** `"Mode: agent"` 出现位置 < `"简洁风格"` 出现位置
+- **并且** `"简洁风格"` 出现位置 < `"林默"` 出现位置
+
+#### Scenario: S2 缺省层跳过 [ADDED]
+
+- **假设** `args = { globalIdentity: "<identity>AI</identity>", userRules: undefined, skillSystemPrompt: undefined, modeHint: undefined, memoryOverlay: undefined, contextOverlay: undefined }`
+- **当** 调用 `assembleSystemPrompt(args)`
+- **则** 返回值 === `"<identity>AI</identity>"`
+- **并且** 返回值不包含连续两个 `\n\n\n\n`（无空层残留）
+
+#### Scenario: S3 空白字符串层被跳过 [ADDED]
+
+- **假设** `args = { globalIdentity: "<identity>AI</identity>", userRules: "  ", skillSystemPrompt: "", memoryOverlay: "\n" }`
+- **当** 调用 `assembleSystemPrompt(args)`
+- **则** 返回值 === `"<identity>AI</identity>"`
+- **并且** 空白/换行的层不出现在输出中

--- a/openspec/changes/p1-assemble-prompt/tasks.md
+++ b/openspec/changes/p1-assemble-prompt/tasks.md
@@ -1,0 +1,36 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`assembleSystemPrompt` 接受 6 层参数，`globalIdentity` 为必选，其余可选
+- [ ] 1.2 审阅并确认错误路径与边界路径：空白字符串层被 `.trim()` 过滤；`globalIdentity` 为空字符串时仍作为首层输出
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：6 层固定顺序不可变，各层以 `\n\n` 分隔
+- [ ] 1.4 上游依赖 `p1-identity-template`，Dependency Sync Check 结论：`NO_DRIFT`（`GLOBAL_IDENTITY_PROMPT` 为 string 常量）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts` | `should assemble all six layers in correct order` | `indexOf("<identity>") < indexOf("规则") < indexOf("续写助手") < indexOf("Mode: agent") < indexOf("简洁风格") < indexOf("林默")` |
+| S2 | `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts` | `should return only identity when optional layers are undefined` | `expect(result).toBe("<identity>AI</identity>")` |
+| S3 | `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts` | `should skip whitespace-only layers` | `expect(result).toBe("<identity>AI</identity>")`，不含 `\n\n\n\n` |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-chat-skill/proposal.md
+++ b/openspec/changes/p1-chat-skill/proposal.md
@@ -1,0 +1,56 @@
+# 提案：p1-chat-skill
+
+## 背景
+
+搜索整个 `skills/` 目录，不存在 `chat` / `ask` / `conversation` 等自由对话技能。用户能做的只有润色、续写、改写——全部是对已有文本的变换操作。当用户输入自由对话（如"帮我想一个悬疑小说的开头"），现有技能无法正确处理。
+
+同时缺少意图路由：用户在 AI 面板输入文本后，系统无法自动推断目标技能，需手动选择。
+
+审计来源：`docs/audit/01-system-prompt-and-identity.md` §3.3、§3.4
+
+不改的风险：AI 面板仅支持文本变换操作，无法作为创作对话伙伴使用。
+
+## 变更内容
+
+- 创建 `apps/desktop/main/src/services/skills/skillRouter.ts`，导出 `inferSkillFromInput()` 函数
+- 实现基于关键词匹配的意图路由规则：
+  - 包含 "续写"/"写下去"/"继续写" → `builtin:continue`
+  - 包含 "扩写"/"展开" → `builtin:expand`
+  - 包含 "缩写"/"精简" → `builtin:condense`
+  - 包含 "头脑风暴"/"帮我想" → `builtin:brainstorm`
+  - 有选中文本且无输入 → `builtin:polish`
+  - 有选中文本且短输入含改写关键词 → `builtin:rewrite`
+  - 无匹配 → `builtin:chat`（默认）
+- chat 技能作为默认对话技能，空输入时也路由到 chat
+
+## 受影响模块
+
+- skill-system delta：`openspec/changes/p1-chat-skill/specs/skill-system-delta.md`
+- 实现文件：`apps/desktop/main/src/services/skills/skillRouter.ts`
+
+## 不做什么
+
+- 不创建 chat 技能的 SKILL.md 文件（技能定义文件由后续 Phase 3 统一管理）
+- 不实现 LLM 意图分类（初期用关键词+启发式规则）
+- 不涉及前端 UI 变更
+
+## 依赖关系
+
+- 上游依赖：无
+- 下游依赖：无（独立泳道）
+
+## Dependency Sync Check
+
+- 核对输入：无上游依赖，N/A
+- 结论：`N/A`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/main/src/services/skills/skillRouter.ts`
+- 测试文件路径：`apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts`
+- Mock 要求：无外部依赖，纯函数测试
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-chat-skill/specs/skill-system-delta.md
+++ b/openspec/changes/p1-chat-skill/specs/skill-system-delta.md
@@ -1,0 +1,83 @@
+# Skill System Specification Delta
+
+## Change: p1-chat-skill
+
+### Requirement: chat 默认对话技能 [ADDED]
+
+技能系统**必须**包含 `builtin:chat` 技能，作为默认对话技能。当意图路由无法匹配到具体技能时，统一路由到 `builtin:chat`。
+
+REQ-ID: `REQ-SKL-CHAT`
+
+### Requirement: 意图路由函数 [ADDED]
+
+技能系统**必须**提供 `inferSkillFromInput` 函数，根据用户输入文本和上下文推断目标技能 ID。
+
+函数签名：
+```typescript
+function inferSkillFromInput(args: {
+  input: string;
+  hasSelection: boolean;
+  explicitSkillId?: string;
+}): string
+```
+
+路由优先级：
+1. 显式技能覆盖（`explicitSkillId` 非空时直接返回）
+2. 选中文本上下文启发式（有选中 + 无输入 → `builtin:polish`；有选中 + 短改写指令 → `builtin:rewrite`）
+3. 关键词匹配规则：
+
+| 关键词 | 目标技能 ID |
+|--------|------------|
+| "续写"/"写下去"/"接着写"/"继续写" | `builtin:continue` |
+| "头脑风暴"/"帮我想想" | `builtin:brainstorm` |
+| "大纲"/"提纲" | `builtin:outline` |
+| "总结"/"摘要" | `builtin:summarize` |
+| "翻译" | `builtin:translate` |
+| "扩写"/"展开" | `builtin:expand` |
+| "缩写"/"精简" | `builtin:condense` |
+
+4. 默认 → `builtin:chat`
+
+REQ-ID: `REQ-SKL-ROUTE`
+
+#### Scenario: S1 默认路由到 chat [ADDED]
+
+- **假设** `args = { input: "你好，这个故事写得怎么样？", hasSelection: false }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:chat"`
+
+#### Scenario: S2 识别"续写"关键词 [ADDED]
+
+- **假设** `args = { input: "帮我接着写下去", hasSelection: false }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:continue"`
+
+#### Scenario: S3 识别"头脑风暴"关键词 [ADDED]
+
+- **假设** `args = { input: "帮我想想接下来的剧情", hasSelection: false }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:brainstorm"`
+
+#### Scenario: S4 空输入返回 chat [ADDED]
+
+- **假设** `args = { input: "", hasSelection: false }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:chat"`
+
+#### Scenario: S5 显式技能覆盖优先 [ADDED]
+
+- **假设** `args = { input: "帮我续写", hasSelection: false, explicitSkillId: "builtin:polish" }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:polish"`（显式覆盖优先于关键词匹配）
+
+#### Scenario: S6 有选中文本且无输入路由到 polish [ADDED]
+
+- **假设** `args = { input: "", hasSelection: true }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:polish"`
+
+#### Scenario: S7 有选中文本且短改写指令路由到 rewrite [ADDED]
+
+- **假设** `args = { input: "改写", hasSelection: true }`
+- **当** 调用 `inferSkillFromInput(args)`
+- **则** 返回值 === `"builtin:rewrite"`

--- a/openspec/changes/p1-chat-skill/tasks.md
+++ b/openspec/changes/p1-chat-skill/tasks.md
@@ -1,0 +1,40 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`inferSkillFromInput` 接受 `{input, hasSelection, explicitSkillId?}`，返回技能 ID 字符串
+- [ ] 1.2 审阅并确认错误路径与边界路径：空输入 → chat；显式覆盖优先；选中文本启发式优先于关键词
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：路由优先级固定为 显式 > 选中上下文 > 关键词 > 默认 chat
+- [ ] 1.4 无上游依赖，标注 N/A
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route unmatched input to builtin:chat` | `expect(result).toBe("builtin:chat")` |
+| S2 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route "续写" keywords to builtin:continue` | `expect(result).toBe("builtin:continue")` |
+| S3 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route "头脑风暴" keywords to builtin:brainstorm` | `expect(result).toBe("builtin:brainstorm")` |
+| S4 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route empty input to builtin:chat` | `expect(result).toBe("builtin:chat")` |
+| S5 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should prefer explicit skill override` | `expect(result).toBe("builtin:polish")` |
+| S6 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route selection + empty input to builtin:polish` | `expect(result).toBe("builtin:polish")` |
+| S7 | `apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts` | `should route selection + short rewrite keyword to builtin:rewrite` | `expect(result).toBe("builtin:rewrite")` |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-identity-template/proposal.md
+++ b/openspec/changes/p1-identity-template/proposal.md
@@ -1,0 +1,48 @@
+# 提案：p1-identity-template
+
+## 背景
+
+当前 `aiService.ts` 的 `combineSystemText` 仅拼接技能级 `systemPrompt` 和动态 `system` overlay，不存在始终注入的全局 AI 身份提示词。当技能未定义 systemPrompt 且无动态 overlay 时，系统提示词为 `null`，LLM 没有任何角色定义。
+
+审计来源：`docs/audit/01-system-prompt-and-identity.md` §3.1
+
+不改的风险：AI 无写作专业素养，无角色流动能力，在自由对话场景下表现为通用 chatbot。
+
+## 变更内容
+
+- 创建 `apps/desktop/main/src/services/ai/identityPrompt.ts`，导出 `GLOBAL_IDENTITY_PROMPT` 常量
+- 模板包含 5 个 XML 区块：`<identity>`、`<writing_awareness>`、`<role_fluidity>`、`<behavior>`、`<context_awareness>`
+- 写作素养区块包含叙事结构、角色塑造、Show don't tell 等核心概念
+- 角色流动区块定义 ghostwriter / muse / editor / actor / painter 五个角色
+
+## 受影响模块
+
+- ai-service delta：`openspec/changes/p1-identity-template/specs/ai-service-delta.md`
+- 实现文件：`apps/desktop/main/src/services/ai/identityPrompt.ts`
+
+## 不做什么
+
+- 不改造 `combineSystemText`（由 C2 负责）
+- 不实现动态上下文注入（由后续 Phase 2 负责）
+- 不涉及前端 UI 变更
+
+## 依赖关系
+
+- 上游依赖：无
+- 下游依赖：`p1-assemble-prompt`（C2 使用本模板作为 identity 层输入）
+
+## Dependency Sync Check
+
+- 核对输入：无上游依赖，N/A
+- 结论：`N/A`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/main/src/services/ai/identityPrompt.ts`
+- 测试文件路径：`apps/desktop/main/src/services/ai/__tests__/identityPrompt.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/services/ai/__tests__/identityPrompt.test.ts`
+- Mock 要求：无外部依赖，纯函数/常量测试
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-identity-template/specs/ai-service-delta.md
+++ b/openspec/changes/p1-identity-template/specs/ai-service-delta.md
@@ -1,0 +1,46 @@
+# AI Service Specification Delta
+
+## Change: p1-identity-template
+
+### Requirement: 全局 AI 身份提示词模板 [ADDED]
+
+AI 服务**必须**提供全局身份提示词模板（`GLOBAL_IDENTITY_PROMPT` 常量），始终作为系统提示词的第一层注入。模板**必须**包含以下 5 个 XML 区块：
+
+| 区块 | 标签 | 内容 |
+|------|------|------|
+| 身份定义 | `<identity>` | AI 创作伙伴核心身份，首要原则：尊重创作者风格和意图 |
+| 写作素养 | `<writing_awareness>` | 叙事结构（narrative structure）、角色塑造（characterization）、场景 blocking、Show don't tell、POV 一致性、节奏控制、伏笔与回收 |
+| 角色流动 | `<role_fluidity>` | ghostwriter（续写）、muse（头脑风暴）、editor（评审）、actor（扮演角色）、painter（描写）五个角色及切换规则 |
+| 行为约束 | `<behavior>` | 中文回应、保持创作者风格、不确定时追问、纯文本/Markdown 输出、不重复用户输入 |
+| 上下文感知 | `<context_awareness>` | 声明后续动态注入的上下文类型（项目、文档、光标、偏好、KG） |
+
+REQ-ID: `REQ-AIS-IDENTITY`
+
+#### Scenario: S1 模板包含五个 XML 区块 [ADDED]
+
+- **假设** 导入 `GLOBAL_IDENTITY_PROMPT` 常量
+- **当** 读取其值
+- **则** `typeof GLOBAL_IDENTITY_PROMPT === "string"`
+- **并且** 值包含 `"<identity>"` 和 `"</identity>"`
+- **并且** 值包含 `"<writing_awareness>"` 和 `"</writing_awareness>"`
+- **并且** 值包含 `"<role_fluidity>"` 和 `"</role_fluidity>"`
+- **并且** 值包含 `"<behavior>"` 和 `"</behavior>"`
+- **并且** 值包含 `"<context_awareness>"` 和 `"</context_awareness>"`
+
+#### Scenario: S2 写作素养区块包含核心概念 [ADDED]
+
+- **假设** 导入 `GLOBAL_IDENTITY_PROMPT` 常量
+- **当** 提取 `<writing_awareness>` 与 `</writing_awareness>` 之间的内容
+- **则** 内容包含 `"Show don't tell"` 或 `"展示而非叙述"`
+- **并且** 内容包含 `"blocking"` 或 `"场景"`
+- **并且** 内容包含 `"POV"` 或 `"叙事"` 或 `"第一人称"`
+
+#### Scenario: S3 角色流动区块定义五个角色 [ADDED]
+
+- **假设** 导入 `GLOBAL_IDENTITY_PROMPT` 常量
+- **当** 提取 `<role_fluidity>` 与 `</role_fluidity>` 之间的内容
+- **则** 内容包含 `"ghostwriter"`
+- **并且** 内容包含 `"muse"`
+- **并且** 内容包含 `"editor"`
+- **并且** 内容包含 `"actor"`
+- **并且** 内容包含 `"painter"`

--- a/openspec/changes/p1-identity-template/tasks.md
+++ b/openspec/changes/p1-identity-template/tasks.md
@@ -1,0 +1,36 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`GLOBAL_IDENTITY_PROMPT` 为字符串常量，包含 5 个 XML 区块
+- [ ] 1.2 审阅并确认错误路径与边界路径：常量导出无错误路径，仅验证内容完整性
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：5 个 XML 区块标签对必须完整闭合；写作素养包含 Show don't tell；角色流动包含 5 个角色名
+- [ ] 1.4 无上游依赖，标注 N/A
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/services/ai/__tests__/identityPrompt.test.ts` | `should be a string containing all five XML block pairs` | `expect(GLOBAL_IDENTITY_PROMPT).toContain("<identity>")` 等 5 对标签 |
+| S2 | `apps/desktop/main/src/services/ai/__tests__/identityPrompt.test.ts` | `should include writing awareness core concepts` | 提取 `<writing_awareness>` 内容，断言包含 "Show don't tell"、"blocking"/"场景"、"POV"/"叙事" |
+| S3 | `apps/desktop/main/src/services/ai/__tests__/identityPrompt.test.ts` | `should define five roles in role_fluidity block` | 提取 `<role_fluidity>` 内容，断言包含 ghostwriter/muse/editor/actor/painter |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->

--- a/openspec/changes/p1-multiturn-assembly/proposal.md
+++ b/openspec/changes/p1-multiturn-assembly/proposal.md
@@ -1,0 +1,58 @@
+# 提案：p1-multiturn-assembly
+
+## 背景
+
+当前 LLM 调用只传单条 system + 单条 user 消息，无多轮历史。用户说"继续刚才的方向"，AI 没有"刚才"的上下文。需要实现多轮消息组装函数，将 system prompt + 历史消息 + 当前输入组装为 LLM API 的 messages 数组，并在总 token 超预算时从最早的非 system 消息开始裁剪。
+
+审计来源：`docs/audit/02-conversation-and-context.md` §3.2
+
+不改的风险：AI 面板每次交互都是无状态单轮，无法支持多轮对话和上下文延续。
+
+## 变更内容
+
+- 创建 `apps/desktop/main/src/services/ai/buildLLMMessages.ts`，导出 `buildLLMMessages()` 和 `estimateMessageTokens()` 函数
+- `buildLLMMessages` 组装顺序：`[system, ...history, currentUser]`
+- Token 预算裁剪策略：
+  1. system 消息永远保留
+  2. 当前用户消息永远保留
+  3. 历史消息从旧到新裁剪，直到总 token 在预算内
+- Token 估算使用 UTF-8 字节长度 / 4 的确定性近似
+
+## 受影响模块
+
+- ai-service delta：`openspec/changes/p1-multiturn-assembly/specs/ai-service-delta.md`
+- 实现文件：`apps/desktop/main/src/services/ai/buildLLMMessages.ts`
+
+## 不做什么
+
+- 不修改 `aiService.ts` 的调用链路（集成由后续任务负责）
+- 不实现对话摘要压缩（Phase 4）
+- 不涉及前端 UI
+
+## 依赖关系
+
+- 上游依赖：`p1-assemble-prompt`（C2，提供 systemPrompt 输入）、`p1-aistore-messages`（C4，提供 ChatMessage 历史）
+- 下游依赖：无（Phase 1 终端节点）
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `p1-assemble-prompt`：`assembleSystemPrompt` 返回 `string` → 作为 `buildLLMMessages` 的 `systemPrompt` 参数 ✓
+  - `p1-aistore-messages`：`ChatMessage` 类型含 `role: "user" | "assistant"` 和 `content: string` → 映射为 `HistoryMessage` ✓
+- 核对项：
+  - 数据结构：`systemPrompt` 为 string，`history` 为 `{role, content}[]`，`currentUserMessage` 为 string ✓
+  - IPC 契约：不涉及新 IPC ✓
+  - 错误码：不涉及 ✓
+  - 阈值：`maxTokenBudget` 由调用方指定，无硬编码上限 ✓
+- 结论：`NO_DRIFT`
+
+## Codex 实现指引
+
+- 目标文件路径：`apps/desktop/main/src/services/ai/buildLLMMessages.ts`
+- 测试文件路径：`apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts`
+- 验证命令：`pnpm vitest run apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts`
+- Mock 要求：无外部依赖；token 估算为纯函数（`Math.ceil(Buffer.byteLength(text, "utf8") / 4)`），测试需要根据此公式计算预期值
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/p1-multiturn-assembly/specs/ai-service-delta.md
+++ b/openspec/changes/p1-multiturn-assembly/specs/ai-service-delta.md
@@ -1,0 +1,72 @@
+# AI Service Specification Delta
+
+## Change: p1-multiturn-assembly
+
+### Requirement: LLM 多轮消息组装与 Token 裁剪 [ADDED]
+
+LLM 调用**必须**通过 `buildLLMMessages` 函数组装多轮消息数组。
+
+组装顺序：`[system, ...history, currentUser]`
+
+Token 预算裁剪规则：
+1. system 消息**永远**保留
+2. 当前用户消息**永远**保留
+3. 当总 token 超过 `maxTokenBudget` 时，从最早的历史消息开始裁剪
+4. system + currentUser 的 token 之和超过预算时，仍强制保留两者，历史全部裁掉
+
+函数签名：
+```typescript
+type LLMMessage = { role: "system" | "user" | "assistant"; content: string };
+type HistoryMessage = { role: "user" | "assistant"; content: string };
+
+function buildLLMMessages(args: {
+  systemPrompt: string;
+  history: HistoryMessage[];
+  currentUserMessage: string;
+  maxTokenBudget: number;
+}): LLMMessage[]
+```
+
+Token 估算函数：
+```typescript
+function estimateMessageTokens(text: string): number
+// 空字符串 → 0
+// 非空 → Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4))
+```
+
+REQ-ID: `REQ-AIS-MULTITURN`
+
+#### Scenario: S1 标准多轮组装 [ADDED]
+
+- **假设** `systemPrompt = "<identity>AI</identity>"`，`history = [{ role: "user", content: "介绍林默" }, { role: "assistant", content: "林默是28岁侦探" }]`，`currentUserMessage = "他的性格？"`，`maxTokenBudget = 10000`
+- **当** 调用 `buildLLMMessages({ systemPrompt, history, currentUserMessage, maxTokenBudget })`
+- **则** `result.length === 4`
+- **并且** `result[0].role === "system"` 且 `result[0].content === "<identity>AI</identity>"`
+- **并且** `result[1].role === "user"` 且 `result[1].content === "介绍林默"`
+- **并且** `result[2].role === "assistant"` 且 `result[2].content === "林默是28岁侦探"`
+- **并且** `result[3].role === "user"` 且 `result[3].content === "他的性格？"`
+
+#### Scenario: S2 Token 超预算裁剪最早历史 [ADDED]
+
+- **假设** `systemPrompt = "S"`（estimateMessageTokens → 1），`history = [{ role: "user", content: "AAAA" }, { role: "assistant", content: "BBBB" }, { role: "user", content: "CCCC" }, { role: "assistant", content: "DDDD" }]`（每条约 1 token），`currentUserMessage = "E"`（1 token），`maxTokenBudget = 4`
+- **当** 调用 `buildLLMMessages({ systemPrompt, history, currentUserMessage, maxTokenBudget })`
+- **则** result 包含 system 和 currentUser（固定 2 tokens）
+- **并且** 剩余 2 token 预算分配给最近的历史消息
+- **并且** result 最后一条是 `{ role: "user", content: "E" }`
+- **并且** 最早的历史消息被裁掉
+
+#### Scenario: S3 空历史 [ADDED]
+
+- **假设** `systemPrompt = "system text"`，`history = []`，`currentUserMessage = "你好"`，`maxTokenBudget = 10000`
+- **当** 调用 `buildLLMMessages({ systemPrompt, history, currentUserMessage, maxTokenBudget })`
+- **则** `result.length === 2`
+- **并且** `result[0].role === "system"`
+- **并且** `result[1].role === "user"` 且 `result[1].content === "你好"`
+
+#### Scenario: S4 预算不足以容纳全部历史时强制保留 system + current [ADDED]
+
+- **假设** `systemPrompt` 占 100 tokens，`currentUserMessage` 占 50 tokens，`history` 有 10 条消息，`maxTokenBudget = 160`（仅够 system + current + 极少历史）
+- **当** 调用 `buildLLMMessages({ systemPrompt, history, currentUserMessage, maxTokenBudget })`
+- **则** result 包含 system + currentUser（强制保留）
+- **并且** 仅保留预算范围内的最近历史消息
+- **并且** `result[result.length - 1].role === "user"`（当前输入在最后）

--- a/openspec/changes/p1-multiturn-assembly/tasks.md
+++ b/openspec/changes/p1-multiturn-assembly/tasks.md
@@ -1,0 +1,37 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：`buildLLMMessages` 接受 `{systemPrompt, history, currentUserMessage, maxTokenBudget}`，返回 `LLMMessage[]`
+- [ ] 1.2 审阅并确认错误路径与边界路径：空历史 → 仅 system + current；预算极小 → 强制保留 system + current，裁掉全部历史
+- [ ] 1.3 审阅并确认验收阈值与不可变契约：system 永远保留；current 永远保留；历史从旧到新裁剪；token 估算为 `Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4))`
+- [ ] 1.4 上游依赖 `p1-assemble-prompt` 和 `p1-aistore-messages`，Dependency Sync Check 结论：`NO_DRIFT`
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID | 测试文件 | 测试用例名 | 断言要点 |
+|-------------|---------|-----------|----------|
+| S1 | `apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts` | `should assemble system + history + current in order` | `result.length === 4`，顺序验证 |
+| S2 | `apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts` | `should trim oldest history when over token budget` | 最早消息被裁掉，最后一条为 current |
+| S3 | `apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts` | `should return system + current when history is empty` | `result.length === 2` |
+| S4 | `apps/desktop/main/src/services/ai/__tests__/buildLLMMessages.test.ts` | `should force-retain system + current even when budget is tight` | system 和 current 存在，历史被裁剪 |
+
+## 3. Red（先写失败测试）
+
+<!-- Codex 填写 -->
+
+## 4. Green（最小实现通过）
+
+<!-- Codex 填写 -->
+
+## 5. Refactor（保持绿灯）
+
+<!-- Codex 填写 -->
+
+## 6. Evidence
+
+<!-- Codex 填写 -->


### PR DESCRIPTION
Closes #464

## 变更内容

交付 Phase 1 的 7 组 OpenSpec change 文档，覆盖审计报告 01/02/06 中的 C1-C7 变更。

### 文件清单（23 files）
- `openspec/changes/p1-identity-template/` — C1: 全局 AI 身份提示词模板
- `openspec/changes/p1-assemble-prompt/` — C2: 系统提示词分层组装
- `openspec/changes/p1-chat-skill/` — C3: chat 默认对话技能 + 意图路由
- `openspec/changes/p1-aistore-messages/` — C4: 对话消息管理器
- `openspec/changes/p1-multiturn-assembly/` — C5: LLM 多轮消息组装与 Token 裁剪
- `openspec/changes/p1-apikey-storage/` — C6: API Key 加密存储与配置管理
- `openspec/changes/p1-ai-settings-ui/` — C7: AI 配置设置面板
- `openspec/changes/EXECUTION_ORDER.md` — 更新为 7 个活跃 change
- `openspec/_ops/task_runs/ISSUE-464.md` — RUN_LOG

### 验证
- 9 个 REQ-ID 唯一，与现有 spec 无冲突
- 35 个测试用例覆盖全部 Scenario
- 二次核对 + 三次核对通过

### Test Plan
纯文档变更，无代码改动。CI lint 通过即可。