### PR TITLE
fix: update builtin skill list to include chat (#466)

### DIFF
--- a/apps/desktop/tests/unit/skill-executor.test.ts
+++ b/apps/desktop/tests/unit/skill-executor.test.ts
@@ -37,10 +37,11 @@ function createNoopEmitter(): (event: AiStreamEvent) => void {
 
 /**
  * S0: 内置技能清单完整 [ADDED]
- * should expose exactly 8 builtin skills in package directory
+ * should expose exactly 9 builtin skills in package directory
  */
 {
   assert.deepEqual(builtinSkillNames(), [
+    "chat",
     "condense",
     "continue",
     "expand",

--- a/openspec/_ops/task_runs/ISSUE-466.md
+++ b/openspec/_ops/task_runs/ISSUE-466.md
@@ -1,0 +1,12 @@
+# ISSUE-466
+- Issue: #466
+- Branch: task/466-fix-skill-test
+- PR: <fill-after-created>
+
+## Plan
+- 修复 skill-executor.test.ts 中 builtin skill 清单缺少 chat 的断言失败
+
+## Runs
+### 2026-02-12 22:48 修复测试
+- Command: `multi_edit skill-executor.test.ts`
+- Key output: 将 expected skill list 从 8 个更新为 9 个（添加 "chat"）

--- a/openspec/_ops/task_runs/ISSUE-466.md
+++ b/openspec/_ops/task_runs/ISSUE-466.md
@@ -1,7 +1,7 @@
 # ISSUE-466
 - Issue: #466
 - Branch: task/466-fix-skill-test
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/467
 
 ## Plan
 - 修复 skill-executor.test.ts 中 builtin skill 清单缺少 chat 的断言失败


### PR DESCRIPTION
Closes #466

skill-executor.test.ts 中的 builtin skill 清单断言缺少 chat（实际已有 9 个技能），导致 CI unit-test 失败。

## 变更
- `apps/desktop/tests/unit/skill-executor.test.ts`: expected list 从 8 个更新为 9 个（添加 "chat"）

## Test Plan
`pnpm vitest run apps/desktop/tests/unit/skill-executor.test.ts`