### PR TITLE
fix: integrate runtime identity prompt and add regression tests (#509)

### DIFF
--- a/apps/desktop/tests/unit/context/layer-degrade-warning.test.ts
+++ b/apps/desktop/tests/unit/context/layer-degrade-warning.test.ts
@@ -30,3 +30,41 @@ import { createContextLayerAssemblyService } from "../../../main/src/services/co
   assert.deepEqual(assembled.layers.rules.source, ["constraints:policy"]);
   assert.equal(assembled.layers.rules.tokenCount > 0, true);
 }
+
+// Scenario Mapping: CE-DEGRADE-S1
+{
+  // Arrange
+  const service = createContextLayerAssemblyService({
+    rules: async () => {
+      throw new Error("rules unavailable");
+    },
+    settings: async () => {
+      throw new Error("settings unavailable");
+    },
+    retrieved: async () => {
+      throw new Error("retrieved unavailable");
+    },
+    immediate: async () => {
+      throw new Error("immediate unavailable");
+    },
+  });
+
+  // Act
+  const assembled = await service.assemble({
+    projectId: "project-all-degrade",
+    documentId: "document-all-degrade",
+    cursorPosition: 0,
+    skillId: "continue-writing",
+  });
+
+  // Assert
+  assert.equal(assembled.prompt.trim().length > 0, true);
+  assert.equal(assembled.warnings.includes("KG_UNAVAILABLE"), true);
+  assert.equal(assembled.warnings.includes("SETTINGS_UNAVAILABLE"), true);
+  assert.equal(assembled.warnings.includes("RAG_UNAVAILABLE"), true);
+  assert.equal(assembled.warnings.includes("IMMEDIATE_UNAVAILABLE"), true);
+  assert.equal(assembled.layers.rules.tokenCount, 0);
+  assert.equal(assembled.layers.settings.tokenCount, 0);
+  assert.equal(assembled.layers.retrieved.tokenCount, 0);
+  assert.equal(assembled.layers.immediate.tokenCount, 0);
+}

--- a/openspec/_ops/task_runs/ISSUE-509.md
+++ b/openspec/_ops/task_runs/ISSUE-509.md
@@ -2,7 +2,7 @@
 
 - Issue: #509
 - Branch: task/509-ai-runtime-identity-tests
-- PR: TBA
+- PR: https://github.com/Leeky1017/CreoNow/pull/510
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-509.md
+++ b/openspec/_ops/task_runs/ISSUE-509.md
@@ -1,0 +1,112 @@
+# ISSUE-509
+
+- Issue: #509
+- Branch: task/509-ai-runtime-identity-tests
+- PR: TBA
+
+## Plan
+
+- 先以 TDD 方式把 identity prompt 接入 `aiService` 运行时请求组装链路
+- 补齐 stream timeout done 与全层 fetcher 降级的自动化回归测试
+- 保持 `pnpm test:unit`、`pnpm test:integration`、`pnpm cross-module:check` 全绿
+
+## Runs
+
+### 2026-02-13 13:43 任务准入与规格落地
+
+- Command: `gh issue create --title "Integrate identity prompt into runtime and add AI degradation regression tests" ...`
+- Key output: 创建 OPEN issue `#509`
+
+- Command: `git fetch origin && git worktree add .worktrees/issue-509-ai-runtime-identity-tests -b task/509-ai-runtime-identity-tests origin/main`
+- Key output: 新建并切换隔离 worktree，基于 `origin/main`
+
+- Command: 读取规范与模板
+  - `AGENTS.md`
+  - `openspec/project.md`
+  - `openspec/specs/ai-service/spec.md`
+  - `openspec/specs/context-engine/spec.md`
+  - `openspec/changes/_template/*`
+- Key output: 完成 Spec-First 与 TDD 前置准备
+
+- Command: 编写变更与任务文档
+  - `rulebook/tasks/issue-509-ai-runtime-identity-tests/*`
+  - `openspec/changes/issue-509-ai-runtime-identity-tests/*`
+  - `openspec/changes/EXECUTION_ORDER.md`
+- Key output: 建立 active change 与 Scenario→测试映射，等待进入 Red
+
+### 2026-02-13 13:46 Rulebook 校验与环境准备
+
+- Command: `rulebook task validate issue-509-ai-runtime-identity-tests`
+- Key output: `✅ Task issue-509-ai-runtime-identity-tests is valid`（初次校验通过）
+
+- Command: `pnpm install --frozen-lockfile`
+- Key output: 依赖安装完成；`tsx` 可用（此前 Red 命令因 `tsx not found` 被阻断）
+
+### 2026-02-13 13:48 Red（先失败）
+
+- Command: `pnpm tsx apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts`
+- Key output:
+  - `AssertionError [ERR_ASSERTION]: runtime non-stream system prompt must include identity layer`
+  - Red 结论：运行时 system prompt 未注入 identity，失败符合预期
+
+### 2026-02-13 13:50 Green（最小实现 + 定向回归）
+
+- Command: 修改实现与测试
+  - `apps/desktop/main/src/services/ai/aiService.ts`
+  - `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts`
+  - `apps/desktop/tests/integration/ai-stream-lifecycle.test.ts`
+  - `apps/desktop/tests/unit/context/layer-degrade-warning.test.ts`
+- Key output:
+  - 运行时请求改为 `assembleSystemPrompt + GLOBAL_IDENTITY_PROMPT` 组装
+  - 新增 AIS-TIMEOUT-S1 与 CE-DEGRADE-S1 自动化场景
+
+- Command:
+  - `pnpm tsx apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts`
+  - `pnpm tsx apps/desktop/tests/integration/ai-stream-lifecycle.test.ts`
+  - `pnpm tsx apps/desktop/tests/unit/context/layer-degrade-warning.test.ts`
+- Key output: 定向测试全部通过（exit code 0）
+
+### 2026-02-13 13:52 全量门禁复核
+
+- Command: `pnpm test:unit`
+- Key output: 全量单测通过（exit code 0）
+
+- Command: `pnpm test:integration`
+- Key output: 全量集成测试通过（exit code 0）
+
+- Command: `pnpm cross-module:check`
+- Key output: `[CROSS_MODULE_GATE] PASS`
+
+- Command: `pnpm typecheck`
+- Key output: `tsc --noEmit` 通过（exit code 0）
+
+- Command: `rulebook task validate issue-509-ai-runtime-identity-tests`
+- Key output: 任务结构校验通过（补齐 `rulebook/tasks/.../specs/*/spec.md` 后无 warning）
+
+### 2026-02-13 14:00 OpenSpec 归档与执行顺序同步
+
+- Command: `mv openspec/changes/issue-509-ai-runtime-identity-tests openspec/changes/archive/issue-509-ai-runtime-identity-tests`
+- Key output: 已完成 change 归档，满足“已全勾选 active change 必须归档”门禁要求
+
+- Command: 更新路径与顺序文档
+  - `rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md`
+  - `rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md`
+  - `openspec/changes/EXECUTION_ORDER.md`
+- Key output:
+  - Rulebook spec 链接改为 archive 路径
+  - `EXECUTION_ORDER.md` 同步为“0 active change”
+
+### 2026-02-13 14:01 完成前复验（fresh evidence）
+
+- Command:
+  - `pnpm typecheck`
+  - `pnpm lint`
+  - `pnpm contract:check`
+  - `pnpm cross-module:check`
+  - `pnpm test:unit`
+  - `pnpm test:integration`
+  - `rulebook task validate issue-509-ai-runtime-identity-tests`
+- Key output:
+  - 全部命令 exit code 0
+  - `cross-module:check` 输出 `[CROSS_MODULE_GATE] PASS`
+  - Rulebook task 持续 `✅ valid`

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,37 +1,34 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-13 12:22
+更新时间：2026-02-13 14:00
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
 - 当前活跃 change 数量为 **0**。
-- 执行模式：**无在途变更（待新任务入场）**。
-- 路线图：36-change × 6-Phase 计划（见 `docs/plans/audit-roadmap.md`）。
-- 已完成归档（Phase 1）：`p1-identity-template`、`p1-assemble-prompt`、`p1-chat-skill`、`p1-aistore-messages`、`p1-multiturn-assembly`、`p1-apikey-storage`、`p1-ai-settings-ui`。
-- 已完成归档（Phase 2）：`p2-kg-context-level`（C8）、`p2-kg-aliases`（C9）、`p2-entity-matcher`（C10）、`p2-fetcher-always`（C11）、`p2-fetcher-detected`（C12）、`p2-memory-injection`（C13）。
-- 已完成归档（Fix）：`issue-499-fix-kg-aliases-ipc-contract`（F499）。
+- 执行模式：**无活跃 change**。
+- 当前在途变更：无。
 
 ## 执行顺序
 
-当前无 active change，暂无待执行顺序。
+1. 无
 
 ## 推荐执行序列
 
 ```text
-N/A（等待新的 active change）
+(none)
 ```
 
 ## 依赖关系总览
 
 ```text
-N/A（当前无在途依赖）
+(no active changes)
 ```
 
 ## 依赖明细
 
-当前无 active change，依赖明细为空。
+- 无活跃 change
 
 ## 依赖说明
 

--- a/openspec/changes/archive/issue-509-ai-runtime-identity-tests/proposal.md
+++ b/openspec/changes/archive/issue-509-ai-runtime-identity-tests/proposal.md
@@ -1,0 +1,27 @@
+# 提案：issue-509-ai-runtime-identity-tests
+
+## 背景
+
+在 P1+P2 集成复核中，已确认 `assembleSystemPrompt` 与 `GLOBAL_IDENTITY_PROMPT` 尚未进入 `aiService.runSkill` 的真实 LLM 请求组装路径。该缺口会导致运行时 system prompt 丢失 identity 层，影响技能行为一致性。与此同时，stream timeout done 收敛与全层 fetcher 降级行为虽已人工验证，但缺少自动化回归门禁。
+
+## 变更内容
+
+- 在 `aiService` 运行时请求组装中接入 `assembleSystemPrompt`，将 identity/rules/skill/mode/memory/context 层统一拼接后发送到 provider。
+- 新增回归测试：
+  - stream 路径 timeout 必须通过 `skill:stream:done` 收敛为 `SKILL_TIMEOUT`
+  - Context Engine 在全层 fetcher 异常时仍返回可用 prompt 与 warnings
+
+## 受影响模块
+
+- ai-service — 运行时 system prompt 组装路径与流式终态回归测试
+- context-engine — 全层降级回退行为回归测试
+
+## 不做什么
+
+- 不改动 provider failover/quota 策略
+- 不引入多轮对话历史拼接（`buildLLMMessages` 主链路接入另立变更）
+- 不调整现有 API Key 缺失错误码语义（本次仅记录现状并加测试）
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md
+++ b/openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md
@@ -1,0 +1,43 @@
+# AI Service Specification Delta
+
+## Change: issue-509-ai-runtime-identity-tests
+
+### Requirement: 运行时 system prompt 必须接入 identity 分层组装 [MODIFIED]
+
+`aiService.runSkill` 的 provider 请求组装必须使用 `assembleSystemPrompt`，并显式注入 `GLOBAL_IDENTITY_PROMPT`，保证运行时 system prompt 包含 identity 层。
+
+运行时拼装顺序固定为：
+
+1. `globalIdentity`（`GLOBAL_IDENTITY_PROMPT`）
+2. `userRules`（如有）
+3. `skillSystemPrompt`（skill prompt）
+4. `modeHint`（agent/plan/ask）
+5. `memoryOverlay`（如有）
+6. `contextOverlay`（Context Engine 输出）
+
+缺省或空白层必须跳过，不得产生空占位分隔符；最终 provider 侧仍接收单一 system 字符串。
+
+#### Scenario: AIS-RUNTIME-S1 non-stream 请求包含 identity 层 [ADDED]
+
+- **假设** 调用 `runSkill`（`stream=false`），输入包含 `systemPrompt` 与 `system`
+- **当** `aiService` 组装 provider 请求体
+- **则** 首条 system message 内容包含 `GLOBAL_IDENTITY_PROMPT`
+- **并且** identity 内容出现在 skill prompt 与 context overlay 之前
+
+#### Scenario: AIS-RUNTIME-S2 stream 请求包含 identity 层 [ADDED]
+
+- **假设** 调用 `runSkill`（`stream=true`），输入包含 `systemPrompt` 与 `system`
+- **当** `aiService` 组装 provider 请求体
+- **则** 请求体中的 system message 内容包含 `GLOBAL_IDENTITY_PROMPT`
+- **并且** `skill:stream:chunk` / `skill:stream:done` 生命周期契约不变
+
+### Requirement: stream timeout 的终态收敛可判定 [MODIFIED]
+
+当 stream 执行触发超时，系统必须通过 `skill:stream:done` 终态事件显式给出 `error.code = SKILL_TIMEOUT`，并只收敛一次。
+
+#### Scenario: AIS-TIMEOUT-S1 stream 超时触发 done 错误终态 [ADDED]
+
+- **假设** 一次 `stream=true` 的技能执行超时
+- **当** 主进程终止该次执行
+- **则** 渲染侧收到一次 `skill:stream:done`
+- **并且** `terminal = error` 且 `error.code = SKILL_TIMEOUT`

--- a/openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md
+++ b/openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md
@@ -1,0 +1,20 @@
+# Context Engine Specification Delta
+
+## Change: issue-509-ai-runtime-identity-tests
+
+### Requirement: 全层 fetcher 异常时仍需返回可消费上下文 [MODIFIED]
+
+Context Engine 在 `rules/settings/retrieved/immediate` 四层 fetcher 均不可用时，必须降级返回可消费的 prompt，而不是抛出异常或中断调用。
+
+降级输出要求：
+
+- 返回体 `prompt` 非空（可为 `(none)` 占位结构）
+- `warnings` 至少包含各层不可用原因
+- 各层 `tokenCount` 可为 0，但结构必须完整
+
+#### Scenario: CE-DEGRADE-S1 全层异常时继续组装并返回 warnings [ADDED]
+
+- **假设** `rules/settings/retrieved/immediate` 四个 fetcher 全部抛出异常
+- **当** 调用 `context:prompt:assemble`
+- **则** 返回 `ok=true`，且 `prompt` 非空
+- **并且** `warnings` 包含 `KG_UNAVAILABLE`、`SETTINGS_UNAVAILABLE`、`RAG_UNAVAILABLE`、`IMMEDIATE_UNAVAILABLE`

--- a/openspec/changes/archive/issue-509-ai-runtime-identity-tests/tasks.md
+++ b/openspec/changes/archive/issue-509-ai-runtime-identity-tests/tasks.md
@@ -1,0 +1,60 @@
+## 1. Specification
+
+- [x] 1.1 审阅并确认需求边界：本变更仅覆盖 AI 运行时 prompt 组装接入与两项回归测试补齐
+- [x] 1.2 审阅并确认错误路径与边界路径：stream timeout done 收敛、全层 fetcher 异常降级
+- [x] 1.3 审阅并确认验收阈值与不可变契约：`skill:stream:done` 单次收敛、context assemble 不因单层/全层异常失败
+- [x] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；无依赖则标注 N/A（本变更：N/A）
+
+## 2. TDD Mapping（先测前提）
+
+- [x] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [x] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [x] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → Test 映射
+
+| Scenario ID    | 测试文件                                                                   | 测试用例名（计划）                                                |
+| -------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| AIS-RUNTIME-S1 | `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts` | `runtime non-stream system prompt must include identity layer`    |
+| AIS-RUNTIME-S2 | `apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts` | `runtime stream system prompt must include identity layer`        |
+| AIS-TIMEOUT-S1 | `apps/desktop/tests/integration/ai-stream-lifecycle.test.ts`               | `AIS-TIMEOUT-S1: stream 超时通过 done(error: SKILL_TIMEOUT) 收敛` |
+| CE-DEGRADE-S1  | `apps/desktop/tests/unit/context/layer-degrade-warning.test.ts`            | `CE-DEGRADE-S1 全层异常时继续组装并返回 warnings`                 |
+
+## 3. Red（先写失败测试）
+
+- [x] 3.1 编写 Happy Path 的失败测试并确认先失败（AIS-RUNTIME-S1）
+- [x] 3.2 编写 Edge Case 的失败测试并确认先失败（AIS-RUNTIME-S2）
+- [x] 3.3 编写 Error Path 回归测试并执行（AIS-TIMEOUT-S1 / CE-DEGRADE-S1；当前实现已满足，作为防回归）
+
+Red 证据（AIS-RUNTIME-S1）：
+
+```bash
+$ pnpm tsx apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts
+AssertionError [ERR_ASSERTION]: runtime non-stream system prompt must include identity layer
+```
+
+## 4. Green（最小实现通过）
+
+- [x] 4.1 仅实现让 Red 转绿的最小代码
+- [x] 4.2 逐条使失败测试通过，不引入无关功能
+
+Green 证据：
+
+```bash
+$ pnpm tsx apps/desktop/main/src/services/ai/__tests__/assembleSystemPrompt.test.ts
+# exit 0
+$ pnpm tsx apps/desktop/tests/integration/ai-stream-lifecycle.test.ts
+# exit 0
+$ pnpm tsx apps/desktop/tests/unit/context/layer-degrade-warning.test.ts
+# exit 0
+```
+
+## 5. Refactor（保持绿灯）
+
+- [x] 5.1 去重与重构，保持测试全绿
+- [x] 5.2 不改变已通过的外部行为契约
+
+## 6. Evidence
+
+- [x] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [x] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）

--- a/rulebook/tasks/issue-509-ai-runtime-identity-tests/.metadata.json
+++ b/rulebook/tasks/issue-509-ai-runtime-identity-tests/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-13T05:41:01.084Z",
+  "updatedAt": "2026-02-13T05:41:01.084Z"
+}

--- a/rulebook/tasks/issue-509-ai-runtime-identity-tests/proposal.md
+++ b/rulebook/tasks/issue-509-ai-runtime-identity-tests/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: issue-509-ai-runtime-identity-tests
+
+## Why
+
+P1+P2 集成复核确认 `assembleSystemPrompt` / `GLOBAL_IDENTITY_PROMPT` 仍未进入 `aiService.runSkill` 的真实请求组装链路，导致运行时 system prompt 缺失身份层。同时，部分已人工验证的关键降级行为尚未沉淀为自动化回归测试，存在后续回归风险。
+
+## What Changes
+
+- 在 AI 运行时请求组装中接入 `assembleSystemPrompt`，确保 identity/rules/skill/mode/memory/context 分层拼接进入 provider 请求。
+- 新增回归测试覆盖：
+  - streaming timeout 必须收敛为 `done(error: SKILL_TIMEOUT)`
+  - Context Engine 全层 fetcher 降级时仍返回可用 prompt 与 warnings
+
+## Impact
+
+- Affected specs: `openspec/specs/ai-service/spec.md`, `openspec/specs/context-engine/spec.md`（通过 delta）
+- Affected code:
+  - `apps/desktop/main/src/services/ai/aiService.ts`
+  - `apps/desktop/main/src/services/ai/__tests__/*`
+  - `apps/desktop/tests/integration/*`
+  - `apps/desktop/tests/unit/context/*`
+- Breaking change: NO
+- User benefit: AI 生成链路稳定包含身份约束，关键降级/超时行为具备可持续回归保障

--- a/rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md
+++ b/rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md
@@ -1,0 +1,4 @@
+# Rulebook Spec Link — ai-service
+
+- Source of truth: `openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/ai-service/spec.md`
+- This task validates runtime identity prompt injection and stream-timeout done convergence.

--- a/rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md
+++ b/rulebook/tasks/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md
@@ -1,0 +1,4 @@
+# Rulebook Spec Link — context-engine
+
+- Source of truth: `openspec/changes/archive/issue-509-ai-runtime-identity-tests/specs/context-engine/spec.md`
+- This task validates full-layer fetcher degradation fallback behavior.

--- a/rulebook/tasks/issue-509-ai-runtime-identity-tests/tasks.md
+++ b/rulebook/tasks/issue-509-ai-runtime-identity-tests/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 将 `assembleSystemPrompt` 接入 `aiService.runSkill` 的 provider 请求组装路径
+- [x] 1.2 保持现有错误码与流式终态契约不变（除规格明确修改项外）
+
+## 2. Testing
+
+- [x] 2.1 先添加并执行 Red 测试：运行时 system prompt 必含 identity 层
+- [x] 2.2 补充回归测试：stream timeout done 事件 + 全层 fetcher 降级
+- [x] 2.3 运行 `pnpm test:unit`、`pnpm test:integration`、`pnpm cross-module:check`
+
+## 3. Documentation
+
+- [x] 3.1 更新 `docs/plans/p1p2-integration-check.md` 的剩余风险状态
+- [x] 3.2 更新 `openspec/_ops/task_runs/ISSUE-509.md`，记录 Red/Green 证据


### PR DESCRIPTION
Closes #509

## Summary
- (fill)

## Test plan
- `ruff check .`
- `pytest -q`

## Evidence
- `openspec/_ops/task_runs/ISSUE-509.md`