### PR TITLE
Enforce main-session audit hard gate (#518)

### DIFF
--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Validate RUN_LOG or Skip-Reason
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           BRANCH="${{ github.head_ref }}"
 
@@ -76,6 +77,86 @@ jobs:
               exit 1
             fi
             echo "✅ RUN_LOG format validated"
+
+            python3 - "$RUN_LOG" "$PR_HEAD_SHA" <<'PY'
+            import pathlib
+            import re
+            import sys
+
+            run_log = pathlib.Path(sys.argv[1])
+            head_sha = sys.argv[2]
+
+            content = run_log.read_text(encoding="utf-8")
+            section_match = re.search(
+                r"^## Main Session Audit\s*$([\s\S]*?)(?=^##\s|\Z)",
+                content,
+                re.MULTILINE,
+            )
+            if not section_match:
+                print(f"❌ [MAIN_AUDIT] missing required section '## Main Session Audit' in {run_log}")
+                raise SystemExit(1)
+
+            section = section_match.group(1)
+            required_fields = (
+                "Audit-Owner",
+                "Reviewed-HEAD-SHA",
+                "Spec-Compliance",
+                "Code-Quality",
+                "Fresh-Verification",
+                "Blocking-Issues",
+                "Decision",
+            )
+            values: dict[str, str] = {}
+            for field in required_fields:
+                field_match = re.search(rf"^- {re.escape(field)}:\s*(.+)$", section, re.MULTILINE)
+                if not field_match:
+                    print(f"❌ [MAIN_AUDIT] missing required field '{field}' in {run_log}")
+                    raise SystemExit(1)
+                value = field_match.group(1).strip()
+                if not value:
+                    print(f"❌ [MAIN_AUDIT] field '{field}' cannot be empty in {run_log}")
+                    raise SystemExit(1)
+                values[field] = value
+
+            if values["Audit-Owner"] != "main-session":
+                print(f"❌ [MAIN_AUDIT] Audit-Owner must be 'main-session', got '{values['Audit-Owner']}'")
+                raise SystemExit(1)
+
+            reviewed_sha = values["Reviewed-HEAD-SHA"]
+            if not re.match(r"^[0-9a-fA-F]{40}$", reviewed_sha):
+                print(f"❌ [MAIN_AUDIT] Reviewed-HEAD-SHA must be a 40-hex commit sha, got '{reviewed_sha}'")
+                raise SystemExit(1)
+            if reviewed_sha.lower() != head_sha.lower():
+                print(f"❌ [MAIN_AUDIT] Reviewed-HEAD-SHA mismatch: audit={reviewed_sha}, head={head_sha}")
+                raise SystemExit(1)
+
+            for gate_field in ("Spec-Compliance", "Code-Quality", "Fresh-Verification"):
+                value = values[gate_field]
+                if value not in {"PASS", "FAIL"}:
+                    print(f"❌ [MAIN_AUDIT] {gate_field} must be PASS or FAIL, got '{value}'")
+                    raise SystemExit(1)
+                if value != "PASS":
+                    print(f"❌ [MAIN_AUDIT] {gate_field} must be PASS to continue, got '{value}'")
+                    raise SystemExit(1)
+
+            blocking_raw = values["Blocking-Issues"]
+            if not re.match(r"^\d+$", blocking_raw):
+                print(f"❌ [MAIN_AUDIT] Blocking-Issues must be a non-negative integer, got '{blocking_raw}'")
+                raise SystemExit(1)
+            if int(blocking_raw) != 0:
+                print(f"❌ [MAIN_AUDIT] Blocking-Issues must be 0 to continue, got '{blocking_raw}'")
+                raise SystemExit(1)
+
+            decision = values["Decision"]
+            if decision not in {"ACCEPT", "REJECT"}:
+                print(f"❌ [MAIN_AUDIT] Decision must be ACCEPT or REJECT, got '{decision}'")
+                raise SystemExit(1)
+            if decision != "ACCEPT":
+                print(f"❌ [MAIN_AUDIT] Decision must be ACCEPT to continue, got '{decision}'")
+                raise SystemExit(1)
+
+            print("✅ Main Session Audit validated")
+            PY
 
           else
             if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -10,6 +10,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Validate completed active changes are archived (tasks.md all checked)
         run: |
@@ -78,13 +80,26 @@ jobs:
             fi
             echo "✅ RUN_LOG format validated"
 
-            python3 - "$RUN_LOG" "$PR_HEAD_SHA" <<'PY'
+            PR_HEAD_PARENT_SHA="$(git rev-parse "${PR_HEAD_SHA}^" 2>/dev/null || true)"
+            if [ -z "$PR_HEAD_PARENT_SHA" ]; then
+              git fetch --no-tags --depth=2 origin "$PR_HEAD_SHA" >/dev/null 2>&1 || true
+              PR_HEAD_PARENT_SHA="$(git rev-parse "${PR_HEAD_SHA}^" 2>/dev/null || true)"
+            fi
+            if [ -z "$PR_HEAD_PARENT_SHA" ]; then
+              echo "❌ [MAIN_AUDIT] failed to resolve parent SHA for PR head: $PR_HEAD_SHA"
+              exit 1
+            fi
+
+            python3 - "$RUN_LOG" "$PR_HEAD_SHA" "$PR_HEAD_PARENT_SHA" "$RUN_LOG" <<'PY'
             import pathlib
             import re
+            import subprocess
             import sys
 
             run_log = pathlib.Path(sys.argv[1])
             head_sha = sys.argv[2]
+            head_parent_sha = sys.argv[3]
+            run_log_rel = sys.argv[4]
 
             content = run_log.read_text(encoding="utf-8")
             section_match = re.search(
@@ -126,8 +141,11 @@ jobs:
             if not re.match(r"^[0-9a-fA-F]{40}$", reviewed_sha):
                 print(f"❌ [MAIN_AUDIT] Reviewed-HEAD-SHA must be a 40-hex commit sha, got '{reviewed_sha}'")
                 raise SystemExit(1)
-            if reviewed_sha.lower() != head_sha.lower():
-                print(f"❌ [MAIN_AUDIT] Reviewed-HEAD-SHA mismatch: audit={reviewed_sha}, head={head_sha}")
+            if reviewed_sha.lower() != head_parent_sha.lower():
+                print(
+                    "❌ [MAIN_AUDIT] Reviewed-HEAD-SHA mismatch: "
+                    f"audit={reviewed_sha}, expected_head_parent={head_parent_sha}, head={head_sha}"
+                )
                 raise SystemExit(1)
 
             for gate_field in ("Spec-Compliance", "Code-Quality", "Fresh-Verification"):
@@ -153,6 +171,31 @@ jobs:
                 raise SystemExit(1)
             if decision != "ACCEPT":
                 print(f"❌ [MAIN_AUDIT] Decision must be ACCEPT to continue, got '{decision}'")
+                raise SystemExit(1)
+
+            diff_proc = subprocess.run(
+                ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{head_parent_sha}..{head_sha}"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if diff_proc.returncode != 0:
+                print("❌ [MAIN_AUDIT] failed to inspect signing commit diff")
+                if diff_proc.stdout.strip():
+                    print(diff_proc.stdout.rstrip())
+                raise SystemExit(1)
+
+            changed_files = [line.strip() for line in diff_proc.stdout.splitlines() if line.strip()]
+            if run_log_rel not in changed_files:
+                print(f"❌ [MAIN_AUDIT] signing commit must include RUN_LOG update: {run_log_rel}")
+                raise SystemExit(1)
+
+            disallowed = sorted(path for path in changed_files if path != run_log_rel)
+            if disallowed:
+                print(
+                    "❌ [MAIN_AUDIT] signing commit must only change RUN_LOG; found additional files: "
+                    + ", ".join(disallowed)
+                )
                 raise SystemExit(1)
 
             print("✅ Main Session Audit validated")

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate completed active changes are archived (tasks.md all checked)
         run: |
@@ -80,126 +81,7 @@ jobs:
             fi
             echo "✅ RUN_LOG format validated"
 
-            PR_HEAD_PARENT_SHA="$(git rev-parse "${PR_HEAD_SHA}^" 2>/dev/null || true)"
-            if [ -z "$PR_HEAD_PARENT_SHA" ]; then
-              git fetch --no-tags --depth=2 origin "$PR_HEAD_SHA" >/dev/null 2>&1 || true
-              PR_HEAD_PARENT_SHA="$(git rev-parse "${PR_HEAD_SHA}^" 2>/dev/null || true)"
-            fi
-            if [ -z "$PR_HEAD_PARENT_SHA" ]; then
-              echo "❌ [MAIN_AUDIT] failed to resolve parent SHA for PR head: $PR_HEAD_SHA"
-              exit 1
-            fi
-
-            python3 - "$RUN_LOG" "$PR_HEAD_SHA" "$PR_HEAD_PARENT_SHA" "$RUN_LOG" <<'PY'
-            import pathlib
-            import re
-            import subprocess
-            import sys
-
-            run_log = pathlib.Path(sys.argv[1])
-            head_sha = sys.argv[2]
-            head_parent_sha = sys.argv[3]
-            run_log_rel = sys.argv[4]
-
-            content = run_log.read_text(encoding="utf-8")
-            section_match = re.search(
-                r"^## Main Session Audit\s*$([\s\S]*?)(?=^##\s|\Z)",
-                content,
-                re.MULTILINE,
-            )
-            if not section_match:
-                print(f"❌ [MAIN_AUDIT] missing required section '## Main Session Audit' in {run_log}")
-                raise SystemExit(1)
-
-            section = section_match.group(1)
-            required_fields = (
-                "Audit-Owner",
-                "Reviewed-HEAD-SHA",
-                "Spec-Compliance",
-                "Code-Quality",
-                "Fresh-Verification",
-                "Blocking-Issues",
-                "Decision",
-            )
-            values: dict[str, str] = {}
-            for field in required_fields:
-                field_match = re.search(rf"^- {re.escape(field)}:\s*(.+)$", section, re.MULTILINE)
-                if not field_match:
-                    print(f"❌ [MAIN_AUDIT] missing required field '{field}' in {run_log}")
-                    raise SystemExit(1)
-                value = field_match.group(1).strip()
-                if not value:
-                    print(f"❌ [MAIN_AUDIT] field '{field}' cannot be empty in {run_log}")
-                    raise SystemExit(1)
-                values[field] = value
-
-            if values["Audit-Owner"] != "main-session":
-                print(f"❌ [MAIN_AUDIT] Audit-Owner must be 'main-session', got '{values['Audit-Owner']}'")
-                raise SystemExit(1)
-
-            reviewed_sha = values["Reviewed-HEAD-SHA"]
-            if not re.match(r"^[0-9a-fA-F]{40}$", reviewed_sha):
-                print(f"❌ [MAIN_AUDIT] Reviewed-HEAD-SHA must be a 40-hex commit sha, got '{reviewed_sha}'")
-                raise SystemExit(1)
-            if reviewed_sha.lower() != head_parent_sha.lower():
-                print(
-                    "❌ [MAIN_AUDIT] Reviewed-HEAD-SHA mismatch: "
-                    f"audit={reviewed_sha}, expected_head_parent={head_parent_sha}, head={head_sha}"
-                )
-                raise SystemExit(1)
-
-            for gate_field in ("Spec-Compliance", "Code-Quality", "Fresh-Verification"):
-                value = values[gate_field]
-                if value not in {"PASS", "FAIL"}:
-                    print(f"❌ [MAIN_AUDIT] {gate_field} must be PASS or FAIL, got '{value}'")
-                    raise SystemExit(1)
-                if value != "PASS":
-                    print(f"❌ [MAIN_AUDIT] {gate_field} must be PASS to continue, got '{value}'")
-                    raise SystemExit(1)
-
-            blocking_raw = values["Blocking-Issues"]
-            if not re.match(r"^\d+$", blocking_raw):
-                print(f"❌ [MAIN_AUDIT] Blocking-Issues must be a non-negative integer, got '{blocking_raw}'")
-                raise SystemExit(1)
-            if int(blocking_raw) != 0:
-                print(f"❌ [MAIN_AUDIT] Blocking-Issues must be 0 to continue, got '{blocking_raw}'")
-                raise SystemExit(1)
-
-            decision = values["Decision"]
-            if decision not in {"ACCEPT", "REJECT"}:
-                print(f"❌ [MAIN_AUDIT] Decision must be ACCEPT or REJECT, got '{decision}'")
-                raise SystemExit(1)
-            if decision != "ACCEPT":
-                print(f"❌ [MAIN_AUDIT] Decision must be ACCEPT to continue, got '{decision}'")
-                raise SystemExit(1)
-
-            diff_proc = subprocess.run(
-                ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{head_parent_sha}..{head_sha}"],
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            if diff_proc.returncode != 0:
-                print("❌ [MAIN_AUDIT] failed to inspect signing commit diff")
-                if diff_proc.stdout.strip():
-                    print(diff_proc.stdout.rstrip())
-                raise SystemExit(1)
-
-            changed_files = [line.strip() for line in diff_proc.stdout.splitlines() if line.strip()]
-            if run_log_rel not in changed_files:
-                print(f"❌ [MAIN_AUDIT] signing commit must include RUN_LOG update: {run_log_rel}")
-                raise SystemExit(1)
-
-            disallowed = sorted(path for path in changed_files if path != run_log_rel)
-            if disallowed:
-                print(
-                    "❌ [MAIN_AUDIT] signing commit must only change RUN_LOG; found additional files: "
-                    + ", ".join(disallowed)
-                )
-                raise SystemExit(1)
-
-            print("✅ Main Session Audit validated")
-            PY
+            python3 scripts/validate_main_session_audit_ci.py "$RUN_LOG"
 
           else
             if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then

--- a/docs/delivery-rule-mapping.md
+++ b/docs/delivery-rule-mapping.md
@@ -2,17 +2,18 @@
 
 本表用于审计“规则声明 -> 仓库门禁 -> 脚本校验”是否一致。
 
-| 规则项                             | 外部 Skill                                       | 仓库规则主源                        | 宪法入口             | Workflow / Script                                      |
-| ---------------------------------- | ------------------------------------------------ | ----------------------------------- | -------------------- | ------------------------------------------------------ |
-| 身份锚点：Issue / Branch / RUN_LOG | `openspec-rulebook-github-delivery/SKILL.md` §一 | `docs/delivery-skill.md` §一        | `AGENTS.md` P3 + §五 | `openspec-log-guard.yml`, `agent_pr_preflight.py`      |
-| Spec-first + Rulebook-first        | 外部 Skill §二 规则 1                            | `docs/delivery-skill.md` §二 规则 1 | `AGENTS.md` P1 + §五 | `agent_pr_preflight.py`（Rulebook validate 强制）      |
-| 红灯先行（TDD）                    | 外部 Skill §二 规则 2                            | `docs/delivery-skill.md` §二 规则 2 | `AGENTS.md` P2       | CI `unit-test`, `integration-test`                     |
-| 证据落盘（RUN_LOG）                | 外部 Skill §二 规则 3                            | `docs/delivery-skill.md` §二 规则 3 | `AGENTS.md` P3       | `openspec-log-guard.yml`                               |
-| 门禁一致（文档=远端）              | 外部 Skill §二 规则 4                            | `docs/delivery-skill.md` §二 规则 4 | `AGENTS.md` P4       | branch protection required checks                      |
-| 门禁全绿 + auto-merge              | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5 | `AGENTS.md` P4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml` |
-| 控制面收口（必须回到 `main`）      | 外部 Skill §二 规则 6                            | `docs/delivery-skill.md` §二 规则 6 | `AGENTS.md` P4 + §五 | `agent_pr_preflight.py`（分支与任务收口校验）          |
-| 非 task 分支必须 Skip-Reason       | 外部 Skill §四                                   | `docs/delivery-skill.md` §四        | `AGENTS.md` §七      | `openspec-log-guard.yml`                               |
-| gh 超时 3 次 + 升级                | 外部 Skill §四                                   | `docs/delivery-skill.md` §四        | `AGENTS.md` §七      | 执行规范（RUN_LOG 记录）                               |
+| 规则项                              | 外部 Skill                                       | 仓库规则主源                         | 宪法入口             | Workflow / Script                                      |
+| ----------------------------------- | ------------------------------------------------ | ------------------------------------ | -------------------- | ------------------------------------------------------ |
+| 身份锚点：Issue / Branch / RUN_LOG  | `openspec-rulebook-github-delivery/SKILL.md` §一 | `docs/delivery-skill.md` §一         | `AGENTS.md` P3 + §五 | `openspec-log-guard.yml`, `agent_pr_preflight.py`      |
+| Spec-first + Rulebook-first         | 外部 Skill §二 规则 1                            | `docs/delivery-skill.md` §二 规则 1  | `AGENTS.md` P1 + §五 | `agent_pr_preflight.py`（Rulebook validate 强制）      |
+| 红灯先行（TDD）                     | 外部 Skill §二 规则 2                            | `docs/delivery-skill.md` §二 规则 2  | `AGENTS.md` P2       | CI `unit-test`, `integration-test`                     |
+| 证据落盘（RUN_LOG）                 | 外部 Skill §二 规则 3                            | `docs/delivery-skill.md` §二 规则 3  | `AGENTS.md` P3       | `openspec-log-guard.yml`                               |
+| 门禁一致（文档=远端）               | 外部 Skill §二 规则 4                            | `docs/delivery-skill.md` §二 规则 4  | `AGENTS.md` P4       | branch protection required checks                      |
+| 门禁全绿 + auto-merge               | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5  | `AGENTS.md` P4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml` |
+| 控制面收口（必须回到 `main`）       | 外部 Skill §二 规则 6                            | `docs/delivery-skill.md` §二 规则 6  | `AGENTS.md` P4 + §五 | `agent_pr_preflight.py`（分支与任务收口校验）          |
+| 主会话审计强制（子代理完成≠可合并） | 外部 Skill §二 规则 3/5                          | `docs/delivery-skill.md` §二 规则 16 | `AGENTS.md` P3 + P4  | `agent_pr_preflight.py` + `openspec-log-guard.yml`     |
+| 非 task 分支必须 Skip-Reason        | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | `openspec-log-guard.yml`                               |
+| gh 超时 3 次 + 升级                 | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | 执行规范（RUN_LOG 记录）                               |
 
 ## Canonical Checks
 

--- a/docs/delivery-rule-mapping.md
+++ b/docs/delivery-rule-mapping.md
@@ -2,18 +2,18 @@
 
 本表用于审计“规则声明 -> 仓库门禁 -> 脚本校验”是否一致。
 
-| 规则项                              | 外部 Skill                                       | 仓库规则主源                         | 宪法入口             | Workflow / Script                                      |
-| ----------------------------------- | ------------------------------------------------ | ------------------------------------ | -------------------- | ------------------------------------------------------ |
-| 身份锚点：Issue / Branch / RUN_LOG  | `openspec-rulebook-github-delivery/SKILL.md` §一 | `docs/delivery-skill.md` §一         | `AGENTS.md` P3 + §五 | `openspec-log-guard.yml`, `agent_pr_preflight.py`      |
-| Spec-first + Rulebook-first         | 外部 Skill §二 规则 1                            | `docs/delivery-skill.md` §二 规则 1  | `AGENTS.md` P1 + §五 | `agent_pr_preflight.py`（Rulebook validate 强制）      |
-| 红灯先行（TDD）                     | 外部 Skill §二 规则 2                            | `docs/delivery-skill.md` §二 规则 2  | `AGENTS.md` P2       | CI `unit-test`, `integration-test`                     |
-| 证据落盘（RUN_LOG）                 | 外部 Skill §二 规则 3                            | `docs/delivery-skill.md` §二 规则 3  | `AGENTS.md` P3       | `openspec-log-guard.yml`                               |
-| 门禁一致（文档=远端）               | 外部 Skill §二 规则 4                            | `docs/delivery-skill.md` §二 规则 4  | `AGENTS.md` P4       | branch protection required checks                      |
-| 门禁全绿 + auto-merge               | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5  | `AGENTS.md` P4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml` |
-| 控制面收口（必须回到 `main`）       | 外部 Skill §二 规则 6                            | `docs/delivery-skill.md` §二 规则 6  | `AGENTS.md` P4 + §五 | `agent_pr_preflight.py`（分支与任务收口校验）          |
-| 主会话审计强制（子代理完成≠可合并） | 外部 Skill §二 规则 3/5                          | `docs/delivery-skill.md` §二 规则 16 | `AGENTS.md` P3 + P4  | `agent_pr_preflight.py` + `openspec-log-guard.yml`     |
-| 非 task 分支必须 Skip-Reason        | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | `openspec-log-guard.yml`                               |
-| gh 超时 3 次 + 升级                 | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | 执行规范（RUN_LOG 记录）                               |
+| 规则项                              | 外部 Skill                                       | 仓库规则主源                         | 宪法入口             | Workflow / Script                                                                                 |
+| ----------------------------------- | ------------------------------------------------ | ------------------------------------ | -------------------- | ------------------------------------------------------------------------------------------------- |
+| 身份锚点：Issue / Branch / RUN_LOG  | `openspec-rulebook-github-delivery/SKILL.md` §一 | `docs/delivery-skill.md` §一         | `AGENTS.md` P3 + §五 | `openspec-log-guard.yml`, `agent_pr_preflight.py`                                                 |
+| Spec-first + Rulebook-first         | 外部 Skill §二 规则 1                            | `docs/delivery-skill.md` §二 规则 1  | `AGENTS.md` P1 + §五 | `agent_pr_preflight.py`（Rulebook validate 强制）                                                 |
+| 红灯先行（TDD）                     | 外部 Skill §二 规则 2                            | `docs/delivery-skill.md` §二 规则 2  | `AGENTS.md` P2       | CI `unit-test`, `integration-test`                                                                |
+| 证据落盘（RUN_LOG）                 | 外部 Skill §二 规则 3                            | `docs/delivery-skill.md` §二 规则 3  | `AGENTS.md` P3       | `openspec-log-guard.yml`                                                                          |
+| 门禁一致（文档=远端）               | 外部 Skill §二 规则 4                            | `docs/delivery-skill.md` §二 规则 4  | `AGENTS.md` P4       | branch protection required checks                                                                 |
+| 门禁全绿 + auto-merge               | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5  | `AGENTS.md` P4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml`                                            |
+| 控制面收口（必须回到 `main`）       | 外部 Skill §二 规则 6                            | `docs/delivery-skill.md` §二 规则 6  | `AGENTS.md` P4 + §五 | `agent_pr_preflight.py`（分支与任务收口校验）                                                     |
+| 主会话审计强制（子代理完成≠可合并） | 外部 Skill §二 规则 3/5                          | `docs/delivery-skill.md` §二 规则 16 | `AGENTS.md` P3 + P4  | `agent_pr_preflight.py` + `openspec-log-guard.yml`（`Reviewed-HEAD-SHA == HEAD^` + 签字提交隔离） |
+| 非 task 分支必须 Skip-Reason        | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | `openspec-log-guard.yml`                                                                          |
+| gh 超时 3 次 + 升级                 | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | 执行规范（RUN_LOG 记录）                                                                          |
 
 ## Canonical Checks
 

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -40,8 +40,9 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 13. **Issue 新鲜度强制**：新任务必须使用当前 OPEN Issue；禁止复用已关闭或历史 Issue。
 14. **环境基线强制**：创建 `task/*` 分支和 worktree 前，必须先同步控制面到最新 `origin/main`。
 15. **RUN_LOG PR 真实链接强制**：`openspec/_ops/task_runs/ISSUE-<N>.md` 的 `PR` 字段不得为占位符（如 `待回填/TBD/TODO`）。
-16. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
-17. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
+16. **主会话审计强制**：RUN_LOG 必须包含 `## Main Session Audit`，且同时满足 `Audit-Owner=main-session`、`Reviewed-HEAD-SHA==当前 HEAD`、`Spec-Compliance/Code-Quality/Fresh-Verification` 全部 `PASS`、`Blocking-Issues=0`、`Decision=ACCEPT`；任一不满足必须被 preflight 与 `openspec-log-guard` 阻断，子代理完成不得替代主会话签字。
+17. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
+18. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
 
 ---
 
@@ -73,6 +74,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | required checks 与本文件不一致       | 阻断交付并升级治理，禁止宣称“门禁全绿”                                                      |
 | 误用已关闭/历史 Issue                | 立即停止实现，改为新建 OPEN Issue，并从最新 `origin/main` 重建 worktree                     |
 | RUN_LOG PR 字段是占位符              | 先回填真实 PR 链接，再进入交付与合并流程                                                    |
+| RUN_LOG 主会话审计缺失/未通过        | 阻断交付；先补齐 `## Main Session Audit` 并满足全部通过条件                                 |
 | 活跃 change 已完成但未归档           | 阻断交付，先归档到 `openspec/changes/archive/` 再继续                                       |
 | 当前任务已在同 PR 归档               | 允许 preflight 通过 archive 路径校验，不要求再次创建 closeout issue                         |
 
@@ -103,3 +105,5 @@ openspec/             rulebook/tasks/        .github/workflows/
   - 现行防线：对存在上游依赖的 change 强制执行 Dependency Sync Check，发现漂移先更新 change 文档再进入 Red/Green。
 - 既往不符合项 D：治理 closeout task 归档后仍遗留 active，触发递归 closeout issue。
   - 现行防线：preflight 支持当前任务 `active/archive` 双路径，并允许同 PR 自归档收口。
+- 既往不符合项 E：子代理自报完成但主会话未审计签字，仍进入合并路径。
+  - 现行防线：RUN_LOG 强制 `Main Session Audit`，preflight 与 `openspec-log-guard` 双门禁校验并阻断未通过场景。

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -40,7 +40,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 13. **Issue 新鲜度强制**：新任务必须使用当前 OPEN Issue；禁止复用已关闭或历史 Issue。
 14. **环境基线强制**：创建 `task/*` 分支和 worktree 前，必须先同步控制面到最新 `origin/main`。
 15. **RUN_LOG PR 真实链接强制**：`openspec/_ops/task_runs/ISSUE-<N>.md` 的 `PR` 字段不得为占位符（如 `待回填/TBD/TODO`）。
-16. **主会话审计强制**：RUN_LOG 必须包含 `## Main Session Audit`，且同时满足 `Audit-Owner=main-session`、`Reviewed-HEAD-SHA==当前 HEAD`、`Spec-Compliance/Code-Quality/Fresh-Verification` 全部 `PASS`、`Blocking-Issues=0`、`Decision=ACCEPT`；任一不满足必须被 preflight 与 `openspec-log-guard` 阻断，子代理完成不得替代主会话签字。
+16. **主会话审计强制**：RUN_LOG 必须包含 `## Main Session Audit`，且同时满足 `Audit-Owner=main-session`、`Reviewed-HEAD-SHA==签字提交的 HEAD^`、`Spec-Compliance/Code-Quality/Fresh-Verification` 全部 `PASS`、`Blocking-Issues=0`、`Decision=ACCEPT`；并且签字提交 `HEAD^..HEAD` 仅允许变更当前任务 RUN_LOG。任一不满足必须被 preflight 与 `openspec-log-guard` 阻断，子代理完成不得替代主会话签字。
 17. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
 18. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
 
@@ -74,7 +74,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | required checks 与本文件不一致       | 阻断交付并升级治理，禁止宣称“门禁全绿”                                                      |
 | 误用已关闭/历史 Issue                | 立即停止实现，改为新建 OPEN Issue，并从最新 `origin/main` 重建 worktree                     |
 | RUN_LOG PR 字段是占位符              | 先回填真实 PR 链接，再进入交付与合并流程                                                    |
-| RUN_LOG 主会话审计缺失/未通过        | 阻断交付；先补齐 `## Main Session Audit` 并满足全部通过条件                                 |
+| RUN_LOG 主会话审计缺失/未通过        | 阻断交付；先补齐 `## Main Session Audit` 并满足全部通过条件，确保签字提交仅变更 RUN_LOG     |
 | 活跃 change 已完成但未归档           | 阻断交付，先归档到 `openspec/changes/archive/` 再继续                                       |
 | 当前任务已在同 PR 归档               | 允许 preflight 通过 archive 路径校验，不要求再次创建 closeout issue                         |
 

--- a/openspec/_ops/task_runs/ISSUE-518.md
+++ b/openspec/_ops/task_runs/ISSUE-518.md
@@ -3,8 +3,8 @@
 - Issue: #518
 - Issue URL: https://github.com/Leeky1017/CreoNow/issues/518
 - Branch: task/518-main-session-audit-hard-gate
-- PR: https://github.com/Leeky1017/CreoNow/pull/518
-- Scope: 实现主会话审计硬门禁，要求 preflight 与 openspec-log-guard 同步阻断未审计场景
+- PR: https://github.com/Leeky1017/CreoNow/pull/519
+- Scope: 实现主会话审计硬门禁，要求 preflight 与 openspec-log-guard 同步阻断未审计场景，并修复 Reviewed-HEAD-SHA 自引用悖论（改为签字提交 `HEAD^`）
 - Out of Scope: 新增 required checks、任务级临时 CI 分叉逻辑
 
 ## Plan
@@ -111,10 +111,42 @@
   - `tsc --noEmit` 通过
   - 单元测试链路通过（含 `cross-module` gate 与 Storybook inventory 检查）
 
+### 2026-02-13 21:46 悖论修复（HEAD^ + 签字提交隔离）
+
+- Edited:
+  - `scripts/agent_pr_preflight.py`
+  - `scripts/tests/test_agent_pr_preflight.py`
+  - `.github/workflows/openspec-log-guard.yml`
+  - `docs/delivery-skill.md`
+  - `docs/delivery-rule-mapping.md`
+  - `openspec/changes/main-session-audit-hard-gate/*`
+- Command:
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+  - `git commit -m "ci: resolve main-audit HEAD paradox (#518)"`
+- Exit code: `0`
+- Key output:
+  - `Ran 14 tests ... OK`
+  - 新增签字提交隔离校验：`HEAD^..HEAD` 仅允许变更当前任务 RUN_LOG
+
+### 2026-02-13 21:49 PR 创建与补跑验证
+
+- Command:
+  - `git push -u origin task/518-main-session-audit-hard-gate`
+  - `gh pr create --base main --head task/518-main-session-audit-hard-gate --title "Enforce main-session audit hard gate (#518)" ...`
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+  - `pnpm lint`
+  - `pnpm typecheck`
+  - `pnpm test:unit`
+- Exit code: `0`
+- Key output:
+  - PR 创建成功：`https://github.com/Leeky1017/CreoNow/pull/519`
+  - `Ran 14 tests ... OK`
+  - `eslint` / `tsc --noEmit` / `test:unit` 全部通过
+
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 1da4f9ccc36cad7a9fe495128043913b443178fc
+- Reviewed-HEAD-SHA: a6f07e11f37210f25d1d0c6244fff541af404b7a
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-518.md
+++ b/openspec/_ops/task_runs/ISSUE-518.md
@@ -1,0 +1,122 @@
+# ISSUE-518
+
+- Issue: #518
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/518
+- Branch: task/518-main-session-audit-hard-gate
+- PR: https://github.com/Leeky1017/CreoNow/pull/518
+- Scope: 实现主会话审计硬门禁，要求 preflight 与 openspec-log-guard 同步阻断未审计场景
+- Out of Scope: 新增 required checks、任务级临时 CI 分叉逻辑
+
+## Plan
+
+- [x] 完成任务准入（OPEN issue、task branch、worktree、Rulebook）
+- [x] 完成 change proposal/tasks/spec 与 Dependency Sync Check
+- [x] 按 TDD 完成 Red→Green（新增单测 + preflight 校验实现）
+- [x] 接入 CI workflow、模板与文档同步
+- [x] 执行验证命令并收口
+
+## Runs
+
+### 2026-02-13 21:02 准入与环境隔离
+
+- Command:
+  - `gh issue create --title "Enforce main-session audit hard gate for sub-agent outputs" ...`
+  - `scripts/agent_worktree_setup.sh 518 main-session-audit-hard-gate`
+  - `rulebook task create issue-518-main-session-audit-hard-gate`
+  - `rulebook task validate issue-518-main-session-audit-hard-gate`
+- Exit code: `0`
+- Key output:
+  - Issue 创建成功：`#518`
+  - Worktree 创建成功：`.worktrees/issue-518-main-session-audit-hard-gate`
+  - Rulebook task 创建并 validate 通过
+
+### 2026-02-13 21:06 Dependency Sync Check（无上游依赖）
+
+- Input checks:
+  - 审阅 `openspec/specs/cross-module-integration-spec.md`
+  - 审阅 `docs/delivery-skill.md`
+  - 审阅 `.github/workflows/openspec-log-guard.yml`
+  - 审阅 `scripts/agent_pr_preflight.py`
+- Conclusion:
+  - 当前 change 无上游依赖，`N/A`，可进入 Red。
+
+### 2026-02-13 21:14 Red 失败证据（先测）
+
+- Command:
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+- Exit code: `1`（预期 Red）
+- Key output:
+  - `AttributeError: module 'agent_pr_preflight' has no attribute 'validate_main_session_audit'`
+  - `FAILED (errors=6)`
+
+### 2026-02-13 21:20 Green 实现与测试回归
+
+- Edited:
+  - `scripts/tests/test_agent_pr_preflight.py`
+  - `scripts/agent_pr_preflight.py`
+  - `.github/workflows/openspec-log-guard.yml`
+  - `openspec/changes/_template/tasks.md`
+  - `docs/delivery-skill.md`
+  - `docs/delivery-rule-mapping.md`
+  - `openspec/changes/main-session-audit-hard-gate/*`
+- Command:
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+  - `rulebook task validate issue-518-main-session-audit-hard-gate`
+- Exit code: `0`
+- Key output:
+  - `Ran 10 tests ... OK`
+  - `Task issue-518-main-session-audit-hard-gate is valid`
+
+### 2026-02-13 21:26 preflight 首次失败（格式）
+
+- Command:
+  - `scripts/agent_pr_preflight.sh`
+- Exit code: `1`
+- Key output:
+  - `PRE-FLIGHT FAILED: ... pnpm exec prettier --check ... (exit 1)`
+  - `[warn] Code style issues found in 5 files. Run Prettier with --write to fix.`
+
+### 2026-02-13 21:27 preflight 二次失败（依赖）
+
+- Command:
+  - `pnpm exec prettier --write docs/delivery-rule-mapping.md openspec/changes/main-session-audit-hard-gate/proposal.md rulebook/tasks/issue-518-main-session-audit-hard-gate/.metadata.json rulebook/tasks/issue-518-main-session-audit-hard-gate/proposal.md rulebook/tasks/issue-518-main-session-audit-hard-gate/tasks.md`
+  - `scripts/agent_pr_preflight.sh`
+- Exit code: `1`
+- Key output:
+  - `All matched files use Prettier code style!`
+  - `PRE-FLIGHT FAILED: command failed: pnpm typecheck (exit 1)`
+  - `sh: 1: tsc: not found`
+
+### 2026-02-13 21:28 preflight 三次通过（修复后）
+
+- Command:
+  - `pnpm install --frozen-lockfile`
+  - `scripts/agent_pr_preflight.sh`
+- Exit code: `0`
+- Key output:
+  - `Lockfile is up to date`
+  - `pnpm typecheck` / `pnpm lint` / `pnpm contract:check` / `pnpm cross-module:check` / `pnpm test:unit` 全部通过
+
+### 2026-02-13 21:29 补跑验证命令
+
+- Command:
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+  - `pnpm lint`
+  - `pnpm typecheck`
+  - `pnpm test:unit`
+- Exit code: `0`
+- Key output:
+  - `Ran 10 tests ... OK`
+  - `eslint . --ext .ts,.tsx` 通过
+  - `tsc --noEmit` 通过
+  - 单元测试链路通过（含 `cross-module` gate 与 Storybook inventory 检查）
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 1da4f9ccc36cad7a9fe495128043913b443178fc
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-518.md
+++ b/openspec/_ops/task_runs/ISSUE-518.md
@@ -143,10 +143,23 @@
   - `Ran 14 tests ... OK`
   - `eslint` / `tsc --noEmit` / `test:unit` 全部通过
 
+### 2026-02-13 21:58 CI 失败修复（openspec-log-guard heredoc 解析）
+
+- Command:
+  - `gh run view 21991883603 --log-failed`
+  - `python3 scripts/validate_main_session_audit_ci.py openspec/_ops/task_runs/ISSUE-518.md`
+  - `python3 -m unittest scripts/tests/test_agent_pr_preflight.py`
+  - `git commit -m "ci: fix openspec-log-guard main-audit parser (#518)"`
+- Exit code: `0`
+- Key output:
+  - 失败根因：workflow heredoc 终止符解析失败（`syntax error: unexpected end of file`）
+  - 修复方案：改为调用 `scripts/validate_main_session_audit_ci.py`
+  - 本地校验：`✅ Main Session Audit validated`，`Ran 14 tests ... OK`
+
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: a6f07e11f37210f25d1d0c6244fff541af404b7a
+- Reviewed-HEAD-SHA: 051193bd1cbe4cbc277ac8b20fbec521012c109e
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/changes/_template/tasks.md
+++ b/openspec/changes/_template/tasks.md
@@ -31,4 +31,4 @@
 
 - [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
 - [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
-- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA/三项 PASS/Blocking-Issues=0/Decision=ACCEPT）并确认通过条件全部满足
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/_template/tasks.md
+++ b/openspec/changes/_template/tasks.md
@@ -31,3 +31,4 @@
 
 - [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
 - [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA/三项 PASS/Blocking-Issues=0/Decision=ACCEPT）并确认通过条件全部满足

--- a/openspec/changes/main-session-audit-hard-gate/proposal.md
+++ b/openspec/changes/main-session-audit-hard-gate/proposal.md
@@ -7,13 +7,14 @@
 不改的风险：
 
 - 子代理产出在缺少主会话审计结论时仍可能进入合并流程。
-- preflight 与 CI 不能阻断“未审计/审计失败/审计对象非当前 HEAD”的风险提交。
+- preflight 与 CI 不能阻断“未审计/审计失败/审计对象非签字提交 `HEAD^`”的风险提交。
 - RUN_LOG 无法作为“主会话最终责任签字”的机器可验证证据。
 
 ## 变更内容
 
-- 在 RUN_LOG 增加固定、可机读的 `## Main Session Audit` 段并定义通过条件。
+- 在 RUN_LOG 增加固定、可机读的 `## Main Session Audit` 段并定义通过条件（`Reviewed-HEAD-SHA == 签字提交 HEAD^`）。
 - 在 `scripts/agent_pr_preflight.py` 增加 `validate_main_session_audit(run_log, head_sha)` 并接入主流程。
+- 在 preflight 与 CI 增加签字提交隔离校验：`HEAD^..HEAD` 仅允许变更当前任务 RUN_LOG。
 - 在 `.github/workflows/openspec-log-guard.yml` 增加同等 Main Session Audit 校验，确保 PR 到 `main` 时可阻断。
 - 更新 `openspec/changes/_template/tasks.md` 的 Evidence 清单，显式要求主会话审计记录与通过条件。
 - 同步更新 `docs/delivery-skill.md` 与 `docs/delivery-rule-mapping.md`。

--- a/openspec/changes/main-session-audit-hard-gate/proposal.md
+++ b/openspec/changes/main-session-audit-hard-gate/proposal.md
@@ -1,0 +1,35 @@
+# 提案：main-session-audit-hard-gate
+
+## 背景
+
+当前流程中，子代理报告“已完成”并不等于主会话已完成审计签字。现有门禁只校验 RUN_LOG 基础字段与 Rulebook/OpenSpec 结构，未强制“主会话审计通过”这一阻断条件。
+
+不改的风险：
+
+- 子代理产出在缺少主会话审计结论时仍可能进入合并流程。
+- preflight 与 CI 不能阻断“未审计/审计失败/审计对象非当前 HEAD”的风险提交。
+- RUN_LOG 无法作为“主会话最终责任签字”的机器可验证证据。
+
+## 变更内容
+
+- 在 RUN_LOG 增加固定、可机读的 `## Main Session Audit` 段并定义通过条件。
+- 在 `scripts/agent_pr_preflight.py` 增加 `validate_main_session_audit(run_log, head_sha)` 并接入主流程。
+- 在 `.github/workflows/openspec-log-guard.yml` 增加同等 Main Session Audit 校验，确保 PR 到 `main` 时可阻断。
+- 更新 `openspec/changes/_template/tasks.md` 的 Evidence 清单，显式要求主会话审计记录与通过条件。
+- 同步更新 `docs/delivery-skill.md` 与 `docs/delivery-rule-mapping.md`。
+
+## 受影响模块
+
+- 交付门禁链路：`scripts/agent_pr_preflight.py`、`scripts/tests/test_agent_pr_preflight.py`、`.github/workflows/openspec-log-guard.yml`
+- OpenSpec change template：`openspec/changes/_template/tasks.md`
+- 交付文档：`docs/delivery-skill.md`、`docs/delivery-rule-mapping.md`
+
+## 不做什么
+
+- 不新增 required check 名称（保持 `ci` / `openspec-log-guard` / `merge-serial`）。
+- 不为单个任务定制临时 CI 逻辑。
+- 不依赖子代理自报完成作为交付依据。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/main-session-audit-hard-gate/specs/cross-module-integration-delta.md
+++ b/openspec/changes/main-session-audit-hard-gate/specs/cross-module-integration-delta.md
@@ -1,0 +1,28 @@
+# Cross Module Integration Specification Delta
+
+## Change: main-session-audit-hard-gate
+
+### Requirement: Main Session Audit Hard Gate [ADDED]
+
+RUN_LOG 必须包含可机器校验的主会话审计段。preflight 与 `openspec-log-guard` 必须基于同一字段和同一通过条件执行阻断。
+
+#### Scenario: Main Session Audit 全部通过时放行 [ADDED]
+
+- **假设** RUN_LOG 包含 `## Main Session Audit` 固定字段
+- **当** 审计字段满足全部通过条件
+- **则** preflight 与 `openspec-log-guard` 通过该门禁
+- **并且** 不改变现有 required checks 名称
+
+#### Scenario: 审计字段缺失或不合法时阻断 [ADDED]
+
+- **假设** RUN_LOG 缺少 Main Session Audit 或字段值非法
+- **当** 执行 preflight 或 PR 触发 `openspec-log-guard`
+- **则** 门禁失败并阻断交付
+- **并且** preflight 报错前缀统一为 `[MAIN_AUDIT]`
+
+#### Scenario: 审计对象不是当前 HEAD 时阻断 [ADDED]
+
+- **假设** `Reviewed-HEAD-SHA` 与当前 HEAD 不一致
+- **当** 执行 preflight 或 PR 触发 `openspec-log-guard`
+- **则** 门禁失败并阻断交付
+- **并且** 只有审计对象等于当前 HEAD 才允许进入合并

--- a/openspec/changes/main-session-audit-hard-gate/specs/cross-module-integration-delta.md
+++ b/openspec/changes/main-session-audit-hard-gate/specs/cross-module-integration-delta.md
@@ -20,9 +20,9 @@ RUN_LOG 必须包含可机器校验的主会话审计段。preflight 与 `opensp
 - **则** 门禁失败并阻断交付
 - **并且** preflight 报错前缀统一为 `[MAIN_AUDIT]`
 
-#### Scenario: 审计对象不是当前 HEAD 时阻断 [ADDED]
+#### Scenario: 审计对象不是签字提交的 HEAD^ 时阻断 [ADDED]
 
-- **假设** `Reviewed-HEAD-SHA` 与当前 HEAD 不一致
+- **假设** `Reviewed-HEAD-SHA` 与签字提交的 `HEAD^` 不一致
 - **当** 执行 preflight 或 PR 触发 `openspec-log-guard`
 - **则** 门禁失败并阻断交付
-- **并且** 只有审计对象等于当前 HEAD 才允许进入合并
+- **并且** `HEAD^..HEAD` 仅允许变更当前任务 RUN_LOG（主会话签字提交隔离）

--- a/openspec/changes/main-session-audit-hard-gate/tasks.md
+++ b/openspec/changes/main-session-audit-hard-gate/tasks.md
@@ -19,20 +19,26 @@
   - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_any_gate_field_is_fail`
   - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_blocking_issues_not_zero`
   - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_decision_not_accept`
-- [x] S3「审计对象不是当前 HEAD 时阻断」→ `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_reviewed_sha_mismatch`
+- [x] S3「审计对象不是签字提交的 HEAD^ 时阻断」→ `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_reviewed_sha_mismatch`
+- [x] S4「签字提交隔离（仅 RUN_LOG 可变更）」→
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_signature_commit_should_pass_when_only_run_log_changed`
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_signature_commit_should_fail_when_run_log_not_changed`
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_signature_commit_should_fail_when_other_files_changed`
 
 ## 3. Red（先写失败测试）
 
 - [x] 3.1 新增 Main Session Audit 通过路径测试并确认先失败
 - [x] 3.2 新增字段缺失/字段 FAIL/Blocking-Issues 非零/Decision 非 ACCEPT/SHA 不一致失败测试并确认先失败
-- [x] 3.3 记录 Red 失败输出与关键日志至 RUN_LOG
+- [x] 3.3 新增签字提交隔离（仅 RUN_LOG 可变更）测试并确认先失败
+- [x] 3.4 记录 Red 失败输出与关键日志至 RUN_LOG
 
 ## 4. Green（最小实现通过）
 
 - [x] 4.1 新增并接入 `validate_main_session_audit(run_log, head_sha)`
 - [x] 4.2 preflight 缺字段、格式错、值不合法、条件不满足统一 `RuntimeError`，报错前缀 `[MAIN_AUDIT]`
-- [x] 4.3 `openspec-log-guard.yml` 增加同等 Main Session Audit 校验并阻断未审计场景
-- [x] 4.4 同步模板与文档（tasks template / delivery-skill / delivery-rule-mapping）
+- [x] 4.3 preflight 与 CI 同步校验 `Reviewed-HEAD-SHA == HEAD^`，并强制签字提交仅变更 RUN_LOG
+- [x] 4.4 `openspec-log-guard.yml` 增加同等 Main Session Audit 校验并阻断未审计场景
+- [x] 4.5 同步模板与文档（tasks template / delivery-skill / delivery-rule-mapping）
 
 ## 5. Refactor（保持绿灯）
 

--- a/openspec/changes/main-session-audit-hard-gate/tasks.md
+++ b/openspec/changes/main-session-audit-hard-gate/tasks.md
@@ -1,0 +1,45 @@
+## 1. Specification
+
+- [x] 1.1 审阅并确认主会话审计固定字段与取值域
+- [x] 1.2 审阅并确认主会话审计通过条件（全量 AND 条件）
+- [x] 1.3 审阅并确认 preflight 与 CI 的一致性约束
+- [x] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；无依赖则标注 N/A
+
+## 2. TDD Mapping（先测前提）
+
+- [x] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [x] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [x] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → 测试映射
+
+- [x] S1「Main Session Audit 全部通过时放行」→ `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_pass_with_complete_section`
+- [x] S2「审计字段缺失或不合法时阻断」→
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_section_missing`
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_any_gate_field_is_fail`
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_blocking_issues_not_zero`
+  - `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_decision_not_accept`
+- [x] S3「审计对象不是当前 HEAD 时阻断」→ `scripts/tests/test_agent_pr_preflight.py::test_validate_main_session_audit_should_fail_when_reviewed_sha_mismatch`
+
+## 3. Red（先写失败测试）
+
+- [x] 3.1 新增 Main Session Audit 通过路径测试并确认先失败
+- [x] 3.2 新增字段缺失/字段 FAIL/Blocking-Issues 非零/Decision 非 ACCEPT/SHA 不一致失败测试并确认先失败
+- [x] 3.3 记录 Red 失败输出与关键日志至 RUN_LOG
+
+## 4. Green（最小实现通过）
+
+- [x] 4.1 新增并接入 `validate_main_session_audit(run_log, head_sha)`
+- [x] 4.2 preflight 缺字段、格式错、值不合法、条件不满足统一 `RuntimeError`，报错前缀 `[MAIN_AUDIT]`
+- [x] 4.3 `openspec-log-guard.yml` 增加同等 Main Session Audit 校验并阻断未审计场景
+- [x] 4.4 同步模板与文档（tasks template / delivery-skill / delivery-rule-mapping）
+
+## 5. Refactor（保持绿灯）
+
+- [x] 5.1 抽取校验常量与解析逻辑，避免重复正则分支
+- [x] 5.2 保持新增测试与既有测试全绿
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [x] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）

--- a/rulebook/tasks/issue-518-main-session-audit-hard-gate/.metadata.json
+++ b/rulebook/tasks/issue-518-main-session-audit-hard-gate/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-13T14:35:08.417Z",
+  "updatedAt": "2026-02-13T14:35:08.417Z"
+}

--- a/rulebook/tasks/issue-518-main-session-audit-hard-gate/proposal.md
+++ b/rulebook/tasks/issue-518-main-session-audit-hard-gate/proposal.md
@@ -1,0 +1,20 @@
+# Proposal: issue-518-main-session-audit-hard-gate
+
+## Why
+
+Sub-agent reported completion cannot be treated as merge-ready delivery unless the main session explicitly audits and signs off.
+Without a machine-enforced audit section, preflight and CI cannot reliably block unaudited or rejected outputs.
+
+## What Changes
+
+- Add hard validation for RUN_LOG `## Main Session Audit` in `scripts/agent_pr_preflight.py`.
+- Add equivalent CI guard in `.github/workflows/openspec-log-guard.yml`.
+- Add unit tests covering pass and blocking scenarios.
+- Sync OpenSpec template and delivery docs with mandatory main-session audit rule.
+
+## Impact
+
+- Affected specs: `openspec/changes/main-session-audit-hard-gate/specs/cross-module-integration-delta.md`
+- Affected code: `scripts/agent_pr_preflight.py`, `scripts/tests/test_agent_pr_preflight.py`, `.github/workflows/openspec-log-guard.yml`
+- Breaking change: NO (governance tightening only)
+- User benefit: unaudited sub-agent outputs are blocked before merge by both local preflight and CI guard

--- a/rulebook/tasks/issue-518-main-session-audit-hard-gate/tasks.md
+++ b/rulebook/tasks/issue-518-main-session-audit-hard-gate/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Add `validate_main_session_audit(run_log, head_sha)` and wire into preflight main flow.
+- [x] 1.2 Add CI-level Main Session Audit guard in `openspec-log-guard`.
+- [x] 1.3 Keep required checks unchanged (`ci` / `openspec-log-guard` / `merge-serial`).
+
+## 2. Testing
+
+- [x] 2.1 Add unit tests for pass + fail scenarios in `scripts/tests/test_agent_pr_preflight.py`.
+- [x] 2.2 Run `python3 -m unittest scripts/tests/test_agent_pr_preflight.py` and verify green.
+- [x] 2.3 Run `scripts/agent_pr_preflight.sh` and verify gate behavior.
+
+## 3. Documentation
+
+- [x] 3.1 Update OpenSpec change docs (`proposal/tasks/spec`) with TDD mapping and evidence.
+- [x] 3.2 Update `openspec/changes/_template/tasks.md` evidence checklist.
+- [x] 3.3 Update `docs/delivery-skill.md` and `docs/delivery-rule-mapping.md`.

--- a/scripts/tests/test_agent_pr_preflight.py
+++ b/scripts/tests/test_agent_pr_preflight.py
@@ -65,5 +65,94 @@ class RulebookTaskResolutionTests(unittest.TestCase):
             agent_pr_preflight.resolve_rulebook_task_location(self.repo, task_id)
 
 
+class MainSessionAuditValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = self.tmp.name
+        self.head_sha = "a" * 40
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_run_log(self, body: str) -> str:
+        path = os.path.join(self.repo, "ISSUE-518.md")
+        with open(path, "w", encoding="utf-8") as fp:
+            fp.write(body)
+        return path
+
+    def _run_log_with_audit(
+        self,
+        *,
+        audit_owner: str = "main-session",
+        reviewed_sha: str | None = None,
+        spec_compliance: str = "PASS",
+        code_quality: str = "PASS",
+        fresh_verification: str = "PASS",
+        blocking_issues: str = "0",
+        decision: str = "ACCEPT",
+    ) -> str:
+        reviewed = reviewed_sha or self.head_sha
+        return (
+            "# ISSUE-518\n\n"
+            "- Issue: #518\n"
+            "- Branch: task/518-main-session-audit-hard-gate\n"
+            "- PR: https://github.com/Leeky1017/CreoNow/pull/999\n\n"
+            "## Plan\n\n"
+            "- [x] plan\n\n"
+            "## Runs\n\n"
+            "- run\n\n"
+            "## Main Session Audit\n"
+            f"- Audit-Owner: {audit_owner}\n"
+            f"- Reviewed-HEAD-SHA: {reviewed}\n"
+            f"- Spec-Compliance: {spec_compliance}\n"
+            f"- Code-Quality: {code_quality}\n"
+            f"- Fresh-Verification: {fresh_verification}\n"
+            f"- Blocking-Issues: {blocking_issues}\n"
+            f"- Decision: {decision}\n"
+        )
+
+    def test_validate_main_session_audit_should_pass_with_complete_section(self) -> None:
+        run_log = self._write_run_log(self._run_log_with_audit())
+
+        agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+    def test_validate_main_session_audit_should_fail_when_section_missing(self) -> None:
+        run_log = self._write_run_log(
+            "# ISSUE-518\n\n"
+            "- Issue: #518\n"
+            "- Branch: task/518-main-session-audit-hard-gate\n"
+            "- PR: https://github.com/Leeky1017/CreoNow/pull/999\n\n"
+            "## Plan\n- [x] plan\n\n"
+            "## Runs\n- run\n"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, r"^\[MAIN_AUDIT\]"):
+            agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+    def test_validate_main_session_audit_should_fail_when_any_gate_field_is_fail(self) -> None:
+        run_log = self._write_run_log(self._run_log_with_audit(code_quality="FAIL"))
+
+        with self.assertRaisesRegex(RuntimeError, r"^\[MAIN_AUDIT\]"):
+            agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+    def test_validate_main_session_audit_should_fail_when_blocking_issues_not_zero(self) -> None:
+        run_log = self._write_run_log(self._run_log_with_audit(blocking_issues="2"))
+
+        with self.assertRaisesRegex(RuntimeError, r"^\[MAIN_AUDIT\]"):
+            agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+    def test_validate_main_session_audit_should_fail_when_decision_not_accept(self) -> None:
+        run_log = self._write_run_log(self._run_log_with_audit(decision="REJECT"))
+
+        with self.assertRaisesRegex(RuntimeError, r"^\[MAIN_AUDIT\]"):
+            agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+    def test_validate_main_session_audit_should_fail_when_reviewed_sha_mismatch(self) -> None:
+        run_log = self._write_run_log(self._run_log_with_audit(reviewed_sha="b" * 40))
+
+        with self.assertRaisesRegex(RuntimeError, r"^\[MAIN_AUDIT\]"):
+            agent_pr_preflight.validate_main_session_audit(run_log, self.head_sha)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate_main_session_audit_ci.py
+++ b/scripts/validate_main_session_audit_ci.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+import agent_pr_preflight as preflight
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python3 scripts/validate_main_session_audit_ci.py <run-log-path>", file=sys.stderr)
+        return 2
+
+    run_log_rel = sys.argv[1]
+    repo = preflight.git_root()
+    run_log_abs = os.path.join(repo, run_log_rel)
+
+    preflight.require_file(run_log_abs)
+    reviewed_target_sha = preflight.current_head_parent_sha(repo)
+    preflight.validate_main_session_audit(run_log_abs, reviewed_target_sha)
+    preflight.validate_main_session_audit_signature_commit(repo, run_log_abs)
+
+    print("✅ Main Session Audit validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #518

## Summary
- add hard gate validation for `Main Session Audit` in preflight and `openspec-log-guard`
- resolve SHA paradox by validating `Reviewed-HEAD-SHA == HEAD^` plus signing-commit isolation (only RUN_LOG mutable in signing commit)
- add unit tests and update OpenSpec/doc mappings

## Verification
- python3 -m unittest scripts/tests/test_agent_pr_preflight.py
- scripts/agent_pr_preflight.sh
- pnpm lint
- pnpm typecheck
- pnpm test:unit
