### PR TITLE
Deliver Sprint0 OpenSpec changes in one batch (#522)

### DIFF
--- a/openspec/_ops/task_runs/ISSUE-522.md
+++ b/openspec/_ops/task_runs/ISSUE-522.md
@@ -1,0 +1,49 @@
+# ISSUE-522
+
+- Issue: #522
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/522
+- Branch: task/522-sprint0-batch-delivery
+- PR: (pending)
+- Scope: Sprint0 8 个 OpenSpec changes 一次性治理交付并合并到控制面 `main`
+- Out of Scope: Sprint0 代码实现与测试修复（本任务仅交付变更文档与治理工件）
+
+## Plan
+
+- [x] 创建单一总 Issue 与隔离 worktree 分支
+- [x] 迁移本地 Sprint0 changes 到 `task/522-sprint0-batch-delivery`
+- [x] 创建 Rulebook task 并补齐 proposal/tasks/spec
+- [ ] 完成 preflight、PR、auto-merge、main 同步与 worktree 清理
+
+## Runs
+
+### 2026-02-14 11:52 准入与单 Issue 建立
+
+- Command:
+  - `gh issue create --repo Leeky1017/CreoNow --title "Deliver Sprint0 OpenSpec changes in one governed batch" ...`
+- Exit code: `0`
+- Key output:
+  - 创建 OPEN issue：`#522`
+  - URL：`https://github.com/Leeky1017/CreoNow/issues/522`
+
+### 2026-02-14 11:53 控制面改动迁移与隔离分支建立
+
+- Command:
+  - `git stash push -u -m 'issue-522-sprint0-batch-delivery'`
+  - `scripts/agent_worktree_setup.sh 522 sprint0-batch-delivery`
+  - `(cd .worktrees/issue-522-sprint0-batch-delivery && git stash pop stash@{0})`
+- Exit code: `0`
+- Key output:
+  - 创建 worktree：`.worktrees/issue-522-sprint0-batch-delivery`
+  - 创建分支：`task/522-sprint0-batch-delivery`
+  - Sprint0 changes 成功迁移到隔离分支
+
+### 2026-02-14 11:55 环境与 Rulebook 任务准备
+
+- Command:
+  - `pnpm install --frozen-lockfile`
+  - `rulebook task create issue-522-sprint0-batch-delivery`
+  - `rulebook task validate issue-522-sprint0-batch-delivery`
+- Exit code: `0`
+- Key output:
+  - 依赖安装完成（lockfile frozen）
+  - Rulebook task 创建并通过 validate

--- a/openspec/_ops/task_runs/ISSUE-522.md
+++ b/openspec/_ops/task_runs/ISSUE-522.md
@@ -3,7 +3,7 @@
 - Issue: #522
 - Issue URL: https://github.com/Leeky1017/CreoNow/issues/522
 - Branch: task/522-sprint0-batch-delivery
-- PR: (pending)
+- PR: https://github.com/Leeky1017/CreoNow/pull/523
 - Scope: Sprint0 8 个 OpenSpec changes 一次性治理交付并合并到控制面 `main`
 - Out of Scope: Sprint0 代码实现与测试修复（本任务仅交付变更文档与治理工件）
 
@@ -47,3 +47,37 @@
 - Key output:
   - 依赖安装完成（lockfile frozen）
   - Rulebook task 创建并通过 validate
+
+### 2026-02-14 11:56 文档质量校验与首个内容提交
+
+- Command:
+  - `pnpm exec prettier --check openspec/changes/EXECUTION_ORDER.md openspec/changes/s0-*/proposal.md openspec/changes/s0-*/tasks.md openspec/changes/s0-*/specs/*.md openspec/_ops/task_runs/ISSUE-522.md rulebook/tasks/issue-522-sprint0-batch-delivery/.metadata.json rulebook/tasks/issue-522-sprint0-batch-delivery/proposal.md rulebook/tasks/issue-522-sprint0-batch-delivery/tasks.md rulebook/tasks/issue-522-sprint0-batch-delivery/specs/governance/spec.md`
+  - `rulebook task validate issue-522-sprint0-batch-delivery`
+  - `git add -A`
+  - `git commit -m "docs: deliver sprint0 openspec changes batch (#522)"`
+  - `git push -u origin task/522-sprint0-batch-delivery`
+- Exit code: `0`
+- Key output:
+  - 内容提交 SHA：`3192cf8567ab8997b0a42939a37cff09ba2495ea`
+  - 分支成功推送到 `origin/task/522-sprint0-batch-delivery`
+
+### 2026-02-14 11:57 创建单 PR 与 preflight 首次阻断
+
+- Command:
+  - `gh pr create --base main --head Leeky1017:task/522-sprint0-batch-delivery --title "Deliver Sprint0 OpenSpec changes in one batch (#522)" ...`
+  - `scripts/agent_pr_preflight.sh`
+- Exit code: `1`（preflight）
+- Key output:
+  - PR 创建成功：`https://github.com/Leeky1017/CreoNow/pull/523`
+  - preflight 阻断：`[RUN_LOG] PR field must be a real URL ... (pending)`
+  - 动作：回填 RUN_LOG 的 PR 链接并进入主会话签字提交
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 3192cf8567ab8997b0a42939a37cff09ba2495ea
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,37 +1,35 @@
 # Active Changes Execution Order
 
-更新时间：2026-02-13 18:20
+更新时间：2026-02-14 11:50
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 **0**。
-- 执行模式：**无活跃 change**。
-- 当前在途变更：无。
+- 当前活跃 change 数量为 **8**。
+- 执行模式：**并行 + 串行混合**。
+- 执行分组：
+  - 并行组 A（独立）：`s0-fake-queued-fix`、`s0-window-load-catch`、`s0-app-ready-catch`、`s0-skill-loader-error`、`s0-sandbox-enable`
+  - 串行组 B（同模块先后依赖）：`s0-metadata-failfast` → `s0-kg-async-validate`
+  - 并行组 C（独立）：`s0-context-observe`
+- 推荐执行方式：A 与 C 并行推进；B 必须按顺序执行。
 
 ## 执行顺序
 
-1. 无
-
-## 推荐执行序列
-
-```text
-(none)
-```
-
-## 依赖关系总览
-
-```text
-(no active changes)
-```
-
-## 依赖明细
-
-- 无活跃 change
+1. `s0-fake-queued-fix`
+2. `s0-window-load-catch`
+3. `s0-app-ready-catch`
+4. `s0-skill-loader-error`
+5. `s0-sandbox-enable`
+6. `s0-metadata-failfast`
+7. `s0-kg-async-validate`
+8. `s0-context-observe`
 
 ## 依赖说明
 
+- 唯一显式上游依赖：`s0-kg-async-validate` 依赖 `s0-metadata-failfast`，进入 Red 前必须完成并落盘 Dependency Sync Check。
+- `s0-window-load-catch` 与 `s0-app-ready-catch` 同改 `apps/desktop/main/src/index.ts`，建议同 PR 协同提交以减少冲突，但两者仍为独立 change。
+- 其余 change 均为独立项，可并行执行。
 - 当新增 active change 且存在上游依赖时，进入 Red 前必须完成并落盘 Dependency Sync Check（至少核对数据结构、IPC 契约、错误码、阈值）。
 - 若任一 active change 发现 `DRIFT`，必须先更新该 change 的 `proposal.md`、`specs/*`、`tasks.md`，再推进 Red/Green。
 

--- a/openspec/changes/s0-app-ready-catch/proposal.md
+++ b/openspec/changes/s0-app-ready-catch/proposal.md
@@ -1,0 +1,47 @@
+# 提案：s0-app-ready-catch
+
+## 背景
+
+`apps/desktop/main/src/index.ts` 当前使用 `void app.whenReady().then(...)` 启动链路。  
+链路任一点异常会变成 unhandled rejection，缺少统一日志与进程级收敛动作，可能造成启动失败且难以诊断。
+
+## 变更内容
+
+- 为 `app.whenReady().then(...)` 链尾补充 `.catch((err) => ...)`，记录 `app_init_fatal` 结构化错误日志。
+- 在链尾 `catch` 中调用 `app.quit()`，确保主进程在致命初始化异常时快速收口。
+- 移除 `void` fire-and-forget 写法，改为显式链式兜底，避免未处理 Promise 拒绝。
+
+## 协同关系（同文件独立 change）
+
+- 本 change 与 `s0-window-load-catch` 同改 `apps/desktop/main/src/index.ts`，建议同一 PR 合并，统一处理启动链路异常治理。
+- 两者保持独立边界：本 change 仅覆盖 `app.whenReady()` 初始化链尾，窗口 `loadURL/loadFile` 失败兜底由 `s0-window-load-catch` 定义。
+
+## 受影响模块
+
+- Workbench（Main 启动生命周期）— `apps/desktop/main/src/index.ts`
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 A，独立项）。
+- 横向协同：与 `s0-window-load-catch` 同改 `apps/desktop/main/src/index.ts`，建议同 PR 协同提交以减少冲突。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-app-ready-catch` 条目；
+  - `openspec/specs/workbench/spec.md` 中应用壳层启动稳定性相关要求。
+- 核对项：
+  - `app.whenReady().then(...)` 初始化链路异常必须被链尾收敛；
+  - 致命异常日志必须结构化记录并可定位；
+  - 变更边界仅限 `app.whenReady()` 链尾兜底，不扩展到资源加载分支。
+- 结论：`NO_DRIFT`（与 Sprint0 定义一致，可进入后续 TDD 实施）。
+
+## 不做什么
+
+- 不改变 `BrowserWindow` 创建参数与页面加载分支逻辑。
+- 不新增重试/延迟退出机制。
+- 不扩展到其他异步链路（仅限 `app.whenReady()` 初始化主链）。
+
+## 审阅状态
+
+- 审阅状态：Owner 审阅：`PENDING`

--- a/openspec/changes/s0-app-ready-catch/specs/workbench-delta.md
+++ b/openspec/changes/s0-app-ready-catch/specs/workbench-delta.md
@@ -1,0 +1,43 @@
+# Workbench Specification Delta
+
+## Change: s0-app-ready-catch
+
+### Requirement: 应用初始化主链路必须有链尾兜底 [MODIFIED]
+
+主进程启动时，`app.whenReady()` 初始化链路必须显式处理致命异常：
+
+- `app.whenReady().then(...)` 链尾必须追加 `.catch((err) => ...)` [ADDED 实现]
+- 链尾 `catch` 必须记录 `app_init_fatal` 错误日志，包含可定位的错误文本与堆栈（可用时）[ADDED]
+- 捕获到致命异常后必须调用 `app.quit()` 做进程收口 [ADDED]
+- 不再使用无链尾兜底的 `void ...` fire-and-forget 形式 [MODIFIED]
+
+#### Scenario: 初始化链路异常触发致命日志与退出 [ADDED]
+
+- **假设** `app.whenReady().then(...)` 链路任一步骤抛错或 Promise reject
+- **当** 启动链路执行到链尾 `.catch`
+- **则** 系统记录一次 `app_init_fatal` 错误日志
+- **并且** 日志包含错误文本，若异常为 `Error` 则包含 `stack`
+- **并且** 调用 `app.quit()` 终止应用
+
+#### Scenario: 初始化链路成功不误触退出 [ADDED]
+
+- **假设** `app.whenReady()` 及后续初始化步骤全部成功
+- **当** 启动链路执行完成
+- **则** 不记录 `app_init_fatal` 错误日志
+- **并且** 不调用 `app.quit()`
+
+#### Scenario: 启动链路无未处理拒绝泄漏 [ADDED]
+
+- **假设** 初始化流程发生 Promise reject
+- **当** 启动链路完成异常收敛
+- **则** 异常由链尾 `.catch` 处理，不形成未处理拒绝泄漏
+
+## 协同说明（同文件独立 change）
+
+- 本 change 与 `s0-window-load-catch` 同改 `apps/desktop/main/src/index.ts`，建议同 PR 协同交付。
+- 责任边界：`s0-app-ready-catch` 仅约束 `app.whenReady()` 链尾兜底；`s0-window-load-catch` 仅约束窗口资源加载 Promise 兜底。
+
+## Out of Scope
+
+- `win.loadURL/loadFile` 失败日志策略
+- 启动异常后的重试/恢复页机制

--- a/openspec/changes/s0-app-ready-catch/tasks.md
+++ b/openspec/changes/s0-app-ready-catch/tasks.md
@@ -1,0 +1,48 @@
+## 1. Specification
+
+- [ ] 1.1 审阅 `docs/plans/unified-roadmap.md` 中 `s0-app-ready-catch（A6-H-002）` 的问题定义与操作边界
+- [ ] 1.2 审阅 `apps/desktop/main/src/index.ts` 的 `app.whenReady().then(...)` 启动链路，确认当前缺失链尾兜底
+- [ ] 1.3 审阅/补充 `openspec/changes/s0-app-ready-catch/specs/workbench-delta.md`，确保 Requirement 与 Scenario 可测试化
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；本 change 对上游活跃 change 结论为 N/A
+- [ ] 1.5 标注同文件协同约束：与 `s0-window-load-catch` 并行改 `index.ts` 时保持启动链路一致且不相互覆盖
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 每个 Scenario 映射为至少一个失败测试，覆盖 `index.ts` 启动链路关键分支
+- [ ] 2.2 为测试用例标注 Scenario ID（S0-ARC-1/2/3），建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [ ] 2.4 明确 `index.ts` 启动链路测试名并写入 RUN_LOG
+
+### Scenario → 测试映射
+
+| Scenario ID | 测试文件                                        | `index.ts` 启动链路相关测试名                                              | 断言要点                                                                              |
+| ----------- | ----------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| S0-ARC-1    | `apps/desktop/main/src/__tests__/index.test.ts` | `appReady chain rejection logs app_init_fatal and quits app`               | `whenReady().then(...)` 链中任一点 reject 时，记录 `app_init_fatal` 并调用 `app.quit` |
+| S0-ARC-2    | `apps/desktop/main/src/__tests__/index.test.ts` | `appReady success path does not quit app`                                  | 初始化链正常完成时不触发 `app.quit`                                                   |
+| S0-ARC-3    | `apps/desktop/main/src/__tests__/index.test.ts` | `appReady startup chain is catch-terminated (no unhandled rejection leak)` | Promise 链具备链尾 `.catch`，异常被收敛且无未处理拒绝泄漏                             |
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 在 `apps/desktop/main/src/__tests__/index.test.ts` 编写 S0-ARC-1 失败测试：mock 初始化步骤 reject，断言日志与退出动作
+- [ ] 3.2 编写 S0-ARC-2 失败测试：成功启动链路不应触发 `app.quit`
+- [ ] 3.3 编写 S0-ARC-3 失败测试：验证链尾兜底前置条件（当前实现应先 Red）
+- [ ] 3.4 运行 `pnpm exec vitest run apps/desktop/main/src/__tests__/index.test.ts`，记录 Red 证据
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 在 `index.ts` 的 `app.whenReady().then(...)` 链尾追加 `.catch((err) => { logger.error("app_init_fatal", ...); app.quit(); })`
+- [ ] 4.2 移除 `void` 前缀，确保启动链路不再是无兜底 fire-and-forget
+- [ ] 4.3 仅做让 Red 变绿的最小改动，不引入额外初始化分支改造
+- [ ] 4.4 复跑测试确认全部 Green
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 统一 `app_init_fatal` 日志字段（`error`/`stack`）与其他启动日志风格
+- [ ] 5.2 与 `s0-window-load-catch` 联合检查同文件改动顺序，确保 `index.ts` 启动链路可读且冲突最小
+- [ ] 5.3 执行启动路径回归（至少 `index.test.ts` + 必要 smoke），确认保持绿灯
+
+## 6. Evidence
+
+- [ ] 6.1 在 RUN_LOG 记录 Red/Green 命令、关键输出与结论
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（N/A 或无漂移/已更新）
+- [ ] 6.3 记录与 `s0-window-load-catch` 的同文件协同结论（同 PR/冲突处理策略/最终一致性）

--- a/openspec/changes/s0-context-observe/proposal.md
+++ b/openspec/changes/s0-context-observe/proposal.md
@@ -1,0 +1,42 @@
+# 提案：s0-context-observe
+
+## 背景
+
+`docs/plans/unified-roadmap.md` 的 Sprint0（A2-H-001）指出：`skillExecutor.ts` 在 context 组装异常时使用空 `catch {}` 吞错，仅保留注释“best-effort”，导致真实故障不可观测。当前行为违背“Fail loud, not silent”的治理要求，故障发生后缺乏定位信号。
+
+## 变更内容
+
+- 将 context 组装异常路径从“静默吞错”升级为“降级但可观测（记录结构化 warning）”。
+- 结构化 warning 至少包含 `executionId`、`skillId`、`error` 字段，便于跨日志检索。
+- 保持技能执行主流程不中断，确保降级策略仍为 best-effort。
+
+## 受影响模块
+
+- Skill System（`apps/desktop/main/src/services/skills/skillExecutor.ts`）— 异常观测性增强。
+- Skill System 测试（`apps/desktop/main/src/services/skills/__tests__/skillExecutor.test.ts`）— 新增 warning 结构断言。
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 C，独立项）。
+- 横向关注：日志注入路径需与现有 `SkillExecutor` 依赖注入方式一致，不新增全局单例。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` Sprint0 `s0-context-observe` 条目；
+  - `openspec/specs/skill-system/spec.md` 中“技能执行失败错误处理”与“可取消执行”约束。
+- 核对项：
+  - 降级策略：context 失败时技能执行不中断；
+  - 可观测性：必须记录结构化 warning，而非空 `catch`；
+  - 测试映射：Scenario 与 `skillExecutor` 测试用例一一对应。
+- 结论：`NO_DRIFT`（符合 Sprint0 止血目标，可进入后续 TDD 实施）。
+
+## 不做什么
+
+- 不改动 Context Engine 的组装算法与上下文分层策略。
+- 不引入新的错误码体系或 UI 交互提示。
+- 不改变技能成功/失败 envelope，仅补齐 warning 观测信号。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-context-observe/specs/skill-system-delta.md
+++ b/openspec/changes/s0-context-observe/specs/skill-system-delta.md
@@ -1,0 +1,22 @@
+# Skill System Specification Delta
+
+## Change: s0-context-observe
+
+### Requirement: 上下文组装异常必须降级但可观测（记录结构化 warning） [ADDED]
+
+SkillExecutor 在组装上下文（context assembly）时出现异常，必须保持 best-effort 降级继续执行，同时输出可追踪的结构化 warning，避免静默吞错。
+
+#### Scenario: context 组装失败时记录结构化 warning 且技能继续执行 [ADDED]
+
+- **假设** `assembleContextPrompt` 在一次技能执行中抛出异常（例如 `KG_UNAVAILABLE`）
+- **当** SkillExecutor 捕获到该异常
+- **则** 必须记录 warning 事件 `context_assembly_degraded`
+- **并且** warning payload 必须包含 `executionId`、`skillId`、`error`
+- **并且** 技能执行链路保持可继续（降级但不中断）
+
+#### Scenario: context 组装成功时不产生降级 warning [ADDED]
+
+- **假设** `assembleContextPrompt` 正常返回上下文
+- **当** SkillExecutor 继续执行技能
+- **则** 不应记录 `context_assembly_degraded` warning
+- **并且** 返回结果与现有成功路径契约一致

--- a/openspec/changes/s0-context-observe/tasks.md
+++ b/openspec/changes/s0-context-observe/tasks.md
@@ -1,0 +1,43 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：仅处理 context 组装异常的观测性，不改技能主流程
+- [ ] 1.2 审阅并确认错误路径：禁止空 `catch` 静默吞错
+- [ ] 1.3 审阅并确认验收阈值：context 失败时记录结构化 warning，且技能执行可降级继续
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；本 change 为独立项，结论 `N/A（无上游依赖）`
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → 测试映射
+
+- [ ] S1 `context 组装失败时记录结构化 warning 且技能继续执行 [ADDED]`
+  - 测试文件：`apps/desktop/main/src/services/skills/__tests__/skillExecutor.test.ts`
+  - 测试名：`"context assembly failure emits structured warning"`
+- [ ] S2 `context 组装成功时不产生降级 warning [ADDED]`
+  - 测试文件：`apps/desktop/main/src/services/skills/__tests__/skillExecutor.test.ts`
+  - 测试名：`"context assembly success does not emit degraded warning"`
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 新增 `S1` 失败测试，确认当前空 `catch` 导致无 warning 记录
+- [ ] 3.2 新增 `S2` 失败测试，防止后续实现误报 warning
+- [ ] 3.3 运行 `pnpm vitest run skillExecutor` 记录 Red 证据
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 修改 `apps/desktop/main/src/services/skills/skillExecutor.ts`：空 `catch` 改为记录结构化 `logger.warn("context_assembly_degraded", ...)`
+- [ ] 4.2 确保 warning 字段至少包含 `executionId`、`skillId`、`error`，并保持技能执行降级继续
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 统一 warning payload 结构，避免日志字段漂移
+- [ ] 5.2 保持 best-effort 语义清晰：仅增强可观测性，不改变执行结果契约
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-fake-queued-fix/proposal.md
+++ b/openspec/changes/s0-fake-queued-fix/proposal.md
@@ -1,0 +1,42 @@
+# 提案：s0-fake-queued-fix
+
+## 背景
+
+`docs/plans/unified-roadmap.md` 的 Sprint0（A3-C-001）指出：`kgRecognitionRuntime.ts` 在空内容输入时返回 `ok: true + status: "queued" + randomUUID taskId`，但实际并未入队，属于“表面正确、结果错误”的伪造输出。该行为会误导下游取消/追踪链路，把不存在的任务当作真实任务处理。
+
+## 变更内容
+
+- 将空内容识别请求的返回语义从“伪 queued”修正为“明确 skipped”。
+- 禁止为空内容分支生成伪造 `taskId`，改为 `taskId: null`。
+- 在测试层补齐 Scenario 覆盖，确保空内容分支不再伪造队列状态。
+
+## 受影响模块
+
+- Knowledge Graph（`apps/desktop/main/src/services/kg/`）— 识别入队返回契约修正。
+- Knowledge Graph 测试（`apps/desktop/main/src/services/kg/__tests__/`）— 新增空内容行为断言。
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 A，独立项）。
+- 横向关注：`enqueueRecognition` 调用链中基于 `taskId` 的取消/追踪逻辑需要兼容 `null`。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` Sprint0 `s0-fake-queued-fix` 条目；
+  - `openspec/specs/knowledge-graph/spec.md` 中“自动识别与建议添加”行为要求。
+- 核对项：
+  - 返回状态语义：空内容必须表达为“跳过”而非“已入队”；
+  - 数据契约：空内容分支 `taskId` 允许为 `null`；
+  - 测试契约：Scenario 对应测试名与文件路径可追踪。
+- 结论：`NO_DRIFT`（与当前 Sprint0 路线图一致，可进入规格编写与后续 Red 阶段）。
+
+## 不做什么
+
+- 不改动真实队列调度与任务生命周期实现。
+- 不改动 UI 展示或新增提示文案。
+- 不在本 change 引入新的状态枚举或跨模块协议变更。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-fake-queued-fix/specs/knowledge-graph-delta.md
+++ b/openspec/changes/s0-fake-queued-fix/specs/knowledge-graph-delta.md
@@ -1,0 +1,23 @@
+# Knowledge Graph Specification Delta
+
+## Change: s0-fake-queued-fix
+
+### Requirement: 空内容识别请求不得伪造队列任务 [ADDED]
+
+知识图谱识别入口在接收空内容时，必须返回“跳过（skipped）”语义，且不得生成任何伪造任务标识。系统必须保证调用方可区分“真实入队任务”与“未入队跳过结果”。
+
+#### Scenario: 空内容请求返回 skipped 且 taskId 为 null [ADDED]
+
+- **假设** 调用方执行 `enqueueRecognition`，输入 `contentText` 归一化后长度为 `0`
+- **当** 主进程处理识别请求
+- **则** 返回结果保持 `ok: true`
+- **并且** `data.status` 必须为 `"skipped"`（不得为 `"queued"`）
+- **并且** `data.taskId` 必须为 `null`
+- **并且** `data.queuePosition` 必须为 `0`
+
+#### Scenario: 空内容分支不触发可取消任务语义 [ADDED]
+
+- **假设** 调用方收到空内容识别结果且 `taskId` 为 `null`
+- **当** 调用方执行后续任务追踪/取消判断
+- **则** 系统将该结果视为“未入队”而非“运行中任务”
+- **并且** 不得向不存在的任务 ID 发起取消或追踪操作

--- a/openspec/changes/s0-fake-queued-fix/tasks.md
+++ b/openspec/changes/s0-fake-queued-fix/tasks.md
@@ -1,0 +1,43 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界：仅修正空内容识别返回语义，不扩展队列能力
+- [ ] 1.2 审阅并确认错误路径：空内容不得伪造 `queued`/伪造 `taskId`
+- [ ] 1.3 审阅并确认验收阈值：空内容返回 `status: "skipped"` 且 `taskId: null`
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；本 change 为独立项，结论 `N/A（无上游依赖）`
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+### Scenario → 测试映射
+
+- [ ] S1 `空内容请求返回 skipped 且 taskId 为 null [ADDED]`
+  - 测试文件：`apps/desktop/main/src/services/kg/__tests__/kgRecognitionRuntime.test.ts`
+  - 测试名：`"empty content returns skipped, not queued"`
+- [ ] S2 `空内容分支不触发可取消任务语义 [ADDED]`
+  - 测试文件：`apps/desktop/main/src/services/kg/__tests__/kgRecognitionRuntime.test.ts`
+  - 测试名：`"empty content result is non-trackable when taskId is null"`
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 新增 `S1` 对应失败测试并确认当前实现返回 `queued` 导致断言失败
+- [ ] 3.2 新增 `S2` 对应失败测试并确认当前实现仍暴露可追踪任务语义
+- [ ] 3.3 运行 `pnpm vitest run kgRecognitionRuntime` 记录 Red 证据
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 修改 `apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts` 空内容分支：返回 `status: "skipped"` 与 `taskId: null`
+- [ ] 4.2 逐条使 `S1/S2` 失败测试转绿，不引入额外功能分支
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 清理与 `queued` 语义耦合的局部分支，保持行为一致
+- [ ] 5.2 保持 `enqueueRecognition` 对外契约清晰：空内容=跳过且不可追踪
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-kg-async-validate/proposal.md
+++ b/openspec/changes/s0-kg-async-validate/proposal.md
@@ -1,0 +1,43 @@
+# 提案：s0-kg-async-validate
+
+## 背景
+
+Sprint 0 紧急止血项（来源：A6-H-003）。
+
+当前 `KnowledgeGraphPanel.tsx` 存在多处异步写入调用在完成后未检查 `ServiceResult.ok`，导致失败被当作成功处理（静默失败/幽灵状态），进而出现 UI 状态被错误清空、偏好被错误保存、批量更新部分失败不透明等问题。
+
+## 变更内容
+
+- 对 `relationDelete` / `entityUpdate` 等异步写入结果进行显式校验：`ok:false` 时不得继续执行后续成功路径副作用。
+- 批量更新从 `Promise.all` 改为 `Promise.allSettled`，支持部分失败的可观测汇报（失败数量/错误提示），避免单点失败导致整体行为不确定。
+
+## 受影响模块
+
+- Knowledge Graph（Renderer）— `KnowledgeGraphPanel.tsx` 的异步写入链路与 UI 状态更新；新增对应测试覆盖。
+
+## 依赖关系
+
+- 依赖 `s0-metadata-failfast`（同触 `KnowledgeGraphPanel.tsx`，执行顺序需先 metadata fail-fast 再异步校验）。
+- 串行约束：在 `s0-metadata-failfast` 文档与实现落地前，不进入本 change 的 Red 阶段。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-kg-async-validate` 条目；
+  - `openspec/changes/s0-metadata-failfast/specs/knowledge-graph-delta.md`；
+  - `openspec/specs/knowledge-graph/spec.md` 中 KG 异步写入与失败处理相关要求。
+- 核对项：
+  - `s0-metadata-failfast` 引入的 `parseMetadataJson(): Record<string, unknown> | null` 不影响本 change 的 `ServiceResult.ok` 校验路径；
+  - 两者虽然同改 `KnowledgeGraphPanel.tsx`，但关注点分别为“metadata 解析 fail-fast”与“异步写入结果校验”；
+  - 批量更新 `allSettled` 方案与上游 metadata 解析策略不存在语义冲突。
+- 结论：`NO_DRIFT`（维持串行执行：先 `s0-metadata-failfast`，后 `s0-kg-async-validate`）。
+
+## 不做什么
+
+- 不引入新的异步任务系统/队列抽象（仅在现有调用点增加校验与错误处理）。
+- 不新增新的错误提示框架（复用既有错误提示机制；若缺失则升级给 Owner 决策）。
+- 不修改 KG 数据模型、IPC schema、错误码命名空间（仅消费既有 `ServiceResult`）。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-kg-async-validate/specs/knowledge-graph-delta.md
+++ b/openspec/changes/s0-kg-async-validate/specs/knowledge-graph-delta.md
@@ -1,0 +1,33 @@
+# Knowledge Graph Specification Delta
+
+## Change: s0-kg-async-validate
+
+### Requirement: KG Panel 异步写入必须校验结果并可观测化失败 [ADDED]
+
+Knowledge Graph 面板中，所有会改变持久化状态或关键 UI 状态的异步写入调用必须检查 `ServiceResult.ok`。失败不得被当作成功路径继续执行，并且必须向用户或日志暴露失败事实（至少一种）。
+
+#### Scenario: KG-S0-AV-S1 relationDelete 失败不得清空编辑态 [ADDED]
+
+- **假设** 用户正在编辑某条关系（`editing.mode === "relation"` 且 `editing.relationId` 为目标关系）
+- **当** 用户触发删除关系且 `relationDelete` 返回 `ok:false`（或请求 reject）
+- **则** 系统不得将编辑态强制切换为 idle（不得“假装删除成功”）
+- **并且** 必须提示/记录删除失败（复用既有错误提示机制）
+
+#### Scenario: KG-S0-AV-S2 entityUpdate 失败不得保存视图偏好 [ADDED]
+
+- **假设** 用户触发实体更新后会执行视图偏好保存（例如 `saveKgViewPreferences`）
+- **当** `entityUpdate` 返回 `ok:false`（或请求 reject）
+- **则** 系统不得执行视图偏好保存的后续副作用
+- **并且** 必须提示/记录更新失败
+
+#### Scenario: KG-S0-AV-S3 批量 entityUpdate 必须 allSettled 并汇报部分失败 [ADDED]
+
+- **假设** 用户触发批量实体更新，目标实体数为 N
+- **当** 部分 `entityUpdate` 失败（`ok:false` 或 reject），其余成功
+- **则** 系统必须使用 `Promise.allSettled`（或等价策略）等待所有结果，且不得因单点失败导致整体行为不确定
+- **并且** 成功的更新必须生效，失败的更新必须被统计并向用户/日志汇报（例如 “k/N 个实体更新失败”）
+
+## Out of Scope
+
+- 引入新的通用异步任务框架、队列或重试策略。
+- 修改 IPC schema、错误码体系或 KG 数据层结构。

--- a/openspec/changes/s0-kg-async-validate/tasks.md
+++ b/openspec/changes/s0-kg-async-validate/tasks.md
@@ -1,0 +1,37 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界（仅限 KnowledgeGraphPanel 异步写入结果校验与批量处理；不得扩展为架构重构）
+- [ ] 1.2 审阅并确认错误路径与边界路径（ok:false、reject、部分失败、重复点击触发并发）
+- [ ] 1.3 审阅并确认验收阈值与不可变契约（失败不得当作成功；编辑态/偏好保存/批量更新必须可判定）
+- [ ] 1.4 依赖同步检查（Dependency Sync Check）：依赖 `s0-metadata-failfast`；核对 `KnowledgeGraphPanel` 变更面（metadata fail-fast vs async 校验）与共享 helper 签名；结论：`NO_DRIFT`（进入 Red 前需在 RUN_LOG 记录核对输入与结论）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [ ] 2.4 Scenario→测试映射：`KG-S0-AV-S1` → `apps/desktop/renderer/src/features/kg/__tests__/kg-async-validation.test.tsx`（`"relationDelete failure does not clear editing state"`，覆盖 KnowledgeGraphPanel）
+- [ ] 2.5 Scenario→测试映射：`KG-S0-AV-S2` → `apps/desktop/renderer/src/features/kg/__tests__/kg-async-validation.test.tsx`（`"entityUpdate failure does not save view preferences"`，覆盖 KnowledgeGraphPanel）
+- [ ] 2.6 Scenario→测试映射：`KG-S0-AV-S3` → `apps/desktop/renderer/src/features/kg/__tests__/kg-async-validation.test.tsx`（`"batch entityUpdate partial failure reports errors"`，覆盖 KnowledgeGraphPanel）
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败（ok:true 时保持既有成功路径行为不变）
+- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败（部分失败时成功项仍生效；失败数可见）
+- [ ] 3.3 编写 Error Path 的失败测试并确认先失败（ok:false/reject 时不得清空 editing / 不得保存偏好 / 不得静默吞错）
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 仅实现让 Red 转绿的最小代码（在调用点增加 `ok` 检查与最小错误处理）
+- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 去重与重构，保持测试全绿（统一处理 fulfilled-but-ok:false 与 rejected 的分支，避免重复逻辑）
+- [ ] 5.2 不改变已通过的外部行为契约
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）= `NO_DRIFT`（依赖 `s0-metadata-failfast`）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-metadata-failfast/proposal.md
+++ b/openspec/changes/s0-metadata-failfast/proposal.md
@@ -1,0 +1,42 @@
+# 提案：s0-metadata-failfast
+
+## 背景
+
+Sprint 0 紧急止血项（来源：A2-H-002 + A2-H-003）。
+
+当前在 Knowledge Graph 相关链路中存在“metadata JSON 解析失败 → 静默降级为 `{}` → 随后写入 `ui.position` / `timeline.order` → 覆盖原有 metadata”的行为，导致**数据丢失**且难以察觉。
+
+## 变更内容
+
+- metadata JSON 解析失败时 **fail-fast**：不再降级为 `{}` 并继续写入；改为保留原始 metadata（不覆盖、不回写）。
+- `KnowledgeGraphPanel` 中 `parseMetadataJson` 在非法 JSON 时返回 `null`（而非 `{}`），调用方必须显式处理 `null` 并停止后续写入。
+
+## 受影响模块
+
+- Knowledge Graph（Renderer）— `kgToGraph.ts` 与 `KnowledgeGraphPanel.tsx` 的 metadata 解析与写入路径；新增对应测试覆盖。
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 B 的首项）。
+- 下游依赖：`s0-kg-async-validate`（同触 `KnowledgeGraphPanel.tsx`，需先稳定 metadata fail-fast 契约）。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-metadata-failfast` 条目；
+  - `openspec/specs/knowledge-graph/spec.md` 中 KG 面板写入与错误处理相关要求。
+- 核对项：
+  - 非法 metadata JSON 不得被默认对象覆盖；
+  - `parseMetadataJson` 非法输入返回 `null`，调用方必须 fail-fast；
+  - 为 `s0-kg-async-validate` 保持可预期的 helper 返回语义。
+- 结论：`NO_DRIFT`（可作为 `s0-kg-async-validate` 的前置变更进入实施）。
+
+## 不做什么
+
+- 不引入新的 metadata schema/migration。
+- 不新增/替换全局 toast/notification 机制（错误提示复用既有机制，若不存在则升级给 Owner 决策）。
+- 不扩展到其他非 KG 相关模块的 metadata 解析逻辑。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-metadata-failfast/specs/knowledge-graph-delta.md
+++ b/openspec/changes/s0-metadata-failfast/specs/knowledge-graph-delta.md
@@ -1,0 +1,26 @@
+# Knowledge Graph Specification Delta
+
+## Change: s0-metadata-failfast
+
+### Requirement: KG Panel metadata 写入必须 fail-fast 防止数据丢失 [MODIFIED]
+
+当系统从 `metadataJson` 解析 metadata 并进行增量写入（例如写入 `ui.position`、`timeline.order`）时，解析失败不得以默认空对象继续写入，从而覆盖用户已有 metadata。
+
+#### Scenario: KG-S0-MFF-S1 kgToGraph 在 metadataJson 非法时保留原字符串 [ADDED]
+
+- **假设** `currentMetadataJson` 为非法 JSON（例如 `"{{invalid"`）
+- **当** `kgToGraph` 尝试解析并准备写入位置/顺序字段
+- **则** `kgToGraph` 必须直接返回原始 `currentMetadataJson`（不覆盖、不回写）
+- **并且** 必须记录可观测日志/告警（至少含固定前缀与截断后的 metadata 片段）
+
+#### Scenario: KG-S0-MFF-S2 KnowledgeGraphPanel parseMetadataJson 非法时返回 null，调用方必须停止写入 [ADDED]
+
+- **假设** `metadataJson` 为非法 JSON（例如 `"not-json"`）
+- **当** `KnowledgeGraphPanel` 调用 `parseMetadataJson(metadataJson)`
+- **则** 返回值必须为 `null`（而不是 `{}`）
+- **并且** 任意依赖 metadata 的后续写入（`ui.position`、`timeline.order`、视图偏好保存等）必须 fail-fast 中止
+
+## Out of Scope
+
+- 对历史已损坏/被覆盖的 metadata 的修复与迁移。
+- 全局错误提示样式/文案系统化改造。

--- a/openspec/changes/s0-metadata-failfast/tasks.md
+++ b/openspec/changes/s0-metadata-failfast/tasks.md
@@ -1,0 +1,36 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认需求边界（仅限 KG metadata 解析失败的 fail-fast；不得引入额外“修复”）
+- [ ] 1.2 审阅并确认错误路径与边界路径（非法 JSON、空字符串、非对象 JSON、超大字符串截断日志）
+- [ ] 1.3 审阅并确认验收阈值与不可变契约（解析失败不得覆盖原 metadata；不得静默写入）
+- [ ] 1.4 依赖同步检查（Dependency Sync Check）：N/A（无上游 active change）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [ ] 2.4 Scenario→测试映射：`KG-S0-MFF-S1` → `apps/desktop/renderer/src/features/kg/__tests__/metadata-parse-failfast.test.ts`（`"kgToGraph: invalid metadataJson preserves original"`）
+- [ ] 2.5 Scenario→测试映射：`KG-S0-MFF-S2` → `apps/desktop/renderer/src/features/kg/__tests__/metadata-parse-failfast.test.ts`（`"KnowledgeGraphPanel: parseMetadataJson returns null on invalid JSON"`）
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败（metadata 合法时写入位置/顺序仍然生效）
+- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败（metadataJson 为 `""`/仅空白/合法但非对象）
+- [ ] 3.3 编写 Error Path 的失败测试并确认先失败（非法 JSON 时保持原始 metadata，不覆盖回写；`parseMetadataJson` 返回 `null`）
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 仅实现让 Red 转绿的最小代码
+- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 去重与重构，保持测试全绿（复用既有 parse/merge helper，避免重复链路）
+- [ ] 5.2 不改变已通过的外部行为契约
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）（本 change 为 N/A 也需记录 N/A 理由）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-sandbox-enable/proposal.md
+++ b/openspec/changes/s0-sandbox-enable/proposal.md
@@ -1,0 +1,41 @@
+# 提案：s0-sandbox-enable
+
+## 背景
+
+当前窗口创建配置中 `webPreferences.sandbox` 为 `false`，渲染层在遭遇 XSS 或依赖链污染时，主进程边界保护不足。Sprint0 需要将 sandbox 打开，并验证 preload/contextBridge 在受限环境下仍满足既有 IPC 能力且不泄露 Node 能力。
+
+## 变更内容
+
+- 将主窗口 `webPreferences.sandbox` 显式改为 `true`。
+- 对 preload 边界进行验证：仅允许 `contextBridge.exposeInMainWorld` 暴露契约 API，不暴露 `ipcRenderer`/`require`/Node 内建能力。
+- 增加 sandbox 回归验证与 E2E 回归，覆盖启动路径和渲染进程边界行为。
+
+## 受影响模块
+
+- `ipc` — Preload 桥接安全边界与渲染进程访问模型。
+- `workbench`（回归影响面）— 应用启动后基础交互链路可用性。
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 A，独立项）。
+- 横向关注：与 preload 相关实现必须维持 `window.api` 可用，同时保持 Node 能力隔离。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-sandbox-enable` 条目；
+  - `openspec/specs/ipc/spec.md` 中 Preload Bridge 安全层与 Node 隔离要求。
+- 核对项：
+  - `webPreferences.sandbox` 必须显式为 `true`；
+  - sandbox 启用后仍仅通过 `contextBridge` 暴露受控 API；
+  - 渲染层不可直接访问 `ipcRenderer`、`require`、Node 内建能力。
+- 结论：`NO_DRIFT`（与 IPC 主 spec 安全约束一致，可进入后续 TDD 实施）。
+
+## 不做什么
+
+- 不引入新的 IPC 通道或修改业务层 handler 语义。
+- 不在本 change 内扩展 ACL、鉴权与细粒度来源校验规则（由后续安全 change 处理）。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-sandbox-enable/specs/ipc-delta.md
+++ b/openspec/changes/s0-sandbox-enable/specs/ipc-delta.md
@@ -1,0 +1,40 @@
+# IPC Specification Delta
+
+## Change: s0-sandbox-enable
+
+### Requirement: 渲染进程必须在 Sandbox 下运行 [MODIFIED]
+
+主窗口创建时必须启用 Electron sandbox，禁止以 `sandbox: false` 运行渲染进程。
+
+#### Scenario: SSE-S1 BrowserWindow 启用 sandbox [ADDED]
+
+- **假设** 应用创建主窗口
+- **当** 构造 `BrowserWindow` 的 `webPreferences`
+- **则** `sandbox` 为 `true`
+- **并且** 不允许在同路径下回退为 `false`
+
+### Requirement: Preload/contextBridge 边界必须在 sandbox 下可验证 [MODIFIED]
+
+在 sandbox 模式下，preload 必须继续作为唯一桥接层，并满足以下边界验证点：
+
+- 仅通过 `contextBridge.exposeInMainWorld` 暴露受控 API（如 `window.api`）
+- 不暴露 `ipcRenderer` 引用
+- 不暴露 `require`、`process` 或 Node 内建模块能力
+
+#### Scenario: SSE-S2 渲染进程仅能通过 contextBridge 调用 IPC [ADDED]
+
+- **假设** 应用以 sandbox 模式启动
+- **当** 渲染进程尝试访问 `window.api`
+- **则** 受控 API 可用并可完成既有 IPC 调用
+- **并且** 访问 `window.require` 与 `window.ipcRenderer` 失败或为 `undefined`
+
+### Requirement: Sandbox 启用后必须通过 E2E 回归 [ADDED]
+
+启用 sandbox 后，应用必须通过 E2E 回归验证启动链路与核心交互不回归，并包含至少一个 sandbox 边界断言点。
+
+#### Scenario: SSE-S3 启动与主交互链路 E2E 通过 [ADDED]
+
+- **假设** 已将主窗口 `sandbox` 设为 `true`
+- **当** 执行 `pnpm test:e2e` 回归
+- **则** 应用可正常启动并完成主交互链路
+- **并且** E2E 结果包含 sandbox 边界验证结论（渲染进程受沙箱约束）

--- a/openspec/changes/s0-sandbox-enable/tasks.md
+++ b/openspec/changes/s0-sandbox-enable/tasks.md
@@ -1,0 +1,34 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认 `s0-sandbox-enable` 的范围：启用 sandbox + 验证 preload 边界 + E2E 回归
+- [ ] 1.2 审阅并确认错误路径与边界路径：sandbox 启用后 preload 失效、Node 能力泄露、启动回归失败
+- [ ] 1.3 审阅并确认不可变契约：`window.api` 可用、IPC 主路径可用、渲染层不可直接访问 Node 能力
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；无依赖则标注 N/A（本 change：N/A）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 建立 Scenario→测试映射：SSE-S1→`index` 窗口配置测试（`sandbox: true`），SSE-S2→preload 边界测试（仅 `contextBridge` 暴露 API、无 `window.require`/`window.ipcRenderer`），SSE-S3→E2E 回归（启动与主交互链路）
+- [ ] 2.2 为每个测试标注 Scenario ID（`SSE-S1`/`SSE-S2`/`SSE-S3`），并在 E2E 用例中标注 sandbox 断言点
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 编写 `SSE-S1` 失败测试：窗口创建配置断言 `webPreferences.sandbox === true`
+- [ ] 3.2 编写 `SSE-S2` 失败测试：渲染层仅可访问 `window.api`，访问 `window.require` 或 `window.ipcRenderer` 失败
+- [ ] 3.3 编写 `SSE-S3` 失败测试：执行 E2E 启动回归并增加 sandbox 相关断言（渲染进程受沙箱约束且主流程可用）
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 仅实现让 `SSE-S1`/`SSE-S2`/`SSE-S3` 转绿的最小代码（`sandbox: false` → `sandbox: true`）
+- [ ] 4.2 逐条使失败测试通过，并在 preload 中修复任何 sandbox 不兼容调用（仅限必要最小改动）
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 清理 preload 暴露面，保持 `contextBridge` 入口单一且可审计
+- [ ] 5.2 不改变既有 IPC 契约命名、返回包络与主进程业务行为
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-skill-loader-error/proposal.md
+++ b/openspec/changes/s0-skill-loader-error/proposal.md
@@ -1,0 +1,40 @@
+# 提案：s0-skill-loader-error
+
+## 背景
+
+`apps/desktop/main/src/services/skills/skillLoader.ts` 在目录读取异常（如 `ENOENT`/`EACCES`）时会静默 `return []`，上层被误导为“当前没有技能”。该行为掩盖真实故障，导致排障困难，并可能触发错误的空状态分支。
+
+## 变更内容
+
+- 将 `listSubdirs` 从“仅返回数组”调整为“返回 `dirs + structured error`”。
+- 统一记录目录读取失败的结构化信息（错误码、路径）并向上层透传。
+- 为 `skillLoader` 增加目录不存在/权限不足/正常路径的回归测试，确保不再静默降级。
+
+## 受影响模块
+
+- `skill-system` — 技能目录扫描与加载入口的错误语义。
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 A，独立项）。
+- 横向关注：调用方（`loadBuiltinSkills`、`loadUserSkills`）需区分“读取失败”与“目录为空”语义。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-skill-loader-error` 条目；
+  - `openspec/specs/skill-system/spec.md` 中技能加载与错误处理相关要求。
+- 核对项：
+  - 目录读取失败必须返回结构化错误而非静默空列表；
+  - 成功路径目录发现行为保持不变；
+  - 上层可追踪失败原因（`code/path`）并保留失败语义。
+- 结论：`NO_DRIFT`（与 Sprint0 定义一致，可进入后续 TDD 实施）。
+
+## 不做什么
+
+- 不改动 Skill 执行器、调度器、IPC 通道契约。
+- 不引入新的技能来源或存储机制。
+
+## 审阅状态
+
+- Owner 审阅：`PENDING`

--- a/openspec/changes/s0-skill-loader-error/specs/skill-system-delta.md
+++ b/openspec/changes/s0-skill-loader-error/specs/skill-system-delta.md
@@ -1,0 +1,47 @@
+# Skill System Specification Delta
+
+## Change: s0-skill-loader-error
+
+### Requirement: 技能目录扫描错误必须结构化暴露 [ADDED]
+
+技能目录扫描在发生文件系统异常时，必须返回结构化错误信息，禁止以空数组静默替代真实失败。
+
+返回结构至少包含：
+
+- `dirs: string[]`
+- `error.code: string`（如 `ENOENT`、`EACCES`、`UNKNOWN`）
+- `error.path: string`
+
+当扫描失败时，加载器必须保留 `dirs: []`，并通过日志事件记录失败上下文。
+
+#### Scenario: SLE-S1 目录不存在返回结构化错误 [ADDED]
+
+- **假设** `listSubdirs` 的目标路径不存在
+- **当** 执行技能目录扫描
+- **则** 返回 `{ dirs: [], error: { code: "ENOENT", path: "<dirPath>" } }`
+- **并且** 记录目录读取失败日志（包含 `code` 与 `path`）
+
+#### Scenario: SLE-S2 目录无权限返回结构化错误 [ADDED]
+
+- **假设** `listSubdirs` 的目标路径存在但当前进程无读取权限
+- **当** 执行技能目录扫描
+- **则** 返回 `{ dirs: [], error: { code: "EACCES", path: "<dirPath>" } }`
+- **并且** 不得将该异常伪装为“无技能目录”
+
+#### Scenario: SLE-S3 可读目录保持原有发现行为 [ADDED]
+
+- **假设** 目标目录可读且包含若干子目录
+- **当** 执行技能目录扫描
+- **则** 返回 `dirs` 为实际子目录列表
+- **并且** `error` 为空或不存在
+
+### Requirement: 上层加载流程不得吞并目录读取错误语义 [ADDED]
+
+`loadBuiltinSkills` 与 `loadUserSkills` 等调用方在使用扫描结果时，必须保留错误语义（用于日志、诊断或上层返回值），不得将“读取失败”与“目录为空”混同。
+
+#### Scenario: SLE-S4 加载流程区分 empty 与 failed [ADDED]
+
+- **假设** 扫描结果为 `{ dirs: [], error: { code: "ENOENT", path: "/x" } }`
+- **当** 上层执行技能加载流程
+- **则** 上层输出保留 `ENOENT` 失败语义
+- **并且** 不以“空技能列表”作为唯一结论

--- a/openspec/changes/s0-skill-loader-error/tasks.md
+++ b/openspec/changes/s0-skill-loader-error/tasks.md
@@ -1,0 +1,34 @@
+## 1. Specification
+
+- [ ] 1.1 审阅并确认 `s0-skill-loader-error` 的边界：仅修复目录读取错误被静默吞掉的问题
+- [ ] 1.2 审阅并确认错误路径与边界路径：`ENOENT`、`EACCES`、可读目录三类
+- [ ] 1.3 审阅并确认不可变契约：成功路径不变；失败路径返回结构化错误且可追踪
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；无依赖则标注 N/A（本 change：N/A）
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 建立 Scenario→测试映射：SLE-S1→`skillLoader.test.ts`（missing dir structured error），SLE-S2→`skillLoader.test.ts`（permission denied structured error），SLE-S3→`skillLoader.test.ts`（normal dir returns dirs only）
+- [ ] 2.2 为每个测试标注 Scenario ID（`SLE-S1`/`SLE-S2`/`SLE-S3`），确保 RUN_LOG 可回溯
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 编写 `SLE-S1` 失败测试：目录不存在时返回 `{ dirs: [], error: { code: "ENOENT", path } }`
+- [ ] 3.2 编写 `SLE-S2` 失败测试：目录无权限时返回 `{ dirs: [], error: { code: "EACCES", path } }`
+- [ ] 3.3 编写 `SLE-S3` 失败测试：目录可读时仅返回 `dirs` 且 `error` 为空
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 仅实现让 `SLE-S1`/`SLE-S2`/`SLE-S3` 转绿的最小代码
+- [ ] 4.2 逐条使失败测试通过，并适配 `skillLoader` 内所有 `listSubdirs` 调用点，不引入无关行为
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 去重 `listSubdirs` 错误组装与日志逻辑，保持测试全绿
+- [ ] 5.2 不改变既有技能发现优先级与作用域解析契约（`builtin/global/project`）
+
+## 6. Evidence
+
+- [ ] 6.1 记录 RUN_LOG（含 Red 失败证据、Green 通过证据与关键命令输出）
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（无漂移/已更新）
+- [ ] 6.3 记录 Main Session Audit（Audit-Owner/Reviewed-HEAD-SHA=签字提交 HEAD^/三项 PASS/Blocking-Issues=0/Decision=ACCEPT），并确认签字提交仅变更当前任务 RUN_LOG

--- a/openspec/changes/s0-window-load-catch/proposal.md
+++ b/openspec/changes/s0-window-load-catch/proposal.md
@@ -1,0 +1,47 @@
+# 提案：s0-window-load-catch
+
+## 背景
+
+`apps/desktop/main/src/index.ts` 的主窗口加载分支当前使用 `void win.loadURL(...)` / `void win.loadFile(...)` 丢弃 Promise。  
+当资源加载失败时，进程侧没有结构化日志，渲染层可能表现为黑屏，故障不可观测且难以快速定位。
+
+## 变更内容
+
+- 为 `win.loadURL(...)` 增加链式 `.catch(...)`，记录 `window_load_failed` 错误日志（含目标地址与错误信息）。
+- 为 `win.loadFile(...)` 增加同等 `.catch(...)` 兜底，保证 dev/prod 两个 if/else 分支行为一致。
+- 保持现有窗口创建流程不变，仅补齐失败路径可观测性。
+
+## 协同关系（同文件独立 change）
+
+- 本 change 与 `s0-app-ready-catch` 同时修改 `apps/desktop/main/src/index.ts`，建议同一 PR 串联提交以降低冲突成本。
+- 两者保持独立变更边界：本 change 只覆盖窗口资源加载 Promise 兜底，不覆盖 `app.whenReady()` 初始化链尾兜底。
+
+## 受影响模块
+
+- Workbench（Main 启动链路）— `apps/desktop/main/src/index.ts`
+
+## 依赖关系
+
+- 上游依赖：无（Sprint0 并行组 A，独立项）。
+- 横向协同：与 `s0-app-ready-catch` 同改 `apps/desktop/main/src/index.ts`，建议同 PR 串联提交以降低冲突成本。
+
+## Dependency Sync Check
+
+- 核对输入：
+  - `docs/plans/unified-roadmap.md` 中 `s0-window-load-catch` 条目；
+  - `openspec/specs/workbench/spec.md` 中启动与应用壳层稳定性相关要求。
+- 核对项：
+  - dev/prod 双分支资源加载失败均可观测；
+  - 日志事件名与字段在两分支保持一致；
+  - 变更边界仅限 `loadURL/loadFile` Promise 失败兜底。
+- 结论：`NO_DRIFT`（与 Sprint0 定义一致，可进入后续 TDD 实施）。
+
+## 不做什么
+
+- 不调整窗口布局、尺寸、生命周期事件注册逻辑。
+- 不引入新的重试策略或降级页面。
+- 不改动 `app.whenReady()` 链尾异常处理（由 `s0-app-ready-catch` 负责）。
+
+## 审阅状态
+
+- 审阅状态：Owner 审阅：`PENDING`

--- a/openspec/changes/s0-window-load-catch/specs/workbench-delta.md
+++ b/openspec/changes/s0-window-load-catch/specs/workbench-delta.md
@@ -1,0 +1,41 @@
+# Workbench Specification Delta
+
+## Change: s0-window-load-catch
+
+### Requirement: 主窗口资源加载失败必须可观测 [MODIFIED]
+
+主进程在创建主窗口后，资源加载 Promise 必须具备显式失败兜底：
+
+- `win.loadURL(...)` 分支必须链式 `.catch(...)`，并记录 `window_load_failed` 日志 [ADDED 实现]
+- `win.loadFile(...)` 分支必须链式 `.catch(...)`，并记录同名日志 [ADDED 实现]
+- 日志至少包含目标（URL 或文件路径）与错误信息，便于排查黑屏根因 [ADDED]
+
+#### Scenario: dev 分支 loadURL 失败被记录 [ADDED]
+
+- **假设** 应用运行在 dev 模式，`loadURL` Promise 被拒绝（例如本地 dev server 不可达）
+- **当** 主窗口执行资源加载
+- **则** 系统记录一次 `window_load_failed` 错误日志
+- **并且** 日志包含失败 URL 与错误文本
+
+#### Scenario: prod 分支 loadFile 失败被记录 [ADDED]
+
+- **假设** 应用运行在 prod 模式，`loadFile` Promise 被拒绝（例如入口文件缺失）
+- **当** 主窗口执行资源加载
+- **则** 系统记录一次 `window_load_failed` 错误日志
+- **并且** 日志包含失败文件路径与错误文本
+
+#### Scenario: 资源加载成功不产生误报 [ADDED]
+
+- **假设** `loadURL/loadFile` Promise 正常 resolve
+- **当** 主窗口完成资源加载
+- **则** 不产生 `window_load_failed` 错误日志
+
+## 协同说明（同文件独立 change）
+
+- 本 change 与 `s0-app-ready-catch` 同改 `apps/desktop/main/src/index.ts`，建议同 PR 提交以减少冲突。
+- 责任边界：`s0-window-load-catch` 只约束窗口资源加载 Promise；`s0-app-ready-catch` 只约束 `app.whenReady()` 初始化链尾异常兜底。
+
+## Out of Scope
+
+- `app.whenReady()` 链尾 `.catch` 与 `app.quit()` 退出策略
+- 启动流程重试机制与恢复页面

--- a/openspec/changes/s0-window-load-catch/tasks.md
+++ b/openspec/changes/s0-window-load-catch/tasks.md
@@ -1,0 +1,48 @@
+## 1. Specification
+
+- [ ] 1.1 审阅 `docs/plans/unified-roadmap.md` 中 `s0-window-load-catch（A6-H-001）` 的问题定义与验收边界
+- [ ] 1.2 审阅 `apps/desktop/main/src/index.ts` 中主窗口创建与 `loadURL/loadFile` 分支，确认仅覆盖窗口加载失败路径
+- [ ] 1.3 审阅/补充 `openspec/changes/s0-window-load-catch/specs/workbench-delta.md`，确认 Requirement 与 Scenario 可直接映射测试
+- [ ] 1.4 若存在上游依赖，先完成依赖同步检查（Dependency Sync Check）并记录“无漂移/已更新”；本 change 对上游活跃 change 结论为 N/A
+- [ ] 1.5 记录同文件协同约束：`index.ts` 与 `s0-app-ready-catch` 并行修改时保持同一启动链路语义一致，不互相覆盖
+
+## 2. TDD Mapping（先测前提）
+
+- [ ] 2.1 将 delta spec 每个 Scenario 映射为至少一个失败测试，且全部落在 `index.ts` 启动链路相关测试
+- [ ] 2.2 为测试用例标注 Scenario ID（S0-WLC-1/2/3），建立可追踪关系
+- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [ ] 2.4 明确 `index.ts` 启动链路测试名并写入 RUN_LOG
+
+### Scenario → 测试映射
+
+| Scenario ID | 测试文件                                        | `index.ts` 启动链路相关测试名                                         | 断言要点                                                          |
+| ----------- | ----------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| S0-WLC-1    | `apps/desktop/main/src/__tests__/index.test.ts` | `createMainWindow logs window_load_failed when loadURL rejects`       | `loadURL` reject 后记录 `logger.error("window_load_failed", ...)` |
+| S0-WLC-2    | `apps/desktop/main/src/__tests__/index.test.ts` | `createMainWindow logs window_load_failed when loadFile rejects`      | `loadFile` reject 后记录同名错误事件                              |
+| S0-WLC-3    | `apps/desktop/main/src/__tests__/index.test.ts` | `createMainWindow does not log window_load_failed when load succeeds` | Promise resolve 时不产生误报错误日志                              |
+
+## 3. Red（先写失败测试）
+
+- [ ] 3.1 在 `apps/desktop/main/src/__tests__/index.test.ts` 编写 S0-WLC-1 失败测试：mock `loadURL` reject，先看到断言失败
+- [ ] 3.2 编写 S0-WLC-2 失败测试：mock `loadFile` reject，先看到断言失败
+- [ ] 3.3 编写 S0-WLC-3 失败测试：成功分支不应误报错误日志
+- [ ] 3.4 运行 `pnpm exec vitest run apps/desktop/main/src/__tests__/index.test.ts`，记录 Red 证据
+
+## 4. Green（最小实现通过）
+
+- [ ] 4.1 在 `index.ts` dev 分支将 `win.loadURL(...)` 改为链式 `.catch((err) => logger.error("window_load_failed", ...))`
+- [ ] 4.2 在 `index.ts` prod 分支将 `win.loadFile(...)` 改为同等 `.catch(...)` 处理，保持日志字段一致
+- [ ] 4.3 仅做让 Red 转绿的最小改动，不引入窗口加载重试或 UI 降级逻辑
+- [ ] 4.4 复跑上述测试，确认全部 Green
+
+## 5. Refactor（保持绿灯）
+
+- [ ] 5.1 抽查 `index.ts` 日志字段命名一致性（事件名、错误文本、目标路径/URL）
+- [ ] 5.2 与 `s0-app-ready-catch` 协同审查同文件改动，确保链路可读性和最小冲突
+- [ ] 5.3 执行启动相关回归（至少 `index.test.ts` + 必要启动 smoke），确认保持绿灯
+
+## 6. Evidence
+
+- [ ] 6.1 在 RUN_LOG 记录 Red/Green 命令、关键输出与结论
+- [ ] 6.2 记录 Dependency Sync Check 的输入、核对结论与后续动作（N/A 或无漂移/已更新）
+- [ ] 6.3 记录与 `s0-app-ready-catch` 的同文件协同结论（同 PR/冲突处理策略/最终一致性）

--- a/rulebook/tasks/issue-522-sprint0-batch-delivery/.metadata.json
+++ b/rulebook/tasks/issue-522-sprint0-batch-delivery/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-14T03:56:08.148Z",
+  "updatedAt": "2026-02-14T03:56:08.148Z"
+}

--- a/rulebook/tasks/issue-522-sprint0-batch-delivery/proposal.md
+++ b/rulebook/tasks/issue-522-sprint0-batch-delivery/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: issue-522-sprint0-batch-delivery
+
+## Why
+
+Sprint0 的 8 个 OpenSpec change 文档已经在本地生成，但尚未进入受治理的交付闭环。若继续停留在本地未合并状态，会导致执行顺序、依赖关系与后续实现入口不一致，且无法作为团队共享的规范基线。
+
+## What Changes
+
+- 交付并提交 `openspec/changes/s0-*` 共 8 个 active changes 的 proposal/tasks/spec 文档包。
+- 更新 `openspec/changes/EXECUTION_ORDER.md`，声明 Sprint0 的并行/串行拓扑与依赖关系。
+- 建立并完善本任务的 RUN_LOG、Rulebook task 与主会话审计证据，完成单 PR 合并收口。
+
+## Impact
+
+- Affected specs:
+  - `openspec/changes/s0-fake-queued-fix/*`
+  - `openspec/changes/s0-window-load-catch/*`
+  - `openspec/changes/s0-app-ready-catch/*`
+  - `openspec/changes/s0-metadata-failfast/*`
+  - `openspec/changes/s0-skill-loader-error/*`
+  - `openspec/changes/s0-sandbox-enable/*`
+  - `openspec/changes/s0-kg-async-validate/*`
+  - `openspec/changes/s0-context-observe/*`
+  - `openspec/changes/EXECUTION_ORDER.md`
+- Affected code: 无（仅文档与治理交付工件）
+- Breaking change: NO
+- User benefit: Sprint0 全部 change 可一次性进入受治理主干，后续实现团队可直接按统一文档执行。

--- a/rulebook/tasks/issue-522-sprint0-batch-delivery/specs/governance/spec.md
+++ b/rulebook/tasks/issue-522-sprint0-batch-delivery/specs/governance/spec.md
@@ -1,0 +1,14 @@
+# Governance Delivery Delta
+
+## Change: issue-522-sprint0-batch-delivery
+
+### Requirement: Sprint0 OpenSpec changes must be delivered in one governed batch [ADDED]
+
+The repository must deliver all Sprint0 OpenSpec change documents in one task branch and one pull request, then merge to `main` with required checks and auto-merge enabled.
+
+#### Scenario: Single-issue single-PR delivery closure [ADDED]
+
+- **Given** Sprint0 has 8 active changes prepared under `openspec/changes/s0-*`
+- **When** the delivery task runs through Rulebook + preflight + GitHub checks
+- **Then** all Sprint0 change documents and execution-order updates are merged into `main` in one PR
+- **And** RUN_LOG records commands, outcomes, and main-session audit evidence

--- a/rulebook/tasks/issue-522-sprint0-batch-delivery/tasks.md
+++ b/rulebook/tasks/issue-522-sprint0-batch-delivery/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [ ] 1.1 在独立 worktree 建立 `task/522-sprint0-batch-delivery` 并迁移本地改动
+- [ ] 1.2 落盘 8 个 Sprint0 change 文档包与 `EXECUTION_ORDER.md`
+- [ ] 1.3 创建并完善 RUN_LOG、Rulebook task 与交付证据
+
+## 2. Testing
+
+- [ ] 2.1 执行文档格式校验（Prettier）
+- [ ] 2.2 执行 `scripts/agent_pr_preflight.sh` 并修复阻断项
+- [ ] 2.3 确认 GitHub required checks 全绿并完成 auto-merge
+
+## 3. Documentation
+
+- [ ] 3.1 完成本任务 proposal/tasks/spec 文档
+- [ ] 3.2 在 RUN_LOG 记录关键命令与主会话审计结论


### PR DESCRIPTION
Closes #522

## Summary
- add all Sprint0 OpenSpec changes under `openspec/changes/s0-*` (8 changes)
- update `openspec/changes/EXECUTION_ORDER.md` for Sprint0 active topology and dependencies
- add Rulebook task and RUN_LOG evidence for governed delivery

## Test plan
- `pnpm exec prettier --check openspec/changes/EXECUTION_ORDER.md openspec/changes/s0-*/proposal.md openspec/changes/s0-*/tasks.md openspec/changes/s0-*/specs/*.md openspec/_ops/task_runs/ISSUE-522.md rulebook/tasks/issue-522-sprint0-batch-delivery/.metadata.json rulebook/tasks/issue-522-sprint0-batch-delivery/proposal.md rulebook/tasks/issue-522-sprint0-batch-delivery/tasks.md rulebook/tasks/issue-522-sprint0-batch-delivery/specs/governance/spec.md`
- `rulebook task validate issue-522-sprint0-batch-delivery`
