### PR TITLE
Fix bundled template loading regression after W3 (#583)

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -31,9 +31,35 @@ function copyBuiltinSkillsPlugin() {
   } as const;
 }
 
+/**
+ * Copy builtin project templates into `dist/main/templates/project`.
+ *
+ * Why: bundled runtimes resolve templates from `dist/main/**`, not source paths.
+ */
+function copyBuiltinProjectTemplatesPlugin() {
+  return {
+    name: "creonow-copy-builtin-project-templates",
+    closeBundle() {
+      const src = path.join(__dirname, "main", "templates", "project");
+      const dest = path.join(__dirname, "dist", "main", "templates", "project");
+      if (!fs.existsSync(src)) {
+        return;
+      }
+
+      fs.rmSync(dest, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.cpSync(src, dest, { recursive: true });
+    },
+  } as const;
+}
+
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin(), copyBuiltinSkillsPlugin()],
+    plugins: [
+      externalizeDepsPlugin(),
+      copyBuiltinSkillsPlugin(),
+      copyBuiltinProjectTemplatesPlugin(),
+    ],
     resolve: {
       alias: {
         "@shared": sharedAliasPath,

--- a/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
@@ -10,6 +10,10 @@ import {
   createProjectTestDb,
 } from "../../../../../tests/unit/projectService.test-helpers";
 
+function hasFieldDetails(value: unknown): value is { field: unknown } {
+  return typeof value === "object" && value !== null && "field" in value;
+}
+
 async function main(): Promise<void> {
   const userDataDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "creonow-s3-template-dir-invalid-"),
@@ -53,7 +57,11 @@ async function main(): Promise<void> {
       created.error.message,
       /Configured built-in template directory/,
     );
-    assert.equal(created.error.details?.field, "template.directory");
+    assert.ok(
+      hasFieldDetails(created.error.details),
+      "error.details should include field",
+    );
+    assert.equal(created.error.details.field, "template.directory");
   } finally {
     process.env.CREONOW_TEMPLATE_DIR = previousTemplateDir;
     resetBuiltInTemplateCacheForTests();

--- a/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
@@ -49,7 +49,10 @@ async function main(): Promise<void> {
       );
     }
     assert.equal(created.error.code, "INVALID_ARGUMENT");
-    assert.match(created.error.message, /Configured built-in template directory/);
+    assert.match(
+      created.error.message,
+      /Configured built-in template directory/,
+    );
     assert.equal(created.error.details?.field, "template.directory");
   } finally {
     process.env.CREONOW_TEMPLATE_DIR = previousTemplateDir;

--- a/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { createProjectService } from "../projectService";
+import { resetBuiltInTemplateCacheForTests } from "../templateService";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../../../../../tests/unit/projectService.test-helpers";
+
+async function main(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-s3-template-dir-invalid-"),
+  );
+  const db = createProjectTestDb();
+  const previousTemplateDir = process.env.CREONOW_TEMPLATE_DIR;
+
+  try {
+    process.env.CREONOW_TEMPLATE_DIR = path.join(
+      userDataDir,
+      "missing-template-dir",
+    );
+    resetBuiltInTemplateCacheForTests();
+
+    const svc = createProjectService({
+      db,
+      userDataDir,
+      logger: createNoopLogger(),
+    });
+
+    const created = svc.create({
+      name: "Invalid Builtin Template Directory",
+      template: {
+        kind: "builtin",
+        id: "novel",
+      },
+    } as unknown as { name?: string });
+
+    assert.equal(
+      created.ok,
+      false,
+      "unavailable built-in template directory must reject create",
+    );
+    if (created.ok) {
+      throw new Error(
+        "expected unavailable built-in template directory to reject create",
+      );
+    }
+    assert.equal(created.error.code, "INVALID_ARGUMENT");
+    assert.match(created.error.message, /Configured built-in template directory/);
+    assert.equal(created.error.details?.field, "template.directory");
+  } finally {
+    process.env.CREONOW_TEMPLATE_DIR = previousTemplateDir;
+    resetBuiltInTemplateCacheForTests();
+    db.close();
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
@@ -38,7 +38,9 @@ async function main(): Promise<void> {
     "bundled runtime should resolve built-in template directory",
   );
   if (!resolved.ok) {
-    throw new Error("bundled runtime should resolve built-in template directory");
+    throw new Error(
+      "bundled runtime should resolve built-in template directory",
+    );
   }
   assert.equal(path.resolve(resolved.data), expectedDir);
 

--- a/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import {
+  resetBuiltInTemplateCacheForTests,
+  resolveBuiltInTemplateDirectory,
+} from "../templateService";
+
+async function main(): Promise<void> {
+  resetBuiltInTemplateCacheForTests();
+
+  const bundledMainModulePath = path.resolve(
+    process.cwd(),
+    "apps/desktop/dist/main/index.js",
+  );
+  const expectedDir = path.resolve(
+    process.cwd(),
+    "apps/desktop/main/templates/project",
+  );
+
+  const resolved = resolveBuiltInTemplateDirectory({
+    moduleFilePath: bundledMainModulePath,
+    cwd: process.cwd(),
+    env: {},
+  });
+
+  assert.equal(
+    resolved.ok,
+    true,
+    "bundled runtime should resolve built-in template directory",
+  );
+  if (!resolved.ok) {
+    throw new Error(resolved.error.message);
+  }
+  assert.equal(path.resolve(resolved.data), expectedDir);
+
+  const missingDir = path.resolve(
+    process.cwd(),
+    "apps/desktop/main/templates/__missing__",
+  );
+  const configured = resolveBuiltInTemplateDirectory({
+    moduleFilePath: bundledMainModulePath,
+    cwd: process.cwd(),
+    env: { CREONOW_TEMPLATE_DIR: missingDir },
+  });
+
+  assert.equal(
+    configured.ok,
+    false,
+    "invalid explicit template directory must fail deterministically",
+  );
+  if (configured.ok) {
+    throw new Error("expected invalid configured template directory to fail");
+  }
+  assert.equal(configured.error.field, "template.directory");
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 
 import {
@@ -13,10 +14,17 @@ async function main(): Promise<void> {
     process.cwd(),
     "apps/desktop/dist/main/index.js",
   );
-  const expectedDir = path.resolve(
+  const bundledExpectedDir = path.resolve(
+    process.cwd(),
+    "apps/desktop/dist/main/templates/project",
+  );
+  const sourceFallbackDir = path.resolve(
     process.cwd(),
     "apps/desktop/main/templates/project",
   );
+  const expectedDir = fs.existsSync(bundledExpectedDir)
+    ? bundledExpectedDir
+    : sourceFallbackDir;
 
   const resolved = resolveBuiltInTemplateDirectory({
     moduleFilePath: bundledMainModulePath,

--- a/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
+++ b/apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     "bundled runtime should resolve built-in template directory",
   );
   if (!resolved.ok) {
-    throw new Error(resolved.error.message);
+    throw new Error("bundled runtime should resolve built-in template directory");
   }
   assert.equal(path.resolve(resolved.data), expectedDir);
 

--- a/apps/desktop/main/src/services/projects/templateService.ts
+++ b/apps/desktop/main/src/services/projects/templateService.ts
@@ -192,7 +192,10 @@ function loadBuiltInTemplates(): Result<
     try {
       parsed = JSON.parse(raw);
     } catch {
-      return fail("template.resource", `Invalid JSON template file: ${filename}`);
+      return fail(
+        "template.resource",
+        `Invalid JSON template file: ${filename}`,
+      );
     }
     if (!isRecord(parsed)) {
       return fail(

--- a/apps/desktop/main/src/services/projects/templateService.ts
+++ b/apps/desktop/main/src/services/projects/templateService.ts
@@ -52,9 +52,72 @@ function fail(field: string, message: string): Err {
   };
 }
 
-function getTemplateDirPath(): string {
-  const filePath = fileURLToPath(import.meta.url);
-  return path.resolve(path.dirname(filePath), "../../../templates/project");
+function isDirectory(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function uniquePaths(candidates: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const candidate of candidates) {
+    const normalized = path.resolve(candidate);
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    unique.push(normalized);
+  }
+  return unique;
+}
+
+export function resolveBuiltInTemplateDirectory(args?: {
+  moduleFilePath?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}): Result<string> {
+  const moduleFilePath = args?.moduleFilePath ?? fileURLToPath(import.meta.url);
+  const cwd = args?.cwd ?? process.cwd();
+  const env = args?.env ?? process.env;
+
+  const configuredDir = env.CREONOW_TEMPLATE_DIR?.trim();
+  if (configuredDir && configuredDir.length > 0) {
+    const resolvedConfiguredDir = path.resolve(cwd, configuredDir);
+    if (isDirectory(resolvedConfiguredDir)) {
+      return { ok: true, data: resolvedConfiguredDir };
+    }
+    return fail(
+      "template.directory",
+      `Configured built-in template directory is unavailable: ${resolvedConfiguredDir}`,
+    );
+  }
+
+  const moduleDir = path.dirname(moduleFilePath);
+  const candidates = uniquePaths([
+    path.resolve(moduleDir, "../../../templates/project"),
+    path.resolve(moduleDir, "templates/project"),
+    path.resolve(moduleDir, "../../main/templates/project"),
+    path.resolve(cwd, "apps/desktop/main/templates/project"),
+    path.resolve(cwd, "main/templates/project"),
+  ]);
+
+  for (const candidate of candidates) {
+    if (isDirectory(candidate)) {
+      return { ok: true, data: candidate };
+    }
+  }
+
+  return fail(
+    "template.directory",
+    `Built-in template directory not found (checked ${candidates.join(", ")})`,
+  );
+}
+
+export function resetBuiltInTemplateCacheForTests(): void {
+  builtInTemplateCache = null;
 }
 
 function normalizeBuiltInTemplateId(rawId: string): BuiltInTemplateId | null {
@@ -88,16 +151,49 @@ function loadBuiltInTemplates(): Result<
     return { ok: true, data: builtInTemplateCache };
   }
 
-  const directory = getTemplateDirPath();
-  const filenames = fs
-    .readdirSync(directory)
-    .filter((filename) => filename.endsWith(".json"));
+  const directory = resolveBuiltInTemplateDirectory();
+  if (!directory.ok) {
+    return directory;
+  }
+
+  let filenames: string[] = [];
+  try {
+    filenames = fs
+      .readdirSync(directory.data)
+      .filter((filename) => filename.endsWith(".json"));
+  } catch {
+    return fail(
+      "template.directory",
+      `Failed to read built-in template directory: ${directory.data}`,
+    );
+  }
+
+  if (filenames.length === 0) {
+    return fail(
+      "template.directory",
+      `No built-in template resources found in ${directory.data}`,
+    );
+  }
 
   const map = new Map<BuiltInTemplateId, BuiltInTemplate>();
 
   for (const filename of filenames) {
-    const raw = fs.readFileSync(path.join(directory, filename), "utf8");
-    const parsed: unknown = JSON.parse(raw);
+    let raw = "";
+    try {
+      raw = fs.readFileSync(path.join(directory.data, filename), "utf8");
+    } catch {
+      return fail(
+        "template.resource",
+        `Failed to read built-in template resource: ${filename}`,
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return fail("template.resource", `Invalid JSON template file: ${filename}`);
+    }
     if (!isRecord(parsed)) {
       return fail(
         "template.resource",

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CreateProjectDialog } from "./CreateProjectDialog";
 import type { ProjectStore } from "../../stores/projectStore";
+import type { ProjectTemplate } from "../../stores/templateStore";
 
 /**
  * Build a fully-typed project store shape for tests.
@@ -59,6 +60,64 @@ function createMockProjectState(
   };
 }
 
+function createPresetTemplate(
+  id: string,
+  name: string,
+): ProjectTemplate & { type: "preset" } {
+  return {
+    id,
+    name,
+    type: "preset",
+    structure: { folders: [], files: [] },
+  };
+}
+
+const DEFAULT_PRESET_TEMPLATES: Array<ProjectTemplate & { type: "preset" }> = [
+  createPresetTemplate("preset-novel", "Novel"),
+  createPresetTemplate("preset-short", "Short Story"),
+  createPresetTemplate("preset-script", "Screenplay"),
+  createPresetTemplate("preset-other", "Other"),
+];
+
+type MockTemplateStoreState = {
+  presets: ProjectTemplate[];
+  customs: ProjectTemplate[];
+  loading: boolean;
+  error: string | null;
+  loadTemplates: () => Promise<void>;
+  createTemplate: () => Promise<ProjectTemplate>;
+  updateTemplate: () => Promise<void>;
+  deleteTemplate: () => Promise<void>;
+  getAllTemplates: () => ProjectTemplate[];
+  getTemplateById: (id: string) => ProjectTemplate | undefined;
+  clearError: () => void;
+};
+
+function createMockTemplateState(
+  overrides: Partial<MockTemplateStoreState> = {},
+): MockTemplateStoreState {
+  const state: MockTemplateStoreState = {
+    presets: DEFAULT_PRESET_TEMPLATES,
+    customs: [],
+    loading: false,
+    error: null,
+    loadTemplates: vi.fn().mockResolvedValue(undefined),
+    createTemplate: vi.fn().mockRejectedValue(new Error("Not implemented")),
+    updateTemplate: vi.fn().mockResolvedValue(undefined),
+    deleteTemplate: vi.fn().mockResolvedValue(undefined),
+    getAllTemplates: vi.fn().mockReturnValue(DEFAULT_PRESET_TEMPLATES),
+    getTemplateById: vi
+      .fn<(id: string) => ProjectTemplate | undefined>()
+      .mockImplementation((id: string) =>
+        [...state.presets, ...state.customs].find((template) => template.id === id),
+      ),
+    clearError: vi.fn(),
+  };
+  return { ...state, ...overrides };
+}
+
+let templateStoreState = createMockTemplateState();
+
 // Mock stores
 vi.mock("../../stores/projectStore", () => ({
   useProjectStore: vi.fn((selector) => {
@@ -68,47 +127,7 @@ vi.mock("../../stores/projectStore", () => ({
 }));
 
 vi.mock("../../stores/templateStore", () => ({
-  useTemplateStore: vi.fn((selector) => {
-    const state = {
-      presets: [
-        {
-          id: "preset-novel",
-          name: "Novel",
-          type: "preset",
-          structure: { folders: [], files: [] },
-        },
-        {
-          id: "preset-short",
-          name: "Short Story",
-          type: "preset",
-          structure: { folders: [], files: [] },
-        },
-        {
-          id: "preset-script",
-          name: "Screenplay",
-          type: "preset",
-          structure: { folders: [], files: [] },
-        },
-        {
-          id: "preset-other",
-          name: "Other",
-          type: "preset",
-          structure: { folders: [], files: [] },
-        },
-      ],
-      customs: [],
-      loading: false,
-      error: null,
-      loadTemplates: vi.fn().mockResolvedValue(undefined),
-      createTemplate: vi.fn(),
-      updateTemplate: vi.fn(),
-      deleteTemplate: vi.fn(),
-      getAllTemplates: vi.fn(),
-      getTemplateById: vi.fn(),
-      clearError: vi.fn(),
-    };
-    return selector(state);
-  }),
+  useTemplateStore: vi.fn((selector) => selector(templateStoreState)),
 }));
 
 // Mock CreateTemplateDialog
@@ -122,6 +141,7 @@ vi.mock("./CreateTemplateDialog", () => ({
 describe("CreateProjectDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    templateStoreState = createMockTemplateState();
   });
 
   // ===========================================================================
@@ -287,6 +307,82 @@ describe("CreateProjectDialog", () => {
       await user.click(screen.getByText("Create Template"));
 
       expect(screen.getByTestId("create-template-dialog")).toBeInTheDocument();
+    });
+
+    it("默认模板后到达时应同步为可提交的 preset", async () => {
+      const { useProjectStore } = await import("../../stores/projectStore");
+      const createAndSetCurrent = vi.fn().mockResolvedValue({
+        ok: true,
+        data: { projectId: "new-project", rootPath: "/mock/path" },
+      });
+      vi.mocked(useProjectStore).mockImplementation((selector) => {
+        const state = createMockProjectState({ createAndSetCurrent });
+        return selector(state);
+      });
+
+      templateStoreState = createMockTemplateState({ presets: [] });
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <CreateProjectDialog open={true} onOpenChange={onOpenChange} />,
+      );
+
+      templateStoreState = createMockTemplateState();
+      rerender(<CreateProjectDialog open={true} onOpenChange={onOpenChange} />);
+
+      await user.type(screen.getByTestId("create-project-name"), "New Project");
+      await user.click(screen.getByTestId("create-project-submit"));
+
+      await waitFor(() => {
+        expect(createAndSetCurrent).toHaveBeenCalledWith({
+          name: "New Project",
+          description: "",
+          type: undefined,
+          template: {
+            kind: "builtin",
+            id: "novel",
+          },
+        });
+      });
+    });
+
+    it("用户手动选择模板后不应被默认模板同步覆盖", async () => {
+      const { useProjectStore } = await import("../../stores/projectStore");
+      const createAndSetCurrent = vi.fn().mockResolvedValue({
+        ok: true,
+        data: { projectId: "new-project", rootPath: "/mock/path" },
+      });
+      vi.mocked(useProjectStore).mockImplementation((selector) => {
+        const state = createMockProjectState({ createAndSetCurrent });
+        return selector(state);
+      });
+
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <CreateProjectDialog open={true} onOpenChange={vi.fn()} />,
+      );
+
+      await user.click(screen.getByRole("radio", { name: "Short Story" }));
+
+      templateStoreState = createMockTemplateState({
+        presets: [...DEFAULT_PRESET_TEMPLATES],
+      });
+      rerender(<CreateProjectDialog open={true} onOpenChange={vi.fn()} />);
+
+      await user.type(screen.getByTestId("create-project-name"), "New Project");
+      await user.click(screen.getByTestId("create-project-submit"));
+
+      await waitFor(() => {
+        expect(createAndSetCurrent).toHaveBeenCalledWith({
+          name: "New Project",
+          description: "",
+          type: undefined,
+          template: {
+            kind: "builtin",
+            id: "short-story",
+          },
+        });
+      });
     });
   });
 

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -109,7 +109,9 @@ function createMockTemplateState(
     getTemplateById: vi
       .fn<(id: string) => ProjectTemplate | undefined>()
       .mockImplementation((id: string) =>
-        [...state.presets, ...state.customs].find((template) => template.id === id),
+        [...state.presets, ...state.customs].find(
+          (template) => template.id === id,
+        ),
       ),
     clearError: vi.fn(),
   };

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -84,6 +84,10 @@ function FormContent({
   const [imageError, setImageError] = useState<string | null>(null);
   const [nameError, setNameError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const selectableTemplateIds = useMemo(
+    () => new Set([...presetOptions, ...customOptions].map((opt) => opt.value)),
+    [customOptions, presetOptions],
+  );
 
   useEffect(() => {
     if (initialName !== undefined) {
@@ -110,6 +114,16 @@ function FormContent({
       setTemplateId(presetOptions[0].value);
     }
   }, [initialType, presetOptions]);
+
+  useEffect(() => {
+    if (!defaultTemplateId) {
+      return;
+    }
+    if (templateId.length > 0 && selectableTemplateIds.has(templateId)) {
+      return;
+    }
+    setTemplateId(defaultTemplateId);
+  }, [defaultTemplateId, selectableTemplateIds, templateId]);
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {

--- a/apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts
+++ b/apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+
+import electronViteConfig from "../../../electron.vite.config";
+
+type NamedPlugin = {
+  name?: string;
+};
+
+type MainConfig = {
+  plugins?: NamedPlugin[];
+};
+
+const config = electronViteConfig as { main: MainConfig };
+const pluginNames = (config.main.plugins ?? [])
+  .map((plugin) => plugin.name)
+  .filter((name): name is string => typeof name === "string");
+
+// S1-BUNDLE-TPL-1
+// main build must include the builtin template copy plugin for bundled runtime.
+assert.equal(
+  pluginNames.includes("creonow-copy-builtin-project-templates"),
+  true,
+  "main build should copy builtin project templates into dist/main",
+);

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -1,0 +1,107 @@
+# ISSUE-583
+
+- Issue: #583
+- Issue URL: `<fill-issue-url>`
+- Branch: `task/583-windows-e2e-create-dialog-regression`
+- PR: `<fill-pr-url-after-create>`
+- Scope:
+  - `apps/desktop/electron.vite.config.ts`
+  - `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/**`
+  - `openspec/_ops/task_runs/ISSUE-583.md`
+- Out of Scope:
+  - 新增/删除模板功能（W3 内置模板语义不变）
+  - PR 创建与合并收口（本日志阶段尚未执行）
+
+## Plan
+
+- [x] 捕获 windows-e2e 失败根因并形成可复现证据
+- [x] 以最小补丁修复 bundled runtime 内置模板加载
+- [x] 保持结构化失败路径（模板目录不可用时返回 `INVALID_ARGUMENT`，无未捕获 fs throw）
+- [x] 完成聚焦验证（模板相关测试 + build 产物检查）
+- [x] 补齐 Rulebook 与 RUN_LOG 治理文件
+- [ ] 创建 PR 并回填 issue/pr 占位符为真实链接
+- [ ] 开启 auto-merge 并等待 required checks 全绿
+- [ ] 合并回 `main`、同步控制面、清理 worktree、归档 Rulebook task
+
+## Delivery Checklist
+
+- [x] 根因证据已记录（路径解析偏移 + dist 产物缺失）
+- [x] 修复补丁已提交到当前任务分支
+- [x] 聚焦验证已通过（见 Runs）
+- [x] Rulebook 治理文件已创建并对齐当前状态
+- [ ] PR 已创建（当前：未创建）
+- [ ] Auto-merge 已开启（当前：未开启）
+- [ ] Required checks 全绿（当前：未触发）
+- [ ] 已合并至 `main`（当前：未合并）
+
+## Runs
+
+### 2026-02-15 Root-Cause Capture（windows-e2e create dialog 卡住）
+
+- Command:
+  - `sed -n '1,260p' apps/desktop/main/src/services/projects/templateService.ts`
+  - `rg -n "templates/project" apps/desktop/dist/main/index.js`
+  - `ls -la apps/desktop/dist/main`
+  - `sed -n '1,200p' apps/desktop/tests/e2e/_helpers/projectReadiness.ts`
+- Exit code: `0`
+- Key output:
+  - `templateService` 在 bundled 主进程仍走 `../../../templates/project` 相关路径解析。
+  - `dist/main/index.js` 可见模板目录解析逻辑，但构建产物目录仅有 `index.js` 与 `skills/`，缺少 `templates/project/`。
+  - `waitForEditorReady` 首先断言 `create-project-dialog` 变为 hidden；模板加载失败会阻断创建闭环并导致该等待超时。
+- Conclusion:
+  - 根因为 bundled runtime 缺少内置模板资源，导致项目创建提交后模板加载失败，create dialog 不关闭。
+
+### 2026-02-15 Subagent Patch Iteration #1（最小补丁落地）
+
+- Command:
+  - 编辑 `apps/desktop/electron.vite.config.ts`：新增 `creonow-copy-builtin-project-templates` 插件
+  - 新增 `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `pnpm exec tsx apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-service-apply.test.ts`
+- Exit code:
+  - 配置回归测试：`0`
+  - 两个模板服务脚本测试：`1`（`better-sqlite3` Node ABI mismatch）
+- Key output:
+  - 新插件已注入 `main.plugins`。
+  - `ERR_DLOPEN_FAILED`: `better_sqlite3.node` `NODE_MODULE_VERSION` 不匹配（143 vs 115）。
+
+### 2026-02-15 Subagent Patch Iteration #2（环境修复 + 测试期望修正）
+
+- Command:
+  - `pnpm --filter @creonow/desktop rebuild better-sqlite3`
+  - 复跑两个模板服务脚本测试
+  - 复跑 `template-runtime-resolution.test.ts`
+  - 编辑 `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`（改为 `dist/main/templates/project` 优先，源码目录回退）
+- Exit code:
+  - native rebuild：`0`
+  - 模板服务脚本测试：`0`
+  - `template-runtime-resolution.test.ts` 首次复跑：`1`（旧断言仍固定期望 `main/templates/project`）
+  - 修正断言后复跑：`0`
+- Key output:
+  - 当前真实行为为 bundled 目录优先命中，符合修复目标。
+
+### 2026-02-15 Verification Commands And Results
+
+- Command:
+  - `pnpm exec tsx apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-service-apply.test.ts`
+  - `pnpm --filter @creonow/desktop build`
+  - `ls apps/desktop/dist/main/templates/project`
+- Exit code: `0`
+- Key output:
+  - 聚焦测试全部通过。
+  - 构建后模板产物存在：`custom.json`、`novel.json`、`screenplay.json`、`short-story.json`。
+
+### 2026-02-15 Commit（功能修复）
+
+- Command:
+  - `git commit -m "fix: resolve builtin template path for bundled runtime (#583)"`
+- Exit code: `0`
+- Key output:
+  - Commit: `84637469d474784e6001522399cdb4cea07c9ed7`

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -1,36 +1,43 @@
 # ISSUE-583
 
 - Issue: #583
-- Issue URL: `<fill-issue-url>`
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/583
 - Branch: `task/583-windows-e2e-create-dialog-regression`
 - PR: `<fill-pr-url-after-create>`
-- Scope:
+- Scope (Functional):
+  - `apps/desktop/main/src/services/projects/templateService.ts`
   - `apps/desktop/electron.vite.config.ts`
-  - `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx`
+  - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx`
+  - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
   - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
-  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/**`
+  - `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+- Scope (Governance):
   - `openspec/_ops/task_runs/ISSUE-583.md`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/.metadata.json`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/specs/governance/spec.md`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md`
 - Out of Scope:
-  - 新增/删除模板功能（W3 内置模板语义不变）
-  - PR 创建与合并收口（本日志阶段尚未执行）
+  - 新增/删除内置模板能力（W3 模板功能保持）
+  - PR 创建、auto-merge、main 收口（本日志版本尚未执行）
 
 ## Plan
 
 - [x] 捕获 windows-e2e 失败根因并形成可复现证据
-- [x] 以最小补丁修复 bundled runtime 内置模板加载
-- [x] 保持结构化失败路径（模板目录不可用时返回 `INVALID_ARGUMENT`，无未捕获 fs throw）
-- [x] 完成聚焦验证（模板相关测试 + build 产物检查）
-- [x] 补齐 Rulebook 与 RUN_LOG 治理文件
-- [ ] 创建 PR 并回填 issue/pr 占位符为真实链接
+- [x] 接收并整合 3 个功能补丁提交（create-dialog、templateService、build copy）
+- [x] 保持结构化失败路径（模板目录不可用时返回 `INVALID_ARGUMENT`）
+- [x] 完成主会话最新验证证据（unit/vitest/build/playwright 单测）
+- [x] 补齐并校准 Rulebook + RUN_LOG 治理文件
+- [ ] 创建 PR 并回填 PR 链接
 - [ ] 开启 auto-merge 并等待 required checks 全绿
 - [ ] 合并回 `main`、同步控制面、清理 worktree、归档 Rulebook task
 
 ## Delivery Checklist
 
-- [x] 根因证据已记录（路径解析偏移 + dist 产物缺失）
-- [x] 修复补丁已提交到当前任务分支
-- [x] 聚焦验证已通过（见 Runs）
-- [x] Rulebook 治理文件已创建并对齐当前状态
+- [x] Scope 已与当前分支真实改动对齐
+- [x] 已记录 accepted commits（4 个）
+- [x] 已记录主会话最新验证证据
 - [ ] PR 已创建（当前：未创建）
 - [ ] Auto-merge 已开启（当前：未开启）
 - [ ] Required checks 全绿（当前：未触发）
@@ -38,7 +45,7 @@
 
 ## Runs
 
-### 2026-02-15 Root-Cause Capture（windows-e2e create dialog 卡住）
+### 2026-02-15 Root-Cause Capture（windows-e2e create dialog 未关闭）
 
 - Command:
   - `sed -n '1,260p' apps/desktop/main/src/services/projects/templateService.ts`
@@ -47,61 +54,54 @@
   - `sed -n '1,200p' apps/desktop/tests/e2e/_helpers/projectReadiness.ts`
 - Exit code: `0`
 - Key output:
-  - `templateService` 在 bundled 主进程仍走 `../../../templates/project` 相关路径解析。
-  - `dist/main/index.js` 可见模板目录解析逻辑，但构建产物目录仅有 `index.js` 与 `skills/`，缺少 `templates/project/`。
-  - `waitForEditorReady` 首先断言 `create-project-dialog` 变为 hidden；模板加载失败会阻断创建闭环并导致该等待超时。
+  - bundled 主进程存在模板目录解析逻辑，但 `dist/main` 初始缺少 `templates/project` 产物。
+  - `waitForEditorReady` 首先等待 `create-project-dialog` hidden，模板加载失败会导致提交后对话框停留。
 - Conclusion:
-  - 根因为 bundled runtime 缺少内置模板资源，导致项目创建提交后模板加载失败，create dialog 不关闭。
+  - 根因为 bundled runtime 内置模板资源缺失，触发 create flow 卡住并放大为 windows-e2e 连锁失败。
 
-### 2026-02-15 Subagent Patch Iteration #1（最小补丁落地）
+### 2026-02-15 Accepted Patch Commits（当前分支真实链路）
+
+- `bae420edc30483fa15cf0da5ba84ec0a5501631a`
+  - Message: `fix: restore create-project default template sync for e2e readiness (#583)`
+  - Files:
+    - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx`
+    - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx`
+- `28a4012f4185af91d8388012b9b4ffe0e224b29a`
+  - Message: `fix: make builtin template loading robust in bundled runtime (#583)`
+  - Files:
+    - `apps/desktop/main/src/services/projects/templateService.ts`
+    - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+    - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+- `84637469d474784e6001522399cdb4cea07c9ed7`
+  - Message: `fix: resolve builtin template path for bundled runtime (#583)`
+  - Files:
+    - `apps/desktop/electron.vite.config.ts`
+    - `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+    - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+- `2b98c1741234aabeb525791b6e3fabd3e6ca0937`
+  - Message: `docs: add governance artifacts for issue-583 (#583)`
+  - Files:
+    - `openspec/_ops/task_runs/ISSUE-583.md`
+    - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/**`
+
+### 2026-02-15 Main-Session Verification（Latest Audit Commands）
 
 - Command:
-  - 编辑 `apps/desktop/electron.vite.config.ts`：新增 `creonow-copy-builtin-project-templates` 插件
-  - 新增 `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
   - `pnpm exec tsx apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
   - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
-  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
-  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-service-apply.test.ts`
-- Exit code:
-  - 配置回归测试：`0`
-  - 两个模板服务脚本测试：`1`（`better-sqlite3` Node ABI mismatch）
-- Key output:
-  - 新插件已注入 `main.plugins`。
-  - `ERR_DLOPEN_FAILED`: `better_sqlite3.node` `NODE_MODULE_VERSION` 不匹配（143 vs 115）。
-
-### 2026-02-15 Subagent Patch Iteration #2（环境修复 + 测试期望修正）
-
-- Command:
   - `pnpm --filter @creonow/desktop rebuild better-sqlite3`
-  - 复跑两个模板服务脚本测试
-  - 复跑 `template-runtime-resolution.test.ts`
-  - 编辑 `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`（改为 `dist/main/templates/project` 优先，源码目录回退）
-- Exit code:
-  - native rebuild：`0`
-  - 模板服务脚本测试：`0`
-  - `template-runtime-resolution.test.ts` 首次复跑：`1`（旧断言仍固定期望 `main/templates/project`）
-  - 修正断言后复跑：`0`
-- Key output:
-  - 当前真实行为为 bundled 目录优先命中，符合修复目标。
-
-### 2026-02-15 Verification Commands And Results
-
-- Command:
-  - `pnpm exec tsx apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
-  - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
   - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
   - `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-service-apply.test.ts`
+  - `pnpm -C apps/desktop exec vitest run renderer/src/features/projects/CreateProjectDialog.test.tsx`
   - `pnpm --filter @creonow/desktop build`
-  - `ls apps/desktop/dist/main/templates/project`
+  - `ls -1 apps/desktop/dist/main/templates/project`
+  - `pnpm --filter @creonow/desktop rebuild:native`
+  - `pnpm -C apps/desktop exec playwright test -c tests/e2e/playwright.config.ts tests/e2e/ai-apply.spec.ts --grep "ai apply: success path writes actor=ai version \+ main.log evidence"`
+  - `pnpm -C apps/desktop exec playwright test -c tests/e2e/playwright.config.ts tests/e2e/version-history.spec.ts --grep "version:snapshot:read returns full version content"`
 - Exit code: `0`
 - Key output:
-  - 聚焦测试全部通过。
-  - 构建后模板产物存在：`custom.json`、`novel.json`、`screenplay.json`、`short-story.json`。
-
-### 2026-02-15 Commit（功能修复）
-
-- Command:
-  - `git commit -m "fix: resolve builtin template path for bundled runtime (#583)"`
-- Exit code: `0`
-- Key output:
-  - Commit: `84637469d474784e6001522399cdb4cea07c9ed7`
+  - `CreateProjectDialog.test.tsx`: `22 passed`.
+  - build 成功，且 `dist/main/templates/project` 包含：`custom.json`、`novel.json`、`screenplay.json`、`short-story.json`。
+  - Playwright 单测通过：
+    - `ai-apply.spec.ts` success path: `1 passed`
+    - `version-history.spec.ts` full content path: `1 passed`

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -3,7 +3,7 @@
 - Issue: #583
 - Issue URL: https://github.com/Leeky1017/CreoNow/issues/583
 - Branch: `task/583-windows-e2e-create-dialog-regression`
-- PR: `<fill-pr-url-after-create>`
+- PR: https://github.com/Leeky1017/CreoNow/pull/584
 - Scope (Functional):
   - `apps/desktop/main/src/services/projects/templateService.ts`
   - `apps/desktop/electron.vite.config.ts`
@@ -29,7 +29,7 @@
 - [x] 保持结构化失败路径（模板目录不可用时返回 `INVALID_ARGUMENT`）
 - [x] 完成主会话最新验证证据（unit/vitest/build/playwright 单测）
 - [x] 补齐并校准 Rulebook + RUN_LOG 治理文件
-- [ ] 创建 PR 并回填 PR 链接
+- [x] 创建 PR 并回填 PR 链接
 - [ ] 开启 auto-merge 并等待 required checks 全绿
 - [ ] 合并回 `main`、同步控制面、清理 worktree、归档 Rulebook task
 
@@ -38,7 +38,7 @@
 - [x] Scope 已与当前分支真实改动对齐
 - [x] 已记录 accepted commits（4 个）
 - [x] 已记录主会话最新验证证据
-- [ ] PR 已创建（当前：未创建）
+- [x] PR 已创建（当前：https://github.com/Leeky1017/CreoNow/pull/584）
 - [ ] Auto-merge 已开启（当前：未开启）
 - [ ] Required checks 全绿（当前：未触发）
 - [ ] 已合并至 `main`（当前：未合并）
@@ -105,3 +105,11 @@
   - Playwright 单测通过：
     - `ai-apply.spec.ts` success path: `1 passed`
     - `version-history.spec.ts` full content path: `1 passed`
+
+### 2026-02-15 PR Creation
+
+- Command:
+  - `gh pr create --base main --head task/583-windows-e2e-create-dialog-regression --title "Fix bundled template loading regression after W3 (#583)" --body-file /tmp/pr-583-body.md`
+- Exit code: `0`
+- Key output:
+  - PR: `https://github.com/Leeky1017/CreoNow/pull/584`

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -163,7 +163,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 6ca06737e9fb265b957ead8f3099da550aea77e8
+- Reviewed-HEAD-SHA: 45a7c7b74bc81e3aec5aa703247279c20bc3141f
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -117,7 +117,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 998392aef2f649b81ed756bed117f014d996c7ae
+- Reviewed-HEAD-SHA: aceac8290ce40e27ff2d407ebff183bf5664261e
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -83,6 +83,19 @@
   - Files:
     - `openspec/_ops/task_runs/ISSUE-583.md`
     - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/**`
+- `aceac82923f4bd233d65dcf2c6fca4c735253802`
+  - Message: `chore: format issue-583 artifacts for preflight (#583)`
+  - Files:
+    - `apps/desktop/main/src/services/projects/templateService.ts`
+    - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+    - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx`
+    - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md`
+    - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md`
+- `bafdf9bc5bdc7920a0e999a59aa2be97850e9b1c`
+  - Message: `fix: repair issue-583 template test type narrowing (#583)`
+  - Files:
+    - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+    - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
 
 ### 2026-02-15 Main-Session Verification（Latest Audit Commands）
 
@@ -114,10 +127,32 @@
 - Key output:
   - PR: `https://github.com/Leeky1017/CreoNow/pull/584`
 
+### 2026-02-15 Preflight Blockers And Remediation
+
+- Blocker #1:
+  - `scripts/agent_pr_preflight.sh` failed at Prettier check.
+  - Non-formatted files:
+    - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
+    - `apps/desktop/main/src/services/projects/templateService.ts`
+    - `apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx`
+    - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md`
+    - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md`
+  - Fix:
+    - `pnpm exec prettier --write <5 files>`
+    - commit: `aceac82923f4bd233d65dcf2c6fca4c735253802`
+- Blocker #2:
+  - `scripts/agent_pr_preflight.sh` failed at `pnpm typecheck`.
+  - Errors:
+    - `template-builtin-dir-invalid-argument.test.ts`: `Property 'field' does not exist on type '{}'`.
+    - `template-runtime-resolution.test.ts`: `Property 'error' does not exist on type 'never'.`
+  - Fix:
+    - tightened type narrowing in both test files.
+    - commit: `bafdf9bc5bdc7920a0e999a59aa2be97850e9b1c`
+
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: aceac8290ce40e27ff2d407ebff183bf5664261e
+- Reviewed-HEAD-SHA: bafdf9bc5bdc7920a0e999a59aa2be97850e9b1c
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -163,7 +163,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 6ca067370dbf57999f4f08d42ea5da67a671b9f6
+- Reviewed-HEAD-SHA: 6ca06737e9fb265b957ead8f3099da550aea77e8
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -96,6 +96,10 @@
   - Files:
     - `apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
     - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+- `6ca067370dbf57999f4f08d42ea5da67a671b9f6`
+  - Message: `chore: format template runtime resolution test (#583)`
+  - Files:
+    - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
 
 ### 2026-02-15 Main-Session Verification（Latest Audit Commands）
 
@@ -148,11 +152,18 @@
   - Fix:
     - tightened type narrowing in both test files.
     - commit: `bafdf9bc5bdc7920a0e999a59aa2be97850e9b1c`
+- Blocker #3:
+  - after type-narrowing commit, preflight still reported one-file Prettier drift.
+  - File:
+    - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+  - Fix:
+    - `pnpm exec prettier --write apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+    - commit: `6ca067370dbf57999f4f08d42ea5da67a671b9f6`
 
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: bafdf9bc5bdc7920a0e999a59aa2be97850e9b1c
+- Reviewed-HEAD-SHA: 6ca067370dbf57999f4f08d42ea5da67a671b9f6
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-583.md
+++ b/openspec/_ops/task_runs/ISSUE-583.md
@@ -113,3 +113,13 @@
 - Exit code: `0`
 - Key output:
   - PR: `https://github.com/Leeky1017/CreoNow/pull/584`
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 998392aef2f649b81ed756bed117f014d996c7ae
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/.metadata.json
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-02-15T08:25:29.810Z",
+  "updatedAt": "2026-02-15T08:26:34.000Z"
+}

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md
@@ -1,11 +1,13 @@
 # Proposal: issue-583-windows-e2e-create-dialog-regression
 
 ## Why
+
 Windows E2E 在 bundled Electron 运行时触发项目创建回归：内置模板目录未被打包进
 `dist/main`，`project:create` 提交后模板加载失败，创建对话框保持可见，导致
 `waitForEditorReady` 超时并引发多用例连锁失败。
 
 ## What Changes
+
 - 构建阶段将 `apps/desktop/main/templates/project` 复制到
   `apps/desktop/dist/main/templates/project`，保证 bundled runtime 可读取内置模板。
 - 新增构建配置回归测试，锁定“主进程构建必须包含模板复制插件”契约。
@@ -13,6 +15,7 @@ Windows E2E 在 bundled Electron 运行时触发项目创建回归：内置模�
 - 补齐治理交付文档（Rulebook + RUN_LOG），记录根因、修复迭代与验证证据。
 
 ## Impact
+
 - Affected specs:
   - `openspec/specs/project-management/spec.md`（沿用既有“项目创建 + 模板”契约）
   - `openspec/specs/workbench/spec.md`（沿用既有“创建后进入编辑态”E2E 观察点）

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: issue-583-windows-e2e-create-dialog-regression
+
+## Why
+Windows E2E 在 bundled Electron 运行时触发项目创建回归：内置模板目录未被打包进
+`dist/main`，`project:create` 提交后模板加载失败，创建对话框保持可见，导致
+`waitForEditorReady` 超时并引发多用例连锁失败。
+
+## What Changes
+- 构建阶段将 `apps/desktop/main/templates/project` 复制到
+  `apps/desktop/dist/main/templates/project`，保证 bundled runtime 可读取内置模板。
+- 新增构建配置回归测试，锁定“主进程构建必须包含模板复制插件”契约。
+- 更新模板目录解析回归测试期望，明确 bundled 产物优先于源码目录回退。
+- 补齐治理交付文档（Rulebook + RUN_LOG），记录根因、修复迭代与验证证据。
+
+## Impact
+- Affected specs:
+  - `openspec/specs/project-management/spec.md`（沿用既有“项目创建 + 模板”契约）
+  - `openspec/specs/workbench/spec.md`（沿用既有“创建后进入编辑态”E2E 观察点）
+- Affected code:
+  - `apps/desktop/electron.vite.config.ts`
+  - `apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
+  - `apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
+  - `openspec/_ops/task_runs/ISSUE-583.md`
+  - `rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/**`
+- Breaking change: NO
+- User benefit: bundled Windows 运行时可稳定加载内置模板，项目创建提交后对话框可关闭并进入编辑器，恢复 windows-e2e 稳定性。

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/specs/governance/spec.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/specs/governance/spec.md
@@ -1,0 +1,23 @@
+# Governance Task Spec — issue-583-windows-e2e-create-dialog-regression
+
+## Scope
+
+为 issue #583 建立完整治理交付轨迹：补齐 Rulebook 任务文件与 RUN_LOG，
+记录 windows-e2e 根因、修复迭代、聚焦验证，并保持 PR 前状态一致性。
+
+## Acceptance
+
+- Rulebook 目录存在且完整：
+  - `.metadata.json`
+  - `proposal.md`
+  - `specs/governance/spec.md`
+  - `tasks.md`
+- RUN_LOG `openspec/_ops/task_runs/ISSUE-583.md` 必须包含：
+  - issue/pr 占位符（PR 尚未创建）
+  - 根因捕获记录（bundled 路径与产物缺失）
+  - 补丁迭代记录（至少一轮失败与后续修正）
+  - 验证命令与结果（聚焦测试 + build 产物确认）
+- Plan 与 Delivery checklist 必须反映当前真实状态：
+  - 修复与本地验证已完成
+  - PR / auto-merge / required checks / main 同步尚未完成
+- RUN_LOG 当前阶段不得出现 `Main Session Audit` 区块。

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+- [x] 1.1 捕获 bundled runtime 模板加载根因并落盘（路径解析 + 打包产物缺失）
+- [x] 1.2 最小修复构建流程：复制内置模板到 `dist/main/templates/project`
+- [x] 1.3 保留 W3 内置模板能力并确保失败路径返回结构化错误（无未捕获 fs throw）
+- [x] 1.4 提交功能修复 commit：`fix: resolve builtin template path for bundled runtime (#583)`
+
+## 2. Testing
+- [x] 2.1 新增并通过构建配置回归测试（模板复制插件必须存在）
+- [x] 2.2 通过模板目录解析回归测试（bundled 优先，source 回退）
+- [x] 2.3 通过模板服务聚焦测试（invalid-dir、template-apply）
+- [x] 2.4 通过 `pnpm --filter @creonow/desktop build` 并确认 `dist/main/templates/project/*.json` 存在
+
+## 3. Governance
+- [x] 3.1 创建 Rulebook 治理文件：`.metadata.json`、`proposal.md`、`specs/governance/spec.md`、`tasks.md`
+- [x] 3.2 创建 `openspec/_ops/task_runs/ISSUE-583.md` 并记录根因、补丁迭代、验证证据
+- [ ] 3.3 创建 PR（`Closes #583`）并回填 RUN_LOG issue/pr 占位符为真实链接
+- [ ] 3.4 开启 auto-merge，等待 required checks（`ci`/`openspec-log-guard`/`merge-serial`）全绿
+- [ ] 3.5 合并后执行控制面 `main` 同步、worktree 清理、Rulebook 归档

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
@@ -16,6 +16,6 @@
 ## 3. Governance
 - [x] 3.1 创建 Rulebook 治理文件：`.metadata.json`、`proposal.md`、`specs/governance/spec.md`、`tasks.md`
 - [x] 3.2 创建并对齐 `openspec/_ops/task_runs/ISSUE-583.md`（Scope/accepted commits/verification evidence）
-- [ ] 3.3 创建 PR（`Closes #583`）并回填 RUN_LOG issue/pr 占位符为真实链接
+- [x] 3.3 创建 PR（`Closes #583`）并回填 RUN_LOG issue/pr 占位符为真实链接
 - [ ] 3.4 开启 auto-merge，等待 required checks（`ci`/`openspec-log-guard`/`merge-serial`）全绿
 - [ ] 3.5 合并后执行控制面 `main` 同步、worktree 清理、Rulebook 归档

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
@@ -1,10 +1,12 @@
 ## 1. Implementation
+
 - [x] 1.1 捕获 bundled runtime 模板加载根因并落盘（路径解析 + 打包产物缺失）
 - [x] 1.2 修复 create-dialog 默认模板同步回归，恢复创建提交流程可达（`bae420ed...`）
 - [x] 1.3 强化内置模板目录解析与错误处理，保留 W3 能力且返回结构化失败（`28a4012f...`）
 - [x] 1.4 修复 bundled 构建资源落盘：复制内置模板到 `dist/main/templates/project`（`84637469...`）
 
 ## 2. Testing
+
 - [x] 2.1 通过模板目录/运行时回归测试（`main-build-plugins`、`template-runtime-resolution`）
 - [x] 2.2 通过模板服务聚焦测试（`template-builtin-dir-invalid-argument`、`template-service-apply`）
 - [x] 2.3 通过 `CreateProjectDialog` 相关 Vitest 回归（22 tests）
@@ -14,6 +16,7 @@
   - `version-history.spec.ts`（full version content）
 
 ## 3. Governance
+
 - [x] 3.1 创建 Rulebook 治理文件：`.metadata.json`、`proposal.md`、`specs/governance/spec.md`、`tasks.md`
 - [x] 3.2 创建并对齐 `openspec/_ops/task_runs/ISSUE-583.md`（Scope/accepted commits/verification evidence）
 - [x] 3.3 创建 PR（`Closes #583`）并回填 RUN_LOG issue/pr 占位符为真实链接

--- a/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
+++ b/rulebook/tasks/issue-583-windows-e2e-create-dialog-regression/tasks.md
@@ -1,18 +1,21 @@
 ## 1. Implementation
 - [x] 1.1 捕获 bundled runtime 模板加载根因并落盘（路径解析 + 打包产物缺失）
-- [x] 1.2 最小修复构建流程：复制内置模板到 `dist/main/templates/project`
-- [x] 1.3 保留 W3 内置模板能力并确保失败路径返回结构化错误（无未捕获 fs throw）
-- [x] 1.4 提交功能修复 commit：`fix: resolve builtin template path for bundled runtime (#583)`
+- [x] 1.2 修复 create-dialog 默认模板同步回归，恢复创建提交流程可达（`bae420ed...`）
+- [x] 1.3 强化内置模板目录解析与错误处理，保留 W3 能力且返回结构化失败（`28a4012f...`）
+- [x] 1.4 修复 bundled 构建资源落盘：复制内置模板到 `dist/main/templates/project`（`84637469...`）
 
 ## 2. Testing
-- [x] 2.1 新增并通过构建配置回归测试（模板复制插件必须存在）
-- [x] 2.2 通过模板目录解析回归测试（bundled 优先，source 回退）
-- [x] 2.3 通过模板服务聚焦测试（invalid-dir、template-apply）
+- [x] 2.1 通过模板目录/运行时回归测试（`main-build-plugins`、`template-runtime-resolution`）
+- [x] 2.2 通过模板服务聚焦测试（`template-builtin-dir-invalid-argument`、`template-service-apply`）
+- [x] 2.3 通过 `CreateProjectDialog` 相关 Vitest 回归（22 tests）
 - [x] 2.4 通过 `pnpm --filter @creonow/desktop build` 并确认 `dist/main/templates/project/*.json` 存在
+- [x] 2.5 在 `rebuild:native` 后通过 Playwright 单测：
+  - `ai-apply.spec.ts`（success path）
+  - `version-history.spec.ts`（full version content）
 
 ## 3. Governance
 - [x] 3.1 创建 Rulebook 治理文件：`.metadata.json`、`proposal.md`、`specs/governance/spec.md`、`tasks.md`
-- [x] 3.2 创建 `openspec/_ops/task_runs/ISSUE-583.md` 并记录根因、补丁迭代、验证证据
+- [x] 3.2 创建并对齐 `openspec/_ops/task_runs/ISSUE-583.md`（Scope/accepted commits/verification evidence）
 - [ ] 3.3 创建 PR（`Closes #583`）并回填 RUN_LOG issue/pr 占位符为真实链接
 - [ ] 3.4 开启 auto-merge，等待 required checks（`ci`/`openspec-log-guard`/`merge-serial`）全绿
 - [ ] 3.5 合并后执行控制面 `main` 同步、worktree 清理、Rulebook 归档


### PR DESCRIPTION
## Summary
- fix bundled runtime builtin-template loading path drift introduced by W3 create-template flow
- copy project templates into `dist/main/templates/project` during desktop build
- harden template directory resolution and structured error behavior in `templateService`
- keep create dialog default-template selection stable when templates load asynchronously
- add regression tests for build plugin presence, runtime template resolution, invalid-dir error mapping, and dialog selection sync

## Verification
- `pnpm exec tsx apps/desktop/tests/unit/config/main-build-plugins.runtime.test.ts`
- `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-runtime-resolution.test.ts`
- `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-builtin-dir-invalid-argument.test.ts`
- `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-service-apply.test.ts`
- `pnpm exec tsx apps/desktop/main/src/services/projects/__tests__/template-schema-validation.test.ts`
- `pnpm exec tsx apps/desktop/tests/integration/project-management/project-create-template-contract.test.ts`
- `pnpm -C apps/desktop exec vitest run renderer/src/features/projects/CreateProjectDialog.test.tsx`
- `pnpm -C apps/desktop build`
- `pnpm -C apps/desktop rebuild:native`
- `pnpm -C apps/desktop exec playwright test -c tests/e2e/playwright.config.ts tests/e2e/ai-apply.spec.ts --grep "success path writes actor=ai version" --workers=1`
- `pnpm -C apps/desktop exec playwright test -c tests/e2e/playwright.config.ts tests/e2e/version-history.spec.ts --grep "returns NOT_FOUND for invalid versionId" --workers=1`

Closes #583
