### PR TITLE
rewrite: 15 change tasks §3 Red / §4 Green / §5 Refactor 从模板套话改为针对性内容

### DIFF
--- a/openspec/changes/audit-contextfs-async-ssot/tasks.md
+++ b/openspec/changes/audit-contextfs-async-ssot/tasks.md
@@ -27,19 +27,26 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **异步 SSOT 基线**：调用 `ensureCreonowDirStructureAsync(projectPath)`，断言创建完整 `.creonow` 子目录结构（AUD-C6-S1）
+- [ ] 3.2 **sync/async 一致性（结构）**：分别调用 sync 和 async 版本，断言产出的目录结构完全相同（AUD-C6-S2）
+- [ ] 3.3 **异步状态查询**：调用 `getCreonowDirStatusAsync`，断言返回正确的目录存在/缺失状态（AUD-C6-S3）
+- [ ] 3.4 **sync/async 一致性（状态）**：同一路径分别调用 sync 和 async 状态查询，断言返回值严格相等（AUD-C6-S4）
+- [ ] 3.5 **错误语义一致**：在不可写路径上分别调用 sync 和 async，断言两者抛出/reject 的错误具有相同的 code 和 message 模式（AUD-C6-S5）
+- [ ] 3.6 **幂等性**：对已存在的目录重复调用 `ensureCreonowDirStructureAsync`，断言不报错且目录内容不变（AUD-C6-S6）
+- [ ] 3.7 **单一业务逻辑验证**：AST 或源码扫描 contextFs.ts，断言 `mkdir` / `stat` 调用序列仅出现一次（在异步实现中），sync 版本不含独立的 mkdir/stat 序列（AUD-C6-S7）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 提取 async 版本中的目录结构定义（路径列表、创建顺序）为纯数据常量或共享配置函数
+- [ ] 4.2 重写 sync 版本为薄包装：调用共享配置函数获取目录列表，再用 `fs.mkdirSync` 逐个创建（业务逻辑不重复）
+- [ ] 4.3 同理重写 `getCreonowDirStatus` sync 版本，调用共享纯逻辑后用 `fs.statSync` 适配
+- [ ] 4.4 删除 sync 版本中原有的重复 mkdir/stat 调用序列
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将目录结构定义（`.creonow` 下的子目录清单）抽取为 `CREONOW_DIR_STRUCTURE` 常量，sync/async 共用
+- [ ] 5.2 评估 sync wrapper 是否保持当前的 sync fs API + 共享配置模式（推荐），避免使用 `execSync` + async 函数的反模式
+- [ ] 5.3 确保重构后无多余的 fs import（如同时 import `fs` 和 `fs/promises` 时各自仅用其必要 API）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-dead-code-and-path-resolution-cleanup/tasks.md
+++ b/openspec/changes/audit-dead-code-and-path-resolution-cleanup/tasks.md
@@ -26,19 +26,26 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **phase4-delivery-gate 处置**：扫描生产代码 import 图，断言 `phase4-delivery-gate.ts` 要么被生产代码 import 要么文件已不存在（AUD-C12-S1）
+- [ ] 3.2 **死代码守卫延续**：`ping-dead-code-cleanup.test.ts` 运行通过，断言守卫测试在 phase4 处置后仍有效（AUD-C12-S2）
+- [ ] 3.3 **模板路径确定性**：mock 构建配置输出路径，调用 templateService 路径解析，断言直接命中目标路径而非遍历 5 个候选（AUD-C12-S3）
+- [ ] 3.4 **模板缺失明确报错**：构建配置路径下模板文件不存在，断言抛出的错误包含确切的期望路径（AUD-C12-S4）
+- [ ] 3.5 **preload 路径确定性**：mock 构建配置，断言 preload 路径直接从配置解析，无候选列表遍历（AUD-C12-S5）
+- [ ] 3.6 **preload 缺失明确报错**：preload 文件不存在，断言错误包含确切期望路径而非"在 N 个位置均未找到"（AUD-C12-S6）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 决策 `phase4-delivery-gate.ts`：若无生产用途则连同其测试文件一并删除；若有用途则补齐生产代码的 import
+- [ ] 4.2 更新 `ping-dead-code-cleanup.test.ts` 守卫测试以反映 phase4 处置后的文件清单
+- [ ] 4.3 在 `templateService.ts` 中从 `electron.vite.config.ts` 或构建输出 manifest 读取模板路径，替换 5 候选暴力搜索
+- [ ] 4.4 在 `index.ts` 中从构建配置读取 preload 路径，替换 3 候选暴力搜索
+- [ ] 4.5 为路径不存在场景添加包含具体路径的 Error message（如 `Template not found at ${expectedPath}`）
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 评估是否可抽取 `resolveFromBuildConfig(configKey)` 工具函数，templateService 和 index.ts 共用
+- [ ] 5.2 确保构建配置路径的读取方式在 dev 和 production 环境下均可用（electron.vite dev 模式 vs 打包后的路径）
+- [ ] 5.3 清理删除 phase4 后可能残留的空目录或无用测试 helper
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-degradation-telemetry-escalation/tasks.md
+++ b/openspec/changes/audit-degradation-telemetry-escalation/tasks.md
@@ -29,19 +29,30 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **fetcher 降级日志**：触发 rulesFetcher KG 服务不可用降级，断言 `logger.warn` 被调用且参数包含 `{ event: 'degradation', fetcher: 'rulesFetcher', reason: ... }` 结构（AUD-C3-S1）
+- [ ] 3.2 **连续降级告警升级**：连续触发 N 次降级，断言第 N 次触发 `logger.error`（或更高级别告警），而前 N-1 次仅为 `logger.warn`（AUD-C3-S2）
+- [ ] 3.3 **降级恢复重置**：降级 N-1 次后成功一次，断言计数器重置，后续第 1 次降级仅为 warn（AUD-C3-S3）
+- [ ] 3.4 **embedding 双失败**：primary 和 fallback embedding 均失败，断言两个错误都被记录且包含各自的 error context（AUD-C3-S4）
+- [ ] 3.5 **AiPanel localStorage 异常**：mock `localStorage.getItem` 抛异常，断言 `console.error` 被调用且包含操作类型和 key 名（AUD-C3-S5）
+- [ ] 3.6 **AiPanel judge 异常**：mock judge 评估抛异常，断言 `console.error` 包含 judge 上下文（AUD-C3-S6）
+- [ ] 3.7 **SSE 解析异常**：传入畸形 JSON SSE 数据，断言 `logger.warn` 包含截断的原始数据片段（AUD-C3-S7）
+- [ ] 3.8 **memory 降级日志**：触发 memoryService 语义→确定性降级，断言 `logger.warn` 含结构化降级事件（AUD-C3-S8）
+- [ ] 3.9 **memory 连续降级升级**：连续 N 次 memory 降级，断言告警升级触发（AUD-C3-S9）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 实现 `DegradationCounter` 类：`increment(key)` 返回当前计数，`reset(key)` 归零，`shouldEscalate(key)` 判断是否达到阈值 N
+- [ ] 4.2 在各 context fetcher 降级分支插入 `logger.warn({ event: 'degradation', fetcher, reason, count })` 调用
+- [ ] 4.3 在 fetcher 降级路径接入 `DegradationCounter`，达到阈值时调用 `logger.error({ event: 'degradation_escalation', ... })`
+- [ ] 4.4 在 embeddingService fallback catch 块添加 `logger.warn({ event: 'embedding_fallback_failure', primaryError, fallbackError })`
+- [ ] 4.5 在 AiPanel.tsx 的 localStorage catch 和 judge catch 中添加 `console.error` 调用
+- [ ] 4.6 在 aiService SSE JSON.parse catch 中添加 `logger.warn({ event: 'sse_parse_failure', raw: data.slice(0, 200) })`
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将 `DegradationCounter` 抽取为 `services/shared/degradationCounter.ts`，供 context-engine 和 memory-system 共用
+- [ ] 5.2 统一降级日志结构体字段命名（`event` / `module` / `reason` / `count`），建立结构化日志契约
+- [ ] 5.3 检查告警阈值 N 是否应提取为可配置常量（如 `DEGRADATION_ESCALATION_THRESHOLD`）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-editor-save-queue-extraction/tasks.md
+++ b/openspec/changes/audit-editor-save-queue-extraction/tasks.md
@@ -28,19 +28,28 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **串行执行**：入队 3 个写任务（各含 50ms 模拟延迟），断言执行顺序严格为入队顺序（AUD-C10-S1）
+- [ ] 3.2 **优先级插入**：入队普通任务后立即入队高优先级任务，断言高优先级任务在当前任务完成后、普通任务前执行（AUD-C10-S2）
+- [ ] 3.3 **单任务失败不阻塞**：入队 3 个任务、第 2 个抛异常，断言第 1、3 个正常完成且第 2 个的错误可检索（AUD-C10-S3）
+- [ ] 3.4 **异常不死锁**：任务抛非预期异常后，断言后续入队的任务仍能正常执行、队列未死锁（AUD-C10-S4）
+- [ ] 3.5 **独立实例化**：直接 `new SaveQueue()` 不依赖 editorStore 或 IPC mock，断言可正常入队和处理（AUD-C10-S5）
+- [ ] 3.6 **editorStore 集成**：调用 editorStore 的 save 方法，断言内部委托给提取后的 SaveQueue 模块（AUD-C10-S6）
+- [ ] 3.7 **eslint 通过**：运行 eslint 检查 editorStore.tsx，断言无 `eslint-disable` 注释且通过（AUD-C10-S7）
+- [ ] 3.8 **空队列无副作用**：实例化 SaveQueue 但不入队任何任务，断言无定时器、无轮询、无内存分配增长（AUD-C10-S8）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 创建 `renderer/src/lib/saveQueue.ts`，实现 `SaveQueue` 类：含 `enqueue(task, priority?)` 方法、内部用数组维护队列、串行 `processNext()` 循环
+- [ ] 4.2 实现优先级插入：高优先级任务插入队列头部（当前执行中任务之后）
+- [ ] 4.3 实现错误隔离：`processNext()` 中 try-catch 单个任务，失败后记录错误并继续处理下一个
+- [ ] 4.4 在 `editorStore.tsx` 中替换内联 save queue 逻辑为 `new SaveQueue()` 实例调用
+- [ ] 4.5 删除 `editorStore.tsx:128` 的 `eslint-disable-next-line max-lines-per-function`
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 检查提取后 `createEditorStore` 的行数是否已降至 eslint `max-lines-per-function` 阈值以下（无需豁免）
+- [ ] 5.2 评估 `SaveQueue` 是否需要 `dispose()` 方法（清空队列 + 中断处理循环），为未来 HMR 或组件卸载场景预留
+- [ ] 5.3 确保 SaveQueue 的错误记录使用与 editorStore 一致的日志方式（console.error vs logger），不引入新的依赖
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-error-language-standardization/tasks.md
+++ b/openspec/changes/audit-error-language-standardization/tasks.md
@@ -27,19 +27,26 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **后端错误纯英文**：触发后端 IPC error 响应，断言 `message` 字段不含中文字符（正则 `/[\u4e00-\u9fff]/` 匹配为 0）（AUD-C13-S1）
+- [ ] 3.2 **前端翻译覆盖率**：枚举所有后端 error code，断言前端翻译映射表对每个 code 均有对应中文条目（AUD-C13-S2）
+- [ ] 3.3 **静态守卫**：扫描后端 IPC error 创建点的 message 参数，断言不含中文字符（AUD-C13-S3）
+- [ ] 3.4 **runtime-validation 纯英文**：触发 runtime-validation 所有 6 个错误路径，断言每个错误的 code 和 message 均为英文（AUD-C13-S4）
+- [ ] 3.5 **runtime-validation 前端映射**：前端接收 runtime-validation error code，断言翻译映射产出的中文含义与原硬编码中文语义一致（AUD-C13-S5）
+- [ ] 3.6 **providerResolver 纯英文**：触发 providerResolver 所有 2 个错误路径，断言错误为英文 code + message（AUD-C13-S6）
+- [ ] 3.7 **providerResolver 前端映射**：前端接收 providerResolver error code，断言翻译后语义与原中文一致（AUD-C13-S7）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 在 `runtime-validation.ts` 中将 6 处中文错误消息替换为英文 error code（如 `VALIDATION_FIELD_REQUIRED`）+ 英文 message
+- [ ] 4.2 在 `providerResolver.ts` 中将 2 处中文错误消息替换为英文 error code + message
+- [ ] 4.3 创建 `renderer/src/lib/errorTranslation.ts`，建立 `Record<string, string>` 映射表，将后端 error code 映射为用户可见中文提示
+- [ ] 4.4 在前端错误展示组件中调用翻译映射，未映射 code 兜底显示英文 message
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将后端 error code 常量抽取为 `packages/shared/errorCodes.ts`，前后端共享引用（避免硬编码字符串漂移）
+- [ ] 5.2 评估翻译映射是否应按模块分文件还是统一一个文件（当前规模推荐统一）
+- [ ] 5.3 为后端新增 error code 的 PR 添加 lint 守卫：error message 含中文字符则 CI 报错
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-fatal-error-visibility-guardrails/tasks.md
+++ b/openspec/changes/audit-fatal-error-visibility-guardrails/tasks.md
@@ -24,19 +24,21 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **stderr fallback**：mock `logger.fatal` 抛异常，断言 `process.stderr.write` 被调用且包含错误上下文信息（AUD-C2-S1）
+- [ ] 3.2 **fallback 自身安全**：mock `process.stderr.write` 也抛异常，断言进程不崩溃、不抛未捕获异常（AUD-C2-S2）
+- [ ] 3.3 **用户可见错误**：mock IPC `createProject` 返回错误，渲染 `CreateProjectDialog`，断言 DOM 中出现包含错误描述的可见元素（AUD-C2-S3）
+- [ ] 3.4 **诊断上下文**：mock IPC 返回特定 error code，断言 `console.error` 调用包含该 code 与操作类型（AUD-C2-S4）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 在 `index.ts:466` 的 catch 块中添加 `try { process.stderr.write(\`[FATAL] ${error}\n\`) } catch { /* 最后兜底，不能再抛 */ }`
+- [ ] 4.2 在 `CreateProjectDialog.tsx:456` 的 catch 块中调用 `setError(err.message || '项目创建失败')`，并在 JSX 中条件渲染错误提示区域
+- [ ] 4.3 在 `CreateProjectDialog` catch 块补充 `console.error('[CreateProjectDialog] createProject failed:', err)` 提供诊断信息
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 评估 `index.ts` 的 fatal catch 块是否可抽取为 `safeFatalLog(error)` 工具函数，供其他主进程顶层 catch 复用
+- [ ] 5.2 确保 `CreateProjectDialog` 的错误状态在下次提交时自动清除（`setError(null)` 在 submit 开头）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-ipc-result-unification/tasks.md
+++ b/openspec/changes/audit-ipc-result-unification/tasks.md
@@ -25,19 +25,24 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **共享导出完整性**：import `services/shared/ipcResult.ts`，断言导出包含 `ipcError(code, message, details?, options?)` 签名，`options` 含可选 `traceId` 和 `retryable` 字段（AUD-C4-S1）
+- [ ] 3.2 **零本地重复**：用 `rg` 或 AST 扫描生产代码（排除 shared/ipcResult.ts），断言匹配 `function ipcError` 或 `type ServiceResult` 定义数为 0（AUD-C4-S2）
+- [ ] 3.3 **迁移兼容性**：运行 `tsc --noEmit`，断言零错误；运行既有测试套件，断言全通过（AUD-C4-S3）
+- [ ] 3.4 **签名变体行为一致**：构造原各变体调用（带 traceId、带 retryable、仅 code+message），断言统一后返回结构与原行为一致（AUD-C4-S4）
+- [ ] 3.5 **防回归守卫**：在任意非 shared 文件中新增 `function ipcError`，断言守卫测试失败（AUD-C4-S5）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 扩展 `services/shared/ipcResult.ts` 的 `ipcError` 签名，增加可选 `options: { traceId?, retryable? }` 参数，保持向后兼容
+- [ ] 4.2 逐文件将 33 个本地 `ipcError` / `ServiceResult` 定义替换为 `import { ipcError, ServiceResult, Ok, Err } from 'services/shared/ipcResult'`
+- [ ] 4.3 对各签名变体调用点适配新签名：将 `ipcError(code, msg, details, traceId)` 改为 `ipcError(code, msg, details, { traceId })`
+- [ ] 4.4 删除 33 个文件中的本地定义代码块
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 检查迁移后是否存在 `import` 路径不一致（相对路径 vs 别名），统一为项目约定的模块解析方式
+- [ ] 5.2 确认 `services/shared/ipcResult.ts` 的导出是否应纳入 `packages/shared/` 包（与 cross-module 共享层保持一致）
+- [ ] 5.3 清理迁移过程中可能残留的空行或无用 import
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-legacy-adapter-retirement/tasks.md
+++ b/openspec/changes/audit-legacy-adapter-retirement/tasks.md
@@ -26,19 +26,27 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **原生字段直用**：构造 IPC 返回的 entity 数据（使用 `id` / `type`），在 kgStore consumer 中消费，断言无 `toLegacyEntity` 调用参与（AUD-C11-S1）
+- [ ] 3.2 **关系字段直用**：构造 IPC 返回的 relation 数据（使用 `sourceEntityId` / `targetEntityId`），断言无 `toLegacyRelation` 调用（AUD-C11-S2）
+- [ ] 3.3 **normalizeEntityType 无 legacy 映射**：断言 UI entity type 列表不含 `"other"` 选项，且 `normalizeEntityType` 中无 `"other"→"faction"` 映射（AUD-C11-S3）
+- [ ] 3.4 **历史数据迁移**：构造含 `"other"` type 的历史记录，断言通过数据迁移（而非运行时映射）转换为正确类型（AUD-C11-S4）
+- [ ] 3.5 **bootstrapForProject 调用方迁移**：所有原 `bootstrapForProject` 调用方改用新接口，断言行为一致（AUD-C11-S5）
+- [ ] 3.6 **bootstrapForProject 消除**：`rg bootstrapForProject` 扫描生产代码，断言零匹配；`tsc --noEmit` 通过（AUD-C11-S6）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 修改 kgStore 中 6 个调用 `toLegacyEntity()` 的方法，直接使用 IPC 返回的原生字段名
+- [ ] 4.2 修改 kgStore 中调用 `toLegacyRelation()` 的方法，直接使用原生字段名
+- [ ] 4.3 从 UI 的 entity type 枚举/列表中移除 `"other"` 选项，删除 `normalizeEntityType` 中的遗留映射
+- [ ] 4.4 为含 `"other"` type 的历史数据编写一次性迁移逻辑（在 DB 层或初始化时执行）
+- [ ] 4.5 找到 `bootstrapForProject()` 的所有调用方，迁移到新接口（如直接调用底层方法或新的初始化 API）
+- [ ] 4.6 删除 `toLegacyEntity()` / `toLegacyRelation()` / `normalizeEntityType` 遗留映射 / `bootstrapForProject()` 四处死代码
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 确认 renderer 组件中所有 entity/relation 数据消费点已使用统一字段名（`id` 而非 `entityId` 等混用）
+- [ ] 5.2 检查 `kgStore.ts` 的类型定义是否已同步更新（移除 legacy 字段类型声明）
+- [ ] 5.3 验证删除 `toLegacy*` 后的 kgStore 文件行数下降，确认无多余空行或注释残留
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-memory-leak-prevention/tasks.md
+++ b/openspec/changes/audit-memory-leak-prevention/tasks.md
@@ -26,19 +26,24 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **watcher close 清理监听器**：创建 watcher，注册 error 监听器，close watcher，断言 error 事件的 listener 数量为 0（AUD-C15-S1）
+- [ ] 3.2 **关闭后 error 无副作用**：close watcher 后手动 emit `error` 事件，断言原监听器回调未被调用（AUD-C15-S2）
+- [ ] 3.3 **N 次 create-close 无累积**：循环 N 次 create watcher → close watcher，断言 error listener 数量始终为 0 且无 MaxListenersExceededWarning（AUD-C15-S3）
+- [ ] 3.4 **首次注册**：调用 `installGlobalExceptionHandlers()`，断言 `process.listenerCount('uncaughtException')` 和 `process.listenerCount('unhandledRejection')` 各增加 1（AUD-C15-S4）
+- [ ] 3.5 **重复调用不累积**：连续调用 3 次 `installGlobalExceptionHandlers()`，断言 listener 数量与首次调用后相同（AUD-C15-S5）
+- [ ] 3.6 **异常捕获功能正常**：安装 dedup guard 后触发 uncaughtException，断言处理函数仍被正确调用（AUD-C15-S6）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 在 `watchService.ts` 的 watcher close 逻辑中添加 `watcher.off('error', errorHandler)`（需将 error handler 提取为具名函数引用）
+- [ ] 4.2 在 `globalExceptionHandlers.ts` 顶部添加 `let installed = false` 标志，`installGlobalExceptionHandlers()` 入口检查：已安装则直接 return
+- [ ] 4.3 确保 dedup guard 不影响异常处理函数的正常执行（即 `installed = true` 后 handler 仍生效）
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将 watcher error handler 从匿名箭头函数改为模块级具名函数，确保 `.on()` 和 `.off()` 引用同一函数对象
+- [ ] 5.2 评估 `installed` 标志是否应改为 `WeakRef` 或 `AbortController` 模式（当前场景单 flag 已足够，不过度设计）
+- [ ] 5.3 检查是否有其他 EventEmitter 的 `.on()` 调用存在类似的无 `.off()` 配对问题（本次仅修复审计发现的 2 处）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-proxy-settings-normalization/tasks.md
+++ b/openspec/changes/audit-proxy-settings-normalization/tasks.md
@@ -26,19 +26,26 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **自动归一化**：构造含 legacy flat fields（`baseUrl` / `apiKey`）的配置对象，调用 `getRaw()`，断言返回的结构中 legacy 字段已迁移到 canonical nested 位置（AUD-C7-S1）
+- [ ] 3.2 **仅写规范格式**：调用 `update()` 写入配置，断言存储内容仅包含 canonical 字段、无 `baseUrl` / `apiKey` / `encryptedLegacyKey` 等遗留字段（AUD-C7-S2）
+- [ ] 3.3 **直接解析**：调用 `providerResolver.resolve(provider)`，断言直接从 canonical nested 结构获取 credentials，无三级 fallback 逻辑执行（AUD-C7-S3）
+- [ ] 3.4 **最旧配置无损迁移**：构造 v1（最早）格式配置，经 normalize 后断言所有 provider 均可正确 resolve（AUD-C7-S4）
+- [ ] 3.5 **缺失字段安全默认**：构造部分字段缺失的配置，断言 normalize 填充安全默认值且不抛异常（AUD-C7-S5）
+- [ ] 3.6 **getRaw 零 legacy fallback**：源码扫描 `getRaw` 方法体，断言不包含 `baseUrl` / `apiKey` / `encryptedLegacyKey` 字符串（AUD-C7-S6）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 实现 `normalizeProxySettings(raw)` 纯函数：检测 legacy flat 字段，迁移到 canonical nested 结构，填充缺失字段默认值
+- [ ] 4.2 在 `getRaw()` 入口处调用 `normalizeProxySettings()`，移除原有的遗留字段 fallback 逻辑
+- [ ] 4.3 修改 `update()` 方法，确保写入时仅保存 canonical 格式（通过 normalizeProxySettings 过滤后再写入）
+- [ ] 4.4 重写 `providerResolver` 中每个 provider 的 credentials 获取逻辑为直接读取 canonical 路径，移除三级 fallback
+- [ ] 4.5 删除 `resolveSettingsBackupProvider()` 中重复的 fallback 构造代码
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将 `normalizeProxySettings` 的字段映射规则提取为声明式配置表（`{ legacyField → canonicalPath }`），而非 if-else 链
+- [ ] 5.2 检查 `resolveSettingsBackupProvider()` 是否可完全委托给 `providerResolver.resolve()`，消除重复函数
+- [ ] 5.3 确保 normalize 后的对象通过 `ProxySettings` 类型的 strict type check（无多余字段）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-race-serialization-core/tasks.md
+++ b/openspec/changes/audit-race-serialization-core/tasks.md
@@ -28,19 +28,27 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **并发丢失更新**：构造 N 个并发 `recordEpisode(projectId)` 调用（共享同一 projectId），断言最终 `walQueueByProject` 条目数等于 N，无丢失（AUD-C1-S1）
+- [ ] 3.2 **互斥验证**：并发触发 `recordEpisode` 与 `scheduleBatchDistillation`，断言 `distillingProjects` 在同一 project 上不存在交叠时间窗（AUD-C1-S2）
+- [ ] 3.3 **跨 project 隔离**：并发操作不同 projectId，断言无互相阻塞、各自独立完成（AUD-C1-S3）
+- [ ] 3.4 **switchProject 串行化**：并发触发 2 次 `switchProject(A→B, A→C)`，断言 unbind→persist→bind 序列无交错（AUD-C1-S4）
+- [ ] 3.5 **switchProject 幂等**：同目标并发 `switchProject(A→B, A→B)`，断言仅执行一次完整序列（AUD-C1-S5）
+- [ ] 3.6 **singleflight 去重**：同 key 并发 3 次 `getOrComputeString`，断言 compute 回调仅调用 1 次，3 个调用者拿到同一结果（AUD-C1-S6）
+- [ ] 3.7 **singleflight 不同 key 隔离**：并发请求不同 key，断言各自独立触发 compute、互不阻塞（AUD-C1-S7）
+- [ ] 3.8 **singleflight 异常透传**：compute 抛异常时，断言所有等待者均收到同一异常且缓存不被污染（AUD-C1-S8）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 实现 per-project `Mutex` 类（基于 Promise chain），为 `episodicMemoryService` 的 `recordEpisode` / `scheduleBatchDistillation` 在入口处 `await mutex.acquire(projectId)` → 业务逻辑 → `mutex.release(projectId)`
+- [ ] 4.2 为 `projectLifecycle.switchProject()` 实现 per-project 串行锁：相同 project 的切换请求排队执行，不同 project 不阻塞
+- [ ] 4.3 为 `projectScopedCache.getOrComputeString()` 实现 Promise-based singleflight：cache miss 时将 Promise 存入 inflight Map，后续同 key 请求直接 await 该 Promise；完成后从 inflight Map 移除
+- [ ] 4.4 确保 singleflight 在 compute 抛异常时从 inflight Map 移除 key 且不写入缓存
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将 `Mutex` 和 `Singleflight` 抽取为 `services/shared/concurrency.ts` 中的通用原语，供 episodicMemoryService / projectLifecycle / projectScopedCache 统一引用
+- [ ] 5.2 审查锁粒度：确认 per-project 锁的 Map key 使用 `projectId` 而非对象引用，避免 GC 后 key 失效
+- [ ] 5.3 检查是否有多余的局部变量或中间状态可以简化，保持各 acquire/release 配对清晰可审计
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-shared-runtime-utils-unification/tasks.md
+++ b/openspec/changes/audit-shared-runtime-utils-unification/tasks.md
@@ -28,19 +28,28 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **nowTs 零重复**：`rg` 扫描生产代码（排除 shared 模块），断言 `function nowTs` 或 `const nowTs =` 定义数为 0（AUD-C5-S1）
+- [ ] 3.2 **nowTs 行为一致**：调用共享 `nowTs()`，断言返回值在 `Date.now()` ± 10ms 范围内（AUD-C5-S2）
+- [ ] 3.3 **estimateTokenCount 零重复**：扫描排除 `@shared/tokenBudget.ts` 后，断言无本地 `estimateTokenCount` / `estimateUtf8TokenCount` 定义（AUD-C5-S3）
+- [ ] 3.4 **estimateTokenCount 一致性**：对相同输入，共享版本与原各副本返回值相同（AUD-C5-S4）
+- [ ] 3.5 **hash 零重复**：扫描排除 shared 后，断言无 `hashJson` / `sha256Hex` / `hashText` 本地定义（AUD-C5-S5）
+- [ ] 3.6 **max_tokens 常量引用**：读取 aiService.ts 源码，断言不含字面量 `256` 出现在 `max_tokens` 上下文中，而是引用 `DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE`（AUD-C5-S6）
+- [ ] 3.7 **timeoutMs 常量引用**：读取 skillValidator.ts 源码，断言不含字面量 `120000`，而是引用 `MAX_SKILL_TIMEOUT_MS`（AUD-C5-S7）
+- [ ] 3.8 **防回归守卫**：在非 shared 文件新增 `function nowTs`，断言守卫测试失败（AUD-C5-S8）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 在共享模块中定义 `nowTs()` 函数，11 个消费文件逐一替换为 `import { nowTs } from 'shared/...'`，删除本地定义
+- [ ] 4.2 将 3 个独立 `estimateTokenCount` 副本删除，改为 `import { estimateUtf8TokenCount } from '@shared/tokenBudget'`
+- [ ] 4.3 在共享模块中定义 `hashJson` / `sha256Hex`，5 个消费文件统一 import，删除本地实现
+- [ ] 4.4 `aiService.ts` 中将 `max_tokens: 256` 替换为 `max_tokens: DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE`（从 runtimeConfig import）
+- [ ] 4.5 `skillValidator.ts` 中将 `120000` 替换为 `MAX_SKILL_TIMEOUT_MS`（从 runtimeConfig import）
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 合并 `hashJson` / `sha256Hex` / `hashText` 为单一 `hash(input: string): string` 函数 + 类型重载，消除命名碎片
+- [ ] 5.2 确认共享模块是否放在 `services/shared/` 还是 `packages/shared/`，与 C4 建立的模式保持一致
+- [ ] 5.3 检查 `nowTs` 的共享定义是否已为 fake timer 注入预留接口（如接受可选 `clock` 参数）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-store-provider-style-unification/tasks.md
+++ b/openspec/changes/audit-store-provider-style-unification/tasks.md
@@ -24,19 +24,23 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **全 JSX + 零 createElement**：扫描 `renderer/src/stores/` 目录，断言所有文件为 `.tsx` 扩展名且不含 `React.createElement` 调用（AUD-C14-S1）
+- [ ] 3.2 **import 路径无断裂**：`tsc --noEmit`，断言重命名 `.ts → .tsx` 后无 unresolved module 错误（AUD-C14-S2）
+- [ ] 3.3 **渲染输出一致**：对每个 store 的 Provider 组件，分别用 JSX 和原 `React.createElement` 渲染，断言 DOM 输出严格相等（AUD-C14-S3）
+- [ ] 3.4 **lint 防回归**：在 store 文件中写入 `React.createElement(Provider, ...)`，断言 eslint 报错阻止提交（AUD-C14-S4）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 将 5 个 `.ts` store 文件重命名为 `.tsx`（`kgStore.ts` → `kgStore.tsx`、`memoryStore.ts` → `memoryStore.tsx`、`fileStore.ts` → `fileStore.tsx`、`aiStore.ts` → `aiStore.tsx`、`searchStore.ts` → `searchStore.tsx`）
+- [ ] 4.2 将每个文件中的 `React.createElement(XxxProvider, { value: ... }, children)` 替换为 `<XxxProvider value={...}>{children}</XxxProvider>` JSX 语法
+- [ ] 4.3 更新所有引用这 5 个文件的 import 路径（如需显式扩展名引用的场景）
+- [ ] 4.4 在 `.eslintrc.cjs` 中添加针对 `renderer/src/stores/**` 的规则：禁止 `React.createElement` 模式
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 检查 `.tsx` 重命名后 Storybook / 测试 / 构建配置是否需要同步更新 glob pattern
+- [ ] 5.2 确认 lint 规则范围是仅限 stores 目录还是全 renderer（推荐全 renderer 统一 JSX）
+- [ ] 5.3 清理可能因重命名产生的 git 追踪问题（确保 git 识别为 rename 而非 delete+add）
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-store-refresh-governance/tasks.md
+++ b/openspec/changes/audit-store-refresh-governance/tasks.md
@@ -28,19 +28,27 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **刷新失败可捕获**：mock `refresh()` 抛异常，在 mutation 调用后断言异常可被 caller 捕获（不被 `void` 丢弃）（AUD-C9-S1）
+- [ ] 3.2 **kgStore 返回 Promise**：调用 kgStore mutation（如 `addEntity`），断言返回值为 Promise 且 resolve 后 refresh 已完成（AUD-C9-S2）
+- [ ] 3.3 **memoryStore 返回 Promise**：同理验证 memoryStore mutation（AUD-C9-S3）
+- [ ] 3.4 **projectStore 返回 Promise**：同理验证 projectStore mutation（AUD-C9-S4）
+- [ ] 3.5 **可观测执行器错误记录**：触发 observable executor 中的 failure，断言结构化失败信息被记录（非仅 console.error 字符串）（AUD-C9-S5）
+- [ ] 3.6 **catch 回调异常安全**：observable executor 的 catch 回调自身抛异常，断言不产生 unhandledRejection（AUD-C9-S6）
+- [ ] 3.7 **非关键路径不阻塞**：非关键 fire-and-forget 操作失败，断言主流程正常完成且失败被日志记录（AUD-C9-S7）
+- [ ] 3.8 **静态扫描零 void refresh**：扫描关键 mutation 路径源码，断言不含 `void get().refresh()` 或 `void this.refresh()` 模式（AUD-C9-S8）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 将 kgStore / memoryStore / projectStore 中关键 mutation 的 `void get().refresh()` 改为 `await get().refresh()`，使 mutation 方法返回 `Promise<void>`
+- [ ] 4.2 实现 `ObservableExecutor`：接受 `() => Promise<void>` 和可选 `onError` 回调，内部 catch 异常后写入结构化日志，且 onError 自身异常被安全捕获
+- [ ] 4.3 将非关键路径的 fire-and-forget 调用改为 `ObservableExecutor.run(fn, { onError: logger.warn })`
+- [ ] 4.4 改造 `fireAndForget.ts` 为 `ObservableExecutor` 的简便包装，保留现有调用方兼容
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 将 `ObservableExecutor` 抽取为 `renderer/src/lib/observableExecutor.ts` 独立模块，附完整 JSDoc
+- [ ] 5.2 评估是否可删除 `fireAndForget.ts`（如所有调用方已迁移到 ObservableExecutor），或保留为薄包装
+- [ ] 5.3 确认关键 vs 非关键路径的划分标准已文档化（如注释或常量命名），避免后续混淆
 
 ## 6. Evidence
 

--- a/openspec/changes/audit-type-contract-alignment/tasks.md
+++ b/openspec/changes/audit-type-contract-alignment/tasks.md
@@ -28,19 +28,29 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 编写 Happy Path 的失败测试并确认先失败
-- [ ] 3.2 编写 Edge Case 的失败测试并确认先失败
-- [ ] 3.3 编写 Error Path 的失败测试并确认先失败
+- [ ] 3.1 **IPC bridge 类型对齐**：TypeScript 编译断言 preload `ipc.ts` 的返回类型与 renderer 期望类型直接兼容（无 `as unknown as`）（AUD-C8-S1）
+- [ ] 3.2 **renderer 组件零强转**：ProxySection 和 AiSettingsSection 中的 5 处 `as unknown as` 消除后，tsc 编译通过（AUD-C8-S2）
+- [ ] 3.3 **deriveOutline 类型对齐**：`deriveOutline.ts` 在 :107/:162/:235 的 3 处 `as unknown as` 消除后 tsc 通过（AUD-C8-S3）
+- [ ] 3.4 **ipcAcl 类型对齐**：`ipcAcl.ts:33` 的 `as unknown as` 消除后 tsc 通过（AUD-C8-S4）
+- [ ] 3.5 **白名单文档与守卫**：扫描生产代码 `as unknown as`，断言匹配数为 0 或仅在白名单中（白名单 ≤ 3 条且每条附理由文档）（AUD-C8-S5）
+- [ ] 3.6 **IpcInvoke 共享导入**：扫描 8 个 store 文件，断言均从 `renderer/src/lib/ipcTypes.ts` import `IpcInvoke`，无本地定义（AUD-C8-S6）
+- [ ] 3.7 **tsc 全量通过**：`tsc --noEmit` 零错误且无新增 `@ts-ignore` / `@ts-expect-error`（AUD-C8-S7）
+- [ ] 3.8 **静态扫描守卫**：`rg 'as unknown as'` 结果仅含白名单条目（AUD-C8-S8）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 仅实现让 Red 转绿的最小代码
-- [ ] 4.2 逐条使失败测试通过，不引入无关功能
+- [ ] 4.1 修正 `preload/src/ipc.ts` 的 contextBridge 暴露函数返回类型，使其与 renderer 侧 `window.api` 的期望类型结构性匹配
+- [ ] 4.2 在 C7 归一化 ProxySettings 后，更新 ProxySection / AiSettingsSection 的 props 类型定义，消除 5 处强转
+- [ ] 4.3 修正 `deriveOutline.ts` 的输入/输出类型签名使其与调用方一致，消除 3 处强转
+- [ ] 4.4 修正 `ipcAcl.ts` 的 ACL 类型定义使其与 IPC 层一致，消除 1 处强转
+- [ ] 4.5 抽取 `IpcInvoke` 类型到 `renderer/src/lib/ipcTypes.ts`，8 个 store 统一 import
+- [ ] 4.6 对确实无法消除的强转（如第三方库类型不完整），建立白名单并附内联注释说明理由
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 去重与重构，保持测试全绿
-- [ ] 5.2 不改变已通过的外部行为契约
+- [ ] 5.1 评估白名单中的每一条是否可通过上游类型定义（如 `@types/` 包更新或 module augmentation）彻底消除
+- [ ] 5.2 统一 IPC 响应类型定义的存放位置（`packages/shared/types/` vs `renderer/src/lib/`），与 C4 建立的共享模式对齐
+- [ ] 5.3 清理 8 个 store 文件中 IpcInvoke 本地定义删除后的空行和无用 import
 
 ## 6. Evidence
 


### PR DESCRIPTION
Skip-Reason: 文档质量改善，15 个 change tasks.md 的 §3/§4/§5 从模板套话重写为针对性内容，无代码变更，无需 RUN_LOG。

## 变更内容

15 个活跃 change 的 tasks.md 中 §3 Red / §4 Green / §5 Refactor 原为同一段模板复制粘贴，无任何针对性。现逐个重写为：

- **§3 Red**：每条测试用例绑定具体 Scenario ID，描述精确的输入条件和断言
- **§4 Green**：列出最小实现的具体代码变更步骤（涉及文件、函数、策略）
- **§5 Refactor**：给出该 change 上下文中有建设性的重构方向

### 涉及文件（15 个 tasks.md）

Wave 1: C1 audit-race-serialization-core / C2 audit-fatal-error-visibility-guardrails / C3 audit-degradation-telemetry-escalation
Wave 2: C4 audit-ipc-result-unification / C5 audit-shared-runtime-utils-unification / C6 audit-contextfs-async-ssot / C7 audit-proxy-settings-normalization / C8 audit-type-contract-alignment / C10 audit-editor-save-queue-extraction
Wave 3: C9 audit-store-refresh-governance / C11 audit-legacy-adapter-retirement / C12 audit-dead-code-and-path-resolution-cleanup / C13 audit-error-language-standardization / C14 audit-store-provider-style-unification / C15 audit-memory-leak-prevention

### 额外修正
- 补充 C1 遗漏的 AUD-C1-S7（singleflight 不同 key 隔离）