### PR TITLE
Docs-only smoke: validate skipped-aware CI gate

### DIFF
--- a/ci-docs-only-smoke.md
+++ b/ci-docs-only-smoke.md
@@ -1,0 +1,3 @@
+# CI Docs-only Smoke
+
+This file exists only to validate docs-only CI skip behavior.


### PR DESCRIPTION
## Summary
- add a non-governed markdown file at repo root
- validate docs-only path in optimized CI workflow

Skip-Reason: temporary docs-only smoke PR for CI gate verification on non-task branch.