### PR TITLE
Docs-only smoke after ci workflow merge

### DIFF
--- a/ci-docs-only-smoke-v2.md
+++ b/ci-docs-only-smoke-v2.md
@@ -1,0 +1,3 @@
+# CI Docs-only Smoke V2
+
+Post-merge verification marker for docs-only CI behavior.


### PR DESCRIPTION
## Summary
- add a root markdown marker file (non-governed docs path)
- validate docs-only fast path on latest main (post #670)

Skip-Reason: temporary docs-only smoke PR for CI behavior verification on non-task branch.