### PR TITLE
refactor: extract editor save queue module (#669)

### DIFF
--- a/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createEditorSaveQueue,
+  type EditorSaveRequest,
+} from "./editorSaveQueue";
+
+function createDeferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function makeRequest(
+  patch: Partial<EditorSaveRequest>,
+): EditorSaveRequest {
+  return {
+    projectId: "project-1",
+    documentId: "doc-1",
+    contentJson: '{"v":1}',
+    actor: "auto",
+    reason: "autosave",
+    ...patch,
+  };
+}
+
+describe("editorSaveQueue", () => {
+  it("should insert manual-save ahead of queued autosaves without interrupting current task", async () => {
+    const order: string[] = [];
+    const firstTaskGate = createDeferred();
+    let firstStarted = false;
+
+    const queue = createEditorSaveQueue({
+      executeSave: async (request) => {
+        order.push(request.contentJson);
+        if (!firstStarted) {
+          firstStarted = true;
+          await firstTaskGate.promise;
+        }
+      },
+    });
+
+    const auto1 = queue.enqueue(
+      makeRequest({ contentJson: "auto-1", reason: "autosave", actor: "auto" }),
+    );
+    const auto2 = queue.enqueue(
+      makeRequest({ contentJson: "auto-2", reason: "autosave", actor: "auto" }),
+    );
+    const manual = queue.enqueue(
+      makeRequest({
+        contentJson: "manual",
+        reason: "manual-save",
+        actor: "user",
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(["auto-1"]);
+    });
+
+    firstTaskGate.resolve();
+    await Promise.all([auto1, auto2, manual]);
+
+    expect(order).toEqual(["auto-1", "manual", "auto-2"]);
+  });
+
+  it("should execute queued saves serially", async () => {
+    const order: string[] = [];
+    const gates = [createDeferred(), createDeferred(), createDeferred()];
+    let active = 0;
+    let maxActive = 0;
+    let nextGateIndex = 0;
+
+    const queue = createEditorSaveQueue({
+      executeSave: async (request) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        order.push(request.contentJson);
+
+        const gate = gates[nextGateIndex];
+        nextGateIndex += 1;
+        await gate.promise;
+
+        active -= 1;
+      },
+    });
+
+    const first = queue.enqueue(makeRequest({ contentJson: "first" }));
+    const second = queue.enqueue(makeRequest({ contentJson: "second" }));
+    const third = queue.enqueue(makeRequest({ contentJson: "third" }));
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(["first"]);
+    });
+
+    gates[0].resolve();
+    await vi.waitFor(() => {
+      expect(order).toEqual(["first", "second"]);
+    });
+
+    gates[1].resolve();
+    await vi.waitFor(() => {
+      expect(order).toEqual(["first", "second", "third"]);
+    });
+
+    gates[2].resolve();
+    await Promise.all([first, second, third]);
+
+    expect(maxActive).toBe(1);
+  });
+
+  it("should continue processing tasks after a task throws", async () => {
+    const order: string[] = [];
+
+    const queue = createEditorSaveQueue({
+      executeSave: async (request) => {
+        order.push(request.contentJson);
+        if (request.contentJson === "fail") {
+          throw new Error("save failed");
+        }
+      },
+    });
+
+    const failed = queue.enqueue(makeRequest({ contentJson: "fail" }));
+    const after1 = queue.enqueue(makeRequest({ contentJson: "after-1" }));
+    const after2 = queue.enqueue(makeRequest({ contentJson: "after-2" }));
+
+    await expect(failed).resolves.toBeUndefined();
+    await Promise.all([failed, after1, after2]);
+
+    expect(order).toEqual(["fail", "after-1", "after-2"]);
+  });
+});

--- a/apps/desktop/renderer/src/stores/editorSaveQueue.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.ts
@@ -1,0 +1,81 @@
+export type EditorSaveRequest = {
+  projectId: string;
+  documentId: string;
+  contentJson: string;
+  actor: "user" | "auto";
+  reason: "manual-save" | "autosave";
+};
+
+export type EditorSaveQueueDeps = {
+  executeSave: (request: EditorSaveRequest) => Promise<void>;
+};
+
+export type EditorSaveQueue = {
+  enqueue: (request: EditorSaveRequest) => Promise<void>;
+};
+
+type SaveQueueEntry = {
+  request: EditorSaveRequest;
+  resolve: () => void;
+};
+
+export function createEditorSaveQueue(
+  deps: EditorSaveQueueDeps,
+): EditorSaveQueue {
+  const queue: SaveQueueEntry[] = [];
+  let processing = false;
+
+  const processQueue = async (): Promise<void> => {
+    processing = true;
+    try {
+      while (queue.length > 0) {
+        const current = queue.shift();
+        if (!current) {
+          continue;
+        }
+
+        try {
+          await deps.executeSave(current.request);
+        } catch {
+          // Keep queue alive after unexpected failures from one task.
+        }
+
+        current.resolve();
+      }
+    } finally {
+      processing = false;
+      if (queue.length > 0) {
+        void processQueue();
+      }
+    }
+  };
+
+  const enqueue = async (request: EditorSaveRequest): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      const entry: SaveQueueEntry = { request, resolve };
+
+      if (request.reason === "manual-save") {
+        const firstAutosaveIndex = queue.findIndex(
+          (queued) =>
+            queued.request.projectId === request.projectId &&
+            queued.request.documentId === request.documentId &&
+            queued.request.reason === "autosave",
+        );
+
+        if (firstAutosaveIndex >= 0) {
+          queue.splice(firstAutosaveIndex, 0, entry);
+        } else {
+          queue.push(entry);
+        }
+      } else {
+        queue.push(entry);
+      }
+
+      if (!processing) {
+        void processQueue();
+      }
+    });
+  };
+
+  return { enqueue };
+}

--- a/apps/desktop/renderer/src/stores/editorStore.saveQueue.test.ts
+++ b/apps/desktop/renderer/src/stores/editorStore.saveQueue.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { enqueueMock, createEditorSaveQueueMock } = vi.hoisted(() => {
+  const enqueue = vi.fn<
+    (request: {
+      projectId: string;
+      documentId: string;
+      contentJson: string;
+      actor: "user" | "auto";
+      reason: "manual-save" | "autosave";
+    }) => Promise<void>
+  >();
+
+  const createQueue = vi.fn(() => ({
+    enqueue,
+  }));
+
+  return {
+    enqueueMock: enqueue,
+    createEditorSaveQueueMock: createQueue,
+  };
+});
+
+vi.mock("./editorSaveQueue", () => ({
+  createEditorSaveQueue: createEditorSaveQueueMock,
+}));
+
+import { createEditorStore, type IpcInvoke } from "./editorStore";
+
+describe("editorStore save queue delegation", () => {
+  beforeEach(() => {
+    enqueueMock.mockReset();
+    enqueueMock.mockResolvedValue(undefined);
+    createEditorSaveQueueMock.mockClear();
+  });
+
+  it("should delegate save requests to editorSaveQueue", async () => {
+    const invoke: IpcInvoke = async (channel) => {
+      throw new Error(`Unexpected invoke in mocked queue test: ${channel}`);
+    };
+
+    const store = createEditorStore({ invoke });
+    const request = {
+      projectId: "project-1",
+      documentId: "doc-1",
+      contentJson: '{"v":1}',
+      actor: "auto" as const,
+      reason: "autosave" as const,
+    };
+
+    await store.getState().save(request);
+
+    expect(createEditorSaveQueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -8,6 +8,10 @@ import type {
   IpcInvokeResult,
   IpcRequest,
 } from "@shared/types/ipc-generated";
+import {
+  createEditorSaveQueue,
+  type EditorSaveRequest,
+} from "./editorSaveQueue";
 
 export type IpcInvoke = <C extends IpcChannel>(
   channel: C,
@@ -101,6 +105,21 @@ export type UseEditorStore = ReturnType<typeof createEditorStore>;
 
 const EditorStoreContext = React.createContext<UseEditorStore | null>(null);
 
+function createInitialEntityCompletionSession(): EntityCompletionSession {
+  return {
+    open: false,
+    query: "",
+    triggerFrom: 0,
+    triggerTo: 0,
+    anchorTop: 0,
+    anchorLeft: 0,
+    selectedIndex: 0,
+    status: "idle",
+    candidates: [],
+    message: null,
+  };
+}
+
 /**
  * Create a zustand store for editor/document state.
  *
@@ -108,419 +127,317 @@ const EditorStoreContext = React.createContext<UseEditorStore | null>(null);
  * and StatusBar, and must be driven through typed IPC.
  */
 export function createEditorStore(deps: { invoke: IpcInvoke }) {
-  type SaveRequest = {
-    projectId: string;
-    documentId: string;
-    contentJson: string;
-    actor: "user" | "auto";
-    reason: "manual-save" | "autosave";
-  };
-
-  type SaveQueueEntry = {
-    request: SaveRequest;
-    resolve: () => void;
-  };
-
-  const saveQueue: SaveQueueEntry[] = [];
-  let processingQueue = false;
-
-  // Keep lint-ratchet aligned with current baseline: count the outer factory only.
-  // eslint-disable-next-line max-lines-per-function
-  return create<EditorStore>((set, get) => ({
-    bootstrapStatus: "idle",
-    projectId: null,
-    documentId: null,
-    documentStatus: null,
-    documentContentJson: null,
-    editor: null,
-    lastSavedOrQueuedJson: null,
-    documentCharacterCount: 0,
-    capacityWarning: null,
-    autosaveStatus: "idle",
-    autosaveError: null,
-    entityCompletionSession: {
-      open: false,
-      query: "",
-      triggerFrom: 0,
-      triggerTo: 0,
-      anchorTop: 0,
-      anchorLeft: 0,
-      selectedIndex: 0,
-      status: "idle",
-      candidates: [],
-      message: null,
-    },
-    compareMode: false,
-    compareVersionId: null,
-
-    setAutosaveStatus: (status) => set({ autosaveStatus: status }),
-    setDocumentCharacterCount: (count) =>
-      set({ documentCharacterCount: count }),
-    setCapacityWarning: (warning) => set({ capacityWarning: warning }),
-    setEntityCompletionSession: (patch) =>
-      set((state) => ({
-        entityCompletionSession: {
-          ...state.entityCompletionSession,
-          ...patch,
-        },
-      })),
-    clearEntityCompletionSession: () =>
-      set({
-        entityCompletionSession: {
-          open: false,
-          query: "",
-          triggerFrom: 0,
-          triggerTo: 0,
-          anchorTop: 0,
-          anchorLeft: 0,
-          selectedIndex: 0,
-          status: "idle",
-          candidates: [],
-          message: null,
-        },
-      }),
-    listKnowledgeEntities: async ({ projectId }) => {
-      return await deps.invoke("knowledge:entity:list", { projectId });
-    },
-    clearAutosaveError: () => set({ autosaveError: null }),
-    setEditorInstance: (editor) => set({ editor }),
-    setCompareMode: (enabled, versionId) =>
-      set({
-        compareMode: enabled,
-        compareVersionId: enabled ? (versionId ?? null) : null,
-      }),
-
-    bootstrapForProject: async (projectId) => {
-      set({ bootstrapStatus: "loading" });
-
-      let documentId: string | null = null;
-
-      const currentRes = await deps.invoke("file:document:getcurrent", {
-        projectId,
-      });
-      if (currentRes.ok) {
-        documentId = currentRes.data.documentId;
-      } else if (currentRes.error.code === "NOT_FOUND") {
-        const listRes = await deps.invoke("file:document:list", { projectId });
-        if (!listRes.ok) {
-          set({ bootstrapStatus: "error" });
-          return;
+  return create<EditorStore>((set, get) => {
+    const saveQueue = createEditorSaveQueue({
+      executeSave: async (request: EditorSaveRequest) => {
+        const isCurrent =
+          get().projectId === request.projectId &&
+          get().documentId === request.documentId;
+        if (isCurrent) {
+          set({
+            autosaveStatus: "saving",
+            lastSavedOrQueuedJson: request.contentJson,
+          });
         }
 
-        documentId = listRes.data.items[0]?.documentId ?? null;
-        if (!documentId) {
-          const created = await deps.invoke("file:document:create", {
-            projectId,
+        try {
+          const res = await deps.invoke("file:document:save", {
+            projectId: request.projectId,
+            documentId: request.documentId,
+            contentJson: request.contentJson,
+            actor: request.actor,
+            reason: request.reason,
           });
-          if (!created.ok) {
+
+          if (!res.ok) {
+            const stillCurrent =
+              get().projectId === request.projectId &&
+              get().documentId === request.documentId;
+            if (stillCurrent) {
+              set({ autosaveStatus: "error", autosaveError: res.error });
+            }
+            return;
+          }
+
+          const stillCurrent =
+            get().projectId === request.projectId &&
+            get().documentId === request.documentId;
+          if (stillCurrent) {
+            set({
+              autosaveStatus: "saved",
+              autosaveError: null,
+            });
+          }
+        } catch (error) {
+          const stillCurrent =
+            get().projectId === request.projectId &&
+            get().documentId === request.documentId;
+          if (stillCurrent) {
+            set({
+              autosaveStatus: "error",
+              autosaveError: {
+                code: "INTERNAL_ERROR",
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "file:document:save threw unexpectedly",
+              },
+            });
+          }
+        }
+      },
+    });
+
+    return {
+      bootstrapStatus: "idle",
+      projectId: null,
+      documentId: null,
+      documentStatus: null,
+      documentContentJson: null,
+      editor: null,
+      lastSavedOrQueuedJson: null,
+      documentCharacterCount: 0,
+      capacityWarning: null,
+      autosaveStatus: "idle",
+      autosaveError: null,
+      entityCompletionSession: createInitialEntityCompletionSession(),
+      compareMode: false,
+      compareVersionId: null,
+
+      setAutosaveStatus: (status) => set({ autosaveStatus: status }),
+      setDocumentCharacterCount: (count) =>
+        set({ documentCharacterCount: count }),
+      setCapacityWarning: (warning) => set({ capacityWarning: warning }),
+      setEntityCompletionSession: (patch) =>
+        set((state) => ({
+          entityCompletionSession: {
+            ...state.entityCompletionSession,
+            ...patch,
+          },
+        })),
+      clearEntityCompletionSession: () =>
+        set({
+          entityCompletionSession: createInitialEntityCompletionSession(),
+        }),
+      listKnowledgeEntities: async ({ projectId }) => {
+        return await deps.invoke("knowledge:entity:list", { projectId });
+      },
+      clearAutosaveError: () => set({ autosaveError: null }),
+      setEditorInstance: (editor) => set({ editor }),
+      setCompareMode: (enabled, versionId) =>
+        set({
+          compareMode: enabled,
+          compareVersionId: enabled ? (versionId ?? null) : null,
+        }),
+
+      bootstrapForProject: async (projectId) => {
+        set({ bootstrapStatus: "loading" });
+
+        let documentId: string | null = null;
+
+        const currentRes = await deps.invoke("file:document:getcurrent", {
+          projectId,
+        });
+        if (currentRes.ok) {
+          documentId = currentRes.data.documentId;
+        } else if (currentRes.error.code === "NOT_FOUND") {
+          const listRes = await deps.invoke("file:document:list", { projectId });
+          if (!listRes.ok) {
             set({ bootstrapStatus: "error" });
             return;
           }
-          documentId = created.data.documentId;
-        }
 
-        const setRes = await deps.invoke("file:document:setcurrent", {
-          projectId,
-          documentId,
-        });
-        if (!setRes.ok) {
+          documentId = listRes.data.items[0]?.documentId ?? null;
+          if (!documentId) {
+            const created = await deps.invoke("file:document:create", {
+              projectId,
+            });
+            if (!created.ok) {
+              set({ bootstrapStatus: "error" });
+              return;
+            }
+            documentId = created.data.documentId;
+          }
+
+          const setRes = await deps.invoke("file:document:setcurrent", {
+            projectId,
+            documentId,
+          });
+          if (!setRes.ok) {
+            set({ bootstrapStatus: "error" });
+            return;
+          }
+        } else {
           set({ bootstrapStatus: "error" });
           return;
         }
-      } else {
-        set({ bootstrapStatus: "error" });
-        return;
-      }
 
-      if (!documentId) {
+        if (!documentId) {
+          set({
+            bootstrapStatus: "ready",
+            projectId,
+            documentId: null,
+            documentStatus: null,
+          });
+          return;
+        }
+
+        const readRes = await deps.invoke("file:document:read", {
+          projectId,
+          documentId,
+        });
+        if (!readRes.ok) {
+          set({ bootstrapStatus: "error" });
+          return;
+        }
+
         set({
           bootstrapStatus: "ready",
           projectId,
-          documentId: null,
-          documentStatus: null,
-        });
-        return;
-      }
-
-      const readRes = await deps.invoke("file:document:read", {
-        projectId,
-        documentId,
-      });
-      if (!readRes.ok) {
-        set({ bootstrapStatus: "error" });
-        return;
-      }
-
-      set({
-        bootstrapStatus: "ready",
-        projectId,
-        documentId,
-        documentStatus: readRes.data.status,
-        documentContentJson: readRes.data.contentJson,
-        lastSavedOrQueuedJson: readRes.data.contentJson,
-        documentCharacterCount: 0,
-        capacityWarning: null,
-        autosaveStatus: "idle",
-        autosaveError: null,
-        entityCompletionSession: {
-          open: false,
-          query: "",
-          triggerFrom: 0,
-          triggerTo: 0,
-          anchorTop: 0,
-          anchorLeft: 0,
-          selectedIndex: 0,
-          status: "idle",
-          candidates: [],
-          message: null,
-        },
-      });
-    },
-
-    openDocument: async ({ projectId, documentId }) => {
-      set({
-        bootstrapStatus: "loading",
-        projectId,
-        autosaveError: null,
-      });
-
-      const readRes = await deps.invoke("file:document:read", {
-        projectId,
-        documentId,
-      });
-      if (!readRes.ok) {
-        set({ bootstrapStatus: "error" });
-        return;
-      }
-
-      set({
-        bootstrapStatus: "ready",
-        projectId,
-        documentId,
-        documentStatus: readRes.data.status,
-        documentContentJson: readRes.data.contentJson,
-        lastSavedOrQueuedJson: readRes.data.contentJson,
-        documentCharacterCount: 0,
-        capacityWarning: null,
-        autosaveStatus: "idle",
-        autosaveError: null,
-        entityCompletionSession: {
-          open: false,
-          query: "",
-          triggerFrom: 0,
-          triggerTo: 0,
-          anchorTop: 0,
-          anchorLeft: 0,
-          selectedIndex: 0,
-          status: "idle",
-          candidates: [],
-          message: null,
-        },
-      });
-    },
-
-    openCurrentDocumentForProject: async (projectId) => {
-      set({ bootstrapStatus: "loading", projectId, autosaveError: null });
-
-      const currentRes = await deps.invoke("file:document:getcurrent", {
-        projectId,
-      });
-      if (currentRes.ok) {
-        await get().openDocument({
-          projectId,
-          documentId: currentRes.data.documentId,
-        });
-        return;
-      }
-
-      if (currentRes.error.code === "NOT_FOUND") {
-        set({
-          bootstrapStatus: "ready",
-          projectId,
-          documentId: null,
-          documentStatus: null,
-          documentContentJson: null,
-          lastSavedOrQueuedJson: null,
+          documentId,
+          documentStatus: readRes.data.status,
+          documentContentJson: readRes.data.contentJson,
+          lastSavedOrQueuedJson: readRes.data.contentJson,
           documentCharacterCount: 0,
           capacityWarning: null,
           autosaveStatus: "idle",
           autosaveError: null,
-          entityCompletionSession: {
-            open: false,
-            query: "",
-            triggerFrom: 0,
-            triggerTo: 0,
-            anchorTop: 0,
-            anchorLeft: 0,
-            selectedIndex: 0,
-            status: "idle",
-            candidates: [],
-            message: null,
-          },
+          entityCompletionSession: createInitialEntityCompletionSession(),
         });
-        return;
-      }
+      },
 
-      set({ bootstrapStatus: "error" });
-    },
+      openDocument: async ({ projectId, documentId }) => {
+        set({
+          bootstrapStatus: "loading",
+          projectId,
+          autosaveError: null,
+        });
 
-    save: async ({ projectId, documentId, contentJson, actor, reason }) => {
-      await new Promise<void>((resolve) => {
-        const entry: SaveQueueEntry = {
-          request: { projectId, documentId, contentJson, actor, reason },
-          resolve,
-        };
-
-        if (reason === "manual-save") {
-          const firstAutosaveIndex = saveQueue.findIndex(
-            (queued) =>
-              queued.request.projectId === projectId &&
-              queued.request.documentId === documentId &&
-              queued.request.reason === "autosave",
-          );
-          if (firstAutosaveIndex >= 0) {
-            saveQueue.splice(firstAutosaveIndex, 0, entry);
-          } else {
-            saveQueue.push(entry);
-          }
-        } else {
-          saveQueue.push(entry);
-        }
-
-        if (processingQueue) {
+        const readRes = await deps.invoke("file:document:read", {
+          projectId,
+          documentId,
+        });
+        if (!readRes.ok) {
+          set({ bootstrapStatus: "error" });
           return;
         }
 
-        const processQueue = async () => {
-          processingQueue = true;
-          while (saveQueue.length > 0) {
-            const current = saveQueue.shift();
-            if (!current) {
-              break;
-            }
+        set({
+          bootstrapStatus: "ready",
+          projectId,
+          documentId,
+          documentStatus: readRes.data.status,
+          documentContentJson: readRes.data.contentJson,
+          lastSavedOrQueuedJson: readRes.data.contentJson,
+          documentCharacterCount: 0,
+          capacityWarning: null,
+          autosaveStatus: "idle",
+          autosaveError: null,
+          entityCompletionSession: createInitialEntityCompletionSession(),
+        });
+      },
 
-            const isCurrent =
-              get().projectId === current.request.projectId &&
-              get().documentId === current.request.documentId;
-            if (isCurrent) {
-              set({
-                autosaveStatus: "saving",
-                lastSavedOrQueuedJson: current.request.contentJson,
-              });
-            }
+      openCurrentDocumentForProject: async (projectId) => {
+        set({ bootstrapStatus: "loading", projectId, autosaveError: null });
 
-            try {
-              const res = await deps.invoke("file:document:save", {
-                projectId: current.request.projectId,
-                documentId: current.request.documentId,
-                contentJson: current.request.contentJson,
-                actor: current.request.actor,
-                reason: current.request.reason,
-              });
+        const currentRes = await deps.invoke("file:document:getcurrent", {
+          projectId,
+        });
+        if (currentRes.ok) {
+          await get().openDocument({
+            projectId,
+            documentId: currentRes.data.documentId,
+          });
+          return;
+        }
 
-              if (!res.ok) {
-                const stillCurrent =
-                  get().projectId === current.request.projectId &&
-                  get().documentId === current.request.documentId;
-                if (stillCurrent) {
-                  set({ autosaveStatus: "error", autosaveError: res.error });
-                }
-                current.resolve();
-                continue;
-              }
+        if (currentRes.error.code === "NOT_FOUND") {
+          set({
+            bootstrapStatus: "ready",
+            projectId,
+            documentId: null,
+            documentStatus: null,
+            documentContentJson: null,
+            lastSavedOrQueuedJson: null,
+            documentCharacterCount: 0,
+            capacityWarning: null,
+            autosaveStatus: "idle",
+            autosaveError: null,
+            entityCompletionSession: createInitialEntityCompletionSession(),
+          });
+          return;
+        }
 
-              const stillCurrent =
-                get().projectId === current.request.projectId &&
-                get().documentId === current.request.documentId;
-              if (stillCurrent) {
-                set({
-                  autosaveStatus: "saved",
-                  autosaveError: null,
-                });
-              }
-            } catch (error) {
-              const stillCurrent =
-                get().projectId === current.request.projectId &&
-                get().documentId === current.request.documentId;
-              if (stillCurrent) {
-                set({
-                  autosaveStatus: "error",
-                  autosaveError: {
-                    code: "INTERNAL_ERROR",
-                    message:
-                      error instanceof Error
-                        ? error.message
-                        : "file:document:save threw unexpectedly",
-                  },
-                });
-              }
-            }
+        set({ bootstrapStatus: "error" });
+      },
 
-            current.resolve();
-          }
-          processingQueue = false;
-        };
+      save: async ({ projectId, documentId, contentJson, actor, reason }) => {
+        await saveQueue.enqueue({
+          projectId,
+          documentId,
+          contentJson,
+          actor,
+          reason,
+        });
+      },
 
-        void processQueue();
-      });
-    },
+      downgradeFinalStatusForEdit: async ({ projectId, documentId }) => {
+        const res = await deps.invoke("file:document:updatestatus", {
+          projectId,
+          documentId,
+          status: "draft",
+        });
+        if (!res.ok) {
+          set({ autosaveStatus: "error", autosaveError: res.error });
+          return false;
+        }
 
-    downgradeFinalStatusForEdit: async ({ projectId, documentId }) => {
-      const res = await deps.invoke("file:document:updatestatus", {
-        projectId,
-        documentId,
-        status: "draft",
-      });
-      if (!res.ok) {
-        set({ autosaveStatus: "error", autosaveError: res.error });
-        return false;
-      }
+        set({ documentStatus: "draft", autosaveError: null });
+        return true;
+      },
 
-      set({ documentStatus: "draft", autosaveError: null });
-      return true;
-    },
+      retryLastAutosave: async () => {
+        const state = get();
+        if (
+          !state.projectId ||
+          !state.documentId ||
+          !state.lastSavedOrQueuedJson ||
+          state.lastSavedOrQueuedJson.length === 0
+        ) {
+          return;
+        }
 
-    retryLastAutosave: async () => {
-      const state = get();
-      if (
-        !state.projectId ||
-        !state.documentId ||
-        !state.lastSavedOrQueuedJson ||
-        state.lastSavedOrQueuedJson.length === 0
-      ) {
-        return;
-      }
+        set({ autosaveError: null });
+        await state.save({
+          projectId: state.projectId,
+          documentId: state.documentId,
+          contentJson: state.lastSavedOrQueuedJson,
+          actor: "auto",
+          reason: "autosave",
+        });
+      },
 
-      set({ autosaveError: null });
-      await state.save({
-        projectId: state.projectId,
-        documentId: state.documentId,
-        contentJson: state.lastSavedOrQueuedJson,
-        actor: "auto",
-        reason: "autosave",
-      });
-    },
+      flushPendingAutosave: async () => {
+        const state = get();
+        if (
+          !state.projectId ||
+          !state.documentId ||
+          !state.lastSavedOrQueuedJson ||
+          state.lastSavedOrQueuedJson.length === 0
+        ) {
+          return;
+        }
 
-    flushPendingAutosave: async () => {
-      const state = get();
-      if (
-        !state.projectId ||
-        !state.documentId ||
-        !state.lastSavedOrQueuedJson ||
-        state.lastSavedOrQueuedJson.length === 0
-      ) {
-        return;
-      }
-
-      await state.save({
-        projectId: state.projectId,
-        documentId: state.documentId,
-        contentJson: state.lastSavedOrQueuedJson,
-        actor: "auto",
-        reason: "autosave",
-      });
-    },
-  }));
+        await state.save({
+          projectId: state.projectId,
+          documentId: state.documentId,
+          contentJson: state.lastSavedOrQueuedJson,
+          actor: "auto",
+          reason: "autosave",
+        });
+      },
+    };
+  });
 }
 
 /**

--- a/openspec/_ops/task_runs/ISSUE-669.md
+++ b/openspec/_ops/task_runs/ISSUE-669.md
@@ -1,0 +1,62 @@
+# ISSUE-669
+
+更新时间：2026-02-27 13:10
+
+## Links
+
+- Issue: #669
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/669
+- Branch: `task/669-audit-editor-save-queue-extraction`
+- PR: TBD
+
+## Plan
+
+- [x] 提取 editor save queue 为独立模块 `editorSaveQueue.ts`
+- [x] 为 save queue 编写独立单测（优先级排序、串行执行、错误恢复）
+- [x] `createEditorStore` 改为调用独立 save queue 模块
+- [x] 移除 `eslint-disable-next-line max-lines-per-function` 豁免
+- [x] typecheck / lint / unit / integration 全部通过
+
+## Runs
+
+### 2026-02-27 typecheck 通过
+
+- Command: `pnpm typecheck`
+- Exit code: `0`
+- Key output: 无错误
+
+### 2026-02-27 lint 通过
+
+- Command: `pnpm lint`
+- Exit code: `0`
+- Key output: `0 errors, 67 warnings`（baseline 68，ratchet PASS）
+
+### 2026-02-27 vitest renderer 测试通过
+
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `176 passed (176)` / `1521 passed (1521)`
+
+### 2026-02-27 unit 测试通过
+
+- Command: `pnpm test:unit`
+- Exit code: `0`
+- Key output: 全部通过
+
+### 2026-02-27 C10 scenario 核验
+
+- AUD-C10-S1: save queue 提取为独立模块 `editorSaveQueue.ts` ✅
+- AUD-C10-S2: 优先级插队（manual-save 插到同文档首个 autosave 前）✅
+- AUD-C10-S3: 串行执行 ✅
+- AUD-C10-S4: 错误恢复（单任务异常后继续处理）✅
+- AUD-C10-S5: `eslint-disable-next-line max-lines-per-function` 豁免已移除 ✅
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 3a095f7adff629507073a36bf921a1927b05cbed
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

- 将 `editorStore.tsx` 内联的 save queue（优先级插入、串行处理、错误恢复）提取为独立模块 `editorSaveQueue.ts`
- 移除 `eslint-disable-next-line max-lines-per-function` 豁免
- 新增独立单测覆盖优先级排序、串行执行、错误恢复

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（67 warnings，baseline 68，ratchet PASS）
- [x] `pnpm -C apps/desktop test:run` 通过（176 files, 1521 tests）
- [x] `pnpm test:unit` 通过

## OpenSpec

- Change: `openspec/changes/audit-editor-save-queue-extraction/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-669.md`

Closes #669