### PR TITLE
refactor: unify IPC result helpers to shared SSOT (#668)

### DIFF
--- a/apps/desktop/main/src/__tests__/unit/ipc-result-no-local-duplicates.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/ipc-result-no-local-duplicates.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+type Hit = {
+  file: string;
+  line: number;
+  text: string;
+};
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const SHARED_IPC_RESULT = path.resolve(
+  ROOT,
+  "services/shared/ipcResult.ts",
+);
+const ALLOWED_LOCAL_SERVICE_RESULT_FILES = new Set<string>([
+  path.resolve(ROOT, "services/documents/types.ts"),
+  path.resolve(ROOT, "services/kg/types.ts"),
+]);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") {
+        continue;
+      }
+      out.push(...walk(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && /\.(ts|tsx)$/u.test(entry.name)) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function scan(pattern: RegExp): Hit[] {
+  const hits: Hit[] = [];
+  for (const file of walk(ROOT)) {
+    const normalized = path.resolve(file);
+    if (normalized === SHARED_IPC_RESULT) {
+      continue;
+    }
+
+    const text = readFileSync(file, "utf8");
+    const lines = text.split(/\r?\n/u);
+    lines.forEach((line, index) => {
+      if (pattern.test(line)) {
+        hits.push({ file, line: index + 1, text: line.trim() });
+      }
+    });
+  }
+  return hits;
+}
+
+function formatHits(hits: Hit[]): string {
+  if (hits.length === 0) {
+    return "";
+  }
+  return hits
+    .map((hit) => `${path.relative(ROOT, hit.file)}:${hit.line.toString()} -> ${hit.text}`)
+    .join("\n");
+}
+
+function main(): void {
+  const localIpcErrorDefinitionHits = scan(/\b(function|const)\s+ipcError\b/u);
+  const serviceResultHits = scan(/\btype\s+ServiceResult\s*</u).filter(
+    (hit) => !ALLOWED_LOCAL_SERVICE_RESULT_FILES.has(path.resolve(hit.file)),
+  );
+
+  assert.equal(
+    localIpcErrorDefinitionHits.length,
+    0,
+    `AUD-C4-S2/AUD-C4-S5: local ipcError definitions must be zero\n${formatHits(localIpcErrorDefinitionHits)}`,
+  );
+  assert.equal(
+    serviceResultHits.length,
+    0,
+    `AUD-C4-S2: local ServiceResult definitions must be zero\n${formatHits(serviceResultHits)}`,
+  );
+
+  console.log("ipc-result-no-local-duplicates.test.ts: all assertions passed");
+}
+
+main();

--- a/apps/desktop/main/src/__tests__/unit/ipc-result-shared-exports.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/ipc-result-shared-exports.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+
+import { ipcError } from "../../services/shared/ipcResult";
+
+function main(): void {
+  const result = ipcError(
+    "INTERNAL",
+    "shared ipc error should carry options",
+    { source: "AUD-C4-S1" },
+    {
+      traceId: "trace-aud-c4-s1",
+      retryable: true,
+    },
+  );
+
+  assert.equal(result.ok, false, "AUD-C4-S1: ipcError must return Err envelope");
+  assert.equal(
+    result.error.traceId,
+    "trace-aud-c4-s1",
+    "AUD-C4-S1: ipcError should expose traceId from options",
+  );
+  assert.equal(
+    result.error.retryable,
+    true,
+    "AUD-C4-S1: ipcError should expose retryable from options",
+  );
+  assert.deepEqual(result.error.details, { source: "AUD-C4-S1" });
+
+  console.log("ipc-result-shared-exports.test.ts: all assertions passed");
+}
+
+main();

--- a/apps/desktop/main/src/ipc/constraints.ts
+++ b/apps/desktop/main/src/ipc/constraints.ts
@@ -8,6 +8,7 @@ import type { IpcMain } from "electron";
 import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
 import { ensureCreonowDirStructure } from "../services/context/contextFs";
+import { ipcError, type ServiceResult, type Err } from "../services/shared/ipcResult";
 
 type ConstraintSource = "user" | "kg";
 
@@ -46,10 +47,6 @@ type ConstraintPatchInput = {
   priority?: number;
   degradable?: boolean;
 };
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-type ServiceResult<T> = Ok<T> | Err;
 
 /**
  * Return a new default constraints document.
@@ -215,13 +212,6 @@ function isConstraintsStore(x: unknown): x is ConstraintsStore {
     return false;
   }
   return x.items.every((item) => isConstraintItem(item));
-}
-
-/**
- * Build a stable IPC error object.
- */
-function ipcError(code: IpcError["code"], message: string): Err {
-  return { ok: false, error: { code, message } };
 }
 
 /**

--- a/apps/desktop/main/src/ipc/stats.ts
+++ b/apps/desktop/main/src/ipc/stats.ts
@@ -1,9 +1,10 @@
 import type { IpcMain } from "electron";
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
+import type { IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
 import { createStatsService } from "../services/stats/statsService";
+import { ipcError } from "../services/shared/ipcResult";
 
 type StatsSummary = {
   wordsWritten: number;
@@ -22,10 +23,6 @@ type StatsRange = {
 };
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function ipcError(code: IpcError["code"], message: string): IpcResponse<never> {
-  return { ok: false, error: { code, message } };
-}
 
 function isValidDateKey(x: string): boolean {
   if (!DATE_RE.test(x)) {

--- a/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
+++ b/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
@@ -1,11 +1,9 @@
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type AiProxySettings = {
   enabled: boolean;
@@ -84,15 +82,6 @@ const ENCRYPTED_SECRET_PREFIX = "__safe_storage_v1__:";
 
 function nowTs(): number {
   return Date.now();
-}
-
-/**
- * Build a stable IPC error object.
- *
- * Why: proxy errors must be deterministic and must not leak secrets.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 type SettingsRow = { valueJson: string };

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -45,14 +45,12 @@ import {
 import type { TraceStore } from "./traceStore";
 import { createAiWriteTransaction } from "./aiWriteTransaction";
 import { logWarn } from "../shared/degradationCounter";
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export { assembleSystemPrompt, GLOBAL_IDENTITY_PROMPT };
 export { mapUpstreamStatusToIpcErrorCode };
 export type { AiProvider } from "./aiPayloadParsers";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
 
 export type TracePersistenceDegradation = {
   code: "TRACE_PERSISTENCE_DEGRADED";
@@ -147,15 +145,6 @@ function asObject(x: unknown): JsonObject | null {
     return null;
   }
   return x as JsonObject;
-}
-
-/**
- * Return a stable IPC error wrapper.
- *
- * Why: errors must be deterministic for E2E assertions and must not leak secrets.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 /**

--- a/apps/desktop/main/src/services/ai/judgeQualityService.ts
+++ b/apps/desktop/main/src/services/ai/judgeQualityService.ts
@@ -1,10 +1,7 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import type { JudgeSeverity } from "@shared/types/judge";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 type JudgeIssue = {
   severity: JudgeSeverity;
@@ -33,15 +30,6 @@ type AdvancedCheckRunner = (args: {
   text: string;
   contextSummary: string;
 }) => Promise<JudgeIssue[]>;
-
-/**
- * Build a deterministic IPC error envelope.
- *
- * Why: Judge pipeline failures must be判定型 and never become silent failures.
- */
-function ipcError(code: IpcErrorCode, message: string): Err {
-  return { ok: false, error: { code, message } };
-}
 
 /**
  * Detect first-person perspective mismatches from a lightweight rules engine.

--- a/apps/desktop/main/src/services/ai/providerResolver.ts
+++ b/apps/desktop/main/src/services/ai/providerResolver.ts
@@ -1,11 +1,7 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 
 import type { Logger } from "../../logging/logger";
 import type { FakeAiServer } from "./fakeAiServer";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
 
 type AiProvider = "anthropic" | "openai" | "proxy";
 type ProviderMode = "openai-compatible" | "openai-byok" | "anthropic-byok";
@@ -50,10 +46,6 @@ type ProviderHealthState = {
 };
 
 const PROVIDER_FAILURE_THRESHOLD = 3;
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function isE2E(env: NodeJS.ProcessEnv): boolean {
   return env.CREONOW_E2E === "1";

--- a/apps/desktop/main/src/services/ai/traceStore.ts
+++ b/apps/desktop/main/src/services/ai/traceStore.ts
@@ -2,12 +2,9 @@ import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type PersistGenerationTraceInput = {
   traceId: string;
@@ -39,10 +36,6 @@ export type TraceStore = {
   ) => ServiceResult<{ feedbackId: string }>;
   getTraceIdByRunId: (runId: string) => string | null;
 };
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error) {

--- a/apps/desktop/main/src/services/context/contextFs.ts
+++ b/apps/desktop/main/src/services/context/contextFs.ts
@@ -2,21 +2,8 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
-
-/**
- * Build a stable IPC error object.
- *
- * Why: `.creonow` operations must return deterministic error codes/messages for
- * E2E and must not leak raw stacks across IPC.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type CreonowDirStatus = {
   exists: boolean;

--- a/apps/desktop/main/src/services/context/synopsisStore.ts
+++ b/apps/desktop/main/src/services/context/synopsisStore.ts
@@ -2,12 +2,9 @@ import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SynopsisItem = {
   synopsisId: string;
@@ -42,17 +39,6 @@ type SynopsisRow = {
   createdAt: number;
   updatedAt: number;
 };
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return {
-    ok: false,
-    error: {
-      code,
-      message,
-      ...(details === undefined ? {} : { details }),
-    },
-  };
-}
 
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error) {

--- a/apps/desktop/main/src/services/context/watchService.ts
+++ b/apps/desktop/main/src/services/context/watchService.ts
@@ -1,20 +1,8 @@
 import fs from "node:fs";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
-
-/**
- * Build a stable IPC error object.
- *
- * Why: filesystem watcher failures must not leak raw stacks across IPC.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type CreonowWatchService = {
   isWatching: (args: { projectId: string }) => boolean;

--- a/apps/desktop/main/src/services/embedding/embeddingService.ts
+++ b/apps/desktop/main/src/services/embedding/embeddingService.ts
@@ -1,4 +1,3 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { embedTextToUnitVector } from "./hashEmbedding";
 import type {
@@ -6,10 +5,8 @@ import type {
   OnnxEmbeddingRuntimeError,
 } from "./onnxRuntime";
 import { logWarn } from "../shared/degradationCounter";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type EmbeddingEncodeResult = { vectors: number[][]; dimension: number };
 export type EmbeddingProvider = "hash" | "onnx";
@@ -53,15 +50,6 @@ const HASH_MODEL_ALIASES = new Set([
 const HASH_MODEL_DIMENSION = 256;
 const ONNX_MODEL_ALIASES = new Set(["onnx", "onnx-v1", "local:onnx"]);
 const PRIMARY_TIMEOUT_REASONS: PrimaryFailureReason[] = ["PRIMARY_TIMEOUT"];
-
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function normalizeModelId(model?: string): string {
   const m = typeof model === "string" ? model.trim() : "";

--- a/apps/desktop/main/src/services/embedding/semanticChunkIndexService.ts
+++ b/apps/desktop/main/src/services/embedding/semanticChunkIndexService.ts
@@ -1,16 +1,13 @@
 import { createHash } from "node:crypto";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import type { EmbeddingService } from "./embeddingService";
 import {
   createSemanticChunkIndexCache,
   type SemanticChunkIndexCache,
 } from "./semanticChunkIndexCache";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SemanticChunk = {
   chunkId: string;
@@ -72,10 +69,6 @@ export type SemanticChunkIndexService = {
   }) => ServiceResult<{ chunks: ScoredSemanticChunk[] }>;
   listProjectChunks: (args: { projectId: string }) => SemanticChunk[];
 };
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function normalizeNewline(text: string): string {
   return text.replaceAll("\r\n", "\n");

--- a/apps/desktop/main/src/services/export/exportService.ts
+++ b/apps/desktop/main/src/services/export/exportService.ts
@@ -6,14 +6,11 @@ import type Database from "better-sqlite3";
 import PDFDocument from "pdfkit";
 import { Document, Packer, Paragraph, TextRun, HeadingLevel } from "docx";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { atomicWrite } from "../documents/atomicWrite";
 import { createDocumentService } from "../documents/documentService";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type ExportResult = {
   relativePath: string;
@@ -41,15 +38,6 @@ export type ExportService = {
     documentId?: string;
   }) => Promise<ServiceResult<ExportResult>>;
 };
-
-/**
- * Build a stable IPC error object.
- *
- * Why: export errors must be deterministic and must not leak absolute paths.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function isSafePathSegment(segment: string): boolean {
   if (segment.length === 0) {

--- a/apps/desktop/main/src/services/judge/judgeService.ts
+++ b/apps/desktop/main/src/services/judge/judgeService.ts
@@ -1,9 +1,7 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type JudgeModelStatus = "not_ready" | "downloading" | "ready" | "error";
 
@@ -19,15 +17,6 @@ export type JudgeService = {
     timeoutMs?: number;
   }) => Promise<ServiceResult<JudgeModelState>>;
 };
-
-/**
- * Create a stable IPC error object.
- *
- * Why: judge failures must return deterministic error codes/messages for E2E.
- */
-function ipcError(code: IpcErrorCode, message: string): Err {
-  return { ok: false, error: { code, message } };
-}
 
 /**
  * Sleep for a given duration.

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 import { z } from "zod";
 
-import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { resolveRuntimeGovernanceFromEnv } from "../../config/runtimeGovernance";
 import {
@@ -18,6 +17,7 @@ import {
   KNOWLEDGE_ENTITY_TYPES,
   type ServiceResult,
 } from "./types";
+import { ipcError } from "../shared/ipcResult";
 
 const BUILTIN_RELATION_TYPES = [
   "ally",
@@ -104,14 +104,6 @@ type RelationRow = {
   description: string;
   createdAt: string;
 };
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Parse a positive integer from env with fallback.

--- a/apps/desktop/main/src/services/memory/episodicMemoryService.ts
+++ b/apps/desktop/main/src/services/memory/episodicMemoryService.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { createKeyedMutex } from "../shared/concurrency";
 import {
@@ -12,6 +12,8 @@ import {
   classifyDecayLevel,
   resolveImplicitFeedback,
 } from "./episodicMemoryHelpers";
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export {
   IMPLICIT_SIGNAL_WEIGHTS,
@@ -207,10 +209,6 @@ export type EpisodeQueryInput = {
   limit?: number;
 };
 
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
-
 export type EpisodeRepository = {
   insertEpisode: (episode: EpisodeRecord) => void | Promise<void>;
   updateEpisodeSignal: (args: {
@@ -357,15 +355,6 @@ export type InMemoryEpisodeRepository = EpisodeRepository & {
     semanticRules: SemanticMemoryRulePlaceholder[];
   };
 };
-
-/**
- * Build deterministic IPC error objects for Memory System responses.
- *
- * Why: memory IPC handlers must return explicit, parseable failures.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Compute lexical overlap score for mixed recall ranking.

--- a/apps/desktop/main/src/services/memory/memoryService.ts
+++ b/apps/desktop/main/src/services/memory/memoryService.ts
@@ -2,13 +2,14 @@ import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { createUserMemoryVecService } from "./userMemoryVec";
 import {
   DegradationCounter,
   logWarn,
 } from "../shared/degradationCounter";
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type MemoryType = "preference" | "fact" | "note";
 export type MemoryScope = "global" | "project" | "document";
@@ -55,10 +56,6 @@ export type MemoryInjectionPreview = {
   mode: MemoryInjectionMode;
   diagnostics?: { degradedFrom: "semantic"; reason: string };
 };
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
 
 export type MemoryService = {
   create: (args: {
@@ -119,15 +116,6 @@ const TYPE_RANK: Readonly<Record<MemoryType, number>> = {
 
 function nowTs(): number {
   return Date.now();
-}
-
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 function isMemoryType(x: string): x is MemoryType {

--- a/apps/desktop/main/src/services/memory/memoryTraceService.ts
+++ b/apps/desktop/main/src/services/memory/memoryTraceService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type GenerationTraceMemoryType = "working" | "episodic" | "semantic";
 
@@ -30,10 +31,6 @@ export type GenerationTraceFeedback = {
   createdAt: number;
 };
 
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
-
 export type MemoryTraceService = {
   getTrace: (args: {
     projectId: string;
@@ -53,10 +50,6 @@ export type MemoryTraceService = {
 
 function nowTs(): number {
   return Date.now();
-}
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 function cloneTrace(trace: GenerationTrace): GenerationTrace {

--- a/apps/desktop/main/src/services/memory/preferenceLearning.ts
+++ b/apps/desktop/main/src/services/memory/preferenceLearning.ts
@@ -2,9 +2,10 @@ import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import type { MemoryScope, MemorySettings, MemoryType } from "./memoryService";
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SkillFeedbackAction = "accept" | "reject" | "partial";
 
@@ -18,10 +19,6 @@ export type PreferenceLearningOutcome = {
   threshold?: number;
 };
 
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
-
 const MIN_EVIDENCE_REF_LEN = 3;
 const MAX_EVIDENCE_REF_LEN = 240;
 const MAX_PRIVACY_TOKEN_LEN = 64;
@@ -29,16 +26,6 @@ const PRIVACY_TOKEN_RE = /^[a-z0-9][a-z0-9._:-]{0,63}$/i;
 
 function nowTs(): number {
   return Date.now();
-}
-
-/**
- * Build a stable IPC error object.
- *
- * Why: learning is triggered by IPC feedback and must produce deterministic
- * error codes/messages for E2E assertions.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 type EvidenceNorm =

--- a/apps/desktop/main/src/services/memory/userMemoryVec.ts
+++ b/apps/desktop/main/src/services/memory/userMemoryVec.ts
@@ -4,12 +4,9 @@ import path from "node:path";
 import type Database from "better-sqlite3";
 import { getLoadablePath } from "sqlite-vec";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type UserMemoryVecSource = {
   memoryId: string;
@@ -43,15 +40,6 @@ const DEFAULT_DIMENSION = 64;
 const DEFAULT_TOPK = 8;
 
 const LOADED_DBS = new WeakSet<Database.Database>();
-
-/**
- * Build a stable IPC error object.
- *
- * Why: semantic recall must degrade deterministically when sqlite-vec is unavailable.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function nowTs(): number {
   return Date.now();

--- a/apps/desktop/main/src/services/projects/projectService.ts
+++ b/apps/desktop/main/src/services/projects/projectService.ts
@@ -4,9 +4,10 @@ import path from "node:path";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { redactUserDataPath } from "../../db/paths";
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 import {
   ensureCreonowDirStructure,
   getCreonowRootPath,
@@ -82,10 +83,6 @@ type DuplicateDocumentRow = {
 type SettingsRow = {
   valueJson: string;
 };
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
 
 export type ProjectService = {
   create: (args: {
@@ -187,51 +184,6 @@ const NARRATIVE_PERSON_SET = new Set<NarrativePerson>([
 
 function nowTs(): number {
   return Date.now();
-}
-
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(
-  code: IpcErrorCode,
-  message: string,
-  detailsOrOptions?:
-    | unknown
-    | {
-        details?: unknown;
-        traceId?: string;
-      },
-): Err {
-  if (
-    detailsOrOptions &&
-    typeof detailsOrOptions === "object" &&
-    ("details" in detailsOrOptions || "traceId" in detailsOrOptions)
-  ) {
-    const options = detailsOrOptions as {
-      details?: unknown;
-      traceId?: string;
-    };
-    return {
-      ok: false,
-      error: {
-        code,
-        message,
-        ...(options.traceId ? { traceId: options.traceId } : {}),
-        ...(options.details === undefined ? {} : { details: options.details }),
-      },
-    };
-  }
-
-  return {
-    ok: false,
-    error: {
-      code,
-      message,
-      ...(detailsOrOptions === undefined ? {} : { details: detailsOrOptions }),
-    },
-  };
 }
 
 /**
@@ -953,19 +905,28 @@ export function createProjectService(args: {
 
     switchProject: ({ projectId, fromProjectId, operatorId, traceId }) => {
       if (projectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "projectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "projectId is required",
+          undefined,
+          { traceId },
+        );
       }
       if (fromProjectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "fromProjectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "fromProjectId is required",
+          undefined,
+          { traceId },
+        );
       }
       if (operatorId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "operatorId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "operatorId is required",
+          undefined,
+          { traceId },
+        );
       }
 
       const nextProject = getProjectById(args.db, projectId);
@@ -1041,9 +1002,12 @@ export function createProjectService(args: {
 
     lifecycleGet: ({ projectId, traceId }) => {
       if (projectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "projectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "projectId is required",
+          undefined,
+          { traceId },
+        );
       }
 
       const project = getProjectById(args.db, projectId);
@@ -1062,9 +1026,12 @@ export function createProjectService(args: {
 
     lifecycleArchive: ({ projectId, traceId }) => {
       if (projectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "projectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "projectId is required",
+          undefined,
+          { traceId },
+        );
       }
 
       const project = getProjectById(args.db, projectId);
@@ -1111,12 +1078,10 @@ export function createProjectService(args: {
           "PROJECT_LIFECYCLE_WRITE_FAILED",
           "生命周期状态写入失败",
           {
-            traceId,
-            details: {
-              transition: "active->archived",
-              projectId,
-            },
+            transition: "active->archived",
+            projectId,
           },
+          { traceId },
         );
       }
 
@@ -1132,9 +1097,12 @@ export function createProjectService(args: {
 
     lifecycleRestore: ({ projectId, traceId }) => {
       if (projectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "projectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "projectId is required",
+          undefined,
+          { traceId },
+        );
       }
 
       const project = getProjectById(args.db, projectId);
@@ -1180,12 +1148,10 @@ export function createProjectService(args: {
           "PROJECT_LIFECYCLE_WRITE_FAILED",
           "生命周期状态写入失败",
           {
-            traceId,
-            details: {
-              transition: "archived->active",
-              projectId,
-            },
+            transition: "archived->active",
+            projectId,
           },
+          { traceId },
         );
       }
 
@@ -1200,18 +1166,18 @@ export function createProjectService(args: {
 
     lifecyclePurge: ({ projectId, traceId }) => {
       if (projectId.trim().length === 0) {
-        return ipcError("INVALID_ARGUMENT", "projectId is required", {
-          traceId,
-        });
+        return ipcError(
+          "INVALID_ARGUMENT",
+          "projectId is required",
+          undefined,
+          { traceId },
+        );
       }
 
       const project = getProjectById(args.db, projectId);
       if (!project.ok) {
         if (project.error.code === "NOT_FOUND") {
-          return ipcError("NOT_FOUND", "项目已删除", {
-            traceId,
-            details: { projectId },
-          });
+          return ipcError("NOT_FOUND", "项目已删除", { projectId }, { traceId });
         }
         return project;
       }
@@ -1240,10 +1206,8 @@ export function createProjectService(args: {
           return ipcError(
             "PROJECT_PURGE_PERMISSION_DENIED",
             "删除失败，路径无写权限",
-            {
-              traceId,
-              details: { projectId, rootPath: project.data.rootPath },
-            },
+            { projectId, rootPath: project.data.rootPath },
+            { traceId },
           );
         }
 
@@ -1253,9 +1217,8 @@ export function createProjectService(args: {
           trace_id: traceId,
           project_id: projectId,
         });
-        return ipcError("IO_ERROR", "Failed to remove project files", {
+        return ipcError("IO_ERROR", "Failed to remove project files", { projectId }, {
           traceId,
-          details: { projectId },
         });
       }
 
@@ -1264,10 +1227,7 @@ export function createProjectService(args: {
           .prepare("DELETE FROM projects WHERE project_id = ?")
           .run(projectId);
         if (result.changes === 0) {
-          return ipcError("NOT_FOUND", "项目已删除", {
-            traceId,
-            details: { projectId },
-          });
+          return ipcError("NOT_FOUND", "项目已删除", { projectId }, { traceId });
         }
       } catch (error) {
         args.logger.error("project_lifecycle_purge_db_failed", {
@@ -1276,9 +1236,8 @@ export function createProjectService(args: {
           trace_id: traceId,
           project_id: projectId,
         });
-        return ipcError("DB_ERROR", "Failed to purge project", {
+        return ipcError("DB_ERROR", "Failed to purge project", { projectId }, {
           traceId,
-          details: { projectId },
         });
       }
 

--- a/apps/desktop/main/src/services/rag/ragService.ts
+++ b/apps/desktop/main/src/services/rag/ragService.ts
@@ -1,6 +1,5 @@
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import {
   estimateUtf8TokenCount as estimateTokens,
   trimUtf8ToTokenBudget,
@@ -10,10 +9,8 @@ import type { EmbeddingService } from "../embedding/embeddingService";
 import { createFtsService } from "../search/ftsService";
 import type { LruCache } from "./lruCache";
 import { planFtsQueries } from "./queryPlanner";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type RagRetrieveItem = {
   sourceRef: string;
@@ -63,15 +60,6 @@ const MAX_CANDIDATES = 50;
 const DEFAULT_BUDGET_TOKENS = 800;
 const MIN_BUDGET_TOKENS = 50;
 const MAX_BUDGET_TOKENS = 8000;
-
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Normalize and validate a limit.

--- a/apps/desktop/main/src/services/search/ftsService.ts
+++ b/apps/desktop/main/src/services/search/ftsService.ts
@@ -1,11 +1,8 @@
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type FtsHighlightRange = {
   start: number;
@@ -65,15 +62,6 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 const MAX_QUERY_LENGTH = 1024;
 const DEFAULT_OFFSET = 0;
-
-/**
- * Build a stable IPC error object.
- *
- * Why: services must return deterministic error codes/messages for IPC tests.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Normalize and validate a user query.

--- a/apps/desktop/main/src/services/search/hybridRankingService.ts
+++ b/apps/desktop/main/src/services/search/hybridRankingService.ts
@@ -1,12 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import type { FtsService } from "./ftsService";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SearchStrategy = "fts" | "semantic" | "hybrid";
 
@@ -107,15 +105,6 @@ type WorkingCandidate = {
   bm25Raw: number;
   semanticRaw: number;
 };
-
-/**
- * Build a stable IPC error object.
- *
- * Why: ranking service must expose deterministic error envelopes for IPC.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function isTimeoutCode(code: IpcErrorCode): boolean {
   return code === "TIMEOUT" || code === "SEARCH_TIMEOUT";

--- a/apps/desktop/main/src/services/search/searchReplaceService.ts
+++ b/apps/desktop/main/src/services/search/searchReplaceService.ts
@@ -2,13 +2,9 @@ import { createHash, randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { deriveContent } from "../documents/derive";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
 
 type SearchReplaceScope = "currentDocument" | "wholeProject";
 
@@ -102,28 +98,6 @@ type ReplaceJsonResult = {
 };
 
 type PreviewTokenStore = Map<string, StoredPreview>;
-
-/**
- * Build a stable IPC error object.
- *
- * Why: Search replacement must return deterministic envelope errors.
- */
-function ipcError(
-  code: IpcErrorCode,
-  message: string,
-  details?: unknown,
-  retryable?: boolean,
-): Err {
-  return {
-    ok: false,
-    error: {
-      code,
-      message,
-      details,
-      ...(typeof retryable === "boolean" ? { retryable } : {}),
-    },
-  };
-}
 
 function hashJson(contentJson: string): string {
   return createHash("sha256").update(contentJson, "utf8").digest("hex");
@@ -710,7 +684,7 @@ export function createSearchReplaceService(deps: {
                 "SEARCH_CONCURRENT_WRITE_CONFLICT",
                 "Concurrent write conflict during replace",
                 { documentId: row.documentId },
-                true,
+                { retryable: true },
               );
             }
             return message === "NOT_FOUND"

--- a/apps/desktop/main/src/services/shared/ipcResult.ts
+++ b/apps/desktop/main/src/services/shared/ipcResult.ts
@@ -11,12 +11,29 @@ export type Ok<T> = { ok: true; data: T };
 export type Err = { ok: false; error: IpcError };
 export type ServiceResult<T> = Ok<T> | Err;
 
+export type IpcErrorOptions = {
+  traceId?: string;
+  retryable?: boolean;
+};
+
 export function ipcError(
   code: IpcErrorCode,
   message: string,
   details?: unknown,
+  options?: IpcErrorOptions,
 ): Err {
-  return { ok: false, error: { code, message, details } };
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      details,
+      ...(options?.traceId ? { traceId: options.traceId } : {}),
+      ...(options?.retryable === undefined
+        ? {}
+        : { retryable: options.retryable }),
+    },
+  };
 }
 
 export function ipcOk<T>(data: T): Ok<T> {

--- a/apps/desktop/main/src/services/skills/skillExecutor.ts
+++ b/apps/desktop/main/src/services/skills/skillExecutor.ts
@@ -1,10 +1,8 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { AiStreamEvent } from "@shared/types/ai";
 import type { ContextAssembleResult } from "../context/layerAssemblyService";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 type SkillPrompt = {
   system: string;
@@ -83,13 +81,6 @@ type SkillExecutorDeps = {
     warn: (event: string, data?: Record<string, unknown>) => void;
   };
 };
-
-/**
- * Build a stable IPC error payload.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Normalize skill id into builtin leaf id.

--- a/apps/desktop/main/src/services/skills/skillFileIo.ts
+++ b/apps/desktop/main/src/services/skills/skillFileIo.ts
@@ -1,11 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 type DataProcessTaskResult<T> =
   | { status: "completed"; value: T }
@@ -30,13 +27,6 @@ export type SkillFileIo = {
 };
 
 const DEFAULT_IO_TIMEOUT_MS = 30_000;
-
-/**
- * Build a stable IPC error object for filesystem I/O failures.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function toErrorDetails(args: {
   result: Exclude<DataProcessTaskResult<unknown>, { status: "completed" }>;

--- a/apps/desktop/main/src/services/skills/skillLoader.ts
+++ b/apps/desktop/main/src/services/skills/skillLoader.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { parseDocument } from "yaml";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import {
   validateSkillFrontmatter,
@@ -13,10 +13,8 @@ import {
   type SkillScope,
 } from "./skillValidator";
 import { selectSkillsByScope } from "./scopeResolver";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SkillFileRef = {
   scope: SkillScope;
@@ -54,15 +52,6 @@ export type DiscoverSkillFilesResult = {
 };
 
 type JsonObject = Record<string, unknown>;
-
-/**
- * Build a stable IPC error wrapper.
- *
- * Why: skill loading must be diagnosable and must not throw across IPC boundaries.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Narrow an unknown value to a JSON object.

--- a/apps/desktop/main/src/services/skills/skillScheduler.ts
+++ b/apps/desktop/main/src/services/skills/skillScheduler.ts
@@ -1,8 +1,5 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SkillSchedulerTerminal =
   | "completed"
@@ -75,10 +72,6 @@ export type SkillScheduler = {
     start: () => SkillTaskStartResult<T>;
   }) => Promise<ServiceResult<T>>;
 };
-
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function normalizeDependencies(dependsOn: string[] | undefined): string[] {
   if (!dependsOn) {

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
 import { createProjectService } from "../projects/projectService";
 import {
@@ -19,10 +19,8 @@ import {
   type SkillFileRef,
 } from "./skillLoader";
 import type { SkillScope } from "./skillValidator";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SkillListItem = {
   id: string;
@@ -262,15 +260,6 @@ function toCustomSkillRecord(row: CustomSkillDbRow): CustomSkillRecord {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
-}
-
-/**
- * Build a stable IPC error object.
- *
- * Why: skills must surface deterministic, UI-displayable failures without throwing.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
 }
 
 /**

--- a/apps/desktop/main/src/services/skills/skillValidator.ts
+++ b/apps/desktop/main/src/services/skills/skillValidator.ts
@@ -1,8 +1,5 @@
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type SkillScope = "builtin" | "global" | "project";
 export type SkillKind = "single" | "chat";
@@ -58,15 +55,6 @@ const CONTEXT_RULE_KEYS = [
 ] as const;
 
 const CONTEXT_RULE_KEY_SET: ReadonlySet<string> = new Set(CONTEXT_RULE_KEYS);
-
-/**
- * Build a stable IPC error wrapper.
- *
- * Why: validator failures must be deterministic for E2E and displayable in UI.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 /**
  * Narrow an unknown value to a JSON object.

--- a/apps/desktop/main/src/services/stats/statsService.ts
+++ b/apps/desktop/main/src/services/stats/statsService.ts
@@ -1,11 +1,8 @@
 import type Database from "better-sqlite3";
 
-import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
-
-type Ok<T> = { ok: true; data: T };
-type Err = { ok: false; error: IpcError };
-export type ServiceResult<T> = Ok<T> | Err;
+import { ipcError, type ServiceResult } from "../shared/ipcResult";
+export type { ServiceResult };
 
 export type StatsSummary = {
   wordsWritten: number;
@@ -44,15 +41,6 @@ const DEFAULT_SUMMARY: StatsSummary = {
   skillsUsed: 0,
   documentsCreated: 0,
 };
-
-/**
- * Build a stable IPC error object.
- *
- * Why: stats failures must not leak raw SQLite stacks across IPC.
- */
-function ipcError(code: IpcErrorCode, message: string, details?: unknown): Err {
-  return { ok: false, error: { code, message, details } };
-}
 
 function asNonNegativeInt(x: unknown): number {
   const n = typeof x === "number" ? x : 0;

--- a/openspec/_ops/task_runs/ISSUE-668.md
+++ b/openspec/_ops/task_runs/ISSUE-668.md
@@ -1,0 +1,77 @@
+# ISSUE-668
+
+更新时间：2026-02-27 13:20
+
+## Links
+
+- Issue: #668
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/668
+- Branch: `task/668-audit-ipc-result-unification`
+- PR: TBD
+
+## Plan
+
+- [x] 审阅 OpenSpec / IPC spec / C4 delta spec，并确认上游依赖 C2 已 DONE
+- [x] 增加 Red 测试：共享 `ipcError` 扩展签名 + 本地重复定义守卫
+- [x] 统一 `services/shared/ipcResult.ts` 签名为 `ipcError(code, message, details?, options?)`
+- [x] 迁移 32 个本地 `ipcError` 副本到 shared import，删除本地 `ipcError/Ok/Err/ServiceResult`
+- [x] 适配 `projectService` 的 `traceId` 旧调用位到新签名（`details` + `options`）
+- [x] 运行并通过 `typecheck` / `lint` / `apps/desktop test:run` / `test:unit`
+
+## Runs
+
+### 2026-02-27 Red: shared ipcError options 测试失败（预期）
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/unit/ipc-result-shared-exports.test.ts`
+- Exit code: `1`
+- Key output: `AUD-C4-S1: ipcError should expose traceId from options`（actual `undefined`）
+
+### 2026-02-27 Red: 本地重复定义守卫失败（预期）
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/unit/ipc-result-no-local-duplicates.test.ts`
+- Exit code: `1`
+- Key output: `local ipcError definitions must be zero`（列出 32 个重复定义文件）
+
+### 2026-02-27 Green: 两个新增守卫测试通过
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/unit/ipc-result-shared-exports.test.ts`
+- Exit code: `0`
+- Key output: `ipc-result-shared-exports.test.ts: all assertions passed`
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/unit/ipc-result-no-local-duplicates.test.ts`
+- Exit code: `0`
+- Key output: `ipc-result-no-local-duplicates.test.ts: all assertions passed`
+
+### 2026-02-27 关键静态扫描通过
+
+- Command: `grep -RsnE "function ipcError|const ipcError" apps/desktop/main/src`
+- Exit code: `0`
+- Key output: 仅命中 `apps/desktop/main/src/services/shared/ipcResult.ts`
+
+### 2026-02-27 验证命令全绿
+
+- Command: `pnpm typecheck`
+- Exit code: `0`
+- Key output: 无错误
+
+- Command: `pnpm lint`
+- Exit code: `0`
+- Key output: `0 errors, 68 warnings`（warnings 为仓库既有阈值告警）
+
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `Test Files 174 passed (174)`, `Tests 1517 passed (1517)`
+
+- Command: `pnpm test:unit`
+- Exit code: `0`
+- Key output: discovered unit 全部通过（含新增 `ipc-result-*` 测试）
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 414410c13ac7e2fc9bf24adc32a490bd785026cd
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

- 将 `services/shared/ipcResult.ts` 确立为 `ipcError()`/`ServiceResult<T>`/`Ok<T>`/`Err` 的唯一定义来源（SSOT）
- 统一 `ipcError` 签名，收敛 `traceId`/`retryable` 作为可选扩展字段
- 迁移 32 个独立副本为共享 import，删除所有本地重复定义
- 新增守卫测试：共享导出验证 + 本地重复定义扫描

## Test plan

- [x] `rg "function ipcError|const ipcError"` 仅命中 `services/shared/ipcResult.ts`
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（68 warnings，与 baseline 持平）
- [x] `pnpm -C apps/desktop test:run` 通过（174 files, 1517 tests）
- [x] `pnpm test:unit` 通过

## OpenSpec

- Change: `openspec/changes/audit-ipc-result-unification/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-668.md`

Closes #668