### PR TITLE
fix: prevent watcher/process listener leaks (#679)

### DIFF
--- a/apps/desktop/main/src/__tests__/global-exception-handlers.dedup.test.ts
+++ b/apps/desktop/main/src/__tests__/global-exception-handlers.dedup.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+
+import {
+  type GlobalExceptionHandlerDeps,
+  registerGlobalExceptionHandlers,
+} from "../globalExceptionHandlers";
+
+type FatalEventSource = "uncaughtException" | "unhandledRejection";
+type FatalListener = (reason: unknown) => void;
+
+type CapturedLog = {
+  event: string;
+  data: Record<string, unknown> | undefined;
+};
+
+type Harness = {
+  deps: GlobalExceptionHandlerDeps;
+  listeners: Record<FatalEventSource, FatalListener[]>;
+  logs: CapturedLog[];
+  getQuitCalls: () => number;
+};
+
+function createHarness(): Harness {
+  const listeners: Record<FatalEventSource, FatalListener[]> = {
+    uncaughtException: [],
+    unhandledRejection: [],
+  };
+  const logs: CapturedLog[] = [];
+  let quitCalls = 0;
+
+  const deps: GlobalExceptionHandlerDeps = {
+    processLike: {
+      on: (event, listener) => {
+        listeners[event].push(listener);
+      },
+    },
+    appLike: {
+      once: () => {},
+      quit: () => {
+        quitCalls += 1;
+      },
+    },
+    logger: {
+      error: (event, data) => {
+        logs.push({ event, data });
+      },
+    },
+    shutdownTimeoutMs: 10,
+    exit: () => {},
+    setTimeoutFn: ((() => {
+      return {} as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout),
+    clearTimeoutFn: (() => {}) as typeof clearTimeout,
+  };
+
+  return {
+    deps,
+    listeners,
+    logs,
+    getQuitCalls: () => quitCalls,
+  };
+}
+
+function runScenario(name: string, fn: () => void): void {
+  try {
+    fn();
+  } catch (error) {
+    throw new Error(
+      `[${name}] ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+runScenario(
+  "AUD-C15-S5 repeated registerGlobalExceptionHandlers calls should not add duplicate listeners",
+  () => {
+    const harness = createHarness();
+
+    registerGlobalExceptionHandlers(harness.deps);
+    registerGlobalExceptionHandlers(harness.deps);
+    registerGlobalExceptionHandlers(harness.deps);
+
+    assert.equal(harness.listeners.uncaughtException.length, 1);
+    assert.equal(harness.listeners.unhandledRejection.length, 1);
+  },
+);
+
+runScenario(
+  "AUD-C15-S6 dedup guard should keep fatal exception capture behavior",
+  () => {
+    const harness = createHarness();
+
+    registerGlobalExceptionHandlers(harness.deps);
+    registerGlobalExceptionHandlers(harness.deps);
+
+    const uncaughtExceptionListener = harness.listeners.uncaughtException[0];
+    assert.ok(uncaughtExceptionListener, "expected uncaughtException listener");
+    uncaughtExceptionListener(new Error("fatal"));
+
+    assert.equal(harness.getQuitCalls(), 1);
+    const capturedLogs = harness.logs.filter(
+      (entry) => entry.event === "fatal_exception_captured",
+    );
+    assert.equal(capturedLogs.length, 1);
+    assert.equal(capturedLogs[0]?.data?.source, "uncaughtException");
+  },
+);

--- a/apps/desktop/main/src/globalExceptionHandlers.ts
+++ b/apps/desktop/main/src/globalExceptionHandlers.ts
@@ -22,6 +22,7 @@ export type GlobalExceptionHandlerDeps = {
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const installedProcessLikes = new WeakSet<FatalProcessLike>();
 
 function describeReason(reason: unknown): {
   error_type: string;
@@ -43,6 +44,12 @@ function describeReason(reason: unknown): {
 export function registerGlobalExceptionHandlers(
   deps: GlobalExceptionHandlerDeps,
 ): void {
+  if (installedProcessLikes.has(deps.processLike)) {
+    return;
+  }
+
+  installedProcessLikes.add(deps.processLike);
+
   const timeoutMs = deps.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
   const setTimeoutFn = deps.setTimeoutFn ?? setTimeout;
   const clearTimeoutFn = deps.clearTimeoutFn ?? clearTimeout;
@@ -99,11 +106,16 @@ export function registerGlobalExceptionHandlers(
     }
   };
 
-  deps.processLike.on("uncaughtException", (error) => {
-    handleFatal("uncaughtException", error);
-  });
+  try {
+    deps.processLike.on("uncaughtException", (error) => {
+      handleFatal("uncaughtException", error);
+    });
 
-  deps.processLike.on("unhandledRejection", (reason) => {
-    handleFatal("unhandledRejection", reason);
-  });
+    deps.processLike.on("unhandledRejection", (reason) => {
+      handleFatal("unhandledRejection", reason);
+    });
+  } catch (error) {
+    installedProcessLikes.delete(deps.processLike);
+    throw error;
+  }
 }

--- a/apps/desktop/main/src/services/context/__tests__/watchService.listener-cleanup.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/watchService.listener-cleanup.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type fs from "node:fs";
+
+import type { Logger } from "../../../logging/logger";
+import { createCreonowWatchService } from "../watchService";
+
+class FakeWatcher extends EventEmitter {
+  closed = false;
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function runScenario(name: string, fn: () => void): void {
+  try {
+    fn();
+  } catch (error) {
+    throw new Error(
+      `[${name}] ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+runScenario("AUD-C15-S1 stop should remove watcher error listener", () => {
+  const createdWatchers: FakeWatcher[] = [];
+  const service = createCreonowWatchService({
+    logger: createLogger(),
+    watchFactory: (() => {
+      const watcher = new FakeWatcher();
+      createdWatchers.push(watcher);
+      return watcher as unknown as fs.FSWatcher;
+    }) as typeof fs.watch,
+  });
+
+  const started = service.start({
+    projectId: "project-1",
+    creonowRootPath: "/tmp/project-1/.creonow",
+  });
+  assert.equal(started.ok, true);
+  assert.equal(createdWatchers.length, 1);
+  const watcher = createdWatchers[0];
+  assert.ok(watcher, "expected watcher to be created");
+  assert.equal(watcher.listenerCount("error"), 1);
+
+  const stopped = service.stop({ projectId: "project-1" });
+  assert.equal(stopped.ok, true);
+  assert.equal(watcher.listenerCount("error"), 0);
+  assert.equal(watcher.closed, true);
+});
+
+runScenario("AUD-C15-S2 error path should remove watcher error listener", () => {
+  const createdWatchers: FakeWatcher[] = [];
+  const invalidations: Array<{ projectId: string; reason: "error" }> = [];
+  const service = createCreonowWatchService({
+    logger: createLogger(),
+    watchFactory: (() => {
+      const watcher = new FakeWatcher();
+      createdWatchers.push(watcher);
+      return watcher as unknown as fs.FSWatcher;
+    }) as typeof fs.watch,
+    onWatcherInvalidated: (event) => {
+      invalidations.push(event);
+    },
+  });
+
+  const started = service.start({
+    projectId: "project-2",
+    creonowRootPath: "/tmp/project-2/.creonow",
+  });
+  assert.equal(started.ok, true);
+  const watcher = createdWatchers[0];
+  assert.ok(watcher, "expected watcher to be created");
+  assert.equal(watcher.listenerCount("error"), 1);
+
+  watcher.emit("error", new Error("broken watch"));
+
+  assert.equal(watcher.listenerCount("error"), 0);
+  assert.equal(service.isWatching({ projectId: "project-2" }), false);
+  assert.deepEqual(invalidations, [
+    {
+      projectId: "project-2",
+      reason: "error",
+    },
+  ]);
+});
+
+runScenario("AUD-C15-S3 repeated create-stop cycles should not leak listeners", () => {
+  const createdWatchers: FakeWatcher[] = [];
+  const service = createCreonowWatchService({
+    logger: createLogger(),
+    watchFactory: (() => {
+      const watcher = new FakeWatcher();
+      createdWatchers.push(watcher);
+      return watcher as unknown as fs.FSWatcher;
+    }) as typeof fs.watch,
+  });
+
+  for (let i = 0; i < 5; i += 1) {
+    const projectId = `project-${i.toString()}`;
+    const started = service.start({
+      projectId,
+      creonowRootPath: `/tmp/${projectId}/.creonow`,
+    });
+    assert.equal(started.ok, true);
+    const watcher = createdWatchers[i];
+    assert.ok(watcher, `expected watcher #${i.toString()} to exist`);
+    assert.equal(watcher.listenerCount("error"), 1);
+
+    const stopped = service.stop({ projectId });
+    assert.equal(stopped.ok, true);
+    assert.equal(watcher.listenerCount("error"), 0);
+  }
+});

--- a/apps/desktop/main/src/services/context/watchService.ts
+++ b/apps/desktop/main/src/services/context/watchService.ts
@@ -24,7 +24,10 @@ export function createCreonowWatchService(deps: {
   watchFactory?: typeof fs.watch;
   onWatcherInvalidated?: (args: { projectId: string; reason: "error" }) => void;
 }): CreonowWatchService {
-  const watchers = new Map<string, fs.FSWatcher>();
+  const watchers = new Map<
+    string,
+    { watcher: fs.FSWatcher; onError: (error: unknown) => void }
+  >();
   const watchFactory = deps.watchFactory ?? fs.watch;
   const supportsRecursiveWatch =
     process.platform === "win32" || process.platform === "darwin";
@@ -69,22 +72,24 @@ export function createCreonowWatchService(deps: {
             // Intentionally ignored in P0: renderer will pull fresh context on demand.
           },
         );
-        watcher.on("error", (error) => {
+        const onError = (error: unknown): void => {
           deps.logger.error("context_watch_error", {
             projectId,
             code: "IO_ERROR",
             message: error instanceof Error ? error.message : String(error),
           });
+          watcher.removeListener("error", onError);
           safeClose(watcher);
-          if (watchers.get(projectId) === watcher) {
+          if (watchers.get(projectId)?.watcher === watcher) {
             watchers.delete(projectId);
           }
           deps.onWatcherInvalidated?.({
             projectId,
             reason: "error",
           });
-        });
-        watchers.set(projectId, watcher);
+        };
+        watcher.on("error", onError);
+        watchers.set(projectId, { watcher, onError });
         return { ok: true, data: { watching: true } };
       } catch (error) {
         deps.logger.error("context_watch_start_failed", {
@@ -101,12 +106,13 @@ export function createCreonowWatchService(deps: {
         return ipcError("INVALID_ARGUMENT", "projectId is required");
       }
 
-      const watcher = watchers.get(projectId);
-      if (!watcher) {
+      const entry = watchers.get(projectId);
+      if (!entry) {
         return { ok: true, data: { watching: false } };
       }
 
-      safeClose(watcher);
+      entry.watcher.removeListener("error", entry.onError);
+      safeClose(entry.watcher);
       watchers.delete(projectId);
       return { ok: true, data: { watching: false } };
     },

--- a/openspec/_ops/task_runs/ISSUE-679.md
+++ b/openspec/_ops/task_runs/ISSUE-679.md
@@ -1,0 +1,73 @@
+# ISSUE-679
+
+更新时间：2026-02-27 15:30
+
+## Links
+
+- Issue: #679
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/679
+- Branch: `task/679-audit-memory-leak-prevention`
+- PR: TBD
+
+## Plan
+
+- [x] 审阅 OpenSpec change proposal/spec（`audit-memory-leak-prevention`）与相关实现文件
+- [x] Red：补充 watcher listener 清理测试与全局异常处理 dedup 测试，并验证失败
+- [x] Green：在 `watchService.ts` 显式移除 `error` 监听器；在 `globalExceptionHandlers.ts` 增加防重复注册
+- [x] 回归：本任务相关测试通过（watchService + globalExceptionHandlers）
+- [x] 执行 `typecheck` / `lint` / `apps/desktop test:run` / `test:unit` 并记录真实结果
+
+## Runs
+
+### 2026-02-27 Red: watcher close 未清理 error 监听器（预期失败）
+
+- Command: `pnpm exec tsx apps/desktop/main/src/services/context/__tests__/watchService.listener-cleanup.test.ts`
+- Exit code: `1`
+- Key output: `AUD-C15-S1 ... Expected values to be strictly equal: 1 !== 0`
+
+### 2026-02-27 Red: global exception handlers 重复注册（预期失败）
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/global-exception-handlers.dedup.test.ts`
+- Exit code: `1`
+- Key output: `AUD-C15-S5 ... Expected values to be strictly equal: 3 !== 1`
+
+### 2026-02-27 Green: 本任务相关回归测试通过
+
+- Command: `pnpm exec tsx apps/desktop/main/src/services/context/__tests__/watchService.listener-cleanup.test.ts`
+- Exit code: `0`
+
+- Command: `pnpm exec tsx apps/desktop/main/src/services/context/__tests__/watchService.error-recovery.test.ts`
+- Exit code: `0`
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/global-exception-handlers.dedup.test.ts`
+- Exit code: `0`
+
+- Command: `pnpm exec tsx apps/desktop/main/src/__tests__/global-exception-handlers.contract.test.ts`
+- Exit code: `0`
+
+### 2026-02-27 验证命令结果（clean workspace re-verification）
+
+- Command: `pnpm typecheck`
+- Exit code: `0`
+
+- Command: `pnpm lint`
+- Exit code: `0`
+- Key output: `0 errors, 67 warnings`
+
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `177 files, 1526 tests passed`
+
+- Command: `pnpm test:unit`
+- Exit code: `0`
+- Key output: `7 files, 23 tests passed`
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 09d22b827b888b3091461dbf2b7e6989bbb75abb
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

- `watchService.ts`: watcher 关闭时显式移除 error 监听器，防止监听器泄漏
- `globalExceptionHandlers.ts`: 添加防重复注册机制，多次调用不累积 process 监听器
- 新增单元测试覆盖两处修复

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（67 warnings，baseline 68）
- [x] `pnpm -C apps/desktop test:run` 通过（176 files, 1521 tests）
- [x] `pnpm test:unit` 通过

## OpenSpec

- Change: `openspec/changes/audit-memory-leak-prevention/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-679.md`

Closes #679