### PR TITLE
fix: standardize backend error messages to English (#678)

### DIFF
--- a/apps/desktop/main/src/ipc/runtime-validation.ts
+++ b/apps/desktop/main/src/ipc/runtime-validation.ts
@@ -287,7 +287,7 @@ function toValidationError(
       ok: false,
       error: {
         code: "PROJECT_IPC_SCHEMA_INVALID",
-        message: "项目请求参数不符合契约",
+        message: "Project request payload does not match IPC contract",
         traceId: randomUUID(),
         details: issues,
       },
@@ -298,7 +298,7 @@ function toValidationError(
     ok: false,
     error: {
       code: "VALIDATION_ERROR",
-      message: "请求参数不符合契约",
+      message: "Request payload does not match IPC contract",
       details: issues,
     },
   };
@@ -319,7 +319,7 @@ function toTimeoutError(timeoutMs: number): IpcResponse<never> {
     ok: false,
     error: {
       code: "IPC_TIMEOUT",
-      message: `请求超时（${timeoutMs}ms）`,
+      message: `Request timed out (${timeoutMs}ms)`,
     },
   };
 }
@@ -331,7 +331,7 @@ function toForbiddenError(
     ok: false,
     error: {
       code: "FORBIDDEN",
-      message: "调用方未授权",
+      message: "Caller is not authorized",
       details: {
         reason: decision.reason,
         ...decision.details,
@@ -363,7 +363,7 @@ function sanitizeErrorEnvelope(rawError: IpcError): IpcError {
   if (!isIpcErrorCode(rawError.code)) {
     return {
       code: "INTERNAL_ERROR",
-      message: "内部错误",
+      message: "Internal error",
     };
   }
 
@@ -476,7 +476,7 @@ export function wrapIpcRequestResponse(
           stage: "envelope",
           responseType: getValueType(raw),
         });
-        return toInternalError("响应数据不符合契约");
+        return toInternalError("Response payload does not match IPC contract");
       }
 
       if (!raw.ok) {
@@ -492,7 +492,7 @@ export function wrapIpcRequestResponse(
           channel: args.channel,
           issueCount: responseIssues.length,
         });
-        return toInternalError("响应数据不符合契约");
+        return toInternalError("Response payload does not match IPC contract");
       }
 
       return raw;
@@ -518,7 +518,7 @@ export function wrapIpcRequestResponse(
         channel: args.channel,
         message: error instanceof Error ? error.message : String(error),
       });
-      return toInternalError("内部错误");
+      return toInternalError("Internal error");
     }
   };
 }
@@ -553,7 +553,7 @@ export function createValidatedIpcMain(
         channel,
       });
       args.ipcMain.handle(channel, async () =>
-        toInternalError("IPC 通道缺少契约定义"),
+        toInternalError("IPC channel schema is missing from contract"),
       );
       return;
     }

--- a/apps/desktop/main/src/services/ai/providerResolver.ts
+++ b/apps/desktop/main/src/services/ai/providerResolver.ts
@@ -387,7 +387,10 @@ export function createProviderResolver(deps: {
           env: args.env,
         });
         if (!primary) {
-          return ipcError("AI_NOT_CONFIGURED", "请先在设置中配置 AI 服务");
+          return ipcError(
+            "AI_NOT_CONFIGURED",
+            "AI service is not configured. Configure it in Settings first.",
+          );
         }
         const backup = resolveSettingsBackupProvider({
           settings: proxyFromSettings,
@@ -437,7 +440,10 @@ export function createProviderResolver(deps: {
         : undefined;
 
     if (!isE2E(args.env) && provider !== "proxy" && !apiKey) {
-      return ipcError("AI_NOT_CONFIGURED", "请先在设置中配置 AI 服务");
+      return ipcError(
+        "AI_NOT_CONFIGURED",
+        "AI service is not configured. Configure it in Settings first.",
+      );
     }
 
     return {

--- a/apps/desktop/renderer/src/lib/errorMessages.test.ts
+++ b/apps/desktop/renderer/src/lib/errorMessages.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getUserFacingErrorMessage,
+  localizeIpcError,
+} from "./errorMessages";
+
+describe("errorMessages", () => {
+  it("maps backend english message to chinese by error code", () => {
+    expect(
+      getUserFacingErrorMessage({
+        code: "VALIDATION_ERROR",
+        message: 'Validation failed for field "name"',
+      }),
+    ).toBe("请求参数不符合契约");
+
+    expect(
+      getUserFacingErrorMessage({
+        code: "AI_NOT_CONFIGURED",
+        message: "AI service is not configured",
+      }),
+    ).toBe("请先在设置中配置 AI 服务");
+  });
+
+  it("preserves timeout detail when mapping IPC_TIMEOUT", () => {
+    expect(
+      getUserFacingErrorMessage({
+        code: "IPC_TIMEOUT",
+        message: "Request timed out (30000ms)",
+      }),
+    ).toBe("请求超时（30000ms）");
+  });
+
+  it("falls back to backend message when code is not mapped", () => {
+    expect(
+      getUserFacingErrorMessage({
+        code: "SKILL_TIMEOUT",
+        message: "Skill timed out",
+      }),
+    ).toBe("Skill timed out");
+  });
+
+  it("localizeIpcError keeps original structure and replaces message", () => {
+    const localized = localizeIpcError({
+      code: "FORBIDDEN",
+      message: "Caller is not authorized",
+      details: { reason: "origin_not_allowed" },
+      traceId: "trace-1",
+      retryable: false,
+    });
+
+    expect(localized).toEqual({
+      code: "FORBIDDEN",
+      message: "调用方未授权",
+      details: { reason: "origin_not_allowed" },
+      traceId: "trace-1",
+      retryable: false,
+    });
+  });
+});

--- a/apps/desktop/renderer/src/lib/errorMessages.ts
+++ b/apps/desktop/renderer/src/lib/errorMessages.ts
@@ -1,0 +1,44 @@
+import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+
+type ErrorMessageResolver = (backendMessage: string) => string;
+
+const TIMEOUT_DETAIL_PATTERN = /\((\d+ms)\)/u;
+
+const USER_FACING_MESSAGE_BY_CODE: Partial<
+  Record<IpcErrorCode, ErrorMessageResolver>
+> = {
+  PROJECT_IPC_SCHEMA_INVALID: () => "项目请求参数不符合契约",
+  VALIDATION_ERROR: () => "请求参数不符合契约",
+  FORBIDDEN: () => "调用方未授权",
+  INTERNAL_ERROR: () => "内部错误",
+  AI_NOT_CONFIGURED: () => "请先在设置中配置 AI 服务",
+  IPC_TIMEOUT: (backendMessage) => {
+    const detail = TIMEOUT_DETAIL_PATTERN.exec(backendMessage)?.[1];
+    return detail ? `请求超时（${detail}）` : "请求超时";
+  },
+};
+
+export function getUserFacingErrorMessage(error: {
+  code: IpcErrorCode;
+  message: string;
+}): string {
+  const resolver = USER_FACING_MESSAGE_BY_CODE[error.code];
+  if (!resolver) {
+    return error.message;
+  }
+  return resolver(error.message);
+}
+
+export function localizeIpcError(error: IpcError): IpcError {
+  const localizedMessage = getUserFacingErrorMessage({
+    code: error.code,
+    message: error.message,
+  });
+  if (localizedMessage === error.message) {
+    return error;
+  }
+  return {
+    ...error,
+    message: localizedMessage,
+  };
+}

--- a/apps/desktop/renderer/src/lib/ipcClient.test.ts
+++ b/apps/desktop/renderer/src/lib/ipcClient.test.ts
@@ -62,6 +62,24 @@ describe("ipcClient.invoke", () => {
     expect(result).toEqual({ ok: true, data: {} });
   });
 
+  it("localizes backend error message by stable error code", async () => {
+    setCreonowInvoke(async () => ({
+      ok: false,
+      error: {
+        code: "AI_NOT_CONFIGURED",
+        message: "AI service is not configured",
+      },
+    }));
+
+    const result = await invoke("app:system:ping", {});
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error.code).toBe("AI_NOT_CONFIGURED");
+    expect(result.error.message).toBe("请先在设置中配置 AI 服务");
+  });
+
   it("handles non-Error throwables", async () => {
     setCreonowInvoke(async () => {
       throw "boom";

--- a/apps/desktop/renderer/src/lib/ipcClient.ts
+++ b/apps/desktop/renderer/src/lib/ipcClient.ts
@@ -4,6 +4,7 @@ import type {
   IpcInvokeResult,
   IpcRequest,
 } from "@shared/types/ipc-generated";
+import { localizeIpcError } from "./errorMessages";
 
 function toInvokeError(message: string, details?: unknown): IpcError {
   return {
@@ -51,7 +52,14 @@ export async function safeInvoke<C extends IpcChannel>(
         error: toInvokeError("Invalid IPC response shape"),
       };
     }
-    return response as IpcInvokeResult<C>;
+    const envelope = response as IpcInvokeResult<C>;
+    if (!envelope.ok) {
+      return {
+        ok: false,
+        error: localizeIpcError(envelope.error),
+      } as IpcInvokeResult<C>;
+    }
+    return envelope;
   } catch (error) {
     return {
       ok: false,

--- a/apps/desktop/tests/lint/backend-error-language-guard.test.ts
+++ b/apps/desktop/tests/lint/backend-error-language-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const CJK_PATTERN = /[\u4e00-\u9fff]/gu;
+
+const BACKEND_ERROR_FILES = [
+  "apps/desktop/main/src/ipc/runtime-validation.ts",
+  "apps/desktop/main/src/services/ai/providerResolver.ts",
+] as const;
+
+function findChineseFragments(source: string): string[] {
+  const matches = source.match(CJK_PATTERN);
+  return [...new Set(matches ?? [])].sort((a, b) => a.localeCompare(b));
+}
+
+describe("AUD-C13-S3 backend error language guard", () => {
+  it("detects chinese fragments in fixtures", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "backend-error-lang-"));
+    const fixture = path.join(tempDir, "fixture.ts");
+    await writeFile(
+      fixture,
+      'throw new Error("请求参数不符合契约");\n',
+      "utf8",
+    );
+
+    const source = await readFile(fixture, "utf8");
+    const fragments = findChineseFragments(source);
+
+    expect(fragments.length).toBeGreaterThan(0);
+  });
+
+  it("repo backend target files should contain no chinese characters", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+
+    const violations: string[] = [];
+    for (const relativePath of BACKEND_ERROR_FILES) {
+      const absolutePath = path.join(repoRoot, relativePath);
+      const source = await readFile(absolutePath, "utf8");
+      const fragments = findChineseFragments(source);
+      if (fragments.length > 0) {
+        violations.push(
+          `${relativePath}: ${fragments.join(" ")}`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(
+        `Backend error language violations (AUD-C13-S3):\n${violations
+          .map((line) => `- ${line}`)
+          .join("\n")}`,
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
+++ b/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
@@ -109,7 +109,7 @@ async function invokeWrapped(
     assert.fail("expected error envelope");
   }
   assert.equal(res.error.code, "INTERNAL_ERROR");
-  assert.equal(res.error.message, "响应数据不符合契约");
+  assert.equal(res.error.message, "Response payload does not match IPC contract");
 }
 
 // S4: 未捕获异常统一映射为 INTERNAL_ERROR [ADDED]
@@ -133,7 +133,7 @@ async function invokeWrapped(
     assert.fail("expected error envelope");
   }
   assert.equal(res.error.code, "INTERNAL_ERROR");
-  assert.equal(res.error.message, "内部错误");
+  assert.equal(res.error.message, "Internal error");
   assert.equal(
     JSON.stringify(res).includes("secret-stack-should-not-leak"),
     false,

--- a/openspec/_ops/task_runs/ISSUE-678.md
+++ b/openspec/_ops/task_runs/ISSUE-678.md
@@ -1,0 +1,38 @@
+# ISSUE-678
+
+更新时间：2026-02-27 14:00
+
+## Links
+
+- Issue: #678
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/678
+- Branch: `task/678-audit-error-language-standardization-wt`
+- PR: TBD
+
+## Plan
+
+- [x] runtime-validation.ts 6 处中文错误消息替换为英文
+- [x] providerResolver.ts 2 处中文错误消息替换为英文
+- [x] renderer 翻译映射层 errorMessages.ts 建立
+- [x] ipcClient.ts 统一本地化
+- [x] 回归测试 backend-error-language-guard.test.ts
+- [x] typecheck / lint / test:run / test:unit 全部通过
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (177 files, 1526 tests)
+- pnpm test:unit: 通过 (7 files, 23 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 83da1fd6f5a22b97c35a66d09744b3f4f942cdd1
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

- `runtime-validation.ts` 6 处中文错误消息替换为英文 error code + message
- `providerResolver.ts` 2 处中文错误消息替换为英文 error code + message
- 新增 renderer 翻译映射层 `errorMessages.ts`，ipcClient 统一本地化
- 回归测试防止新增硬编码中文错误消息

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（67 warnings，baseline 68）
- [x] `pnpm -C apps/desktop test:run` 通过（177 files, 1526 tests）
- [x] `pnpm test:unit` 通过（7 files, 23 tests）

## OpenSpec

- Change: `openspec/changes/audit-error-language-standardization/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-678.md`

Closes #678