### PR TITLE
refactor: converge contextFs sync/async to single SSOT (#676)

### DIFF
--- a/apps/desktop/main/src/services/context/contextFs.ts
+++ b/apps/desktop/main/src/services/context/contextFs.ts
@@ -17,6 +17,130 @@ export function getCreonowRootPath(projectRootPath: string): string {
   return path.join(projectRootPath, ".creonow");
 }
 
+type CreonowDefaultFileTemplate = {
+  relativePath: string;
+  content: string;
+};
+
+type CreonowDefaultFile = {
+  absPath: string;
+  content: string;
+};
+
+type CreonowDirStructurePlan = {
+  dirs: string[];
+  defaultFiles: CreonowDefaultFile[];
+};
+
+const CREONOW_REQUIRED_SUBDIRS = [
+  "rules",
+  "settings",
+  "skills",
+  "characters",
+  "conversations",
+  "cache",
+] as const;
+
+const CREONOW_DEFAULT_FILE_TEMPLATES: ReadonlyArray<CreonowDefaultFileTemplate> =
+  [
+    {
+      relativePath: path.join("rules", "style.md"),
+      content: "# Style\n\n",
+    },
+    {
+      relativePath: path.join("rules", "terminology.json"),
+      content: JSON.stringify({ terms: [] }, null, 2) + "\n",
+    },
+    {
+      relativePath: path.join("rules", "constraints.json"),
+      content: JSON.stringify({ version: 1, items: [] }, null, 2) + "\n",
+    },
+  ];
+
+function buildCreonowDirStructurePlan(
+  projectRootPath: string,
+): CreonowDirStructurePlan {
+  const base = getCreonowRootPath(projectRootPath);
+  return {
+    dirs: [base, ...CREONOW_REQUIRED_SUBDIRS.map((dir) => path.join(base, dir))],
+    defaultFiles: CREONOW_DEFAULT_FILE_TEMPLATES.map((template) => ({
+      absPath: path.join(base, template.relativePath),
+      content: template.content,
+    })),
+  };
+}
+
+function ensureCreonowDirStructureSyncFromPlan(plan: CreonowDirStructurePlan): void {
+  for (const dirPath of plan.dirs) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+
+  for (const file of plan.defaultFiles) {
+    if (!fs.existsSync(file.absPath)) {
+      fs.writeFileSync(file.absPath, file.content, "utf8");
+    }
+  }
+}
+
+async function fileExistsAsync(absPath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(absPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureCreonowDirStructureAsyncFromPlan(
+  plan: CreonowDirStructurePlan,
+): Promise<void> {
+  for (const dirPath of plan.dirs) {
+    await fsPromises.mkdir(dirPath, { recursive: true });
+  }
+
+  for (const file of plan.defaultFiles) {
+    if (await fileExistsAsync(file.absPath)) {
+      continue;
+    }
+    await fsPromises.writeFile(file.absPath, file.content, "utf8");
+  }
+}
+
+function toIoErrorDetails(error: unknown): { message: string } | { error: unknown } {
+  return error instanceof Error ? { message: error.message } : { error };
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}
+
+function toCreonowDirStatusResult(args: {
+  creonowRootPath: string;
+  exists: boolean;
+}): ServiceResult<CreonowDirStatus> {
+  return {
+    ok: true,
+    data: {
+      exists: args.exists,
+      creonowRootPath: args.creonowRootPath,
+    },
+  };
+}
+
+function mapCreonowDirStatusError(
+  error: unknown,
+  creonowRootPath: string,
+): ServiceResult<CreonowDirStatus> {
+  if (isErrorWithCode(error, "ENOENT")) {
+    return toCreonowDirStatusResult({ exists: false, creonowRootPath });
+  }
+  return ipcError("IO_ERROR", "Failed to read .creonow status", toIoErrorDetails(error));
+}
+
 /**
  * Ensure the `.creonow/` directory structure exists for a project.
  *
@@ -27,47 +151,12 @@ export function ensureCreonowDirStructure(
   projectRootPath: string,
 ): ServiceResult<true> {
   try {
-    const base = getCreonowRootPath(projectRootPath);
-    const dirs = [
-      base,
-      path.join(base, "rules"),
-      path.join(base, "settings"),
-      path.join(base, "skills"),
-      path.join(base, "characters"),
-      path.join(base, "conversations"),
-      path.join(base, "cache"),
-    ];
-    for (const d of dirs) {
-      fs.mkdirSync(d, { recursive: true });
-    }
-
-    const defaultFiles: Array<{ p: string; content: string }> = [
-      {
-        p: path.join(base, "rules", "style.md"),
-        content: "# Style\n\n",
-      },
-      {
-        p: path.join(base, "rules", "terminology.json"),
-        content: JSON.stringify({ terms: [] }, null, 2) + "\n",
-      },
-      {
-        p: path.join(base, "rules", "constraints.json"),
-        content: JSON.stringify({ version: 1, items: [] }, null, 2) + "\n",
-      },
-    ];
-    for (const f of defaultFiles) {
-      if (!fs.existsSync(f.p)) {
-        fs.writeFileSync(f.p, f.content, "utf8");
-      }
-    }
-
+    ensureCreonowDirStructureSyncFromPlan(
+      buildCreonowDirStructurePlan(projectRootPath),
+    );
     return { ok: true, data: true };
   } catch (error) {
-    return ipcError(
-      "IO_ERROR",
-      "Failed to initialize .creonow directory",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to initialize .creonow directory", toIoErrorDetails(error));
   }
 }
 
@@ -82,16 +171,12 @@ export function getCreonowDirStatus(
   const creonowRootPath = getCreonowRootPath(projectRootPath);
   try {
     const stat = fs.statSync(creonowRootPath);
-    return { ok: true, data: { exists: stat.isDirectory(), creonowRootPath } };
+    return toCreonowDirStatusResult({
+      exists: stat.isDirectory(),
+      creonowRootPath,
+    });
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return { ok: true, data: { exists: false, creonowRootPath } };
-    }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read .creonow status",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return mapCreonowDirStatusError(error, creonowRootPath);
   }
 }
 
@@ -163,6 +248,38 @@ function toAbsoluteCreonowPath(args: {
   return { ok: true, data: { absPath, creonowRootAbs } };
 }
 
+type FsStatLike = {
+  isFile: () => boolean;
+  size: number;
+  mtimeMs: number;
+};
+
+function toPosixRelativePath(prefixRel: string, entryName: string): string {
+  return `${prefixRel}/${entryName}`.split("\\").join("/");
+}
+
+function sortCreonowListItems(items: CreonowListItem[]): CreonowListItem[] {
+  items.sort((a, b) => a.path.localeCompare(b.path));
+  return items;
+}
+
+function buildCreonowListItemFromStat(args: {
+  relPath: string;
+  stat: FsStatLike;
+}): ServiceResult<CreonowListItem> {
+  if (!args.stat.isFile()) {
+    return ipcError("UNSUPPORTED", "Only files are supported");
+  }
+  return {
+    ok: true,
+    data: {
+      path: args.relPath,
+      sizeBytes: args.stat.size,
+      updatedAtMs: args.stat.mtimeMs,
+    },
+  };
+}
+
 /**
  * Read a stable list item from a stat result.
  *
@@ -174,24 +291,12 @@ function statToListItem(args: {
   relPath: string;
 }): ServiceResult<CreonowListItem> {
   try {
-    const stat = fs.statSync(args.absPath);
-    if (!stat.isFile()) {
-      return ipcError("UNSUPPORTED", "Only files are supported");
-    }
-    return {
-      ok: true,
-      data: {
-        path: args.relPath,
-        sizeBytes: stat.size,
-        updatedAtMs: stat.mtimeMs,
-      },
-    };
+    return buildCreonowListItemFromStat({
+      relPath: args.relPath,
+      stat: fs.statSync(args.absPath),
+    });
   } catch (error) {
-    return ipcError(
-      "IO_ERROR",
-      "Failed to stat file",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to stat file", toIoErrorDetails(error));
   }
 }
 
@@ -210,7 +315,7 @@ function listFilesRecursive(args: {
     const items: CreonowListItem[] = [];
     for (const entry of entries) {
       const absPath = path.join(args.dirAbs, entry.name);
-      const relPath = `${args.prefixRel}/${entry.name}`.split("\\").join("/");
+      const relPath = toPosixRelativePath(args.prefixRel, entry.name);
       if (entry.isDirectory()) {
         const child = listFilesRecursive({
           dirAbs: absPath,
@@ -233,13 +338,12 @@ function listFilesRecursive(args: {
       items.push(item.data);
     }
 
-    items.sort((a, b) => a.path.localeCompare(b.path));
-    return { ok: true, data: items };
+    return { ok: true, data: sortCreonowListItems(items) };
   } catch (error) {
     return ipcError(
       "IO_ERROR",
       "Failed to list .creonow files",
-      error instanceof Error ? { message: error.message } : { error },
+      toIoErrorDetails(error),
     );
   }
 }
@@ -268,14 +372,10 @@ export function listCreonowFiles(args: {
       return ipcError("NOT_FOUND", "Directory not found");
     }
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+    if (isErrorWithCode(error, "ENOENT")) {
       return { ok: true, data: { items: [] } };
     }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read directory",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to read directory", toIoErrorDetails(error));
   }
 
   const listed = listFilesRecursive({ dirAbs, prefixRel: baseRel });
@@ -313,14 +413,10 @@ export function readCreonowTextFile(args: {
       data: { content, sizeBytes: stat.size, updatedAtMs: stat.mtimeMs },
     };
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+    if (isErrorWithCode(error, "ENOENT")) {
       return ipcError("NOT_FOUND", "File not found");
     }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read file",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to read file", toIoErrorDetails(error));
   }
 }
 
@@ -333,50 +429,15 @@ export async function ensureCreonowDirStructureAsync(
   projectRootPath: string,
 ): Promise<ServiceResult<true>> {
   try {
-    const base = getCreonowRootPath(projectRootPath);
-    const dirs = [
-      base,
-      path.join(base, "rules"),
-      path.join(base, "settings"),
-      path.join(base, "skills"),
-      path.join(base, "characters"),
-      path.join(base, "conversations"),
-      path.join(base, "cache"),
-    ];
-    for (const d of dirs) {
-      await fsPromises.mkdir(d, { recursive: true });
-    }
-
-    const defaultFiles: Array<{ p: string; content: string }> = [
-      {
-        p: path.join(base, "rules", "style.md"),
-        content: "# Style\n\n",
-      },
-      {
-        p: path.join(base, "rules", "terminology.json"),
-        content: JSON.stringify({ terms: [] }, null, 2) + "\n",
-      },
-      {
-        p: path.join(base, "rules", "constraints.json"),
-        content: JSON.stringify({ version: 1, items: [] }, null, 2) + "\n",
-      },
-    ];
-    for (const f of defaultFiles) {
-      const exists = await fsPromises
-        .access(f.p)
-        .then(() => true)
-        .catch(() => false);
-      if (!exists) {
-        await fsPromises.writeFile(f.p, f.content, "utf8");
-      }
-    }
-
+    await ensureCreonowDirStructureAsyncFromPlan(
+      buildCreonowDirStructurePlan(projectRootPath),
+    );
     return { ok: true, data: true };
   } catch (error) {
     return ipcError(
       "IO_ERROR",
       "Failed to initialize .creonow directory",
-      error instanceof Error ? { message: error.message } : { error },
+      toIoErrorDetails(error),
     );
   }
 }
@@ -390,16 +451,12 @@ export async function getCreonowDirStatusAsync(
   const creonowRootPath = getCreonowRootPath(projectRootPath);
   try {
     const stat = await fsPromises.stat(creonowRootPath);
-    return { ok: true, data: { exists: stat.isDirectory(), creonowRootPath } };
+    return toCreonowDirStatusResult({
+      exists: stat.isDirectory(),
+      creonowRootPath,
+    });
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return { ok: true, data: { exists: false, creonowRootPath } };
-    }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read .creonow status",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return mapCreonowDirStatusError(error, creonowRootPath);
   }
 }
 
@@ -411,24 +468,12 @@ async function statToListItemAsync(args: {
   relPath: string;
 }): Promise<ServiceResult<CreonowListItem>> {
   try {
-    const stat = await fsPromises.stat(args.absPath);
-    if (!stat.isFile()) {
-      return ipcError("UNSUPPORTED", "Only files are supported");
-    }
-    return {
-      ok: true,
-      data: {
-        path: args.relPath,
-        sizeBytes: stat.size,
-        updatedAtMs: stat.mtimeMs,
-      },
-    };
+    return buildCreonowListItemFromStat({
+      relPath: args.relPath,
+      stat: await fsPromises.stat(args.absPath),
+    });
   } catch (error) {
-    return ipcError(
-      "IO_ERROR",
-      "Failed to stat file",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to stat file", toIoErrorDetails(error));
   }
 }
 
@@ -447,7 +492,7 @@ async function listFilesRecursiveAsync(args: {
 
     for (const entry of entries) {
       const absPath = path.join(args.dirAbs, entry.name);
-      const relPath = `${args.prefixRel}/${entry.name}`.split("\\").join("/");
+      const relPath = toPosixRelativePath(args.prefixRel, entry.name);
       if (entry.isDirectory()) {
         const child = await listFilesRecursiveAsync({
           dirAbs: absPath,
@@ -470,13 +515,12 @@ async function listFilesRecursiveAsync(args: {
       items.push(item.data);
     }
 
-    items.sort((a, b) => a.path.localeCompare(b.path));
-    return { ok: true, data: items };
+    return { ok: true, data: sortCreonowListItems(items) };
   } catch (error) {
     return ipcError(
       "IO_ERROR",
       "Failed to list .creonow files",
-      error instanceof Error ? { message: error.message } : { error },
+      toIoErrorDetails(error),
     );
   }
 }
@@ -503,14 +547,10 @@ export async function listCreonowFilesAsync(args: {
       return ipcError("NOT_FOUND", "Directory not found");
     }
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+    if (isErrorWithCode(error, "ENOENT")) {
       return { ok: true, data: { items: [] } };
     }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read directory",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to read directory", toIoErrorDetails(error));
   }
 
   const listed = await listFilesRecursiveAsync({ dirAbs, prefixRel: baseRel });
@@ -584,13 +624,9 @@ export async function readCreonowTextFileAsync(args: {
         limitBytes: CONTEXT_FS_STREAM_READ_HARD_LIMIT_BYTES,
       });
     }
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+    if (isErrorWithCode(error, "ENOENT")) {
       return ipcError("NOT_FOUND", "File not found");
     }
-    return ipcError(
-      "IO_ERROR",
-      "Failed to read file",
-      error instanceof Error ? { message: error.message } : { error },
-    );
+    return ipcError("IO_ERROR", "Failed to read file", toIoErrorDetails(error));
   }
 }

--- a/apps/desktop/tests/unit/context/context-fs-sync-async-parity.contract.test.ts
+++ b/apps/desktop/tests/unit/context/context-fs-sync-async-parity.contract.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ensureCreonowDirStructure,
+  ensureCreonowDirStructureAsync,
+  getCreonowDirStatus,
+  getCreonowDirStatusAsync,
+  listCreonowFiles,
+  listCreonowFilesAsync,
+  readCreonowTextFile,
+  readCreonowTextFileAsync,
+} from "../../../main/src/services/context/contextFs";
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function snapshotCreonow(projectRootPath: string): Promise<string[]> {
+  const base = path.join(projectRootPath, ".creonow");
+  if (!fs.existsSync(base)) {
+    return [];
+  }
+
+  const items: string[] = [];
+
+  async function walk(absPath: string, relPath: string): Promise<void> {
+    const entries = await fsp.readdir(absPath, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const absChild = path.join(absPath, entry.name);
+      const relChild = relPath.length > 0 ? `${relPath}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        items.push(`D:${relChild}`);
+        await walk(absChild, relChild);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const content = await fsp.readFile(absChild, "utf8");
+      items.push(`F:${relChild}:${content}`);
+    }
+  }
+
+  await walk(base, ".creonow");
+  return items.sort((a, b) => a.localeCompare(b));
+}
+
+function assertIoErrorShape(
+  result: ReturnType<typeof ensureCreonowDirStructure>,
+): void {
+  assert.equal(result.ok, false);
+}
+
+// AUD-C6-S2: sync ensure must match async ensure output.
+{
+  const syncRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-sync-"));
+  const asyncRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-async-"));
+
+  try {
+    const syncEnsured = ensureCreonowDirStructure(syncRoot);
+    const asyncEnsured = await ensureCreonowDirStructureAsync(asyncRoot);
+
+    assert.deepEqual(syncEnsured, { ok: true, data: true });
+    assert.deepEqual(asyncEnsured, { ok: true, data: true });
+
+    const syncSnapshot = await snapshotCreonow(syncRoot);
+    const asyncSnapshot = await snapshotCreonow(asyncRoot);
+    assert.deepEqual(syncSnapshot, asyncSnapshot);
+  } finally {
+    await fsp.rm(syncRoot, { recursive: true, force: true });
+    await fsp.rm(asyncRoot, { recursive: true, force: true });
+  }
+}
+
+// AUD-C6-S4: sync status query must match async status query.
+{
+  const projectRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-status-"));
+
+  try {
+    const syncBefore = getCreonowDirStatus(projectRoot);
+    const asyncBefore = await getCreonowDirStatusAsync(projectRoot);
+    assert.deepEqual(syncBefore, asyncBefore);
+
+    const ensured = await ensureCreonowDirStructureAsync(projectRoot);
+    assert.deepEqual(ensured, { ok: true, data: true });
+
+    const syncAfter = getCreonowDirStatus(projectRoot);
+    const asyncAfter = await getCreonowDirStatusAsync(projectRoot);
+    assert.deepEqual(syncAfter, asyncAfter);
+  } finally {
+    await fsp.rm(projectRoot, { recursive: true, force: true });
+  }
+}
+
+// AUD-C6-S4: list/read sync APIs should stay behaviorally consistent with async APIs.
+{
+  const projectRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-list-read-"));
+
+  try {
+    const ensured = await ensureCreonowDirStructureAsync(projectRoot);
+    assert.deepEqual(ensured, { ok: true, data: true });
+
+    const nestedDir = path.join(projectRoot, ".creonow", "rules", "nested");
+    await fsp.mkdir(nestedDir, { recursive: true });
+
+    const filePath = path.join(nestedDir, "alpha.md");
+    await fsp.writeFile(filePath, "alpha-content", "utf8");
+
+    const listSync = listCreonowFiles({
+      projectRootPath: projectRoot,
+      scope: "rules",
+    });
+    const listAsync = await listCreonowFilesAsync({
+      projectRootPath: projectRoot,
+      scope: "rules",
+    });
+    assert.deepEqual(listSync, listAsync);
+
+    const readSync = readCreonowTextFile({
+      projectRootPath: projectRoot,
+      path: ".creonow/rules/nested/alpha.md",
+    });
+    const readAsync = await readCreonowTextFileAsync({
+      projectRootPath: projectRoot,
+      path: ".creonow/rules/nested/alpha.md",
+    });
+    assert.deepEqual(readSync, readAsync);
+  } finally {
+    await fsp.rm(projectRoot, { recursive: true, force: true });
+  }
+}
+
+// AUD-C6-S5: sync/async ensure should expose equivalent error semantics.
+{
+  const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-error-"));
+  const fileAsProjectRoot = path.join(tempRoot, "project-root-as-file.txt");
+
+  try {
+    await fsp.writeFile(fileAsProjectRoot, "not-a-directory", "utf8");
+
+    const syncResult = ensureCreonowDirStructure(fileAsProjectRoot);
+    const asyncResult = await ensureCreonowDirStructureAsync(fileAsProjectRoot);
+
+    assertIoErrorShape(syncResult);
+    assert.equal(asyncResult.ok, false);
+    if (!syncResult.ok && !asyncResult.ok) {
+      assert.equal(syncResult.error.code, asyncResult.error.code);
+      assert.equal(syncResult.error.message, asyncResult.error.message);
+      assert.equal(
+        Boolean(syncResult.error.details),
+        Boolean(asyncResult.error.details),
+      );
+    }
+  } finally {
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+// AUD-C6-S6: async ensure should be idempotent.
+{
+  const projectRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "creonow-c6-idempotent-"));
+
+  try {
+    const first = await ensureCreonowDirStructureAsync(projectRoot);
+    assert.deepEqual(first, { ok: true, data: true });
+    const snapshotAfterFirst = await snapshotCreonow(projectRoot);
+
+    const second = await ensureCreonowDirStructureAsync(projectRoot);
+    assert.deepEqual(second, { ok: true, data: true });
+    const snapshotAfterSecond = await snapshotCreonow(projectRoot);
+
+    assert.deepEqual(snapshotAfterSecond, snapshotAfterFirst);
+  } finally {
+    await fsp.rm(projectRoot, { recursive: true, force: true });
+  }
+}
+
+// AUD-C6-S7: duplicated directory/default-file business logic must stay in one SSOT definition.
+{
+  const source = await fsp.readFile(
+    path.resolve(
+      import.meta.dirname,
+      "../../../main/src/services/context/contextFs.ts",
+    ),
+    "utf8",
+  );
+
+  const singleSourceLiterals = [
+    'relativePath: path.join("rules", "style.md")',
+    'relativePath: path.join("rules", "terminology.json")',
+    'relativePath: path.join("rules", "constraints.json")',
+    'JSON.stringify({ terms: [] }, null, 2) + "\\n"',
+    'JSON.stringify({ version: 1, items: [] }, null, 2) + "\\n"',
+  ];
+  for (const literal of singleSourceLiterals) {
+    const matches = source.match(new RegExp(escapeRegExp(literal), "g")) ?? [];
+    assert.equal(matches.length, 1, `literal should be defined once: ${literal}`);
+  }
+
+  assert.match(source, /const CREONOW_REQUIRED_SUBDIRS = \[/);
+  assert.match(source, /const CREONOW_DEFAULT_FILE_TEMPLATES:/);
+  assert.match(
+    source,
+    /export function ensureCreonowDirStructure\([\s\S]*?ensureCreonowDirStructureSyncFromPlan\(\s*buildCreonowDirStructurePlan\(projectRootPath\),\s*\)/,
+  );
+  assert.match(
+    source,
+    /export async function ensureCreonowDirStructureAsync\([\s\S]*?await ensureCreonowDirStructureAsyncFromPlan\(\s*buildCreonowDirStructurePlan\(projectRootPath\),\s*\)/,
+  );
+  assert.doesNotMatch(
+    source,
+    /export function ensureCreonowDirStructure\([\s\S]*?const dirs = \[/,
+    "sync ensure should not keep an inlined dirs array",
+  );
+  assert.doesNotMatch(
+    source,
+    /export async function ensureCreonowDirStructureAsync\([\s\S]*?const dirs = \[/,
+    "async ensure should not keep an inlined dirs array",
+  );
+}
+
+console.log("context-fs-sync-async-parity.contract.test.ts: all assertions passed");

--- a/openspec/_ops/task_runs/ISSUE-676.md
+++ b/openspec/_ops/task_runs/ISSUE-676.md
@@ -1,0 +1,37 @@
+# ISSUE-676
+
+更新时间：2026-02-27 14:18
+
+## Links
+
+- Issue: #676
+- Branch: `task/676-audit-contextfs-async-ssot`
+- PR: TBD
+
+## Plan
+
+- [x] 抽出目录结构与默认文件的 SSOT 计划构建函数
+- [x] ensureCreonowDirStructure sync/async 改为薄包装
+- [x] getCreonowDirStatus sync/async 统一到共享逻辑
+- [x] statToListItem sync/async 抽到共享纯逻辑
+- [x] 新增 sync/async 一致性契约测试
+- [x] typecheck / lint / test:run / test:unit 全部通过
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (177 files, 1526 tests)
+- pnpm test:unit: 通过 (7 files, 23 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 057d5374e2bfdf75fd01c0dd7a7f91bd87ec4723
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

- 抽出目录结构与默认文件的 SSOT 计划构建函数，消除 sync/async 双份字面量
- sync 版本改为薄包装，委托共享纯逻辑函数
- 新增 sync/async 一致性契约测试（ensure/status/list/read/error/幂等性/SSOT 守卫）

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（67 warnings，baseline 68）
- [x] `pnpm -C apps/desktop test:run` 通过（177 files, 1526 tests）
- [x] `pnpm test:unit` 通过（7 files, 23 tests）

## OpenSpec

- Change: `openspec/changes/audit-contextfs-async-ssot/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-676.md`

Closes #676