### PR TITLE
refactor: unify shared runtime utils (nowTs, hash, tokenCount, constants) (#675)

### DIFF
--- a/apps/desktop/main/src/__tests__/unit/shared-runtime-utils-unification.guard.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/shared-runtime-utils-unification.guard.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { hashJson, hashText, sha256Hex } from "@shared/hashUtils";
+import { estimateUtf8TokenCount } from "@shared/tokenBudget";
+import { nowTs } from "@shared/timeUtils";
+
+type Hit = {
+  file: string;
+  line: number;
+  text: string;
+};
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "../../../../../..");
+const MAIN_SRC_ROOT = path.resolve(PROJECT_ROOT, "apps/desktop/main/src");
+const PRELOAD_SRC_ROOT = path.resolve(PROJECT_ROOT, "apps/desktop/preload/src");
+const AI_SERVICE_FILE = path.resolve(
+  PROJECT_ROOT,
+  "apps/desktop/main/src/services/ai/aiService.ts",
+);
+const SKILL_VALIDATOR_FILE = path.resolve(
+  PROJECT_ROOT,
+  "apps/desktop/main/src/services/skills/skillValidator.ts",
+);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (
+      entry.name === "node_modules" ||
+      entry.name === "dist" ||
+      entry.name === ".worktrees"
+    ) {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") {
+        continue;
+      }
+      out.push(...walk(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && /\.ts$/u.test(entry.name)) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function scan(args: { roots: string[]; pattern: RegExp }): Hit[] {
+  const hits: Hit[] = [];
+  for (const root of args.roots) {
+    for (const file of walk(root)) {
+      const text = readFileSync(file, "utf8");
+      const lines = text.split(/\r?\n/u);
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i] ?? "";
+        if (args.pattern.test(line)) {
+          hits.push({
+            file,
+            line: i + 1,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+function formatHits(hits: Hit[]): string {
+  if (hits.length === 0) {
+    return "";
+  }
+  return hits
+    .map((hit) => {
+      const relative = path.relative(PROJECT_ROOT, hit.file);
+      return `${relative}:${String(hit.line)} -> ${hit.text}`;
+    })
+    .join("\n");
+}
+
+function expectedSha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function expectedLegacyEstimate(text: string): number {
+  if (text.length === 0) {
+    return 0;
+  }
+  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
+}
+
+function main(): void {
+  const nowTsDefinitionHits = scan({
+    roots: [MAIN_SRC_ROOT, PRELOAD_SRC_ROOT],
+    pattern: /\b(function|const)\s+nowTs\b/u,
+  });
+  assert.equal(
+    nowTsDefinitionHits.length,
+    0,
+    `AUD-C5-S1/AUD-C5-S8: local nowTs definitions must be zero\n${formatHits(nowTsDefinitionHits)}`,
+  );
+
+  const before = Date.now();
+  const ts = nowTs();
+  const after = Date.now();
+  assert.equal(
+    ts >= before && ts <= after,
+    true,
+    "AUD-C5-S2: shared nowTs should stay consistent with Date.now",
+  );
+
+  const estimateDefinitionHits = scan({
+    roots: [MAIN_SRC_ROOT],
+    pattern: /\bfunction\s+(estimateTokenCount|estimateMessageTokens)\s*\(/u,
+  });
+  assert.equal(
+    estimateDefinitionHits.length,
+    0,
+    `AUD-C5-S3: local estimateTokenCount/estimateMessageTokens definitions must be zero\n${formatHits(estimateDefinitionHits)}`,
+  );
+
+  const estimateSamples = ["", "hello world", "你好，世界", "emoji🙂text"];
+  for (const sample of estimateSamples) {
+    assert.equal(
+      estimateUtf8TokenCount(sample),
+      expectedLegacyEstimate(sample),
+      `AUD-C5-S4: estimateUtf8TokenCount should stay consistent for sample '${sample}'`,
+    );
+  }
+
+  const hashDefinitionHits = scan({
+    roots: [MAIN_SRC_ROOT],
+    pattern: /\bfunction\s+(hashJson|sha256Hex|hashText)\s*\(/u,
+  });
+  assert.equal(
+    hashDefinitionHits.length,
+    0,
+    `AUD-C5-S5/AUD-C5-S8: local hash function definitions must be zero\n${formatHits(hashDefinitionHits)}`,
+  );
+
+  const hashSample = '{"a":1,"b":"x"}';
+  assert.equal(
+    sha256Hex(hashSample),
+    expectedSha256Hex(hashSample),
+    "AUD-C5-S5: sha256Hex behavior must stay unchanged",
+  );
+  assert.equal(
+    hashText(hashSample),
+    expectedSha256Hex(hashSample),
+    "AUD-C5-S5: hashText behavior must stay unchanged",
+  );
+  assert.equal(
+    hashJson(hashSample),
+    expectedSha256Hex(hashSample),
+    "AUD-C5-S5: hashJson behavior must stay unchanged",
+  );
+
+  const aiServiceSource = readFileSync(AI_SERVICE_FILE, "utf8");
+  assert.match(
+    aiServiceSource,
+    /max_tokens\s*:\s*DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE/u,
+    "AUD-C5-S6: aiService max_tokens should reference DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE",
+  );
+  assert.doesNotMatch(
+    aiServiceSource,
+    /max_tokens\s*:\s*256/u,
+    "AUD-C5-S6: aiService max_tokens should not use literal 256",
+  );
+
+  const skillValidatorSource = readFileSync(SKILL_VALIDATOR_FILE, "utf8");
+  assert.match(
+    skillValidatorSource,
+    /MAX_SKILL_TIMEOUT_MS/u,
+    "AUD-C5-S7: skillValidator should reference MAX_SKILL_TIMEOUT_MS",
+  );
+  assert.doesNotMatch(
+    skillValidatorSource,
+    /120000/u,
+    "AUD-C5-S7: skillValidator should not use literal 120000",
+  );
+
+  console.log(
+    "shared-runtime-utils-unification.guard.test.ts: all assertions passed",
+  );
+}
+
+main();

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -2,6 +2,8 @@
 import type Database from "better-sqlite3";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
+import { estimateUtf8TokenCount as estimateTokenCount } from "@shared/tokenBudget";
+import { nowTs } from "@shared/timeUtils";
 import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
@@ -140,25 +142,6 @@ type ModelPricing = {
   promptPer1kTokens: number;
   completionPer1kTokens: number;
 };
-
-/**
- * Return an epoch-ms timestamp for AI stream events.
- */
-function nowTs(): number {
-  return Date.now();
-}
-
-/**
- * Estimate token usage deterministically from UTF-8 bytes.
- *
- * Why: keep usage accounting stable without introducing provider-specific tokenizers.
- */
-function estimateTokenCount(text: string): number {
-  if (text.length === 0) {
-    return 0;
-  }
-  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
-}
 
 /**
  * Parse candidateCount input and enforce the fixed 1..5 range.

--- a/apps/desktop/main/src/ipc/contextAssembly.ts
+++ b/apps/desktop/main/src/ipc/contextAssembly.ts
@@ -1,7 +1,7 @@
-import { createHash } from "node:crypto";
 import type { IpcMain } from "electron";
 import type Database from "better-sqlite3";
 
+import { sha256Hex } from "@shared/hashUtils";
 import type { IpcResponse } from "@shared/types/ipc-generated";
 import { redactText } from "@shared/redaction/redact";
 import type { Logger } from "../logging/logger";
@@ -40,10 +40,6 @@ function normalizeCallerRole(role: unknown): string {
   }
   const normalized = role.trim().toLowerCase();
   return normalized.length > 0 ? normalized : "unknown";
-}
-
-function sha256Hex(value: string): string {
-  return createHash("sha256").update(value, "utf8").digest("hex");
 }
 
 function buildInputAudit(args: {

--- a/apps/desktop/main/src/ipc/pushBackpressure.ts
+++ b/apps/desktop/main/src/ipc/pushBackpressure.ts
@@ -1,4 +1,5 @@
 import type { AiStreamEvent } from "@shared/types/ai";
+import { nowTs } from "@shared/timeUtils";
 
 export type IpcPushBackpressureDropEvent = {
   droppedInWindow: number;
@@ -11,10 +12,6 @@ type CreateIpcPushBackpressureGateArgs = {
   now?: () => number;
   onDrop?: (event: IpcPushBackpressureDropEvent) => void;
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 /**
  * Build an event-rate gate that drops low-priority `chunk` events under pressure.

--- a/apps/desktop/main/src/logging/logger.ts
+++ b/apps/desktop/main/src/logging/logger.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { nowTs } from "@shared/timeUtils";
 
 export type LogLevel = "info" | "error";
 
@@ -15,13 +16,6 @@ export type Logger = {
   info: (event: string, data?: Record<string, unknown>) => void;
   error: (event: string, data?: Record<string, unknown>) => void;
 };
-
-/**
- * Return an epoch-ms timestamp for log records.
- */
-function nowTs(): number {
-  return Date.now();
-}
 
 /**
  * Best-effort append a JSONL record to disk.

--- a/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
+++ b/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 
 import type { IpcErrorCode } from "@shared/types/ipc-generated";
+import { nowTs } from "@shared/timeUtils";
 import type { Logger } from "../../logging/logger";
 import { ipcError, type ServiceResult } from "../shared/ipcResult";
 export type { ServiceResult };
@@ -79,10 +80,6 @@ const KEY_ANTH_BYOK_BASE_URL =
 const KEY_ANTH_BYOK_API_KEY =
   "creonow.ai.provider.anthropicByok.apiKey" as const;
 const ENCRYPTED_SECRET_PREFIX = "__safe_storage_v1__:";
-
-function nowTs(): number {
-  return Date.now();
-}
 
 type SettingsRow = { valueJson: string };
 

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -791,7 +791,7 @@ export function createAiService(deps: {
         },
         body: JSON.stringify({
           model: args.model,
-          max_tokens: 256,
+          max_tokens: DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE,
           system: args.runtimeMessages.systemText,
           messages: args.runtimeMessages.anthropicMessages,
           stream: false,
@@ -964,7 +964,7 @@ export function createAiService(deps: {
         },
         body: JSON.stringify({
           model: args.model,
-          max_tokens: 256,
+          max_tokens: DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE,
           system: args.runtimeMessages.systemText,
           messages: args.runtimeMessages.anthropicMessages,
           stream: true,

--- a/apps/desktop/main/src/services/ai/buildLLMMessages.ts
+++ b/apps/desktop/main/src/services/ai/buildLLMMessages.ts
@@ -12,6 +12,7 @@
  *
  * Design reference: audit/02 §3.2 — token budget management.
  */
+import { estimateUtf8TokenCount } from "@shared/tokenBudget";
 
 export type LLMMessage = {
   role: "system" | "user" | "assistant";
@@ -23,17 +24,7 @@ type HistoryMessage = {
   content: string;
 };
 
-/**
- * Estimate token count from text using deterministic UTF-8 byte approximation.
- *
- * Matches the existing estimateTokenCount in aiService.ts for consistency.
- */
-export function estimateMessageTokens(text: string): number {
-  if (text.length === 0) {
-    return 0;
-  }
-  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
-}
+export const estimateMessageTokens = estimateUtf8TokenCount;
 
 export function buildLLMMessages(args: {
   systemPrompt: string;

--- a/apps/desktop/main/src/services/ai/runtimeConfig.ts
+++ b/apps/desktop/main/src/services/ai/runtimeConfig.ts
@@ -1,8 +1,9 @@
 import { assembleSystemPrompt } from "./assembleSystemPrompt";
 import { GLOBAL_IDENTITY_PROMPT } from "./identityPrompt";
+export { estimateUtf8TokenCount as estimateTokenCount } from "@shared/tokenBudget";
 
 export const DEFAULT_SKILL_TIMEOUT_MS = 30_000;
-const MAX_SKILL_TIMEOUT_MS = 120_000;
+export const MAX_SKILL_TIMEOUT_MS = 120_000;
 export const DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE = 256;
 const DEFAULT_MAX_SKILL_OUTPUT_CHARS = 120_000;
 const DEFAULT_CHAT_HISTORY_TOKEN_BUDGET = 16_000;
@@ -28,13 +29,6 @@ export function modeSystemHint(mode: "agent" | "plan" | "ask"): string | null {
     return "Mode: agent\nAct as an autonomous writing assistant and make concrete edits.";
   }
   return null;
-}
-
-export function estimateTokenCount(text: string): number {
-  if (text.length === 0) {
-    return 0;
-  }
-  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
 }
 
 export function parseMaxSkillOutputChars(env: NodeJS.ProcessEnv): number {

--- a/apps/desktop/main/src/services/documents/documentCoreService.ts
+++ b/apps/desktop/main/src/services/documents/documentCoreService.ts
@@ -1,6 +1,8 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
+import { hashJson } from "@shared/hashUtils";
+import { nowTs } from "@shared/timeUtils";
 
 import type { Logger } from "../../logging/logger";
 import { deriveContent } from "./derive";
@@ -50,10 +52,6 @@ const DOCUMENT_TYPE_SET = new Set<DocumentType>([
 
 const DOCUMENT_STATUS_SET = new Set<DocumentStatus>(["draft", "final"]);
 
-function nowTs(): number {
-  return Date.now();
-}
-
 /**
  * Build a stable document domain error object.
  *
@@ -65,10 +63,6 @@ function documentError(
   details?: unknown,
 ): Err {
   return { ok: false, error: { code, message, details } };
-}
-
-function hashJson(json: string): string {
-  return createHash("sha256").update(json, "utf8").digest("hex");
 }
 
 function countWords(text: string): number {

--- a/apps/desktop/main/src/services/embedding/semanticChunkIndexService.ts
+++ b/apps/desktop/main/src/services/embedding/semanticChunkIndexService.ts
@@ -1,6 +1,5 @@
-import { createHash } from "node:crypto";
-
 import type { Logger } from "../../logging/logger";
+import { hashText } from "@shared/hashUtils";
 import type { EmbeddingService } from "./embeddingService";
 import {
   createSemanticChunkIndexCache,
@@ -84,10 +83,6 @@ function normalizeModel(args: {
 
 function makeChunkId(documentId: string, paragraphIndex: number): string {
   return `${documentId}:${paragraphIndex}`;
-}
-
-function hashText(text: string): string {
-  return createHash("sha256").update(text, "utf8").digest("hex");
 }
 
 function splitParagraphs(contentText: string): ParagraphSegment[] {

--- a/apps/desktop/main/src/services/memory/memoryService.ts
+++ b/apps/desktop/main/src/services/memory/memoryService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
+import { nowTs } from "@shared/timeUtils";
 
 import type { Logger } from "../../logging/logger";
 import { createUserMemoryVecService } from "./userMemoryVec";
@@ -113,10 +114,6 @@ const TYPE_RANK: Readonly<Record<MemoryType, number>> = {
   fact: 1,
   note: 2,
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function isMemoryType(x: string): x is MemoryType {
   return x === "preference" || x === "fact" || x === "note";

--- a/apps/desktop/main/src/services/memory/memoryTraceService.ts
+++ b/apps/desktop/main/src/services/memory/memoryTraceService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { nowTs } from "@shared/timeUtils";
 
 import { ipcError, type ServiceResult } from "../shared/ipcResult";
 export type { ServiceResult };
@@ -47,10 +48,6 @@ export type MemoryTraceService = {
     generationId: string;
   }) => GenerationTraceFeedback[];
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function cloneTrace(trace: GenerationTrace): GenerationTrace {
   return {

--- a/apps/desktop/main/src/services/memory/preferenceLearning.ts
+++ b/apps/desktop/main/src/services/memory/preferenceLearning.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
+import { nowTs } from "@shared/timeUtils";
 
 import type { Logger } from "../../logging/logger";
 import type { MemoryScope, MemorySettings, MemoryType } from "./memoryService";
@@ -23,10 +24,6 @@ const MIN_EVIDENCE_REF_LEN = 3;
 const MAX_EVIDENCE_REF_LEN = 240;
 const MAX_PRIVACY_TOKEN_LEN = 64;
 const PRIVACY_TOKEN_RE = /^[a-z0-9][a-z0-9._:-]{0,63}$/i;
-
-function nowTs(): number {
-  return Date.now();
-}
 
 type EvidenceNorm =
   | { ok: true; value: string }

--- a/apps/desktop/main/src/services/memory/userMemoryVec.ts
+++ b/apps/desktop/main/src/services/memory/userMemoryVec.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type Database from "better-sqlite3";
 import { getLoadablePath } from "sqlite-vec";
+import { nowTs } from "@shared/timeUtils";
 
 import type { Logger } from "../../logging/logger";
 import { ipcError, type ServiceResult } from "../shared/ipcResult";
@@ -40,10 +41,6 @@ const DEFAULT_DIMENSION = 64;
 const DEFAULT_TOPK = 8;
 
 const LOADED_DBS = new WeakSet<Database.Database>();
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function readSetting(db: Database.Database, key: string): unknown | null {
   try {

--- a/apps/desktop/main/src/services/projects/projectService.ts
+++ b/apps/desktop/main/src/services/projects/projectService.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import type Database from "better-sqlite3";
+import { hashJson } from "@shared/hashUtils";
+import { nowTs } from "@shared/timeUtils";
 
 import type { Logger } from "../../logging/logger";
 import { redactUserDataPath } from "../../db/paths";
@@ -182,10 +184,6 @@ const NARRATIVE_PERSON_SET = new Set<NarrativePerson>([
   "third-omniscient",
 ]);
 
-function nowTs(): number {
-  return Date.now();
-}
-
 /**
  * Compute the app-managed project root path.
  *
@@ -293,10 +291,6 @@ function createDefaultProjectMetadata(args: {
       knowledgeGraphId: null,
     },
   };
-}
-
-function hashJson(json: string): string {
-  return createHash("sha256").update(json, "utf8").digest("hex");
 }
 
 function buildDocumentContentJson(contentMd: string): string {

--- a/apps/desktop/main/src/services/search/searchReplaceService.ts
+++ b/apps/desktop/main/src/services/search/searchReplaceService.ts
@@ -1,6 +1,7 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import type Database from "better-sqlite3";
+import { hashJson } from "@shared/hashUtils";
 
 import type { Logger } from "../../logging/logger";
 import { deriveContent } from "../documents/derive";
@@ -98,10 +99,6 @@ type ReplaceJsonResult = {
 };
 
 type PreviewTokenStore = Map<string, StoredPreview>;
-
-function hashJson(contentJson: string): string {
-  return createHash("sha256").update(contentJson, "utf8").digest("hex");
-}
 
 function normalizeProjectId(projectId: string): ServiceResult<string> {
   const trimmed = projectId.trim();

--- a/apps/desktop/main/src/services/shared/ipcResult.ts
+++ b/apps/desktop/main/src/services/shared/ipcResult.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
+export { nowTs } from "@shared/timeUtils";
 
 export type Ok<T> = { ok: true; data: T };
 export type Err = { ok: false; error: IpcError };
@@ -38,12 +39,4 @@ export function ipcError(
 
 export function ipcOk<T>(data: T): Ok<T> {
   return { ok: true, data };
-}
-
-/**
- * Returns the current timestamp in milliseconds.
- * Centralised so fake-timer injection only needs one patch point.
- */
-export function nowTs(): number {
-  return Date.now();
 }

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import type Database from "better-sqlite3";
+import { nowTs } from "@shared/timeUtils";
 
 import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
@@ -151,10 +152,6 @@ type CustomSkillOwnershipRow = {
 type SkillRegistryCacheEntry = {
   skills: LoadedSkill[];
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function normalizeCustomSkillId(id: string): string {
   if (id.startsWith("custom:")) {

--- a/apps/desktop/main/src/services/skills/skillValidator.ts
+++ b/apps/desktop/main/src/services/skills/skillValidator.ts
@@ -1,3 +1,4 @@
+import { MAX_SKILL_TIMEOUT_MS } from "../ai/runtimeConfig";
 import { ipcError, type ServiceResult } from "../shared/ipcResult";
 export type { ServiceResult };
 
@@ -204,10 +205,14 @@ function optionalIntegerField(
       },
     );
   }
-  if (fieldName === "timeoutMs" && value > 120000) {
-    return ipcError("INVALID_ARGUMENT", "timeoutMs must be <= 120000", {
+  if (fieldName === "timeoutMs" && value > MAX_SKILL_TIMEOUT_MS) {
+    return ipcError(
+      "INVALID_ARGUMENT",
+      `timeoutMs must be <= ${String(MAX_SKILL_TIMEOUT_MS)}`,
+      {
       fieldName,
-    });
+      },
+    );
   }
   return { ok: true, data: value };
 }

--- a/apps/desktop/preload/src/aiStreamSubscriptions.ts
+++ b/apps/desktop/preload/src/aiStreamSubscriptions.ts
@@ -5,6 +5,7 @@ import type {
   IpcErrorCode,
   IpcResponse,
 } from "@shared/types/ipc-generated";
+import { nowTs } from "@shared/timeUtils";
 
 export const MAX_AI_STREAM_SUBSCRIPTIONS = 500;
 
@@ -23,10 +24,6 @@ type CreateAiStreamSubscriptionRegistryArgs = {
   idFactory?: () => string;
   auditLog?: (event: IpcSecurityAuditEvent) => void;
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function createSubscriptionId(): string {
   if (

--- a/apps/desktop/preload/src/ipcGateway.ts
+++ b/apps/desktop/preload/src/ipcGateway.ts
@@ -5,6 +5,7 @@ import type {
   IpcResponse,
 } from "@shared/types/ipc-generated";
 import { RUNTIME_GOVERNANCE_DEFAULTS } from "@shared/runtimeGovernance";
+import { nowTs } from "@shared/timeUtils";
 
 export const MAX_IPC_PAYLOAD_BYTES =
   RUNTIME_GOVERNANCE_DEFAULTS.ipc.maxPayloadBytes;
@@ -26,10 +27,6 @@ type CreatePreloadIpcGatewayArgs = {
   requestIdFactory?: () => string;
   auditLog?: (event: IpcSecurityAuditEvent) => void;
 };
-
-function nowTs(): number {
-  return Date.now();
-}
 
 function createRequestId(): string {
   if (

--- a/openspec/_ops/task_runs/ISSUE-675.md
+++ b/openspec/_ops/task_runs/ISSUE-675.md
@@ -1,0 +1,37 @@
+# ISSUE-675
+
+更新时间：2026-02-27 15:00
+
+## Links
+
+- Issue: #675
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/675
+- Branch: `task/675-audit-shared-runtime-utils-unification`
+- PR: TBD
+
+## Plan
+
+- [x] packages/shared/timeUtils.ts — 新建 nowTs() SSOT 模块
+- [x] packages/shared/hashUtils.ts — 新建 hash 工具 SSOT 模块
+- [x] 21 个服务文件迁移至 shared imports (nowTs/hash/tokenCount/constants)
+- [x] guard test: shared-runtime-utils-unification.guard.test.ts
+- [x] typecheck / lint / test:run / test:unit 全部通过
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (177 files, 1526 tests)
+- pnpm test:unit: 通过 (7 files, 23 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 1257514403aa0970a3ee354b8b5842726f722653
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/packages/shared/hashUtils.ts
+++ b/packages/shared/hashUtils.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Build a SHA-256 hex digest from UTF-8 text.
+ *
+ * Why: hash derivation must stay identical across runtime call sites.
+ */
+export function sha256Hex(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/**
+ * Alias for hashing plain text content.
+ */
+export function hashText(text: string): string {
+  return sha256Hex(text);
+}
+
+/**
+ * Alias for hashing serialized JSON payloads.
+ */
+export function hashJson(json: string): string {
+  return sha256Hex(json);
+}

--- a/packages/shared/timeUtils.ts
+++ b/packages/shared/timeUtils.ts
@@ -1,0 +1,8 @@
+/**
+ * Return current epoch milliseconds.
+ *
+ * Why: keep runtime timestamp sourcing centralized across main/preload modules.
+ */
+export function nowTs(): number {
+  return Date.now();
+}


### PR DESCRIPTION
## Summary

Closes #675

- Extract `nowTs()` into `packages/shared/timeUtils.ts` as single source of truth
- Extract hash utilities into `packages/shared/hashUtils.ts` as single source of truth
- Migrate 21 service files from local `nowTs`/hash/tokenCount/constant definitions to shared imports
- Add guard test to prevent future local duplicates

## Verification

- `pnpm typecheck`: pass
- `pnpm lint`: 0 errors, 67 warnings (baseline 68)
- `pnpm -C apps/desktop test:run`: 177 files, 1526 tests pass
- `pnpm test:unit`: 7 files, 23 tests pass