### PR TITLE
refactor: normalize proxy settings and eliminate fallback chains (#685)

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-config-ipc.test.ts
@@ -321,7 +321,7 @@ async function main(): Promise<void> {
     if (!raw.ok) {
       return;
     }
-    assert.equal(raw.data.openAiByokApiKey, null);
+    assert.equal(raw.data.openAiByok.apiKey, null);
   });
 
   await runScenario(

--- a/apps/desktop/main/src/services/ai/__tests__/ai-public-contract-regression.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/ai-public-contract-regression.test.ts
@@ -50,11 +50,11 @@ try {
     rateLimitPerMinute: 1_000,
     getProxySettings: () => ({
       enabled: false,
-      baseUrl: null,
-      apiKey: null,
       providerMode: "openai-byok",
-      openAiByokBaseUrl: "https://api.openai.com",
-      openAiByokApiKey: "sk-contract",
+      openAiByok: {
+        baseUrl: "https://api.openai.com",
+        apiKey: "sk-contract",
+      },
     }),
   });
 

--- a/apps/desktop/main/src/services/ai/__tests__/aiService-provider-unavailable.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-provider-unavailable.test.ts
@@ -29,11 +29,11 @@ function createLogger(): Logger {
       rateLimitPerMinute: 1_000,
       getProxySettings: () => ({
         enabled: false,
-        baseUrl: null,
-        apiKey: null,
         providerMode: "openai-byok",
-        openAiByokBaseUrl: "https://api.openai.com",
-        openAiByokApiKey: null,
+        openAiByok: {
+          baseUrl: "https://api.openai.com",
+          apiKey: null,
+        },
       }),
     });
 

--- a/apps/desktop/main/src/services/ai/__tests__/llm-proxy-retry-rate-limit.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/llm-proxy-retry-rate-limit.test.ts
@@ -50,11 +50,11 @@ try {
     sleep: async () => {},
     getProxySettings: () => ({
       enabled: false,
-      baseUrl: null,
-      apiKey: null,
       providerMode: "openai-byok",
-      openAiByokBaseUrl: "https://api.openai.com",
-      openAiByokApiKey: "sk-byok",
+      openAiByok: {
+        baseUrl: "https://api.openai.com",
+        apiKey: "sk-byok",
+      },
     }),
   });
 

--- a/apps/desktop/main/src/services/ai/__tests__/provider-failover-half-open.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/provider-failover-half-open.test.ts
@@ -72,15 +72,19 @@ try {
     rateLimitPerMinute: 1_000,
     getProxySettings: () => ({
       enabled: false,
-      baseUrl: null,
-      apiKey: null,
       providerMode: "openai-byok",
-      openAiCompatibleBaseUrl: null,
-      openAiCompatibleApiKey: null,
-      openAiByokBaseUrl: primaryBaseUrl,
-      openAiByokApiKey: "sk-primary",
-      anthropicByokBaseUrl: backupBaseUrl,
-      anthropicByokApiKey: "sk-backup",
+      openAiCompatible: {
+        baseUrl: null,
+        apiKey: null,
+      },
+      openAiByok: {
+        baseUrl: primaryBaseUrl,
+        apiKey: "sk-primary",
+      },
+      anthropicByok: {
+        baseUrl: backupBaseUrl,
+        apiKey: "sk-backup",
+      },
     }),
   });
 

--- a/apps/desktop/main/src/services/ai/__tests__/provider-resolver-no-fallback.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/provider-resolver-no-fallback.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+
+import type { Logger } from "../../../logging/logger";
+import type { ProxySettings } from "../providerResolver";
+import { createProviderResolver } from "../providerResolver";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+// AUD-C7-S3: resolver must not read legacy flat fields
+{
+  const resolver = createProviderResolver({
+    logger: createLogger(),
+    now: () => 1_000,
+  });
+
+  const legacyOnly = {
+    enabled: false,
+    providerMode: "openai-byok",
+    openAiByokBaseUrl: "https://legacy-openai.example",
+    openAiByokApiKey: "sk-legacy-only",
+  } as unknown as ProxySettings;
+
+  const resolved = await resolver.resolveProviderConfig({
+    env: {},
+    runtimeAiTimeoutMs: 30_000,
+    getFakeServer: async () => {
+      throw new Error("should not be called");
+    },
+    getProxySettings: () => legacyOnly,
+  });
+
+  assert.equal(resolved.ok, false);
+  if (resolved.ok) {
+    throw new Error("AUD-C7-S3: legacy-only settings must not resolve");
+  }
+  assert.equal(
+    resolved.error.code,
+    "AI_NOT_CONFIGURED",
+    "AUD-C7-S3: missing canonical credentials should fail fast",
+  );
+}
+
+// AUD-C7-S3: canonical nested fields drive primary and backup resolution
+{
+  const resolver = createProviderResolver({
+    logger: createLogger(),
+    now: () => 1_000,
+  });
+
+  const canonical: ProxySettings = {
+    enabled: true,
+    providerMode: "openai-byok",
+    openAiCompatible: {
+      baseUrl: "https://proxy.example",
+      apiKey: "sk-proxy",
+    },
+    openAiByok: {
+      baseUrl: "https://api.openai.com",
+      apiKey: "sk-openai",
+    },
+    anthropicByok: {
+      baseUrl: null,
+      apiKey: null,
+    },
+  };
+
+  const resolved = await resolver.resolveProviderConfig({
+    env: {},
+    runtimeAiTimeoutMs: 30_000,
+    getFakeServer: async () => {
+      throw new Error("should not be called");
+    },
+    getProxySettings: () => canonical,
+  });
+
+  assert.equal(resolved.ok, true);
+  if (!resolved.ok) {
+    throw new Error("AUD-C7-S3: canonical settings should resolve");
+  }
+
+  assert.equal(resolved.data.primary.provider, "openai");
+  assert.equal(resolved.data.primary.baseUrl, "https://api.openai.com");
+  assert.equal(resolved.data.primary.apiKey, "sk-openai");
+}
+
+// resolveSettingsBackupProvider uses the same canonical direct-read path
+{
+  const resolver = createProviderResolver({
+    logger: createLogger(),
+    now: () => 1_000,
+  });
+
+  const canonical: ProxySettings = {
+    enabled: true,
+    providerMode: "openai-byok",
+    openAiCompatible: {
+      baseUrl: "https://proxy.example",
+      apiKey: "sk-proxy",
+    },
+    openAiByok: {
+      baseUrl: "https://api.openai.com",
+      apiKey: "sk-openai",
+    },
+    anthropicByok: {
+      baseUrl: null,
+      apiKey: null,
+    },
+  };
+
+  const resolved = await resolver.resolveProviderConfig({
+    env: {},
+    runtimeAiTimeoutMs: 30_000,
+    getFakeServer: async () => {
+      throw new Error("should not be called");
+    },
+    getProxySettings: () => canonical,
+  });
+
+  assert.equal(resolved.ok, true);
+  if (!resolved.ok) {
+    throw new Error("backup resolution should succeed");
+  }
+
+  assert.ok(resolved.data.backup, "backup provider should be available");
+  assert.equal(resolved.data.backup?.provider, "proxy");
+  assert.equal(resolved.data.backup?.baseUrl, "https://proxy.example");
+  assert.equal(resolved.data.backup?.apiKey, "sk-proxy");
+}

--- a/apps/desktop/main/src/services/ai/__tests__/proxy-settings-normalization.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/proxy-settings-normalization.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import { createAiProxySettingsService } from "../aiProxySettingsService";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createSettingsDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE settings (
+      scope TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value_json TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (scope, key)
+    )
+  `);
+  return db;
+}
+
+function encryptedValue(secret: string): string {
+  return `__safe_storage_v1__:${Buffer.from(`encrypted:${secret}`, "utf8").toString("base64")}`;
+}
+
+function createServiceWithRows(rows: Array<{ key: string; value: unknown }>) {
+  const db = createSettingsDb();
+  const ts = Date.now();
+  const insert = db.prepare(
+    "INSERT INTO settings (scope, key, value_json, updated_at) VALUES (?, ?, ?, ?)",
+  );
+  for (const row of rows) {
+    insert.run("app", row.key, JSON.stringify(row.value), ts);
+  }
+
+  const service = createAiProxySettingsService({
+    db,
+    logger: createLogger(),
+    secretStorage: {
+      isEncryptionAvailable: () => true,
+      encryptString: (plainText: string) =>
+        Buffer.from(`encrypted:${plainText}`, "utf8"),
+      decryptString: (cipherText: Buffer) => {
+        const text = cipherText.toString("utf8");
+        return text.startsWith("encrypted:")
+          ? text.slice("encrypted:".length)
+          : text;
+      },
+    },
+  });
+
+  return { db, service };
+}
+
+// AUD-C7-S1: legacy flat format -> canonical nested format
+{
+  const { service } = createServiceWithRows([
+    { key: "creonow.ai.proxy.enabled", value: true },
+    { key: "creonow.ai.provider.mode", value: "openai-compatible" },
+    { key: "creonow.ai.proxy.baseUrl", value: "https://legacy-proxy.example" },
+    { key: "creonow.ai.proxy.apiKey", value: encryptedValue("sk-legacy") },
+  ]);
+
+  const rawResult = service.getRaw();
+  assert.equal(rawResult.ok, true, "AUD-C7-S1: getRaw should succeed");
+  if (!rawResult.ok) {
+    throw new Error("AUD-C7-S1: unexpected getRaw failure");
+  }
+
+  const raw = rawResult.data;
+  assert.equal(raw.enabled, true);
+  assert.equal(raw.providerMode, "openai-compatible");
+  assert.equal(raw.openAiCompatible.baseUrl, "https://legacy-proxy.example");
+  assert.equal(raw.openAiCompatible.apiKey, "sk-legacy");
+  assert.equal(raw.openAiByok.baseUrl, "https://legacy-proxy.example");
+  assert.equal(raw.openAiByok.apiKey, "sk-legacy");
+}
+
+// AUD-C7-S4: oldest format migration preserves all credentials
+{
+  const { service } = createServiceWithRows([
+    { key: "creonow.ai.proxy.enabled", value: true },
+    { key: "creonow.ai.provider.mode", value: "openai-byok" },
+    { key: "creonow.ai.proxy.baseUrl", value: "https://legacy-root.example" },
+    { key: "creonow.ai.proxy.apiKey", value: encryptedValue("sk-legacy-root") },
+    {
+      key: "creonow.ai.provider.openaiCompatible.baseUrl",
+      value: "https://proxy.example",
+    },
+    {
+      key: "creonow.ai.provider.openaiCompatible.apiKey",
+      value: encryptedValue("sk-compat"),
+    },
+    {
+      key: "creonow.ai.provider.openaiByok.baseUrl",
+      value: "https://api.openai.com",
+    },
+    {
+      key: "creonow.ai.provider.openaiByok.apiKey",
+      value: encryptedValue("sk-byok"),
+    },
+    {
+      key: "creonow.ai.provider.anthropicByok.baseUrl",
+      value: "https://api.anthropic.com",
+    },
+    {
+      key: "creonow.ai.provider.anthropicByok.apiKey",
+      value: encryptedValue("sk-anthropic"),
+    },
+  ]);
+
+  const rawResult = service.getRaw();
+  assert.equal(rawResult.ok, true, "AUD-C7-S4: getRaw should succeed");
+  if (!rawResult.ok) {
+    throw new Error("AUD-C7-S4: unexpected getRaw failure");
+  }
+
+  const raw = rawResult.data;
+  assert.equal(raw.openAiCompatible.baseUrl, "https://proxy.example");
+  assert.equal(raw.openAiCompatible.apiKey, "sk-compat");
+  assert.equal(raw.openAiByok.baseUrl, "https://api.openai.com");
+  assert.equal(raw.openAiByok.apiKey, "sk-byok");
+  assert.equal(raw.anthropicByok.baseUrl, "https://api.anthropic.com");
+  assert.equal(raw.anthropicByok.apiKey, "sk-anthropic");
+}
+
+// AUD-C7-S5: missing fields don't crash, fill safe defaults
+{
+  const { service } = createServiceWithRows([
+    { key: "creonow.ai.proxy.enabled", value: true },
+    { key: "creonow.ai.proxy.baseUrl", value: "" },
+  ]);
+
+  const rawResult = service.getRaw();
+  assert.equal(rawResult.ok, true, "AUD-C7-S5: getRaw should succeed");
+  if (!rawResult.ok) {
+    throw new Error("AUD-C7-S5: unexpected getRaw failure");
+  }
+
+  const raw = rawResult.data;
+  assert.equal(raw.openAiCompatible.baseUrl, null);
+  assert.equal(raw.openAiCompatible.apiKey, null);
+  assert.equal(raw.openAiByok.baseUrl, null);
+  assert.equal(raw.openAiByok.apiKey, null);
+  assert.equal(raw.anthropicByok.baseUrl, null);
+  assert.equal(raw.anthropicByok.apiKey, null);
+}
+
+// AUD-C7-S6: static scan — getRaw() has no legacy fallback patterns
+{
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const source = fs.readFileSync(
+    path.join(dirname, "..", "aiProxySettingsService.ts"),
+    "utf8",
+  );
+  const getRawMatch = source.match(
+    /function getRaw\(\): ServiceResult<AiProxySettingsRaw> {([\s\S]*?)\n\s+}\n\n\s+function get\(\)/,
+  );
+  assert.ok(getRawMatch, "AUD-C7-S6: getRaw function must exist");
+  const getRawBody = getRawMatch?.[1] ?? "";
+
+  const forbiddenPatterns = [
+    "normalizedLegacyBaseUrl",
+    "normalizedLegacyApiKey",
+    "openAiCompatibleBaseUrl",
+    "openAiCompatibleApiKey",
+    "openAiByokBaseUrl",
+    "openAiByokApiKey",
+    "anthropicByokBaseUrl",
+    "anthropicByokApiKey",
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    assert.equal(
+      getRawBody.includes(pattern),
+      false,
+      `AUD-C7-S6: getRaw() must not contain legacy fallback pattern: ${pattern}`,
+    );
+  }
+}

--- a/apps/desktop/main/src/services/ai/__tests__/trace-audit-continuity.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/trace-audit-continuity.test.ts
@@ -80,15 +80,19 @@ try {
     rateLimitPerMinute: 1_000,
     getProxySettings: () => ({
       enabled: false,
-      baseUrl: null,
-      apiKey: null,
       providerMode: "openai-byok",
-      openAiCompatibleBaseUrl: null,
-      openAiCompatibleApiKey: null,
-      openAiByokBaseUrl: primaryBaseUrl,
-      openAiByokApiKey: "sk-primary",
-      anthropicByokBaseUrl: backupBaseUrl,
-      anthropicByokApiKey: "sk-backup",
+      openAiCompatible: {
+        baseUrl: null,
+        apiKey: null,
+      },
+      openAiByok: {
+        baseUrl: primaryBaseUrl,
+        apiKey: "sk-primary",
+      },
+      anthropicByok: {
+        baseUrl: backupBaseUrl,
+        apiKey: "sk-backup",
+      },
     }),
   });
 

--- a/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
+++ b/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
@@ -19,17 +19,17 @@ export type AiProxySettings = {
   anthropicByokApiKeyConfigured: boolean;
 };
 
-export type AiProxySettingsRaw = {
-  enabled: boolean;
+type ProviderProxyCredentials = {
   baseUrl: string | null;
   apiKey: string | null;
+};
+
+export type AiProxySettingsRaw = {
+  enabled: boolean;
   providerMode: "openai-compatible" | "openai-byok" | "anthropic-byok";
-  openAiCompatibleBaseUrl: string | null;
-  openAiCompatibleApiKey: string | null;
-  openAiByokBaseUrl: string | null;
-  openAiByokApiKey: string | null;
-  anthropicByokBaseUrl: string | null;
-  anthropicByokApiKey: string | null;
+  openAiCompatible: ProviderProxyCredentials;
+  openAiByok: ProviderProxyCredentials;
+  anthropicByok: ProviderProxyCredentials;
 };
 
 export type AiProxySettingsService = {
@@ -225,6 +225,59 @@ function normalizeProviderMode(
   return "openai-compatible";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeProviderCredentials(args: {
+  nested: unknown;
+  flatBaseUrl?: unknown;
+  flatApiKey?: unknown;
+  fallbackBaseUrl?: unknown;
+  fallbackApiKey?: unknown;
+}): ProviderProxyCredentials {
+  const nested = isRecord(args.nested) ? args.nested : null;
+  return {
+    baseUrl: normalizeBaseUrl(
+      nested?.baseUrl ?? args.flatBaseUrl ?? args.fallbackBaseUrl,
+    ),
+    apiKey: normalizeApiKey(
+      nested?.apiKey ?? args.flatApiKey ?? args.fallbackApiKey,
+    ),
+  };
+}
+
+export function normalizeProxySettings(raw: unknown): AiProxySettingsRaw {
+  const data = isRecord(raw) ? raw : {};
+
+  const legacyBaseUrl = normalizeBaseUrl(data.baseUrl);
+  const legacyApiKey = normalizeApiKey(data.apiKey);
+
+  return {
+    enabled: data.enabled === true,
+    providerMode: normalizeProviderMode(data.providerMode),
+    openAiCompatible: normalizeProviderCredentials({
+      nested: data.openAiCompatible,
+      flatBaseUrl: data.openAiCompatibleBaseUrl,
+      flatApiKey: data.openAiCompatibleApiKey,
+      fallbackBaseUrl: legacyBaseUrl,
+      fallbackApiKey: legacyApiKey,
+    }),
+    openAiByok: normalizeProviderCredentials({
+      nested: data.openAiByok,
+      flatBaseUrl: data.openAiByokBaseUrl,
+      flatApiKey: data.openAiByokApiKey,
+      fallbackBaseUrl: legacyBaseUrl,
+      fallbackApiKey: legacyApiKey,
+    }),
+    anthropicByok: normalizeProviderCredentials({
+      nested: data.anthropicByok,
+      flatBaseUrl: data.anthropicByokBaseUrl,
+      flatApiKey: data.anthropicByokApiKey,
+    }),
+  };
+}
+
 function joinApiPath(args: { baseUrl: string; endpointPath: string }): string {
   const base = new URL(args.baseUrl);
   const endpoint = args.endpointPath.startsWith("/")
@@ -262,37 +315,30 @@ function readRawSettings(args: {
   const anthropicByokBaseUrl = readSetting(args.db, KEY_ANTH_BYOK_BASE_URL);
   const anthropicByokApiKey = readSetting(args.db, KEY_ANTH_BYOK_API_KEY);
 
-  const normalizedLegacyBaseUrl = normalizeBaseUrl(baseUrl);
-  const normalizedLegacyApiKey = decryptApiKey({
-    value: apiKey,
-    secretStorage: args.secretStorage,
-    logger: args.logger,
-    field: KEY_API_KEY,
-  });
-
-  return {
+  return normalizeProxySettings({
     enabled: enabled === true,
-    baseUrl: normalizedLegacyBaseUrl,
-    apiKey: normalizedLegacyApiKey,
-    providerMode: normalizeProviderMode(providerMode),
-    openAiCompatibleBaseUrl:
-      normalizeBaseUrl(openAiCompatibleBaseUrl) ?? normalizedLegacyBaseUrl,
-    openAiCompatibleApiKey:
-      decryptApiKey({
-        value: openAiCompatibleApiKey,
-        secretStorage: args.secretStorage,
-        logger: args.logger,
-        field: KEY_OA_COMPAT_API_KEY,
-      }) ?? normalizedLegacyApiKey,
-    openAiByokBaseUrl:
-      normalizeBaseUrl(openAiByokBaseUrl) ?? normalizedLegacyBaseUrl,
-    openAiByokApiKey:
-      decryptApiKey({
-        value: openAiByokApiKey,
-        secretStorage: args.secretStorage,
-        logger: args.logger,
-        field: KEY_OA_BYOK_API_KEY,
-      }) ?? normalizedLegacyApiKey,
+    providerMode,
+    baseUrl: normalizeBaseUrl(baseUrl),
+    apiKey: decryptApiKey({
+      value: apiKey,
+      secretStorage: args.secretStorage,
+      logger: args.logger,
+      field: KEY_API_KEY,
+    }),
+    openAiCompatibleBaseUrl: normalizeBaseUrl(openAiCompatibleBaseUrl),
+    openAiCompatibleApiKey: decryptApiKey({
+      value: openAiCompatibleApiKey,
+      secretStorage: args.secretStorage,
+      logger: args.logger,
+      field: KEY_OA_COMPAT_API_KEY,
+    }),
+    openAiByokBaseUrl: normalizeBaseUrl(openAiByokBaseUrl),
+    openAiByokApiKey: decryptApiKey({
+      value: openAiByokApiKey,
+      secretStorage: args.secretStorage,
+      logger: args.logger,
+      field: KEY_OA_BYOK_API_KEY,
+    }),
     anthropicByokBaseUrl: normalizeBaseUrl(anthropicByokBaseUrl),
     anthropicByokApiKey: decryptApiKey({
       value: anthropicByokApiKey,
@@ -300,27 +346,29 @@ function readRawSettings(args: {
       logger: args.logger,
       field: KEY_ANTH_BYOK_API_KEY,
     }),
-  };
+  });
 }
 
 function toPublic(raw: AiProxySettingsRaw): AiProxySettings {
   return {
     enabled: raw.enabled,
-    baseUrl: raw.baseUrl ?? "",
-    apiKeyConfigured: typeof raw.apiKey === "string" && raw.apiKey.length > 0,
+    baseUrl: raw.openAiCompatible.baseUrl ?? "",
+    apiKeyConfigured:
+      typeof raw.openAiCompatible.apiKey === "string" &&
+      raw.openAiCompatible.apiKey.length > 0,
     providerMode: raw.providerMode,
-    openAiCompatibleBaseUrl: raw.openAiCompatibleBaseUrl ?? "",
+    openAiCompatibleBaseUrl: raw.openAiCompatible.baseUrl ?? "",
     openAiCompatibleApiKeyConfigured:
-      typeof raw.openAiCompatibleApiKey === "string" &&
-      raw.openAiCompatibleApiKey.length > 0,
-    openAiByokBaseUrl: raw.openAiByokBaseUrl ?? "",
+      typeof raw.openAiCompatible.apiKey === "string" &&
+      raw.openAiCompatible.apiKey.length > 0,
+    openAiByokBaseUrl: raw.openAiByok.baseUrl ?? "",
     openAiByokApiKeyConfigured:
-      typeof raw.openAiByokApiKey === "string" &&
-      raw.openAiByokApiKey.length > 0,
-    anthropicByokBaseUrl: raw.anthropicByokBaseUrl ?? "",
+      typeof raw.openAiByok.apiKey === "string" &&
+      raw.openAiByok.apiKey.length > 0,
+    anthropicByokBaseUrl: raw.anthropicByok.baseUrl ?? "",
     anthropicByokApiKeyConfigured:
-      typeof raw.anthropicByokApiKey === "string" &&
-      raw.anthropicByokApiKey.length > 0,
+      typeof raw.anthropicByok.apiKey === "string" &&
+      raw.anthropicByok.apiKey.length > 0,
   };
 }
 
@@ -380,50 +428,52 @@ export function createAiProxySettingsService(deps: {
       return existing;
     }
 
-    const next: AiProxySettingsRaw = {
+    const next: AiProxySettingsRaw = normalizeProxySettings({
       enabled: args.patch.enabled ?? existing.data.enabled,
-      baseUrl:
-        typeof args.patch.baseUrl === "string"
-          ? normalizeBaseUrl(args.patch.baseUrl)
-          : existing.data.baseUrl,
-      apiKey:
-        typeof args.patch.apiKey === "string"
-          ? normalizeApiKey(args.patch.apiKey)
-          : existing.data.apiKey,
       providerMode: normalizeProviderMode(
         args.patch.providerMode ?? existing.data.providerMode,
       ),
-      openAiCompatibleBaseUrl:
-        typeof args.patch.openAiCompatibleBaseUrl === "string"
-          ? normalizeBaseUrl(args.patch.openAiCompatibleBaseUrl)
-          : existing.data.openAiCompatibleBaseUrl,
-      openAiCompatibleApiKey:
-        typeof args.patch.openAiCompatibleApiKey === "string"
-          ? normalizeApiKey(args.patch.openAiCompatibleApiKey)
-          : existing.data.openAiCompatibleApiKey,
-      openAiByokBaseUrl:
-        typeof args.patch.openAiByokBaseUrl === "string"
-          ? normalizeBaseUrl(args.patch.openAiByokBaseUrl)
-          : existing.data.openAiByokBaseUrl,
-      openAiByokApiKey:
-        typeof args.patch.openAiByokApiKey === "string"
-          ? normalizeApiKey(args.patch.openAiByokApiKey)
-          : existing.data.openAiByokApiKey,
-      anthropicByokBaseUrl:
-        typeof args.patch.anthropicByokBaseUrl === "string"
-          ? normalizeBaseUrl(args.patch.anthropicByokBaseUrl)
-          : existing.data.anthropicByokBaseUrl,
-      anthropicByokApiKey:
-        typeof args.patch.anthropicByokApiKey === "string"
-          ? normalizeApiKey(args.patch.anthropicByokApiKey)
-          : existing.data.anthropicByokApiKey,
-    };
+      openAiCompatible: {
+        baseUrl:
+          typeof args.patch.openAiCompatibleBaseUrl === "string"
+            ? args.patch.openAiCompatibleBaseUrl
+            : typeof args.patch.baseUrl === "string"
+              ? args.patch.baseUrl
+              : existing.data.openAiCompatible.baseUrl,
+        apiKey:
+          typeof args.patch.openAiCompatibleApiKey === "string"
+            ? args.patch.openAiCompatibleApiKey
+            : typeof args.patch.apiKey === "string"
+              ? args.patch.apiKey
+              : existing.data.openAiCompatible.apiKey,
+      },
+      openAiByok: {
+        baseUrl:
+          typeof args.patch.openAiByokBaseUrl === "string"
+            ? args.patch.openAiByokBaseUrl
+            : existing.data.openAiByok.baseUrl,
+        apiKey:
+          typeof args.patch.openAiByokApiKey === "string"
+            ? args.patch.openAiByokApiKey
+            : existing.data.openAiByok.apiKey,
+      },
+      anthropicByok: {
+        baseUrl:
+          typeof args.patch.anthropicByokBaseUrl === "string"
+            ? args.patch.anthropicByokBaseUrl
+            : existing.data.anthropicByok.baseUrl,
+        apiKey:
+          typeof args.patch.anthropicByokApiKey === "string"
+            ? args.patch.anthropicByokApiKey
+            : existing.data.anthropicByok.apiKey,
+      },
+    });
 
     if (next.providerMode !== "openai-compatible") {
       next.enabled = false;
     }
 
-    if (next.enabled && !next.baseUrl) {
+    if (next.enabled && !next.openAiCompatible.baseUrl) {
       return ipcError(
         "INVALID_ARGUMENT",
         "proxy baseUrl is required when proxy enabled",
@@ -432,16 +482,8 @@ export function createAiProxySettingsService(deps: {
 
     const ts = nowTs();
 
-    const encryptedLegacyKey = encryptApiKey({
-      value: next.apiKey,
-      secretStorage: deps.secretStorage,
-    });
-    if (!encryptedLegacyKey.ok) {
-      return encryptedLegacyKey;
-    }
-
     const encryptedOpenAiCompatibleKey = encryptApiKey({
-      value: next.openAiCompatibleApiKey,
+      value: next.openAiCompatible.apiKey,
       secretStorage: deps.secretStorage,
     });
     if (!encryptedOpenAiCompatibleKey.ok) {
@@ -449,7 +491,7 @@ export function createAiProxySettingsService(deps: {
     }
 
     const encryptedOpenAiByokKey = encryptApiKey({
-      value: next.openAiByokApiKey,
+      value: next.openAiByok.apiKey,
       secretStorage: deps.secretStorage,
     });
     if (!encryptedOpenAiByokKey.ok) {
@@ -457,7 +499,7 @@ export function createAiProxySettingsService(deps: {
     }
 
     const encryptedAnthropicByokKey = encryptApiKey({
-      value: next.anthropicByokApiKey,
+      value: next.anthropicByok.apiKey,
       secretStorage: deps.secretStorage,
     });
     if (!encryptedAnthropicByokKey.ok) {
@@ -472,24 +514,24 @@ export function createAiProxySettingsService(deps: {
         ) {
           writeSetting(deps.db, KEY_ENABLED, next.enabled, ts);
         }
-        if (typeof args.patch.baseUrl === "string") {
-          writeSetting(deps.db, KEY_BASE_URL, next.baseUrl ?? "", ts);
-        }
-        if (typeof args.patch.apiKey === "string") {
-          writeSetting(deps.db, KEY_API_KEY, encryptedLegacyKey.data ?? "", ts);
-        }
         if (typeof args.patch.providerMode === "string") {
           writeSetting(deps.db, KEY_PROVIDER_MODE, next.providerMode, ts);
         }
-        if (typeof args.patch.openAiCompatibleBaseUrl === "string") {
+        if (
+          typeof args.patch.baseUrl === "string" ||
+          typeof args.patch.openAiCompatibleBaseUrl === "string"
+        ) {
           writeSetting(
             deps.db,
             KEY_OA_COMPAT_BASE_URL,
-            next.openAiCompatibleBaseUrl ?? "",
+            next.openAiCompatible.baseUrl ?? "",
             ts,
           );
         }
-        if (typeof args.patch.openAiCompatibleApiKey === "string") {
+        if (
+          typeof args.patch.apiKey === "string" ||
+          typeof args.patch.openAiCompatibleApiKey === "string"
+        ) {
           writeSetting(
             deps.db,
             KEY_OA_COMPAT_API_KEY,
@@ -501,7 +543,7 @@ export function createAiProxySettingsService(deps: {
           writeSetting(
             deps.db,
             KEY_OA_BYOK_BASE_URL,
-            next.openAiByokBaseUrl ?? "",
+            next.openAiByok.baseUrl ?? "",
             ts,
           );
         }
@@ -517,7 +559,7 @@ export function createAiProxySettingsService(deps: {
           writeSetting(
             deps.db,
             KEY_ANTH_BYOK_BASE_URL,
-            next.anthropicByokBaseUrl ?? "",
+            next.anthropicByok.baseUrl ?? "",
             ts,
           );
         }
@@ -534,8 +576,8 @@ export function createAiProxySettingsService(deps: {
       deps.logger.info("ai_proxy_settings_updated", {
         enabled: next.enabled,
         providerMode: next.providerMode,
-        baseUrlConfigured: typeof next.baseUrl === "string",
-        apiKeyConfigured: typeof next.apiKey === "string",
+        baseUrlConfigured: typeof next.openAiCompatible.baseUrl === "string",
+        apiKeyConfigured: typeof next.openAiCompatible.apiKey === "string",
       });
 
       return { ok: true, data: toPublic(next) };
@@ -575,16 +617,16 @@ export function createAiProxySettingsService(deps: {
     const mode = raw.data.providerMode;
     const targetBaseUrl =
       mode === "anthropic-byok"
-        ? raw.data.anthropicByokBaseUrl
+        ? raw.data.anthropicByok.baseUrl
         : mode === "openai-byok"
-          ? raw.data.openAiByokBaseUrl
-          : raw.data.openAiCompatibleBaseUrl;
+          ? raw.data.openAiByok.baseUrl
+          : raw.data.openAiCompatible.baseUrl;
     const targetApiKey =
       mode === "anthropic-byok"
-        ? raw.data.anthropicByokApiKey
+        ? raw.data.anthropicByok.apiKey
         : mode === "openai-byok"
-          ? raw.data.openAiByokApiKey
-          : raw.data.openAiCompatibleApiKey;
+          ? raw.data.openAiByok.apiKey
+          : raw.data.openAiCompatible.apiKey;
 
     if (!targetBaseUrl) {
       return {

--- a/apps/desktop/main/src/services/ai/providerResolver.ts
+++ b/apps/desktop/main/src/services/ai/providerResolver.ts
@@ -13,18 +13,10 @@ type ProviderCredentials = {
 
 export type ProxySettings = {
   enabled: boolean;
-  baseUrl: string | null;
-  apiKey: string | null;
   providerMode?: ProviderMode;
   openAiCompatible?: ProviderCredentials;
   openAiByok?: ProviderCredentials;
   anthropicByok?: ProviderCredentials;
-  openAiCompatibleBaseUrl?: string | null;
-  openAiCompatibleApiKey?: string | null;
-  openAiByokBaseUrl?: string | null;
-  openAiByokApiKey?: string | null;
-  anthropicByokBaseUrl?: string | null;
-  anthropicByokApiKey?: string | null;
 };
 
 export type ProviderConfig = {
@@ -77,43 +69,19 @@ function resolveSettingsProviderCredentials(args: {
   provider: AiProvider;
   credentials: ProviderCredentials;
 } {
-  const openAiCompatible: ProviderCredentials = {
-    baseUrl:
-      args.settings.openAiCompatible?.baseUrl ??
-      args.settings.openAiCompatibleBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.openAiCompatible?.apiKey ??
-      args.settings.openAiCompatibleApiKey ??
-      args.settings.apiKey ??
-      null,
+  const openAiCompatible: ProviderCredentials = args.settings.openAiCompatible ?? {
+    baseUrl: null,
+    apiKey: null,
   };
 
-  const openAiByok: ProviderCredentials = {
-    baseUrl:
-      args.settings.openAiByok?.baseUrl ??
-      args.settings.openAiByokBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.openAiByok?.apiKey ??
-      args.settings.openAiByokApiKey ??
-      args.settings.apiKey ??
-      null,
+  const openAiByok: ProviderCredentials = args.settings.openAiByok ?? {
+    baseUrl: null,
+    apiKey: null,
   };
 
-  const anthropicByok: ProviderCredentials = {
-    baseUrl:
-      args.settings.anthropicByok?.baseUrl ??
-      args.settings.anthropicByokBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.anthropicByok?.apiKey ??
-      args.settings.anthropicByokApiKey ??
-      args.settings.apiKey ??
-      null,
+  const anthropicByok: ProviderCredentials = args.settings.anthropicByok ?? {
+    baseUrl: null,
+    apiKey: null,
   };
 
   if (args.mode === "anthropic-byok") {
@@ -174,41 +142,17 @@ function resolveSettingsBackupProvider(args: {
   timeoutMs: number;
   env: NodeJS.ProcessEnv;
 }): ProviderConfig | null {
-  const openAiCompatible: ProviderCredentials = {
-    baseUrl:
-      args.settings.openAiCompatible?.baseUrl ??
-      args.settings.openAiCompatibleBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.openAiCompatible?.apiKey ??
-      args.settings.openAiCompatibleApiKey ??
-      args.settings.apiKey ??
-      null,
+  const openAiCompatible: ProviderCredentials = args.settings.openAiCompatible ?? {
+    baseUrl: null,
+    apiKey: null,
   };
-  const openAiByok: ProviderCredentials = {
-    baseUrl:
-      args.settings.openAiByok?.baseUrl ??
-      args.settings.openAiByokBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.openAiByok?.apiKey ??
-      args.settings.openAiByokApiKey ??
-      args.settings.apiKey ??
-      null,
+  const openAiByok: ProviderCredentials = args.settings.openAiByok ?? {
+    baseUrl: null,
+    apiKey: null,
   };
-  const anthropicByok: ProviderCredentials = {
-    baseUrl:
-      args.settings.anthropicByok?.baseUrl ??
-      args.settings.anthropicByokBaseUrl ??
-      args.settings.baseUrl ??
-      null,
-    apiKey:
-      args.settings.anthropicByok?.apiKey ??
-      args.settings.anthropicByokApiKey ??
-      args.settings.apiKey ??
-      null,
+  const anthropicByok: ProviderCredentials = args.settings.anthropicByok ?? {
+    baseUrl: null,
+    apiKey: null,
   };
 
   const candidates: ProviderConfig[] = [];

--- a/apps/desktop/tests/unit/ai-service-model-catalog.test.ts
+++ b/apps/desktop/tests/unit/ai-service-model-catalog.test.ts
@@ -190,8 +190,11 @@ async function withCustomServer(args: {
       env: {},
       getProxySettings: () => ({
         enabled: true,
-        baseUrl,
-        apiKey: "proxy-key",
+        providerMode: "openai-compatible",
+        openAiCompatible: {
+          baseUrl,
+          apiKey: "proxy-key",
+        },
       }),
     });
 

--- a/openspec/_ops/task_runs/ISSUE-685.md
+++ b/openspec/_ops/task_runs/ISSUE-685.md
@@ -1,0 +1,37 @@
+# ISSUE-685
+
+更新时间：2026-02-27 18:15
+
+## Links
+
+- Issue: #685
+- Branch: `task/685-audit-proxy-settings-normalization`
+- PR: TBD
+
+## Plan
+
+- [x] 在 `aiProxySettingsService.ts` 增加 `normalizeProxySettings()`，将 legacy flat/oldest 字段统一归一为 canonical nested 结构
+- [x] 重构 `getRaw()` 仅读取归一化结果，移除方法体内 legacy fallback 逻辑
+- [x] 重构 `update()` 仅写 canonical provider 字段，移除 `encryptedLegacyKey` 写入路径
+- [x] 收敛 `providerResolver.ts`：删除 legacy flat 类型字段与三级 fallback 读取链
+- [x] 新增并修正 C7 相关测试（AUD-C7-S1/S3/S4/S5/S6），同步修复受 `ProxySettings` 类型收敛影响的单测样例
+- [x] 完成 `typecheck/lint/test:run/test:unit` 全绿验证
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (177 files, 1526 tests)
+- pnpm test:unit: 通过 (tsx=241 files, vitest=7 files; vitest=24 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: b41d4a4a305ec8b9029640d6f53f89b2991c23bf
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

Closes #685

- Add `normalizeProxySettings()` one-time migration layer in `aiProxySettingsService.ts`
- Remove three-level fallback chains in `providerResolver.ts` credential resolution
- Remove `resolveSettingsBackupProvider()` duplicated fallback construction
- Remove legacy `baseUrl`/`apiKey` flat fields from `ProxySettings` type
- Add migration tests for old → canonical format conversion

## Verification

- `pnpm typecheck`: pass
- `pnpm lint`: 0 errors, 67 warnings
- `pnpm -C apps/desktop test:run`: pass
- `pnpm test:unit`: pass

## OpenSpec

- Change: `openspec/changes/audit-proxy-settings-normalization/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-685.md`

Closes #685