### PR TITLE
refactor: store refresh governance and fireAndForget observability (#686)

### DIFF
--- a/apps/desktop/renderer/src/lib/__tests__/fireAndForget.test.ts
+++ b/apps/desktop/renderer/src/lib/__tests__/fireAndForget.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runFireAndForget, type FireAndForgetOptions } from "../fireAndForget";
+
+describe("runFireAndForget", () => {
+  it("logs structured failure details with label (AUD-C9-S5)", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    runFireAndForget(
+      async () => {
+        throw new Error("boom");
+      },
+      { label: "test-task", critical: true },
+    );
+
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [message, details, error] = consoleErrorSpy.mock.calls[0];
+    expect(message).toContain("[fire-and-forget][critical] task failed");
+    expect(details).toMatchObject({
+      label: "test-task",
+      errorType: "Error",
+      message: "boom",
+    });
+    expect(error).toBeInstanceOf(Error);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("catches secondary exception in error handler (AUD-C9-S6)", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const options: FireAndForgetOptions = {
+      label: "handler-task",
+      onError() {
+        throw new Error("handler failed");
+      },
+    };
+
+    runFireAndForget(
+      async () => {
+        throw new Error("boom");
+      },
+      options,
+    );
+
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    const [secondaryMessage, secondaryDetails] = consoleErrorSpy.mock.calls[0];
+    expect(secondaryMessage).toContain("[fire-and-forget] error handler failed");
+    expect(secondaryDetails).toMatchObject({
+      label: "handler-task",
+      errorType: "Error",
+      message: "handler failed",
+    });
+    const [taskMessage, taskDetails] = consoleErrorSpy.mock.calls[1];
+    expect(taskMessage).toContain("[fire-and-forget][critical] task failed");
+    expect(taskDetails).toMatchObject({
+      label: "handler-task",
+      errorType: "Error",
+      message: "boom",
+      critical: true,
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs non-critical failures without blocking (AUD-C9-S7)", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    runFireAndForget(
+      async () => {
+        throw new Error("non-critical failure");
+      },
+      { label: "telemetry-task", critical: false },
+    );
+
+    await Promise.resolve();
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const [message, details] = consoleWarnSpy.mock.calls[0];
+    expect(message).toContain("[fire-and-forget][non-critical] task failed");
+    expect(details).toMatchObject({
+      label: "telemetry-task",
+      errorType: "Error",
+      message: "non-critical failure",
+      critical: false,
+    });
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("keeps backward-compat function options signature", async () => {
+    const handler = vi.fn();
+
+    runFireAndForget(
+      async () => {
+        throw new Error("boom");
+      },
+      handler,
+    );
+
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [error] = handler.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+  });
+});

--- a/apps/desktop/renderer/src/lib/fireAndForget.ts
+++ b/apps/desktop/renderer/src/lib/fireAndForget.ts
@@ -1,3 +1,9 @@
+export type FireAndForgetOptions = {
+  label?: string;
+  onError?: (error: unknown) => void;
+  critical?: boolean;
+};
+
 /**
  * Execute a promise-returning task without awaiting the caller path.
  *
@@ -5,15 +11,60 @@
  */
 export function runFireAndForget(
   task: () => Promise<void>,
-  onError?: (error: unknown) => void,
+  options?: FireAndForgetOptions | ((error: unknown) => void),
 ): void {
-  const errorHandler =
-    onError ??
-    ((error: unknown) => {
-      console.error("[fire-and-forget] task failed", error);
-    });
+  const normalized: FireAndForgetOptions =
+    typeof options === "function"
+      ? { onError: options }
+      : options ?? {};
+
+  const { label, onError, critical = true } = normalized;
+
+  const baseMessage = critical
+    ? "[fire-and-forget][critical] task failed"
+    : "[fire-and-forget][non-critical] task failed";
+
+  const logTaskError = (error: unknown): void => {
+    const details = {
+      label: label ?? "unknown",
+      errorType: error instanceof Error ? error.name : typeof error,
+      message: error instanceof Error ? error.message : String(error),
+      critical,
+    };
+
+    // TODO(C9): wire to central telemetry once available
+    // For now we keep console output as the observable surface.
+    if (critical) {
+      // eslint-disable-next-line no-console
+      console.error(baseMessage, details, error);
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(baseMessage, details, error);
+  };
+
+  const safeHandleError = (error: unknown): void => {
+    try {
+      onError?.(error);
+    } catch (handlerError) {
+      // Secondary exception from error handler must be observable but not crash the app.
+      const secondaryDetails = {
+        label: label ?? "unknown",
+        errorType:
+          handlerError instanceof Error ? handlerError.name : typeof handlerError,
+        message:
+          handlerError instanceof Error
+            ? handlerError.message
+            : String(handlerError),
+      };
+      // eslint-disable-next-line no-console
+      console.error("[fire-and-forget] error handler failed", secondaryDetails);
+    } finally {
+      logTaskError(error);
+    }
+  };
 
   void task().catch((error) => {
-    errorHandler(error);
+    safeHandleError(error);
   });
 }

--- a/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import type {
+  IpcChannel,
+  IpcError,
+  IpcInvokeResult,
+  IpcResponseData,
+} from "@shared/types/ipc-generated";
+import { createKgStore, type IpcInvoke } from "../kgStore";
+
+function ok<C extends IpcChannel>(
+  _channel: C,
+  data: IpcResponseData<C>,
+): IpcInvokeResult<C> {
+  return { ok: true, data };
+}
+
+function err<C extends IpcChannel>(
+  _channel: C,
+  error: IpcError,
+): IpcInvokeResult<C> {
+  return { ok: false, error };
+}
+
+function createEntity(
+  projectId: string,
+  id: string,
+): IpcResponseData<"knowledge:entity:create"> {
+  return {
+    id,
+    projectId,
+    type: "character",
+    name: `name-${id}`,
+    description: "",
+    attributes: {},
+    aliases: [],
+    aiContextLevel: "always",
+    createdAt: "2026-02-27T00:00:00.000Z",
+    updatedAt: "2026-02-27T00:00:00.000Z",
+    version: 1,
+  };
+}
+
+describe("store refresh governance", () => {
+  it("captures refresh failure after mutation (AUD-C9-S1)", async () => {
+    const refreshError: IpcError = {
+      code: "INTERNAL",
+      message: "refresh failed",
+    };
+
+    const invoke: IpcInvoke = async (channel) => {
+      if (channel === "knowledge:entity:create") {
+        return ok(channel, createEntity("project-1", "entity-1"));
+      }
+      if (channel === "knowledge:entity:list") {
+        return err(channel, refreshError);
+      }
+      if (channel === "knowledge:relation:list") {
+        return ok(channel, { items: [] });
+      }
+      throw new Error(`Unexpected channel: ${channel}`);
+    };
+
+    const store = createKgStore({ invoke });
+    store.setState({ projectId: "project-1" });
+
+    const result = await store.getState().entityCreate({
+      name: "entity-1",
+      entityType: "character",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(store.getState().lastError).toMatchObject(refreshError);
+  });
+
+  it("static scan clears void refresh patterns in critical stores (AUD-C9-S8)", () => {
+    const kgStoreSource = readFileSync(
+      resolve(process.cwd(), "renderer/src/stores/kgStore.ts"),
+      "utf8",
+    );
+    const memoryStoreSource = readFileSync(
+      resolve(process.cwd(), "renderer/src/stores/memoryStore.ts"),
+      "utf8",
+    );
+    const projectStoreSource = readFileSync(
+      resolve(process.cwd(), "renderer/src/stores/projectStore.tsx"),
+      "utf8",
+    );
+
+    expect(kgStoreSource).not.toMatch(/void get\(\)\.refresh\(\)/);
+    expect(memoryStoreSource).not.toMatch(/void get\(\)\.refresh\(\)/);
+    expect(projectStoreSource).not.toMatch(/void get\(\)\.refresh\(\)/);
+    expect(projectStoreSource).not.toMatch(/void get\(\)\.bootstrap\(\)/);
+  });
+});

--- a/apps/desktop/renderer/src/stores/kgStore.ts
+++ b/apps/desktop/renderer/src/stores/kgStore.ts
@@ -314,7 +314,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return { ok: true, data: toLegacyEntity(res.data) };
     },
 
@@ -368,7 +368,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return { ok: true, data: toLegacyEntity(res.data) };
     },
 
@@ -389,7 +389,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return res;
     },
 
@@ -412,7 +412,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return { ok: true, data: toLegacyRelation(res.data) };
     },
 
@@ -438,7 +438,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return { ok: true, data: toLegacyRelation(res.data) };
     },
 
@@ -459,7 +459,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return res;
     },
   }));

--- a/apps/desktop/renderer/src/stores/memoryStore.ts
+++ b/apps/desktop/renderer/src/stores/memoryStore.ts
@@ -408,7 +408,7 @@ export function createMemoryStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return res;
     },
 
@@ -419,7 +419,7 @@ export function createMemoryStore(deps: { invoke: IpcInvoke }) {
         return res;
       }
 
-      void get().refresh();
+      await get().refresh();
       return res;
     },
 

--- a/apps/desktop/renderer/src/stores/projectStore.tsx
+++ b/apps/desktop/renderer/src/stores/projectStore.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { create } from "zustand";
 
+import { runFireAndForget } from "../lib/fireAndForget";
 import type {
   IpcChannel,
   IpcError,
@@ -197,7 +198,9 @@ export function createProjectStore(deps: {
       }
 
       set({ current: setRes.data, lastError: null });
-      void get().bootstrap();
+      runFireAndForget(() => get().bootstrap(), {
+        label: "projectStore.bootstrap",
+      });
       return setRes;
     },
 
@@ -272,7 +275,9 @@ export function createProjectStore(deps: {
         current: prev.current?.projectId === projectId ? null : prev.current,
         lastError: null,
       }));
-      void get().bootstrap();
+      runFireAndForget(() => get().bootstrap(), {
+        label: "projectStore.bootstrap",
+      });
       return { ok: true, data: { deleted: true } };
     },
 
@@ -287,7 +292,9 @@ export function createProjectStore(deps: {
       }
 
       set({ lastError: null });
-      void get().bootstrap();
+      runFireAndForget(() => get().bootstrap(), {
+        label: "projectStore.bootstrap",
+      });
       return res;
     },
 
@@ -299,7 +306,9 @@ export function createProjectStore(deps: {
       }
 
       set({ lastError: null });
-      void get().bootstrap();
+      runFireAndForget(() => get().bootstrap(), {
+        label: "projectStore.bootstrap",
+      });
       return res;
     },
 
@@ -326,7 +335,9 @@ export function createProjectStore(deps: {
             : prev.current,
         lastError: null,
       }));
-      void get().bootstrap();
+      runFireAndForget(() => get().bootstrap(), {
+        label: "projectStore.bootstrap",
+      });
       return res;
     },
   }));

--- a/openspec/_ops/task_runs/ISSUE-686.md
+++ b/openspec/_ops/task_runs/ISSUE-686.md
@@ -1,0 +1,37 @@
+# ISSUE-686
+
+更新时间：2026-02-27 18:17
+
+## Links
+
+- Issue: #686
+- Branch: `task/686-audit-store-refresh-governance`
+- PR: TBD
+
+## Plan
+
+- [x] 升级 `runFireAndForget`：增加 `label`/`critical`/`onError` 选项，保留 `(task, onError)` 兼容签名
+- [x] 在 `runFireAndForget` 中加入结构化错误记录与二次异常兜底（AUD-C9-S5/S6/S7）
+- [x] 将 `kgStore.ts`、`memoryStore.ts` 中 mutation 后的 `void get().refresh()` 替换为可追踪 `await get().refresh()`
+- [x] 将 `projectStore.tsx` 中 `void get().bootstrap()` 替换为带 label 的 `runFireAndForget`
+- [x] 新增 `fireAndForget` 行为测试与 store refresh 治理测试，覆盖 AUD-C9-S1/S5/S6/S7/S8
+- [x] 完成四门禁验证并记录结果
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (179 files, 1532 tests)
+- pnpm test:unit: 通过 (mode=unit tsx=239, vitest=7 files/24 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 5415436d45050e142943a6ff8ff5011f757104bc
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

Closes #686

- Upgrade `runFireAndForget` to observable executor with structured error logging and label support
- Replace `void get().refresh()` patterns in `kgStore.ts`, `memoryStore.ts`, `projectStore.tsx`
- Critical mutations use await + catch; non-critical use observable executor
- Add tests for fireAndForget observability and store refresh governance

## Verification

- `pnpm typecheck`: pass
- `pnpm lint`: 0 errors, 67 warnings
- `pnpm -C apps/desktop test:run`: pass (179 files, 1532 tests)
- `pnpm test:unit`: pass

## OpenSpec

- Change: `openspec/changes/audit-store-refresh-governance/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-686.md`

Closes #686