### PR TITLE
C8: audit type contract alignment (#689)

### DIFF
--- a/apps/desktop/main/src/ipc/ipcAcl.ts
+++ b/apps/desktop/main/src/ipc/ipcAcl.ts
@@ -24,22 +24,13 @@ type CreateIpcAclEvaluatorArgs = {
 
 const DEFAULT_PRIVILEGED_PREFIXES = ["db:", "ai:skill:run", "ai:skill:cancel"];
 
-type EventLike = {
-  senderFrame?: { url?: unknown };
-  sender?: { id?: unknown };
-};
-
-function asEventLike(event: IpcMainInvokeEvent): EventLike {
-  return event as unknown as EventLike;
-}
-
 function resolveSenderOrigin(event: IpcMainInvokeEvent): string | null {
-  const maybeUrl = asEventLike(event).senderFrame?.url;
+  const maybeUrl = event.senderFrame?.url;
   return typeof maybeUrl === "string" && maybeUrl.length > 0 ? maybeUrl : null;
 }
 
 function resolveWebContentsId(event: IpcMainInvokeEvent): number | null {
-  const maybeId = asEventLike(event).sender?.id;
+  const maybeId = event.sender.id;
   return typeof maybeId === "number" ? maybeId : null;
 }
 

--- a/apps/desktop/preload/src/ipc.ts
+++ b/apps/desktop/preload/src/ipc.ts
@@ -5,6 +5,7 @@ import {
   type IpcChannel,
   type IpcInvokeResult,
   type IpcRequest,
+  type IpcResponseData,
 } from "@shared/types/ipc-generated";
 import { createPreloadIpcGateway } from "./ipcGateway";
 import { resolveRuntimeGovernance } from "./runtimeGovernance";
@@ -19,7 +20,7 @@ function resolveRendererId(): string {
 }
 
 const gateway = createPreloadIpcGateway({
-  allowedChannels: IPC_CHANNELS as unknown as readonly string[],
+  allowedChannels: IPC_CHANNELS,
   rendererId: resolveRendererId(),
   maxPayloadBytes: resolveRuntimeGovernance().ipc.maxPayloadBytes,
   invoke: async (channel, payload) =>
@@ -35,5 +36,5 @@ export const creonowInvoke: CreonowInvoke = async <C extends IpcChannel>(
   channel: C,
   payload: IpcRequest<C>,
 ): Promise<IpcInvokeResult<C>> => {
-  return (await gateway.invoke(channel, payload)) as IpcInvokeResult<C>;
+  return await gateway.invoke<IpcResponseData<C>>(channel, payload);
 };

--- a/apps/desktop/preload/src/ipcGateway.ts
+++ b/apps/desktop/preload/src/ipcGateway.ts
@@ -170,7 +170,7 @@ function findSerializationIssue(payload: unknown): SerializationIssue | null {
   return visit(payload, "$");
 }
 
-function isIpcResponse(value: unknown): value is IpcResponse<unknown> {
+function isIpcResponse<TData>(value: unknown): value is IpcResponse<TData> {
   if (!isRecord(value) || typeof value.ok !== "boolean") {
     return false;
   }
@@ -336,7 +336,10 @@ function defaultAuditLog(event: IpcSecurityAuditEvent): void {
  * Build preload IPC gateway with whitelist + payload guard + audit hooks.
  */
 export function createPreloadIpcGateway(args: CreatePreloadIpcGatewayArgs): {
-  invoke: (channel: string, payload: unknown) => Promise<IpcResponse<unknown>>;
+  invoke: <TData>(
+    channel: string,
+    payload: unknown,
+  ) => Promise<IpcResponse<TData>>;
 } {
   const channelSet = new Set(args.allowedChannels);
   const limitBytes = args.maxPayloadBytes ?? MAX_IPC_PAYLOAD_BYTES;
@@ -345,7 +348,7 @@ export function createPreloadIpcGateway(args: CreatePreloadIpcGatewayArgs): {
   const auditLog = args.auditLog ?? defaultAuditLog;
 
   return {
-    invoke: async (channel: string, payload: unknown) => {
+    invoke: async <TData>(channel: string, payload: unknown) => {
       const timestamp = getNow();
       const requestId = getRequestId();
 
@@ -407,7 +410,7 @@ export function createPreloadIpcGateway(args: CreatePreloadIpcGatewayArgs): {
 
       try {
         const response = await args.invoke(channel, payload);
-        if (isIpcResponse(response)) {
+        if (isIpcResponse<TData>(response)) {
           return response;
         }
 

--- a/apps/desktop/renderer/src/features/outline/deriveOutline.ts
+++ b/apps/desktop/renderer/src/features/outline/deriveOutline.ts
@@ -2,15 +2,6 @@ import type { JSONContent } from "@tiptap/react";
 import type { OutlineItem, OutlineLevel } from "./OutlinePanel";
 
 /**
- * Represents a heading node from the ProseMirror document.
- */
-interface HeadingNode {
-  type: "heading";
-  attrs?: { level?: number };
-  content?: Array<{ type: string; text?: string }>;
-}
-
-/**
  * Map heading level number (1-6) to OutlineLevel type.
  * We only support H1-H3 for outline display.
  */
@@ -32,17 +23,22 @@ function mapLevelToOutlineLevel(level: number): OutlineLevel | null {
  * Extract text content from a heading node.
  * Handles nested text nodes and concatenates them.
  */
-function extractHeadingText(node: HeadingNode): string {
+function extractHeadingText(node: JSONContent): string {
   if (!node.content || node.content.length === 0) {
     return "(untitled heading)";
   }
 
   const text = node.content
-    .filter((child) => child.type === "text" && child.text)
+    .filter((child) => child.type === "text" && typeof child.text === "string")
     .map((child) => child.text)
     .join("");
 
   return text.trim() || "(untitled heading)";
+}
+
+function resolveHeadingLevel(node: JSONContent): number {
+  const level = node.attrs?.level;
+  return typeof level === "number" ? level : 1;
 }
 
 /**
@@ -104,8 +100,7 @@ export function deriveOutline(
       continue;
     }
 
-    const headingNode = node as unknown as HeadingNode;
-    const level = headingNode.attrs?.level ?? 1;
+    const level = resolveHeadingLevel(node);
     const outlineLevel = mapLevelToOutlineLevel(level);
 
     // Skip H4-H6
@@ -113,7 +108,7 @@ export function deriveOutline(
       continue;
     }
 
-    const title = extractHeadingText(headingNode);
+    const title = extractHeadingText(node);
     const id = generateHeadingId(outlineLevel, headingIndex, title);
 
     items.push({
@@ -159,8 +154,7 @@ export function findActiveOutlineItem(
 
   for (const node of doc.content) {
     if (node.type === "heading") {
-      const headingNode = node as unknown as HeadingNode;
-      const level = headingNode.attrs?.level ?? 1;
+      const level = resolveHeadingLevel(node);
       const outlineLevel = mapLevelToOutlineLevel(level);
 
       if (outlineLevel && headingIndex < items.length) {
@@ -232,8 +226,7 @@ export function findHeadingPosition(
 
   for (const node of doc.content) {
     if (node.type === "heading") {
-      const headingNode = node as unknown as HeadingNode;
-      const level = headingNode.attrs?.level ?? 1;
+      const level = resolveHeadingLevel(node);
       const outlineLevel = mapLevelToOutlineLevel(level);
 
       if (outlineLevel) {

--- a/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { IpcResponseData } from "@shared/types/ipc-generated";
 
 import { Button } from "../../components/primitives/Button";
 import { Card } from "../../components/primitives/Card";
@@ -7,18 +8,7 @@ import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
 import { emitAiModelCatalogUpdated } from "../ai/modelCatalogEvents";
 
-type AiSettings = {
-  enabled: boolean;
-  baseUrl: string;
-  apiKeyConfigured: boolean;
-  providerMode: "openai-compatible" | "openai-byok" | "anthropic-byok";
-  openAiCompatibleBaseUrl: string;
-  openAiCompatibleApiKeyConfigured: boolean;
-  openAiByokBaseUrl: string;
-  openAiByokApiKeyConfigured: boolean;
-  anthropicByokBaseUrl: string;
-  anthropicByokApiKeyConfigured: boolean;
-};
+type AiSettings = IpcResponseData<"ai:config:get">;
 
 /**
  * AI settings section for the Settings panel.
@@ -51,7 +41,7 @@ export function AiSettingsSection(): JSX.Element {
       return;
     }
 
-    const data = res.data as unknown as AiSettings;
+    const data = res.data;
     setStatus("idle");
     setSettings(data);
     setProviderMode(data.providerMode);
@@ -113,7 +103,7 @@ export function AiSettingsSection(): JSX.Element {
       return;
     }
 
-    const data = res.data as unknown as AiSettings;
+    const data = res.data;
     setSettings(data);
     setProviderMode(data.providerMode);
     setApiKeyDraft("");

--- a/apps/desktop/renderer/src/features/settings/ProxySection.tsx
+++ b/apps/desktop/renderer/src/features/settings/ProxySection.tsx
@@ -1,4 +1,5 @@
 ﻿import React from "react";
+import type { IpcResponseData } from "@shared/types/ipc-generated";
 
 import { Button } from "../../components/primitives/Button";
 import { Card } from "../../components/primitives/Card";
@@ -8,23 +9,8 @@ import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
 import { emitAiModelCatalogUpdated } from "../ai/modelCatalogEvents";
 
-type ProxySettings = {
-  enabled: boolean;
-  baseUrl: string;
-  apiKeyConfigured: boolean;
-  providerMode: "openai-compatible" | "openai-byok" | "anthropic-byok";
-  openAiCompatibleBaseUrl: string;
-  openAiCompatibleApiKeyConfigured: boolean;
-  openAiByokBaseUrl: string;
-  openAiByokApiKeyConfigured: boolean;
-  anthropicByokBaseUrl: string;
-  anthropicByokApiKeyConfigured: boolean;
-};
-
-type ModelCatalog = {
-  source: "proxy" | "openai" | "anthropic";
-  items: Array<{ id: string; name: string; provider: string }>;
-};
+type ProxySettings = IpcResponseData<"ai:config:get">;
+type ModelCatalog = IpcResponseData<"ai:models:list">;
 
 /**
  * ProxySection controls optional OpenAI-compatible proxy settings.
@@ -74,7 +60,7 @@ export function ProxySection(): JSX.Element {
     }
 
     setModelsStatus("idle");
-    setModelCatalog(res.data as unknown as ModelCatalog);
+    setModelCatalog(res.data);
     emitAiModelCatalogUpdated();
   }, []);
 
@@ -91,7 +77,7 @@ export function ProxySection(): JSX.Element {
     }
 
     setStatus("idle");
-    setSettings(res.data as unknown as ProxySettings);
+    setSettings(res.data);
     setEnabled(res.data.enabled);
     setProviderMode(res.data.providerMode);
     setOpenAiCompatibleBaseUrl(
@@ -152,7 +138,7 @@ export function ProxySection(): JSX.Element {
       return;
     }
 
-    setSettings(res.data as unknown as ProxySettings);
+    setSettings(res.data);
     setEnabled(res.data.enabled);
     setProviderMode(res.data.providerMode);
     setOpenAiCompatibleApiKeyDraft("");

--- a/apps/desktop/renderer/src/lib/ipcTypes.ts
+++ b/apps/desktop/renderer/src/lib/ipcTypes.ts
@@ -1,0 +1,10 @@
+import type {
+  IpcChannel,
+  IpcInvokeResult,
+  IpcRequest,
+} from "@shared/types/ipc-generated";
+
+export type IpcInvoke = <C extends IpcChannel>(
+  channel: C,
+  payload: IpcRequest<C>,
+) => Promise<IpcInvokeResult<C>>;

--- a/apps/desktop/renderer/src/lib/motion/reducedMotion.ts
+++ b/apps/desktop/renderer/src/lib/motion/reducedMotion.ts
@@ -73,10 +73,12 @@ export function createReducedMotionMatchMediaMock(initialMatches: boolean): {
       }
       listeners.delete(listener as (event: MediaQueryListEvent) => void);
     },
-    dispatchEvent: (event: Event) => {
-      listeners.forEach((listener) =>
-        listener(event as unknown as MediaQueryListEvent),
-      );
+    dispatchEvent: (_event: Event) => {
+      const event = {
+        media: PREFERS_REDUCED_MOTION_QUERY,
+        matches,
+      } as MediaQueryListEvent;
+      listeners.forEach((listener) => listener(event));
       return true;
     },
     addListener: (listener: (event: MediaQueryListEvent) => void) => {

--- a/apps/desktop/renderer/src/stores/aiStore.ts
+++ b/apps/desktop/renderer/src/stores/aiStore.ts
@@ -2,13 +2,11 @@
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
-  IpcInvokeResult,
-  IpcRequest,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
 import type { AiStreamEvent } from "@shared/types/ai";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
 export type AiStatus =
   | "idle"
@@ -62,10 +60,7 @@ export type AiRunRequestSnapshot = {
   context?: { projectId?: string; documentId?: string };
 };
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type AiState = {
   status: AiStatus;

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -3,7 +3,6 @@ import { create } from "zustand";
 import type { Editor } from "@tiptap/react";
 
 import type {
-  IpcChannel,
   IpcError,
   IpcInvokeResult,
   IpcRequest,
@@ -12,11 +11,9 @@ import {
   createEditorSaveQueue,
   type EditorSaveRequest,
 } from "./editorSaveQueue";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type AutosaveStatus = "idle" | "saving" | "saved" | "error";
 export type DocumentStatus = IpcRequest<"file:document:updatestatus">["status"];

--- a/apps/desktop/renderer/src/stores/fileStore.ts
+++ b/apps/desktop/renderer/src/stores/fileStore.ts
@@ -2,18 +2,15 @@ import React from "react";
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
   IpcInvokeResult,
   IpcRequest,
   IpcResponse,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type DocumentListItem =
   IpcResponseData<"file:document:list">["items"][number];

--- a/apps/desktop/renderer/src/stores/kgStore.ts
+++ b/apps/desktop/renderer/src/stores/kgStore.ts
@@ -2,13 +2,12 @@ import React from "react";
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
   IpcInvokeResult,
-  IpcRequest,
   IpcResponse,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
 const META_JSON_ATTRIBUTE_KEY = "__meta_json";
 
@@ -17,10 +16,7 @@ type RelationResponse =
   IpcResponseData<"knowledge:relation:list">["items"][number];
 type AiContextLevel = EntityResponse["aiContextLevel"];
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type KgEntity = EntityResponse & {
   entityId: string;

--- a/apps/desktop/renderer/src/stores/memoryStore.ts
+++ b/apps/desktop/renderer/src/stores/memoryStore.ts
@@ -2,18 +2,15 @@ import React from "react";
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
   IpcInvokeResult,
   IpcRequest,
   IpcResponse,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type MemoryItem = IpcResponseData<"memory:entry:list">["items"][number];
 export type MemorySettings = IpcResponseData<"memory:settings:get">;

--- a/apps/desktop/renderer/src/stores/projectStore.tsx
+++ b/apps/desktop/renderer/src/stores/projectStore.tsx
@@ -3,18 +3,13 @@ import { create } from "zustand";
 
 import { runFireAndForget } from "../lib/fireAndForget";
 import type {
-  IpcChannel,
   IpcError,
-  IpcInvokeResult,
-  IpcRequest,
   IpcResponse,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type ProjectInfo = IpcResponseData<"project:project:getcurrent">;
 export type ProjectListItem =

--- a/apps/desktop/renderer/src/stores/searchStore.ts
+++ b/apps/desktop/renderer/src/stores/searchStore.ts
@@ -2,17 +2,12 @@ import React from "react";
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
-  IpcInvokeResult,
-  IpcRequest,
   IpcResponseData,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 export type SearchItem = IpcResponseData<"search:fts:query">["results"][number];
 

--- a/apps/desktop/renderer/src/stores/versionStore.tsx
+++ b/apps/desktop/renderer/src/stores/versionStore.tsx
@@ -2,16 +2,11 @@ import React from "react";
 import { create } from "zustand";
 
 import type {
-  IpcChannel,
   IpcError,
-  IpcInvokeResult,
-  IpcRequest,
 } from "@shared/types/ipc-generated";
+import type { IpcInvoke } from "../lib/ipcTypes";
 
-export type IpcInvoke = <C extends IpcChannel>(
-  channel: C,
-  payload: IpcRequest<C>,
-) => Promise<IpcInvokeResult<C>>;
+export type { IpcInvoke };
 
 /**
  * Version list item from the backend.

--- a/apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts
+++ b/apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+type Hit = {
+  file: string;
+  line: number;
+  text: string;
+};
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+
+const STORE_FILES = [
+  "apps/desktop/renderer/src/stores/aiStore.ts",
+  "apps/desktop/renderer/src/stores/fileStore.ts",
+  "apps/desktop/renderer/src/stores/searchStore.ts",
+  "apps/desktop/renderer/src/stores/kgStore.ts",
+  "apps/desktop/renderer/src/stores/memoryStore.ts",
+  "apps/desktop/renderer/src/stores/editorStore.tsx",
+  "apps/desktop/renderer/src/stores/versionStore.tsx",
+  "apps/desktop/renderer/src/stores/projectStore.tsx",
+] as const;
+
+const TARGET_CAST_FILES = [
+  "apps/desktop/preload/src/ipc.ts",
+  "apps/desktop/main/src/ipc/ipcAcl.ts",
+  "apps/desktop/renderer/src/features/outline/deriveOutline.ts",
+  "apps/desktop/renderer/src/features/settings/ProxySection.tsx",
+  "apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx",
+] as const;
+
+const PRODUCTION_SCAN_ROOTS = [
+  "apps/desktop/preload/src",
+  "apps/desktop/main/src",
+  "apps/desktop/renderer/src",
+] as const;
+
+const IPC_TYPES_FILE = "apps/desktop/renderer/src/lib/ipcTypes.ts";
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") {
+        continue;
+      }
+      out.push(...walk(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && /\.(ts|tsx)$/u.test(entry.name)) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function isProductionSource(filePath: string): boolean {
+  const normalized = filePath.split(path.sep).join("/");
+  if (normalized.includes("/__tests__/")) {
+    return false;
+  }
+  if (normalized.includes("/tests/")) {
+    return false;
+  }
+  return !/\.(test|spec|stories)\.(ts|tsx)$/u.test(normalized);
+}
+
+function scanAsUnknownAs(): Hit[] {
+  const hits: Hit[] = [];
+  for (const rootRel of PRODUCTION_SCAN_ROOTS) {
+    const rootAbs = path.resolve(REPO_ROOT, rootRel);
+    for (const file of walk(rootAbs)) {
+      if (!isProductionSource(file)) {
+        continue;
+      }
+      const text = readFileSync(file, "utf8");
+      const lines = text.split(/\r?\n/u);
+      lines.forEach((line, index) => {
+        if (line.includes("as unknown as")) {
+          hits.push({
+            file: path.relative(REPO_ROOT, file).split(path.sep).join("/"),
+            line: index + 1,
+            text: line.trim(),
+          });
+        }
+      });
+    }
+  }
+  return hits;
+}
+
+function formatHits(hits: Hit[]): string {
+  if (hits.length === 0) {
+    return "";
+  }
+  return hits
+    .map((hit) => `${hit.file}:${hit.line.toString()} -> ${hit.text}`)
+    .join("\n");
+}
+
+function main(): void {
+  const ipcTypesAbs = path.resolve(REPO_ROOT, IPC_TYPES_FILE);
+  assert.equal(
+    existsSync(ipcTypesAbs),
+    true,
+    "AUD-C8-S6: shared ipcTypes.ts must exist",
+  );
+  const ipcTypesSource = readFileSync(ipcTypesAbs, "utf8");
+  assert.match(
+    ipcTypesSource,
+    /\bexport\s+type\s+IpcInvoke\b/u,
+    "AUD-C8-S6: ipcTypes.ts must export IpcInvoke",
+  );
+
+  for (const storeRel of STORE_FILES) {
+    const source = readFileSync(path.resolve(REPO_ROOT, storeRel), "utf8");
+    assert.match(
+      source,
+      /from\s+["']\.\.\/lib\/ipcTypes["']/u,
+      `AUD-C8-S6: ${storeRel} must import IpcInvoke from renderer/src/lib/ipcTypes.ts`,
+    );
+    assert.doesNotMatch(
+      source,
+      /\bexport?\s*type\s+IpcInvoke\s*=/u,
+      `AUD-C8-S6: ${storeRel} must not define local IpcInvoke type`,
+    );
+  }
+
+  for (const fileRel of TARGET_CAST_FILES) {
+    const source = readFileSync(path.resolve(REPO_ROOT, fileRel), "utf8");
+    assert.equal(
+      source.includes("as unknown as"),
+      false,
+      `AUD-C8-S1/S2/S3/S4: ${fileRel} must not contain "as unknown as"`,
+    );
+  }
+
+  const productionHits = scanAsUnknownAs();
+  assert.equal(
+    productionHits.length,
+    0,
+    `AUD-C8-S5/S8: production code must not contain "as unknown as"\n${formatHits(productionHits)}`,
+  );
+
+  console.log("audit-type-contract-alignment.spec.ts: all assertions passed");
+}
+
+main();

--- a/openspec/_ops/task_runs/ISSUE-689.md
+++ b/openspec/_ops/task_runs/ISSUE-689.md
@@ -1,0 +1,77 @@
+# ISSUE-689
+
+更新时间：2026-02-27 19:18
+
+## Links
+
+- Issue: #689
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/689
+- Branch: `task/689-audit-type-contract-alignment`
+- PR: https://github.com/Leeky1017/CreoNow/pull/690
+
+## Plan
+
+- [x] Dependency Sync Check：核对 C7 `audit-proxy-settings-normalization` 已完成，C8 可进入 Red
+- [x] 新增 C8 守卫测试并先跑 Red（缺少共享 `ipcTypes.ts` 失败）
+- [x] Green 实现：统一 8 个 store `IpcInvoke`、清理 C8 范围内生产代码 `as unknown as`
+- [x] 执行四门禁：`typecheck` / `lint` / `apps/desktop test:run` / `test:unit`
+
+## Runs
+
+### 2026-02-27 Dependency Sync Check
+
+- Command: `rg -n "audit-type-contract-alignment|audit-proxy-settings-normalization" openspec/changes/EXECUTION_ORDER.md openspec/changes/audit-type-contract-alignment/tasks.md openspec/changes/audit-type-contract-alignment/proposal.md`
+- Exit code: `0`
+- Key output: `EXECUTION_ORDER` 显示 C7 `DONE`，C8 `PENDING`，依赖未漂移
+
+### 2026-02-27 Red: C8 守卫测试失败（预期）
+
+- Command: `pnpm exec tsx apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts`
+- Exit code: `1`
+- Key output: `AssertionError: AUD-C8-S6: shared ipcTypes.ts must exist`
+
+### 2026-02-27 Green: C8 守卫测试通过
+
+- Command: `pnpm exec tsx apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts`
+- Exit code: `0`
+- Key output: `audit-type-contract-alignment.spec.ts: all assertions passed`
+
+### 2026-02-27 typecheck 通过
+
+- Command: `pnpm typecheck`
+- Exit code: `0`
+- Key output: `tsc --noEmit` 零错误
+
+### 2026-02-27 lint 通过
+
+- Command: `pnpm lint`
+- Exit code: `0`
+- Key output: `0 errors`（存在既有 warning）
+
+### 2026-02-27 renderer vitest 通过
+
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `Test Files 179 passed (179)` / `Tests 1532 passed (1532)`
+
+### 2026-02-27 unit discovered 通过
+
+- Command: `pnpm test:unit`
+- Exit code: `0`
+- Key output: `tsx=242 vitest=7` 全部通过
+
+### 2026-02-27 静态扫描核验
+
+- Command: `rg -n "as unknown as" apps/desktop/preload/src apps/desktop/main/src apps/desktop/renderer/src --glob '!**/*.test.*' --glob '!**/*.stories.*' --glob '!**/__tests__/**' --glob '!**/tests/**'`
+- Exit code: `0`
+- Key output: 无匹配（生产代码）
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: b71309c5c7d987e3a460dfca5bf70d1c9ca63bfb
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary\n- align preload/main/renderer IPC type contracts to remove production `as unknown as` casts in C8 scope\n- extract shared renderer `IpcInvoke` type to `renderer/src/lib/ipcTypes.ts` and migrate 8 stores\n- add C8 guard test to enforce cast cleanup and shared import rules\n\n## Verification\n- pnpm typecheck\n- pnpm lint\n- pnpm -C apps/desktop test:run\n- pnpm test:unit\n\nCloses #689