### PR TITLE
improve: fix HookProbe effect deps warnings in open settings tests

### DIFF
--- a/apps/desktop/renderer/src/components/layout/OpenSettingsCompat.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/OpenSettingsCompat.test.tsx
@@ -8,11 +8,15 @@ import {
   useOpenSettings as useOpenSettingsFromContext,
 } from "../../contexts/OpenSettingsContext";
 
-function HookProbe(props: { onResolve: (openSettings: () => void) => void }) {
+function HookProbe({
+  onResolve,
+}: {
+  onResolve: (openSettings: () => void) => void;
+}) {
   const openSettings = useOpenSettingsFromRightPanel();
   React.useEffect(() => {
-    props.onResolve(openSettings);
-  }, [props.onResolve, openSettings]);
+    onResolve(openSettings);
+  }, [onResolve, openSettings]);
   return null;
 }
 

--- a/apps/desktop/renderer/src/contexts/OpenSettingsContext.test.tsx
+++ b/apps/desktop/renderer/src/contexts/OpenSettingsContext.test.tsx
@@ -4,11 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import { OpenSettingsContext, useOpenSettings } from "./OpenSettingsContext";
 
-function HookProbe(props: { onResolve: (openSettings: () => void) => void }) {
+function HookProbe({
+  onResolve,
+}: {
+  onResolve: (openSettings: () => void) => void;
+}) {
   const openSettings = useOpenSettings();
   React.useEffect(() => {
-    props.onResolve(openSettings);
-  }, [props.onResolve, openSettings]);
+    onResolve(openSettings);
+  }, [onResolve, openSettings]);
   return null;
 }
 


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)
## 改了什么
修复 OpenSettings 相关两个测试中 `HookProbe` 组件的 `react-hooks/exhaustive-deps` 警告（解构 `onResolve` 后在 effect 依赖中直接使用）。

## 为什么改
保持测试代码与 hooks 规则一致，减少 lint 噪音，避免未来被真实依赖问题掩盖。

## 验证
- [x] typecheck 通过
- [x] lint 通过（相关文件 lint 通过）
- [x] 相关测试通过

执行命令：
- `pnpm typecheck`
- `pnpm eslint apps/desktop/renderer/src/components/layout/OpenSettingsCompat.test.tsx apps/desktop/renderer/src/contexts/OpenSettingsContext.test.tsx`
- `pnpm -C apps/desktop test:run src/components/layout/OpenSettingsCompat.test.tsx src/contexts/OpenSettingsContext.test.tsx`

---
🤖 by 天野 (automated iteration)