### PR TITLE
improve: simplify runtime schema validation branching

### DIFF
--- a/apps/desktop/main/src/ipc/runtime-validation.ts
+++ b/apps/desktop/main/src/ipc/runtime-validation.ts
@@ -129,6 +129,100 @@ function pushIssue(
   });
 }
 
+function validateArraySchemaAtPath(
+  schema: Extract<IpcSchema, { kind: "array" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  if (!Array.isArray(value)) {
+    pushIssue(issues, path, "must be array", renderSchema(schema), value);
+    return;
+  }
+  value.forEach((item, index) => {
+    validateSchemaAtPath(schema.element, item, `${path}[${index}]`, issues);
+  });
+}
+
+function validateRecordSchemaAtPath(
+  schema: Extract<IpcSchema, { kind: "record" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  if (!isRecord(value) || Array.isArray(value)) {
+    pushIssue(issues, path, "must be object record", renderSchema(schema), value);
+    return;
+  }
+  for (const [key, recordValue] of Object.entries(value)) {
+    validateSchemaAtPath(schema.value, recordValue, `${path}.${key}`, issues);
+  }
+}
+
+function validateUnionSchemaAtPath(
+  schema: Extract<IpcSchema, { kind: "union" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  const matchesVariant = schema.variants.some((variant) => {
+    const variantIssues: RuntimeValidationIssue[] = [];
+    validateSchemaAtPath(variant, value, path, variantIssues);
+    return variantIssues.length === 0;
+  });
+  if (!matchesVariant) {
+    pushIssue(
+      issues,
+      path,
+      "must match one union variant",
+      renderSchema(schema),
+      value,
+    );
+  }
+}
+
+function validateObjectSchemaAtPath(
+  schema: Extract<IpcSchema, { kind: "object" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  if (!isRecord(value) || Array.isArray(value)) {
+    pushIssue(issues, path, "must be object", "object", value);
+    return;
+  }
+
+  for (const [fieldName, fieldSchema] of Object.entries(schema.fields)) {
+    const fieldPath = `${path}.${fieldName}`;
+    if (!(fieldName in value)) {
+      if (fieldSchema.kind !== "optional") {
+        pushIssue(
+          issues,
+          fieldPath,
+          "is required",
+          renderSchema(fieldSchema),
+          undefined,
+        );
+      }
+      continue;
+    }
+    validateSchemaAtPath(fieldSchema, value[fieldName], fieldPath, issues);
+  }
+
+  const knownFields = new Set(Object.keys(schema.fields));
+  for (const fieldName of Object.keys(value)) {
+    if (!knownFields.has(fieldName)) {
+      pushIssue(
+        issues,
+        `${path}.${fieldName}`,
+        "is not allowed",
+        "no extra fields",
+        value[fieldName],
+      );
+    }
+  }
+}
+
 function validateSchemaAtPath(
   schema: IpcSchema,
   value: unknown,
@@ -163,94 +257,23 @@ function validateSchemaAtPath(
       }
       return;
     case "array":
-      if (!Array.isArray(value)) {
-        pushIssue(issues, path, "must be array", renderSchema(schema), value);
-        return;
-      }
-      value.forEach((item, index) => {
-        validateSchemaAtPath(schema.element, item, `${path}[${index}]`, issues);
-      });
+      validateArraySchemaAtPath(schema, value, path, issues);
       return;
     case "record":
-      if (!isRecord(value) || Array.isArray(value)) {
-        pushIssue(
-          issues,
-          path,
-          "must be object record",
-          renderSchema(schema),
-          value,
-        );
-        return;
-      }
-      for (const [key, recordValue] of Object.entries(value)) {
-        validateSchemaAtPath(
-          schema.value,
-          recordValue,
-          `${path}.${key}`,
-          issues,
-        );
-      }
+      validateRecordSchemaAtPath(schema, value, path, issues);
       return;
-    case "union": {
-      const matchesVariant = schema.variants.some((variant) => {
-        const variantIssues: RuntimeValidationIssue[] = [];
-        validateSchemaAtPath(variant, value, path, variantIssues);
-        return variantIssues.length === 0;
-      });
-      if (!matchesVariant) {
-        pushIssue(
-          issues,
-          path,
-          "must match one union variant",
-          renderSchema(schema),
-          value,
-        );
-      }
+    case "union":
+      validateUnionSchemaAtPath(schema, value, path, issues);
       return;
-    }
     case "optional":
       if (value === undefined) {
         return;
       }
       validateSchemaAtPath(schema.schema, value, path, issues);
       return;
-    case "object": {
-      if (!isRecord(value) || Array.isArray(value)) {
-        pushIssue(issues, path, "must be object", "object", value);
-        return;
-      }
-
-      for (const [fieldName, fieldSchema] of Object.entries(schema.fields)) {
-        const fieldPath = `${path}.${fieldName}`;
-        if (!(fieldName in value)) {
-          if (fieldSchema.kind !== "optional") {
-            pushIssue(
-              issues,
-              fieldPath,
-              "is required",
-              renderSchema(fieldSchema),
-              undefined,
-            );
-          }
-          continue;
-        }
-        validateSchemaAtPath(fieldSchema, value[fieldName], fieldPath, issues);
-      }
-
-      const knownFields = new Set(Object.keys(schema.fields));
-      for (const fieldName of Object.keys(value)) {
-        if (!knownFields.has(fieldName)) {
-          pushIssue(
-            issues,
-            `${path}.${fieldName}`,
-            "is not allowed",
-            "no extra fields",
-            value[fieldName],
-          );
-        }
-      }
+    case "object":
+      validateObjectSchemaAtPath(schema, value, path, issues);
       return;
-    }
     default:
       pushIssue(
         issues,


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)
## 改了什么
将 `validateSchemaAtPath` 中 `array` / `record` / `union` / `object` 分支抽成独立校验函数，保持行为不变但降低单函数复杂度。

## 为什么改
该函数此前触发 complexity warning，后续继续演进时维护成本高。拆分后职责更清晰，逻辑更容易定位和复用。

## 验证
- [x] typecheck 通过
- [x] lint 通过（相关文件 lint 通过）
- [x] 相关测试通过

执行命令：
- `pnpm eslint apps/desktop/main/src/ipc/runtime-validation.ts`
- `pnpm test:unit`
- `pnpm typecheck`

---
🤖 by 天野 (automated iteration)