### PR TITLE
improve: reduce ai error card complexity

### DIFF
--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -222,6 +222,54 @@ function getBorderColorByType(type: AiErrorType): string {
   }
 }
 
+function getBackgroundColorByType(type: AiErrorType): string {
+  switch (type) {
+    case "rate_limit":
+    case "usage_limit":
+      return "bg-[var(--color-bg-raised)]";
+    case "service_error":
+    case "connection_failed":
+    case "timeout":
+    default:
+      return "bg-[var(--color-error-subtle)]";
+  }
+}
+
+function isRetryableErrorType(type: AiErrorType): boolean {
+  switch (type) {
+    case "connection_failed":
+    case "timeout":
+    case "rate_limit":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function getRetryButtonContent(
+  retryState: RetryState,
+  errorType: AiErrorType,
+): JSX.Element {
+  if (retryState === "loading") {
+    return (
+      <>
+        <Spinner />
+        <span>Retrying...</span>
+      </>
+    );
+  }
+
+  if (retryState === "success") {
+    return <span className="text-[var(--color-success)]">Success!</span>;
+  }
+
+  if (retryState === "error") {
+    return <span className="text-[var(--color-error)]">Failed</span>;
+  }
+
+  return <span>{errorType === "timeout" ? "Try Again" : "Retry"}</span>;
+}
+
 /**
 
  * Card styles
@@ -468,6 +516,91 @@ const dismissButtonStyles = [
   "focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 
+type RenderActionButtonsArgs = {
+  errorType: AiErrorType;
+  onUpgradePlan?: () => void;
+  onViewUsage?: () => void;
+  onRetry?: () => void | Promise<void>;
+  onCheckStatus?: () => void;
+  handleRetry: () => void;
+  retryState: RetryState;
+  isRetryDisabled: boolean;
+  retryButtonContent: JSX.Element;
+};
+
+function renderActionButtons({
+  errorType,
+  onUpgradePlan,
+  onViewUsage,
+  onRetry,
+  onCheckStatus,
+  handleRetry,
+  retryState,
+  isRetryDisabled,
+  retryButtonContent,
+}: RenderActionButtonsArgs): JSX.Element | null {
+  if (errorType === "usage_limit") {
+    return (
+      <>
+        {onUpgradePlan && (
+          <button
+            type="button"
+            className={upgradeButtonStyles}
+            onClick={onUpgradePlan}
+          >
+            Upgrade Plan
+          </button>
+        )}
+
+        {onViewUsage && (
+          <button type="button" className={linkButtonStyles} onClick={onViewUsage}>
+            View Usage
+          </button>
+        )}
+      </>
+    );
+  }
+
+  if (errorType === "service_error") {
+    return (
+      <>
+        {onRetry && (
+          <button
+            type="button"
+            className={retryButtonStyles}
+            onClick={handleRetry}
+            disabled={retryState === "loading"}
+          >
+            {retryButtonContent}
+          </button>
+        )}
+
+        {onCheckStatus && (
+          <button type="button" className={linkButtonStyles} onClick={onCheckStatus}>
+            Check Status
+            <ExternalLinkIcon />
+          </button>
+        )}
+      </>
+    );
+  }
+
+  if (isRetryableErrorType(errorType) && onRetry) {
+    return (
+      <button
+        type="button"
+        className={retryButtonStyles}
+        onClick={handleRetry}
+        disabled={isRetryDisabled}
+      >
+        {retryButtonContent}
+      </button>
+    );
+  }
+
+  return null;
+}
+
 /**
 
  * AiErrorCard - Error state card for AI operations
@@ -550,12 +683,7 @@ export function AiErrorCard({
 
   const borderColor = getBorderColorByType(error.type);
 
-  const bgColor =
-    error.type === "service_error"
-      ? "bg-[var(--color-error-subtle)]"
-      : error.type === "rate_limit" || error.type === "usage_limit"
-        ? "bg-[var(--color-bg-raised)]"
-        : "bg-[var(--color-error-subtle)]";
+  const bgColor = getBackgroundColorByType(error.type);
 
   // Countdown timer for rate limit errors
 
@@ -633,29 +761,7 @@ export function AiErrorCard({
   const opacityClass =
     cardState === "dismissing" ? "opacity-0 scale-95" : "opacity-100 scale-100";
 
-  // Get retry button text and state
-
-  const getRetryButtonContent = () => {
-    if (retryState === "loading") {
-      return (
-        <>
-          <Spinner />
-
-          <span>Retrying...</span>
-        </>
-      );
-    }
-
-    if (retryState === "success") {
-      return <span className="text-[var(--color-success)]">Success!</span>;
-    }
-
-    if (retryState === "error") {
-      return <span className="text-[var(--color-error)]">Failed</span>;
-    }
-
-    return <span>{error.type === "timeout" ? "Try Again" : "Retry"}</span>;
-  };
+  const retryButtonContent = getRetryButtonContent(retryState, error.type);
 
   return (
     <div
@@ -715,75 +821,17 @@ export function AiErrorCard({
           {/* Actions */}
 
           <div className={buttonContainerStyles}>
-            {/* Usage limit: Upgrade Plan + View Usage */}
-
-            {error.type === "usage_limit" && (
-              <>
-                {onUpgradePlan && (
-                  <button
-                    type="button"
-                    className={upgradeButtonStyles}
-                    onClick={onUpgradePlan}
-                  >
-                    Upgrade Plan
-                  </button>
-                )}
-
-                {onViewUsage && (
-                  <button
-                    type="button"
-                    className={linkButtonStyles}
-                    onClick={onViewUsage}
-                  >
-                    View Usage
-                  </button>
-                )}
-              </>
-            )}
-
-            {/* Service error: Retry + Check Status */}
-
-            {error.type === "service_error" && (
-              <>
-                {onRetry && (
-                  <button
-                    type="button"
-                    className={retryButtonStyles}
-                    onClick={handleRetry}
-                    disabled={retryState === "loading"}
-                  >
-                    {getRetryButtonContent()}
-                  </button>
-                )}
-
-                {onCheckStatus && (
-                  <button
-                    type="button"
-                    className={linkButtonStyles}
-                    onClick={onCheckStatus}
-                  >
-                    Check Status
-                    <ExternalLinkIcon />
-                  </button>
-                )}
-              </>
-            )}
-
-            {/* Connection/Timeout/Rate Limit: Retry button */}
-
-            {(error.type === "connection_failed" ||
-              error.type === "timeout" ||
-              error.type === "rate_limit") &&
-              onRetry && (
-                <button
-                  type="button"
-                  className={retryButtonStyles}
-                  onClick={handleRetry}
-                  disabled={isRetryDisabled}
-                >
-                  {getRetryButtonContent()}
-                </button>
-              )}
+            {renderActionButtons({
+              errorType: error.type,
+              onUpgradePlan,
+              onViewUsage,
+              onRetry,
+              onCheckStatus,
+              handleRetry,
+              retryState,
+              isRetryDisabled,
+              retryButtonContent,
+            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)
## 改了什么
对 `AiErrorCard` 的分支逻辑做小步拆分，降低组件函数复杂度：
- 提取背景色判定：`getBackgroundColorByType`
- 提取可重试错误判定：`isRetryableErrorType`
- 提取重试按钮内容：`getRetryButtonContent`
- 提取动作区渲染：`renderActionButtons`

未改业务行为，仅重组条件分支与渲染组织方式。

## 为什么改
该组件触发 complexity 警告，继续叠加逻辑会提高维护风险。拆分后职责更清晰，后续改动更安全。

## 验证
- [x] typecheck 通过
- [x] lint 通过（相关文件）
- [ ] 相关单测

执行命令：
- `pnpm eslint apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx`
- `pnpm typecheck`

---
🤖 by 天野 (automated iteration)