### PR TITLE
improve(renderer): OpenSettings tests lint cleanup

### DIFF
--- a/apps/desktop/renderer/src/components/layout/OpenSettingsCompat.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/OpenSettingsCompat.test.tsx
@@ -9,10 +9,13 @@ import {
 } from "../../contexts/OpenSettingsContext";
 
 function HookProbe(props: { onResolve: (openSettings: () => void) => void }) {
+  const { onResolve } = props;
   const openSettings = useOpenSettingsFromRightPanel();
+
   React.useEffect(() => {
-    props.onResolve(openSettings);
-  }, [props.onResolve, openSettings]);
+    onResolve(openSettings);
+  }, [onResolve, openSettings]);
+
   return null;
 }
 

--- a/apps/desktop/renderer/src/contexts/OpenSettingsContext.test.tsx
+++ b/apps/desktop/renderer/src/contexts/OpenSettingsContext.test.tsx
@@ -5,10 +5,13 @@ import { describe, expect, it, vi } from "vitest";
 import { OpenSettingsContext, useOpenSettings } from "./OpenSettingsContext";
 
 function HookProbe(props: { onResolve: (openSettings: () => void) => void }) {
+  const { onResolve } = props;
   const openSettings = useOpenSettings();
+
   React.useEffect(() => {
-    props.onResolve(openSettings);
-  }, [props.onResolve, openSettings]);
+    onResolve(openSettings);
+  }, [onResolve, openSettings]);
+
   return null;
 }
 


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)
## 主题
修复 OpenSettings 相关测试中的 react-hooks/exhaustive-deps 警告（不改业务行为）

## 改动列表
- 25ec3e37: improve(renderer): fix exhaustive-deps in OpenSettings compat test
- f34fd26e: improve(renderer): fix exhaustive-deps in OpenSettingsContext test

## 为什么改
这些测试里 useEffect 直接引用了 props 对象，触发 eslint react-hooks/exhaustive-deps 的依赖提示。把 props 解构后再写依赖列表，可以消除警告，并保持 hook 行为不变。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仍有历史 warnings；本 PR 消除其中 2 条）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)