### PR TITLE
improve: reduce ProxySection function length

### DIFF
--- a/apps/desktop/renderer/src/features/settings/ProxySection.tsx
+++ b/apps/desktop/renderer/src/features/settings/ProxySection.tsx
@@ -12,6 +12,111 @@ import { emitAiModelCatalogUpdated } from "../ai/modelCatalogEvents";
 type ProxySettings = IpcResponseData<"ai:config:get">;
 type ModelCatalog = IpcResponseData<"ai:models:list">;
 
+type ModelsSectionProps = {
+  modelCatalog: ModelCatalog | null;
+  modelsStatus: "idle" | "loading";
+  modelsErrorText: string | null;
+};
+
+function ModelsSection({
+  modelCatalog,
+  modelsStatus,
+  modelsErrorText,
+}: ModelsSectionProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1.5 border border-[var(--color-border-default)] rounded-[var(--radius-md)] p-2.5">
+      <div className="flex items-center gap-2">
+        <Text size="small" color="muted">
+          Available Models
+        </Text>
+        <Text size="tiny" color="muted" className="ml-auto">
+          {modelCatalog ? `source: ${modelCatalog.source}` : "source: unknown"}
+        </Text>
+      </div>
+
+      {modelsErrorText ? (
+        <Text data-testid="proxy-models-error" size="small" color="muted">
+          {modelsErrorText}
+        </Text>
+      ) : null}
+
+      <div data-testid="proxy-models-list" className="max-h-28 overflow-auto">
+        {modelCatalog && modelCatalog.items.length > 0 ? (
+          modelCatalog.items.map((item) => (
+            <Text key={item.id} size="small" color="muted">
+              {item.name} ({item.id})
+            </Text>
+          ))
+        ) : (
+          <Text size="small" color="muted">
+            {modelsStatus === "loading" ? "Loading models..." : "No models discovered"}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type ProxyActionsProps = {
+  status: "idle" | "loading";
+  modelsStatus: "idle" | "loading";
+  onSave: () => Promise<void>;
+  onTest: () => Promise<void>;
+  onModelsRefresh: () => Promise<void>;
+  onRefresh: () => Promise<void>;
+};
+
+function ProxyActions({
+  status,
+  modelsStatus,
+  onSave,
+  onTest,
+  onModelsRefresh,
+  onRefresh,
+}: ProxyActionsProps): JSX.Element {
+  return (
+    <div className="flex gap-2">
+      <Button
+        data-testid="proxy-save"
+        variant="secondary"
+        size="sm"
+        onClick={() => void onSave()}
+        disabled={status === "loading"}
+      >
+        Save
+      </Button>
+      <Button
+        data-testid="proxy-test"
+        variant="secondary"
+        size="sm"
+        onClick={() => void onTest()}
+        disabled={status === "loading"}
+      >
+        Test
+      </Button>
+      <Button
+        data-testid="proxy-models-refresh"
+        variant="secondary"
+        size="sm"
+        onClick={() => void onModelsRefresh()}
+        disabled={modelsStatus === "loading"}
+      >
+        Refresh Models
+      </Button>
+      <Button
+        data-testid="proxy-refresh"
+        variant="secondary"
+        size="sm"
+        onClick={() => void onRefresh()}
+        disabled={status === "loading"}
+        className="ml-auto"
+      >
+        Refresh
+      </Button>
+    </div>
+  );
+}
+
 /**
  * ProxySection controls optional OpenAI-compatible proxy settings.
  *
@@ -300,80 +405,20 @@ export function ProxySection(): JSX.Element {
         </Text>
       ) : null}
 
-      <div className="flex flex-col gap-1.5 border border-[var(--color-border-default)] rounded-[var(--radius-md)] p-2.5">
-        <div className="flex items-center gap-2">
-          <Text size="small" color="muted">
-            Available Models
-          </Text>
-          <Text size="tiny" color="muted" className="ml-auto">
-            {modelCatalog
-              ? `source: ${modelCatalog.source}`
-              : "source: unknown"}
-          </Text>
-        </div>
+      <ModelsSection
+        modelCatalog={modelCatalog}
+        modelsStatus={modelsStatus}
+        modelsErrorText={modelsErrorText}
+      />
 
-        {modelsErrorText ? (
-          <Text data-testid="proxy-models-error" size="small" color="muted">
-            {modelsErrorText}
-          </Text>
-        ) : null}
-
-        <div data-testid="proxy-models-list" className="max-h-28 overflow-auto">
-          {modelCatalog && modelCatalog.items.length > 0 ? (
-            modelCatalog.items.map((item) => (
-              <Text key={item.id} size="small" color="muted">
-                {item.name} ({item.id})
-              </Text>
-            ))
-          ) : (
-            <Text size="small" color="muted">
-              {modelsStatus === "loading"
-                ? "Loading models..."
-                : "No models discovered"}
-            </Text>
-          )}
-        </div>
-      </div>
-
-      <div className="flex gap-2">
-        <Button
-          data-testid="proxy-save"
-          variant="secondary"
-          size="sm"
-          onClick={() => void onSave()}
-          disabled={status === "loading"}
-        >
-          Save
-        </Button>
-        <Button
-          data-testid="proxy-test"
-          variant="secondary"
-          size="sm"
-          onClick={() => void onTest()}
-          disabled={status === "loading"}
-        >
-          Test
-        </Button>
-        <Button
-          data-testid="proxy-models-refresh"
-          variant="secondary"
-          size="sm"
-          onClick={() => void refreshModels()}
-          disabled={modelsStatus === "loading"}
-        >
-          Refresh Models
-        </Button>
-        <Button
-          data-testid="proxy-refresh"
-          variant="secondary"
-          size="sm"
-          onClick={() => void refresh()}
-          disabled={status === "loading"}
-          className="ml-auto"
-        >
-          Refresh
-        </Button>
-      </div>
+      <ProxyActions
+        status={status}
+        modelsStatus={modelsStatus}
+        onSave={onSave}
+        onTest={onTest}
+        onModelsRefresh={refreshModels}
+        onRefresh={refresh}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)
## 改了什么
将 `ProxySection` 内部的大段 UI 片段抽成两个小组件：
- `ModelsSection`：仅负责渲染 models 列表/错误/来源信息
- `ProxyActions`：仅负责底部按钮组（Save/Test/Refresh Models/Refresh）

目的在于把 `ProxySection` 函数行数降到 lint 阈值以内，逻辑与 UI 行为保持不变。

## 为什么改
该组件触发 `max-lines-per-function` 警告，继续堆逻辑会降低可维护性。拆分后职责更清晰，也更易做局部测试。

## 验证
- [x] typecheck 通过
- [x] lint 通过（相关文件）
- [x] unit tests 通过

执行命令：
- `pnpm typecheck`
- `pnpm eslint apps/desktop/renderer/src/features/settings/ProxySection.tsx`
- `pnpm test:unit`

---
🤖 by 天野 (automated iteration)