### PR TITLE
refactor: retire legacy adapters in kgStore and memoryStore (#699)

### DIFF
--- a/apps/desktop/main/src/__tests__/integration/kg-other-type-migration.test.ts
+++ b/apps/desktop/main/src/__tests__/integration/kg-other-type-migration.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+
+const migrationSqlPath = new URL(
+  "../../db/migrations/0023_kg_type_other_to_faction.sql",
+  import.meta.url,
+);
+const migrationSql = fs.readFileSync(migrationSqlPath, "utf8");
+
+// Scenario: AUD-C11-S4 legacy "other" records are migrated by DB migration.
+{
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "creonow-c11-kg-"));
+  const dbPath = path.join(userDataDir, "migration-test.db");
+
+  try {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version (version) VALUES (22);
+
+      CREATE TABLE kg_entities (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        name TEXT NOT NULL
+      );
+
+      INSERT INTO kg_entities (id, project_id, type, name)
+      VALUES ('legacy-entity-1', 'project-1', 'other', 'Legacy Other Type');
+    `);
+    db.exec(migrationSql);
+
+    const row = db
+      .prepare<
+        [string],
+        {
+          type: string;
+        }
+      >("SELECT type FROM kg_entities WHERE id = ?")
+      .get("legacy-entity-1");
+    db.close();
+
+    assert.equal(
+      row?.type,
+      "faction",
+      "legacy kg_entities.type='other' should be migrated to 'faction'",
+    );
+  } finally {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+}
+
+console.log("kg-other-type-migration.test.ts: all assertions passed");

--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -37,6 +37,7 @@ import kgAliasesSql from "./migrations/0019_kg_aliases.sql?raw";
 import kgLastSeenStateSql from "./migrations/0020_kg_last_seen_state.sql?raw";
 import tracePersistenceSql from "./migrations/0021_s3_trace_persistence.sql?raw";
 import synopsisInjectionSql from "./migrations/0022_s3_synopsis_injection.sql?raw";
+import kgTypeOtherToFactionSql from "./migrations/0023_kg_type_other_to_faction.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -134,6 +135,11 @@ const MIGRATIONS_BASE: readonly Migration[] = [
     version: 22,
     name: "0022_s3_synopsis_injection",
     sql: synopsisInjectionSql,
+  },
+  {
+    version: 23,
+    name: "0023_kg_type_other_to_faction",
+    sql: kgTypeOtherToFactionSql,
   },
 ];
 

--- a/apps/desktop/main/src/db/migrations/0023_kg_type_other_to_faction.sql
+++ b/apps/desktop/main/src/db/migrations/0023_kg_type_other_to_faction.sql
@@ -1,0 +1,6 @@
+-- AUD-C11-S4: migrate legacy kg_entities.type='other' to supported type='faction'.
+-- Why: renderer/runtime no longer performs legacy 'other' compatibility mapping.
+
+UPDATE kg_entities
+SET type = 'faction'
+WHERE lower(trim(type)) = 'other';

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
@@ -33,6 +33,12 @@ const legendItems: Array<{
     colorVar: "var(--color-node-item)",
     shape: "rounded",
   },
+  {
+    type: "faction",
+    label: "Faction",
+    colorVar: "var(--color-node-other)",
+    shape: "rounded",
+  },
 ];
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -9,7 +9,7 @@ const nodeColorVars: Record<NodeType, string> = {
   location: "var(--color-node-location)",
   event: "var(--color-node-event)",
   item: "var(--color-node-item)",
-  other: "var(--color-node-other)",
+  faction: "var(--color-node-other)",
 };
 
 /**
@@ -62,7 +62,7 @@ function NodeIcon({ type, color }: { type: NodeType; color: string }): JSX.Eleme
         </svg>
       );
     default:
-      // character and other types show avatar or initials
+      // character and faction types show avatar or initials
       return <></>;
   }
 }
@@ -95,7 +95,7 @@ const typeStyles: Record<NodeType, string> = {
   location: "rounded-lg",
   event: "rounded-lg rotate-45",
   item: "rounded-xl",
-  other: "rounded-full",
+  faction: "rounded-full",
 };
 
 /**
@@ -192,7 +192,7 @@ export function GraphNode({
     >
       {/* Node content */}
       <div className={`flex items-center justify-center ${isEventType ? "-rotate-45" : ""}`}>
-        {type === "character" || type === "other" ? (
+        {type === "character" || type === "faction" ? (
           avatar ? (
             <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
               <img

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
@@ -26,6 +26,11 @@ const filterButtons: Array<{
     colorClass: "bg-[var(--color-node-event)]",
   },
   { filter: "item", label: "Items", colorClass: "bg-[var(--color-node-item)]" },
+  {
+    filter: "faction",
+    label: "Factions",
+    colorClass: "bg-[var(--color-node-other)]",
+  },
 ];
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -11,7 +11,7 @@ const typeToVariant: Record<NodeType, "info" | "success" | "warning" | "default"
   location: "success",
   event: "warning",
   item: "default",
-  other: "default",
+  faction: "default",
 };
 
 /**
@@ -22,7 +22,7 @@ const typeColorVars: Record<NodeType, string> = {
   location: "var(--color-node-location)",
   event: "var(--color-node-event)",
   item: "var(--color-node-item)",
-  other: "var(--color-node-other)",
+  faction: "var(--color-node-other)",
 };
 
 const typeLabels: Record<NodeType, string> = {
@@ -30,7 +30,7 @@ const typeLabels: Record<NodeType, string> = {
   location: "Location",
   event: "Event",
   item: "Item",
-  other: "Other",
+  faction: "Faction",
 };
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.audit.test.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.audit.test.tsx
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("NodeEditDialog entity type options", () => {
+  it("AUD-C11-S3: UI options must not include 'other'", () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        "renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(source).not.toContain('value: "other"');
+    expect(source).toContain('value: "faction"');
+  });
+});

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -26,7 +26,11 @@ const nodeTypeOptions: Array<{
   },
   { value: "event", label: "事件 (Event)", colorVar: "var(--color-node-event)" },
   { value: "item", label: "物品 (Item)", colorVar: "var(--color-node-item)" },
-  { value: "other", label: "其他 (Other)", colorVar: "var(--color-node-other)" },
+  {
+    value: "faction",
+    label: "阵营 (Faction)",
+    colorVar: "var(--color-node-other)",
+  },
 ];
 
 /**
@@ -177,7 +181,7 @@ export function NodeEditDialog({
         </div>
 
         {/* Role (for characters) */}
-        {(type === "character" || type === "other") && (
+        {(type === "character" || type === "faction") && (
           <div>
             <label className={labelStyles}>角色定位</label>
             <Input

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/types.ts
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/types.ts
@@ -7,11 +7,11 @@
  * - --color-node-location: #22c55e (绿色)
  * - --color-node-event: #f97316 (橙色)
  * - --color-node-item: #06b6d4 (青色)
- * - --color-node-other: #8b5cf6 (紫色)
+ * - --color-node-other: #8b5cf6 (阵营)
  */
 
 /** Node types in the knowledge graph */
-export type NodeType = "character" | "location" | "event" | "item" | "other";
+export type NodeType = "character" | "location" | "event" | "item" | "faction";
 
 /** Graph node representing an entity */
 export interface GraphNode {

--- a/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
@@ -84,20 +84,20 @@ export function CharacterCardListContainer({
   const handleCreateCharacter = React.useCallback(async () => {
     const created = await entityCreate({
       name: "新角色",
-      entityType: "character",
+      type: "character",
       description: "",
     });
     if (!created.ok) {
       return;
     }
-    setSelectedId(created.data.entityId);
+    setSelectedId(created.data.id);
     setDialogOpen(true);
   }, [entityCreate]);
 
   const handleSaveCharacter = React.useCallback(
     async (character: Character) => {
       await entityUpdate({
-        entityId: character.id,
+        id: character.id,
         patch: {
           name: character.name,
           description: character.description ?? "",
@@ -123,7 +123,7 @@ export function CharacterCardListContainer({
       if (!confirmed) {
         return;
       }
-      await entityDelete({ entityId: characterId });
+      await entityDelete({ id: characterId });
       if (selectedId === characterId) {
         setSelectedId(null);
         setDialogOpen(false);

--- a/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
@@ -71,13 +71,13 @@ export function CharacterPanelContainer(
   const handleCreate = React.useCallback(async () => {
     const res = await entityCreate({
       name: "New Character",
-      entityType: "character",
+      type: "character",
       description: "",
     });
 
     if (res.ok) {
       // Select the newly created character
-      setSelectedId(res.data.entityId);
+      setSelectedId(res.data.id);
     }
   }, [entityCreate]);
 
@@ -87,7 +87,7 @@ export function CharacterPanelContainer(
   const handleUpdate = React.useCallback(
     async (character: Character) => {
       await entityUpdate({
-        entityId: character.id,
+        id: character.id,
         patch: {
           name: character.name,
           description: character.description ?? "",
@@ -117,7 +117,7 @@ export function CharacterPanelContainer(
         return;
       }
 
-      await entityDelete({ entityId: characterId });
+      await entityDelete({ id: characterId });
 
       // Clear selection if deleted character was selected
       if (selectedId === characterId) {

--- a/apps/desktop/renderer/src/features/character/characterFromKg.ts
+++ b/apps/desktop/renderer/src/features/character/characterFromKg.ts
@@ -186,12 +186,12 @@ export function kgEntityToCharacter(
 
   for (const rel of relations) {
     // Outgoing relations: this character -> other
-    if (rel.fromEntityId === entity.entityId) {
-      const targetEntity = entityMap.get(rel.toEntityId);
-      if (targetEntity && targetEntity.entityType === "character") {
+    if (rel.sourceEntityId === entity.id) {
+      const targetEntity = entityMap.get(rel.targetEntityId);
+      if (targetEntity && targetEntity.type === "character") {
         const targetMeta = parseCharacterMetadata(targetEntity.metadataJson);
         relationships.push({
-          characterId: targetEntity.entityId,
+          characterId: targetEntity.id,
           characterName: targetEntity.name,
           characterRole: targetMeta.role,
           characterAvatar: targetMeta.avatarUrl,
@@ -200,17 +200,17 @@ export function kgEntityToCharacter(
       }
     }
     // Incoming relations: other -> this character (show as bidirectional)
-    if (rel.toEntityId === entity.entityId) {
-      const sourceEntity = entityMap.get(rel.fromEntityId);
-      if (sourceEntity && sourceEntity.entityType === "character") {
+    if (rel.targetEntityId === entity.id) {
+      const sourceEntity = entityMap.get(rel.sourceEntityId);
+      if (sourceEntity && sourceEntity.type === "character") {
         const sourceMeta = parseCharacterMetadata(sourceEntity.metadataJson);
         // Check if we already have this relationship (avoid duplicates)
         const existing = relationships.find(
-          (r) => r.characterId === sourceEntity.entityId,
+          (r) => r.characterId === sourceEntity.id,
         );
         if (!existing) {
           relationships.push({
-            characterId: sourceEntity.entityId,
+            characterId: sourceEntity.id,
             characterName: sourceEntity.name,
             characterRole: sourceMeta.role,
             characterAvatar: sourceMeta.avatarUrl,
@@ -222,7 +222,7 @@ export function kgEntityToCharacter(
   }
 
   return {
-    id: entity.entityId,
+    id: entity.id,
     name: entity.name,
     age: metadata.age,
     birthDate: metadata.birthDate,
@@ -312,7 +312,7 @@ export function characterToMetadataJson(character: Partial<Character>): string {
  * @returns Entities with entityType="character"
  */
 export function filterCharacterEntities(entities: KgEntity[]): KgEntity[] {
-  return entities.filter((e) => e.entityType === "character");
+  return entities.filter((e) => e.type === "character");
 }
 
 /**
@@ -327,7 +327,7 @@ export function kgToCharacters(
   relations: KgRelation[],
 ): Character[] {
   const characterEntities = filterCharacterEntities(entities);
-  const entityMap = new Map(entities.map((e) => [e.entityId, e]));
+  const entityMap = new Map(entities.map((e) => [e.id, e]));
 
   return characterEntities.map((entity) =>
     kgEntityToCharacter(entity, relations, entityMap),

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.aliases.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.aliases.test.tsx
@@ -64,7 +64,7 @@ describe("KnowledgeGraphPanel.aliases", () => {
 
     expect(mockKgState.entityCreate).toHaveBeenCalledWith({
       name: "林默",
-      entityType: "",
+      type: "",
       description: "",
       aliases: ["小默", "默哥", "小默"],
     });

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.context-level.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.context-level.test.tsx
@@ -6,7 +6,7 @@ import type { KgEntity, KgRelation } from "../../stores/kgStore";
 import { KnowledgeGraphPanel } from "./KnowledgeGraphPanel";
 
 type ServiceResult =
-  | { ok: true; data?: { entityId?: string } }
+  | { ok: true; data?: { id?: string } }
   | { ok: false; error: { code: string; message: string } };
 
 type MockKgState = {
@@ -34,10 +34,8 @@ vi.mock("../../stores/kgStore", () => ({
 function makeEntity(): KgEntity {
   return {
     id: "entity-1",
-    entityId: "entity-1",
     projectId: "project-1",
     type: "character",
-    entityType: "character",
     name: "林远",
     description: "冷静",
     attributes: {},
@@ -82,7 +80,7 @@ describe("KnowledgeGraphPanel.context-level", () => {
 
     await waitFor(() => {
       expect(mockKgState.entityUpdate).toHaveBeenCalledWith({
-        entityId: "entity-1",
+        id: "entity-1",
         patch: expect.objectContaining({
           aiContextLevel: "always",
         }),

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.last-seen-state.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.last-seen-state.test.tsx
@@ -6,7 +6,7 @@ import type { KgEntity, KgRelation } from "../../stores/kgStore";
 import { KnowledgeGraphPanel } from "./KnowledgeGraphPanel";
 
 type ServiceResult =
-  | { ok: true; data?: { entityId?: string } }
+  | { ok: true; data?: { id?: string } }
   | { ok: false; error: { code: string; message: string } };
 
 type MockKgState = {
@@ -34,10 +34,8 @@ vi.mock("../../stores/kgStore", () => ({
 function makeEntity(): KgEntity {
   return {
     id: "entity-1",
-    entityId: "entity-1",
     projectId: "project-1",
     type: "character",
-    entityType: "character",
     name: "林远",
     description: "冷静",
     attributes: {},
@@ -84,7 +82,7 @@ describe("KnowledgeGraphPanel.last-seen-state", () => {
 
     await waitFor(() => {
       expect(mockKgState.entityUpdate).toHaveBeenCalledWith({
-        entityId: "entity-1",
+        id: "entity-1",
         patch: expect.objectContaining({
           lastSeenState: "受伤但清醒",
         }),

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.render.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.render.test.tsx
@@ -34,10 +34,8 @@ describe("KnowledgeGraphPanel.render", () => {
       entities: [
         {
           id: "e-character",
-          entityId: "e-character",
           projectId: "project-1",
           type: "character",
-          entityType: "character",
           name: "林远",
           description: "冷静",
           attributes: {},
@@ -50,10 +48,8 @@ describe("KnowledgeGraphPanel.render", () => {
         },
         {
           id: "e-location",
-          entityId: "e-location",
           projectId: "project-1",
           type: "location",
-          entityType: "location",
           name: "旧港",
           description: "",
           attributes: {},
@@ -68,12 +64,9 @@ describe("KnowledgeGraphPanel.render", () => {
       relations: [
         {
           id: "r-1",
-          relationId: "r-1",
           projectId: "project-1",
           sourceEntityId: "e-character",
-          fromEntityId: "e-character",
           targetEntityId: "e-location",
-          toEntityId: "e-location",
           relationType: "盟友",
           description: "",
           createdAt: "2026-02-08T12:00:00.000Z",

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -26,15 +26,15 @@ type EditingState =
   | { mode: "idle" }
   | {
       mode: "entity";
-      entityId: string;
+      id: string;
       name: string;
-      entityType: string;
+      type: string;
       description: string;
       lastSeenState: string;
       aiContextLevel: AiContextLevel;
       aliasesInput: string;
     }
-  | { mode: "relation"; relationId: string; relationType: string };
+  | { mode: "relation"; id: string; relationType: string };
 
 type AiContextLevel = "always" | "when_detected" | "manual_only" | "never";
 
@@ -56,8 +56,8 @@ type AsyncMutationResult =
   | null
   | undefined;
 
-function entityLabel(args: { name: string; entityType?: string }): string {
-  return args.entityType ? `${args.name} (${args.entityType})` : args.name;
+function entityLabel(args: { name: string; type?: string }): string {
+  return args.type ? `${args.name} (${args.type})` : args.name;
 }
 
 function parseAliasesInput(value: string): string[] {
@@ -75,7 +75,7 @@ function formatAliasesInput(aliases: string[]): string {
  * Map NodeType to KG entity type string.
  */
 function nodeTypeToEntityType(nodeType: NodeType): string {
-  return nodeType === "other" ? "" : nodeType;
+  return nodeType;
 }
 
 function parseMetadataJson(
@@ -123,7 +123,7 @@ export function shouldClearRelationEditingAfterDelete(args: {
   return (
     args.result?.ok === true &&
     args.editing.mode === "relation" &&
-    args.editing.relationId === args.targetRelationId
+    args.editing.id === args.targetRelationId
   );
 }
 
@@ -223,11 +223,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       setRelToId("");
       return;
     }
-    if (!entities.some((e) => e.entityId === relFromId)) {
-      setRelFromId(entities[0]!.entityId);
+    if (!entities.some((e) => e.id === relFromId)) {
+      setRelFromId(entities[0]!.id);
     }
-    if (!entities.some((e) => e.entityId === relToId)) {
-      const fallback = entities[1]?.entityId ?? entities[0]!.entityId;
+    if (!entities.some((e) => e.id === relToId)) {
+      const fallback = entities[1]?.id ?? entities[0]!.id;
       setRelToId(fallback);
     }
   }, [entities, relFromId, relToId]);
@@ -235,7 +235,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   async function onCreateEntity(): Promise<void> {
     const res = await entityCreate({
       name: createName,
-      entityType: createType,
+      type: createType,
       description: createDescription,
       aliases: parseAliasesInput(createAliasesInput),
     });
@@ -259,8 +259,8 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
     if (!confirmed) {
       return;
     }
-    await entityDelete({ entityId });
-    if (editing.mode === "entity" && editing.entityId === entityId) {
+    await entityDelete({ id: entityId });
+    if (editing.mode === "entity" && editing.id === entityId) {
       setEditing({ mode: "idle" });
     }
   }
@@ -281,7 +281,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       return;
     }
     try {
-      const res = await relationDelete({ relationId });
+      const res = await relationDelete({ id: relationId });
       if (!res.ok) {
         console.warn(
           "[KnowledgeGraphPanel] relationDelete failed:",
@@ -312,10 +312,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   async function onSaveEdit(): Promise<void> {
     if (editing.mode === "entity") {
       const res = await entityUpdate({
-        entityId: editing.entityId,
+        id: editing.id,
         patch: {
           name: editing.name,
-          entityType: editing.entityType,
+          type: editing.type,
           description: editing.description,
           lastSeenState: editing.lastSeenState,
           aiContextLevel: editing.aiContextLevel,
@@ -331,7 +331,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
 
     if (editing.mode === "relation") {
       const res = await relationUpdate({
-        relationId: editing.relationId,
+        id: editing.id,
         patch: { relationType: editing.relationType },
       });
       if (!res.ok) {
@@ -347,8 +347,8 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       return;
     }
     const res = await relationCreate({
-      fromEntityId: relFromId,
-      toEntityId: relToId,
+      sourceEntityId: relFromId,
+      targetEntityId: relToId,
       relationType: relType,
     });
     if (!res.ok) {
@@ -358,7 +358,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   }
 
   function getEntityName(entityId: string): string {
-    const e = entities.find((x) => x.entityId === entityId);
+    const e = entities.find((x) => x.id === entityId);
     return e ? e.name : entityId;
   }
 
@@ -375,7 +375,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
 
   const timelineEvents = React.useMemo<TimelineEventItem[]>(() => {
     return entities
-      .filter((entity) => entity.entityType === "event")
+      .filter((entity) => entity.type === "event")
       .map((entity, index) => {
         const metadata = parseMetadataJson(entity.metadataJson);
         const timeline = metadata
@@ -384,7 +384,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
         const chapterValue = timeline.chapter;
         const orderValue = timeline.order;
         return {
-          id: entity.entityId,
+          id: entity.id,
           title: entity.name,
           chapter:
             typeof chapterValue === "string" && chapterValue.length > 0
@@ -404,7 +404,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
     nodeId: string,
     position: { x: number; y: number },
   ): Promise<void> {
-    const entity = entities.find((e) => e.entityId === nodeId);
+    const entity = entities.find((e) => e.id === nodeId);
     if (!entity) {
       return;
     }
@@ -419,7 +419,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
 
     try {
       const res = await entityUpdate({
-        entityId: nodeId,
+        id: nodeId,
         patch: { metadataJson: updatedMetadata },
       });
       if (!res.ok) {
@@ -452,11 +452,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   }
 
   async function onTimelineOrderChange(orderedIds: string[]): Promise<void> {
-    const byId = new Map(entities.map((entity) => [entity.entityId, entity]));
+    const byId = new Map(entities.map((entity) => [entity.id, entity]));
     const writeResults = await Promise.allSettled(
       orderedIds.map(async (entityId, index) => {
         const entity = byId.get(entityId);
-        if (!entity || entity.entityType !== "event") {
+        if (!entity || entity.type !== "event") {
           return { attempted: false as const, failed: false as const };
         }
         const metadataJson = updateTimelineOrderInMetadata(
@@ -468,7 +468,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
         }
         try {
           const res = await entityUpdate({
-            entityId,
+            id: entityId,
             patch: { metadataJson },
           });
           if (!res.ok) {
@@ -528,7 +528,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
 
     const res = await entityCreate({
       name: "New Entity",
-      entityType: nodeTypeToEntityType(nodeType),
+      type: nodeTypeToEntityType(nodeType),
       description: "",
     });
 
@@ -536,10 +536,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       // Update with position metadata
       const metadata = createEntityMetadataWithPosition(nodeType, position);
       await entityUpdate({
-        entityId: res.data.entityId,
+        id: res.data.id,
         patch: { metadataJson: metadata },
       });
-      setSelectedNodeId(res.data.entityId);
+      setSelectedNodeId(res.data.id);
     }
   }
 
@@ -551,7 +551,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       // Create new entity
       const res = await entityCreate({
         name: node.label,
-        entityType: node.type === "other" ? "" : node.type,
+        type: node.type,
         description: node.metadata?.description ?? "",
       });
 
@@ -561,14 +561,14 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
           node.position,
         );
         await entityUpdate({
-          entityId: res.data.entityId,
+          id: res.data.id,
           patch: { metadataJson: metadata },
         });
-        setSelectedNodeId(res.data.entityId);
+        setSelectedNodeId(res.data.id);
       }
     } else {
       // Update existing entity
-      const entity = entities.find((e) => e.entityId === node.id);
+      const entity = entities.find((e) => e.id === node.id);
       if (!entity) return;
 
       const updatedMetadata = updatePositionInMetadata(
@@ -580,10 +580,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       }
 
       await entityUpdate({
-        entityId: node.id,
+        id: node.id,
         patch: {
           name: node.label,
-          entityType: node.type === "other" ? "" : node.type,
+          type: node.type,
           description: node.metadata?.description ?? "",
           metadataJson: updatedMetadata,
         },
@@ -681,16 +681,16 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
             }
             onOpenEvent={(eventId) => {
               const eventEntity = entities.find(
-                (entity) => entity.entityId === eventId,
+                (entity) => entity.id === eventId,
               );
               if (!eventEntity) {
                 return;
               }
               setEditing({
                 mode: "entity",
-                entityId: eventEntity.entityId,
+                id: eventEntity.id,
                 name: eventEntity.name,
-                entityType: eventEntity.entityType,
+                type: eventEntity.type,
                 description: eventEntity.description ?? "",
                 lastSeenState: eventEntity.lastSeenState ?? "",
                 aiContextLevel: eventEntity.aiContextLevel,
@@ -792,11 +792,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
             <div className="mt-3 flex flex-col gap-2">
               {entities.map((e) => {
                 const isEditing =
-                  editing.mode === "entity" && editing.entityId === e.entityId;
+                  editing.mode === "entity" && editing.id === e.id;
                 return (
                   <Card
-                    key={e.entityId}
-                    data-testid={`kg-entity-row-${e.entityId}`}
+                    key={e.id}
+                    data-testid={`kg-entity-row-${e.id}`}
                     noPadding
                     className="p-2.5 flex flex-col gap-2"
                   >
@@ -813,11 +813,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                           fullWidth
                         />
                         <Input
-                          value={editing.entityType}
+                          value={editing.type}
                           onChange={(evt) =>
                             setEditing({
                               ...editing,
-                              entityType: evt.target.value,
+                              type: evt.target.value,
                             })
                           }
                           fullWidth
@@ -872,7 +872,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                         <Text size="small">
                           {entityLabel({
                             name: e.name,
-                            entityType: e.entityType,
+                            type: e.type,
                           })}
                         </Text>
                         {e.description ? (
@@ -909,9 +909,9 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                             onClick={() =>
                               setEditing({
                                 mode: "entity",
-                                entityId: e.entityId,
+                                id: e.id,
                                 name: e.name,
-                                entityType: e.entityType ?? "",
+                                type: e.type ?? "",
                                 description: e.description ?? "",
                                 lastSeenState: e.lastSeenState ?? "",
                                 aiContextLevel: e.aiContextLevel,
@@ -922,10 +922,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                             Edit
                           </Button>
                           <Button
-                            data-testid={`kg-entity-delete-${e.entityId}`}
+                            data-testid={`kg-entity-delete-${e.id}`}
                             variant="ghost"
                             size="sm"
-                            onClick={() => void onDeleteEntity(e.entityId)}
+                            onClick={() => void onDeleteEntity(e.id)}
                           >
                             Delete
                           </Button>
@@ -949,10 +949,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                 onValueChange={(value) => setRelFromId(value)}
                 disabled={!isReady || entities.length === 0}
                 options={entities.map((e) => ({
-                  value: e.entityId,
+                  value: e.id,
                   label: entityLabel({
                     name: e.name,
-                    entityType: e.entityType,
+                    type: e.type,
                   }),
                 }))}
                 placeholder="Select entity..."
@@ -964,10 +964,10 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                 onValueChange={(value) => setRelToId(value)}
                 disabled={!isReady || entities.length === 0}
                 options={entities.map((e) => ({
-                  value: e.entityId,
+                  value: e.id,
                   label: entityLabel({
                     name: e.name,
-                    entityType: e.entityType,
+                    type: e.type,
                   }),
                 }))}
                 placeholder="Select entity..."
@@ -1004,11 +1004,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                 {relations.map((r) => {
                   const isEditing =
                     editing.mode === "relation" &&
-                    editing.relationId === r.relationId;
+                    editing.id === r.id;
                   return (
                     <Card
-                      key={r.relationId}
-                      data-testid={`kg-relation-row-${r.relationId}`}
+                      key={r.id}
+                      data-testid={`kg-relation-row-${r.id}`}
                       noPadding
                       className="p-2.5 flex flex-col gap-2"
                     >
@@ -1025,8 +1025,8 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                         />
                       ) : (
                         <Text size="small">
-                          {getEntityName(r.fromEntityId)} -({r.relationType})→{" "}
-                          {getEntityName(r.toEntityId)}
+                          {getEntityName(r.sourceEntityId)} -({r.relationType})→{" "}
+                          {getEntityName(r.targetEntityId)}
                         </Text>
                       )}
 
@@ -1054,21 +1054,21 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                               variant="ghost"
                               size="sm"
                               onClick={() =>
-                                setEditing({
-                                  mode: "relation",
-                                  relationId: r.relationId,
-                                  relationType: r.relationType,
-                                })
+                              setEditing({
+                                mode: "relation",
+                                id: r.id,
+                                relationType: r.relationType,
+                              })
                               }
                             >
                               Edit
                             </Button>
                             <Button
-                              data-testid={`kg-relation-delete-${r.relationId}`}
+                              data-testid={`kg-relation-delete-${r.id}`}
                               variant="ghost"
                               size="sm"
                               onClick={() =>
-                                void onDeleteRelation(r.relationId)
+                                void onDeleteRelation(r.id)
                               }
                             >
                               Delete

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -271,6 +271,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           />
           Items
         </button>
+        <button
+          class="px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-[var(--color-node-other)]"
+          />
+          Factions
+        </button>
       </div>
       <div
         class="flex items-center gap-3 w-[240px] justify-end"
@@ -518,6 +526,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           />
           Items
         </button>
+        <button
+          class="px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-[var(--color-node-other)]"
+          />
+          Factions
+        </button>
       </div>
       <div
         class="flex items-center gap-3 w-[240px] justify-end"
@@ -745,6 +761,19 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               Item
             </span>
           </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <div
+              class="w-2 h-2 border rounded-full"
+              style="border-color: var(--color-node-other); background-color: color-mix(in srgb, var(--color-node-other) 10%, transparent);"
+            />
+            <span
+              class="text-[11px] text-[var(--color-fg-muted)]"
+            >
+              Faction
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -840,6 +869,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
             class="w-1.5 h-1.5 rounded-full bg-[var(--color-node-item)]"
           />
           Items
+        </button>
+        <button
+          class="px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+        >
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-[var(--color-node-other)]"
+          />
+          Factions
         </button>
       </div>
       <div
@@ -1217,6 +1254,19 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               class="text-[11px] text-[var(--color-fg-muted)]"
             >
               Item
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <div
+              class="w-2 h-2 border rounded-full"
+              style="border-color: var(--color-node-other); background-color: color-mix(in srgb, var(--color-node-other) 10%, transparent);"
+            />
+            <span
+              class="text-[11px] text-[var(--color-fg-muted)]"
+            >
+              Faction
             </span>
           </div>
         </div>

--- a/apps/desktop/renderer/src/features/kg/__tests__/kg-async-validation.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/__tests__/kg-async-validation.test.tsx
@@ -9,7 +9,7 @@ import {
 import * as kgViewPreferences from "../kgViewPreferences";
 
 type ServiceResult =
-  | { ok: true; data?: { entityId?: string } }
+  | { ok: true; data?: { id?: string } }
   | { ok: false; error: { code: string; message: string } };
 
 type MockKgState = {
@@ -42,10 +42,8 @@ function makeEntity(args: {
 }): KgEntity {
   return {
     id: args.id,
-    entityId: args.id,
     projectId: "project-1",
     type: args.type,
-    entityType: args.type,
     name: args.name,
     description: "",
     attributes: {},
@@ -61,12 +59,9 @@ function makeEntity(args: {
 function makeRelation(): KgRelation {
   return {
     id: "rel-1",
-    relationId: "rel-1",
     projectId: "project-1",
     sourceEntityId: "char-1",
-    fromEntityId: "char-1",
     targetEntityId: "loc-1",
-    toEntityId: "loc-1",
     relationType: "盟友",
     description: "",
     createdAt: "2026-02-14T00:00:00.000Z",
@@ -101,7 +96,7 @@ describe("kg async validation", () => {
     const shouldClear = shouldClearRelationEditingAfterDelete({
       editing: {
         mode: "relation",
-        relationId: "rel-1",
+        id: "rel-1",
         relationType: "盟友",
       },
       targetRelationId: "rel-1",
@@ -145,14 +140,14 @@ describe("kg async validation", () => {
 
   it("KG-S0-AV-S3 batch entityUpdate partial failure reports errors", async () => {
     mockKgState.entityUpdate = vi.fn(
-      async ({ entityId }: { entityId: string }) => {
-        if (entityId === "ev-2") {
+      async ({ id }: { id: string }) => {
+        if (id === "ev-2") {
           return {
             ok: false,
             error: { code: "INTERNAL_ERROR", message: "first failed" },
           };
         }
-        if (entityId === "ev-3") {
+        if (id === "ev-3") {
           throw new Error("second failed");
         }
         return { ok: true };

--- a/apps/desktop/renderer/src/features/kg/kgToGraph.ts
+++ b/apps/desktop/renderer/src/features/kg/kgToGraph.ts
@@ -66,11 +66,11 @@ function defaultPosition(index: number): { x: number; y: number } {
  * Map KG entity type to graph node type.
  *
  * Why: KG entity types are free-form strings; we map them to known
- * node types with fallback to "other".
+ * node types with fallback to "faction".
  */
 function mapEntityType(entityType: string | undefined | null): NodeType {
   if (!entityType) {
-    return "other";
+    return "faction";
   }
 
   const normalized = entityType.toLowerCase().trim();
@@ -89,9 +89,10 @@ function mapEntityType(entityType: string | undefined | null): NodeType {
     item: "item",
     object: "item",
     artifact: "item",
+    faction: "faction",
   };
 
-  return typeMap[normalized] ?? "other";
+  return typeMap[normalized] ?? "faction";
 }
 
 /**
@@ -153,9 +154,9 @@ export function kgEntityToNode(entity: KgEntity, index: number): GraphNode {
   const uiMeta = parseEntityUiMetadata(entity.metadataJson);
 
   return {
-    id: entity.entityId,
+    id: entity.id,
     label: entity.name,
-    type: mapEntityType(entity.entityType),
+    type: mapEntityType(entity.type),
     avatar: uiMeta.avatarUrl,
     position: uiMeta.position ?? defaultPosition(index),
     metadata: {
@@ -174,15 +175,15 @@ export function kgEntityToNode(entity: KgEntity, index: number): GraphNode {
  */
 export function kgRelationToEdge(relation: KgRelation): GraphEdge | null {
   // Validate required fields
-  if (!relation.fromEntityId || !relation.toEntityId) {
+  if (!relation.sourceEntityId || !relation.targetEntityId) {
     console.warn("[kgToGraph] Relation missing source/target:", relation);
     return null;
   }
 
   return {
-    id: relation.relationId,
-    source: relation.fromEntityId,
-    target: relation.toEntityId,
+    id: relation.id,
+    source: relation.sourceEntityId,
+    target: relation.targetEntityId,
     label: relation.relationType || "related",
   };
 }

--- a/apps/desktop/renderer/src/features/kg/metadata-parse-failfast.test.tsx
+++ b/apps/desktop/renderer/src/features/kg/metadata-parse-failfast.test.tsx
@@ -34,10 +34,8 @@ describe("metadata parse fail-fast", () => {
       entities: [
         {
           id: "ev-1",
-          entityId: "ev-1",
           projectId: "project-1",
           type: "event",
-          entityType: "event",
           name: "雨夜冲突",
           description: "desc",
           attributes: {},

--- a/apps/desktop/renderer/src/lib/ai/contextAssembler.ts
+++ b/apps/desktop/renderer/src/lib/ai/contextAssembler.ts
@@ -45,16 +45,16 @@ export type AssembledContext = {
 };
 
 export type KnowledgeGraphEntity = {
-  entityId: string;
+  id: string;
   name: string;
-  entityType?: string;
+  type?: string;
   description?: string;
 };
 
 export type KnowledgeGraphRelation = {
-  relationId: string;
-  fromEntityId: string;
-  toEntityId: string;
+  id: string;
+  sourceEntityId: string;
+  targetEntityId: string;
   relationType: string;
 };
 
@@ -75,7 +75,7 @@ export function formatKnowledgeGraphContext(args: {
 
   const entityById = new Map<string, KnowledgeGraphEntity>();
   for (const e of args.entities) {
-    entityById.set(e.entityId, e);
+    entityById.set(e.id, e);
   }
 
   const entities = args.entities.slice(0, maxEntities);
@@ -89,7 +89,7 @@ export function formatKnowledgeGraphContext(args: {
     lines.push("  - (none)");
   } else {
     for (const e of entities) {
-      const type = typeof e.entityType === "string" ? e.entityType.trim() : "";
+      const type = typeof e.type === "string" ? e.type.trim() : "";
       const typeSuffix = type.length > 0 ? ` (${type})` : "";
 
       const rawDesc =
@@ -100,7 +100,7 @@ export function formatKnowledgeGraphContext(args: {
       const descSuffix = desc.length > 0 ? `: ${desc}` : "";
 
       lines.push(
-        `  - [entity:${e.entityId}] ${e.name}${typeSuffix}${descSuffix}`,
+        `  - [entity:${e.id}] ${e.name}${typeSuffix}${descSuffix}`,
       );
     }
   }
@@ -110,10 +110,10 @@ export function formatKnowledgeGraphContext(args: {
     lines.push("  - (none)");
   } else {
     for (const r of relations) {
-      const fromName = entityById.get(r.fromEntityId)?.name ?? r.fromEntityId;
-      const toName = entityById.get(r.toEntityId)?.name ?? r.toEntityId;
+      const fromName = entityById.get(r.sourceEntityId)?.name ?? r.sourceEntityId;
+      const toName = entityById.get(r.targetEntityId)?.name ?? r.targetEntityId;
       lines.push(
-        `  - [rel:${r.relationId}] ${fromName} -(${r.relationType})-> ${toName}`,
+        `  - [rel:${r.id}] ${fromName} -(${r.relationType})-> ${toName}`,
       );
     }
   }

--- a/apps/desktop/renderer/src/stores/__tests__/kgStore.native-contract.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/kgStore.native-contract.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import type {
+  IpcChannel,
+  IpcInvokeResult,
+  IpcResponseData,
+} from "@shared/types/ipc-generated";
+import { createKgStore, type IpcInvoke } from "../kgStore";
+
+function ok<C extends IpcChannel>(
+  _channel: C,
+  data: IpcResponseData<C>,
+): IpcInvokeResult<C> {
+  return { ok: true, data };
+}
+
+describe("kgStore native contract", () => {
+  it("AUD-C11-S1/S2: exposes native IPC fields without legacy alias fields", async () => {
+    const invoke: IpcInvoke = async (channel) => {
+      if (channel === "knowledge:entity:list") {
+        return ok(channel, {
+          items: [
+            {
+              id: "entity-1",
+              projectId: "project-1",
+              type: "character",
+              name: "Entity One",
+              description: "",
+              attributes: {},
+              aliases: [],
+              aiContextLevel: "always",
+              createdAt: "2026-02-27T00:00:00.000Z",
+              updatedAt: "2026-02-27T00:00:00.000Z",
+              version: 1,
+            },
+          ],
+        });
+      }
+      if (channel === "knowledge:relation:list") {
+        return ok(channel, {
+          items: [
+            {
+              id: "relation-1",
+              projectId: "project-1",
+              sourceEntityId: "entity-1",
+              targetEntityId: "entity-2",
+              relationType: "ally",
+              description: "",
+              createdAt: "2026-02-27T00:00:00.000Z",
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected channel: ${channel}`);
+    };
+
+    const store = createKgStore({ invoke });
+    await store.getState().bootstrapForProject("project-1");
+
+    const entity = store.getState().entities[0] as Record<string, unknown>;
+    expect(entity.id).toBe("entity-1");
+    expect(entity.type).toBe("character");
+    expect(entity.entityId).toBeUndefined();
+    expect(entity.entityType).toBeUndefined();
+
+    const relation = store.getState().relations[0] as Record<string, unknown>;
+    expect(relation.id).toBe("relation-1");
+    expect(relation.sourceEntityId).toBe("entity-1");
+    expect(relation.targetEntityId).toBe("entity-2");
+    expect(relation.relationId).toBeUndefined();
+    expect(relation.fromEntityId).toBeUndefined();
+    expect(relation.toEntityId).toBeUndefined();
+  });
+
+  it("AUD-C11-S3: entityCreate must not map 'other' to 'faction'", async () => {
+    let createTypePayload: string | undefined;
+
+    const invoke: IpcInvoke = async (channel, payload) => {
+      if (channel === "knowledge:entity:create") {
+        createTypePayload = (payload as { type?: string }).type;
+        return ok(channel, {
+          id: "entity-created",
+          projectId: "project-1",
+          type: createTypePayload === "character" ? "character" : "item",
+          name: "Created",
+          description: "",
+          attributes: {},
+          aliases: [],
+          aiContextLevel: "always",
+          createdAt: "2026-02-27T00:00:00.000Z",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+          version: 1,
+        });
+      }
+      if (channel === "knowledge:entity:list") {
+        return ok(channel, {
+          items: [],
+        });
+      }
+      if (channel === "knowledge:relation:list") {
+        return ok(channel, {
+          items: [],
+        });
+      }
+      throw new Error(`Unexpected channel: ${channel}`);
+    };
+
+    const store = createKgStore({ invoke });
+    store.setState({ projectId: "project-1" });
+
+    const result = await store.getState().entityCreate({
+      name: "Legacy Type",
+      type: "other",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createTypePayload).toBe("character");
+  });
+
+  it("AUD-C11-S1/S2: source code must not keep toLegacy adapters", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "renderer/src/stores/kgStore.ts"),
+      "utf8",
+    );
+
+    expect(source).not.toContain("toLegacyEntity");
+    expect(source).not.toContain("toLegacyRelation");
+  });
+});

--- a/apps/desktop/renderer/src/stores/__tests__/kgStore.race.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/kgStore.race.test.ts
@@ -91,7 +91,7 @@ describe("kgStore race scenarios", () => {
     );
     await secondBootstrap;
 
-    expect(store.getState().entities.map((entity) => entity.entityId)).toEqual([
+    expect(store.getState().entities.map((entity) => entity.id)).toEqual([
       "entity-b",
     ]);
 
@@ -104,7 +104,7 @@ describe("kgStore race scenarios", () => {
 
     const state = store.getState();
     expect(state.projectId).toBe("project-b");
-    expect(state.entities.map((entity) => entity.entityId)).toEqual([
+    expect(state.entities.map((entity) => entity.id)).toEqual([
       "entity-b",
     ]);
     expect(state.bootstrapStatus).toBe("ready");

--- a/apps/desktop/renderer/src/stores/__tests__/memoryStore.bootstrap-retirement.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/memoryStore.bootstrap-retirement.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("memoryStore bootstrap retirement", () => {
+  it("AUD-C11-S5/S6: memoryStore must not define deprecated bootstrapForProject", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "renderer/src/stores/memoryStore.ts"),
+      "utf8",
+    );
+
+    expect(source).not.toContain("bootstrapForProject");
+    expect(source).toContain("bootstrapForContext");
+  });
+});

--- a/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
@@ -68,7 +68,7 @@ describe("store refresh governance", () => {
 
     const result = await store.getState().entityCreate({
       name: "entity-1",
-      entityType: "character",
+      type: "character",
     });
 
     expect(result.ok).toBe(true);

--- a/apps/desktop/renderer/src/stores/kgStore.ts
+++ b/apps/desktop/renderer/src/stores/kgStore.ts
@@ -19,16 +19,10 @@ type AiContextLevel = EntityResponse["aiContextLevel"];
 export type { IpcInvoke };
 
 export type KgEntity = EntityResponse & {
-  entityId: string;
-  entityType: string;
   metadataJson: string;
 };
 
-export type KgRelation = RelationResponse & {
-  relationId: string;
-  fromEntityId: string;
-  toEntityId: string;
-};
+export type KgRelation = RelationResponse;
 
 export type KgState = {
   projectId: string | null;
@@ -43,43 +37,42 @@ export type KgActions = {
   refresh: () => Promise<void>;
   entityCreate: (args: {
     name: string;
-    entityType?: string;
+    type?: string;
     description?: string;
     lastSeenState?: string;
     aiContextLevel?: AiContextLevel;
     aliases?: string[];
   }) => Promise<IpcResponse<KgEntity>>;
   entityUpdate: (args: {
-    entityId: string;
+    id: string;
     patch: Partial<
       Pick<
         KgEntity,
         | "name"
-        | "entityType"
         | "description"
         | "metadataJson"
         | "lastSeenState"
         | "aiContextLevel"
         | "aliases"
       >
-    >;
+    > & { type?: string };
   }) => Promise<IpcResponse<KgEntity>>;
   entityDelete: (args: {
-    entityId: string;
+    id: string;
   }) => Promise<IpcResponse<{ deleted: true; deletedRelationCount: number }>>;
   relationCreate: (args: {
-    fromEntityId: string;
-    toEntityId: string;
+    sourceEntityId: string;
+    targetEntityId: string;
     relationType: string;
   }) => Promise<IpcResponse<KgRelation>>;
   relationUpdate: (args: {
-    relationId: string;
+    id: string;
     patch: Partial<
-      Pick<KgRelation, "fromEntityId" | "toEntityId" | "relationType">
+      Pick<KgRelation, "sourceEntityId" | "targetEntityId" | "relationType">
     >;
   }) => Promise<IpcResponse<KgRelation>>;
   relationDelete: (args: {
-    relationId: string;
+    id: string;
   }) => Promise<IpcResponse<{ deleted: true }>>;
   clearError: () => void;
 };
@@ -101,7 +94,7 @@ function normalizeEntityType(
     return undefined;
   }
 
-  const normalized = value.trim();
+  const normalized = value.trim().toLowerCase();
 
   switch (normalized) {
     case "character":
@@ -110,8 +103,6 @@ function normalizeEntityType(
     case "item":
     case "faction":
       return normalized;
-    case "other":
-      return "faction";
     default:
       return undefined;
   }
@@ -129,24 +120,6 @@ function toMetadataJson(attributes: Record<string, string>): string {
     return packed;
   }
   return JSON.stringify(attributes);
-}
-
-function toLegacyEntity(entity: EntityResponse): KgEntity {
-  return {
-    ...entity,
-    entityId: entity.id,
-    entityType: entity.type,
-    metadataJson: toMetadataJson(entity.attributes),
-  };
-}
-
-function toLegacyRelation(relation: RelationResponse): KgRelation {
-  return {
-    ...relation,
-    relationId: relation.id,
-    fromEntityId: relation.sourceEntityId,
-    toEntityId: relation.targetEntityId,
-  };
 }
 
 /**
@@ -190,8 +163,11 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
     return {
       ok: true,
-      entities: entitiesRes.data.items.map(toLegacyEntity),
-      relations: relationsRes.data.items.map(toLegacyRelation),
+      entities: entitiesRes.data.items.map((entity) => ({
+        ...entity,
+        metadataJson: toMetadataJson(entity.attributes),
+      })),
+      relations: relationsRes.data.items,
     };
   }
 
@@ -281,7 +257,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
     entityCreate: async ({
       name,
-      entityType,
+      type,
       description,
       lastSeenState,
       aiContextLevel,
@@ -294,7 +270,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return { ok: false, error };
       }
 
-      const normalizedType = normalizeEntityType(entityType) ?? "character";
+      const normalizedType = normalizeEntityType(type) ?? "character";
 
       const res = await deps.invoke("knowledge:entity:create", {
         projectId: state.projectId,
@@ -311,10 +287,16 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       }
 
       await get().refresh();
-      return { ok: true, data: toLegacyEntity(res.data) };
+      return {
+        ok: true,
+        data: {
+          ...res.data,
+          metadataJson: toMetadataJson(res.data.attributes),
+        },
+      };
     },
 
-    entityUpdate: async ({ entityId, patch }) => {
+    entityUpdate: async ({ id, patch }) => {
       const state = get();
       if (!state.projectId) {
         const error = missingProjectError();
@@ -322,9 +304,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
         return { ok: false, error };
       }
 
-      const existing = state.entities.find(
-        (entity) => entity.entityId === entityId,
-      );
+      const existing = state.entities.find((entity) => entity.id === id);
       if (!existing) {
         const error: IpcError = {
           code: "NOT_FOUND",
@@ -335,8 +315,8 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       }
 
       const nextType =
-        typeof patch.entityType === "string"
-          ? normalizeEntityType(patch.entityType)
+        typeof patch.type === "string"
+          ? normalizeEntityType(patch.type)
           : undefined;
 
       const nextAttributes =
@@ -346,7 +326,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
       const res = await deps.invoke("knowledge:entity:update", {
         projectId: state.projectId,
-        id: entityId,
+        id,
         expectedVersion: existing.version,
         patch: {
           name: patch.name,
@@ -365,10 +345,16 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       }
 
       await get().refresh();
-      return { ok: true, data: toLegacyEntity(res.data) };
+      return {
+        ok: true,
+        data: {
+          ...res.data,
+          metadataJson: toMetadataJson(res.data.attributes),
+        },
+      };
     },
 
-    entityDelete: async ({ entityId }) => {
+    entityDelete: async ({ id }) => {
       const state = get();
       if (!state.projectId) {
         const error = missingProjectError();
@@ -378,7 +364,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
       const res = await deps.invoke("knowledge:entity:delete", {
         projectId: state.projectId,
-        id: entityId,
+        id,
       });
       if (!res.ok) {
         set({ lastError: res.error });
@@ -389,7 +375,11 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       return res;
     },
 
-    relationCreate: async ({ fromEntityId, toEntityId, relationType }) => {
+    relationCreate: async ({
+      sourceEntityId,
+      targetEntityId,
+      relationType,
+    }) => {
       const state = get();
       if (!state.projectId) {
         const error = missingProjectError();
@@ -399,8 +389,8 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
       const res = await deps.invoke("knowledge:relation:create", {
         projectId: state.projectId,
-        sourceEntityId: fromEntityId,
-        targetEntityId: toEntityId,
+        sourceEntityId,
+        targetEntityId,
         relationType,
       });
       if (!res.ok) {
@@ -409,10 +399,10 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       }
 
       await get().refresh();
-      return { ok: true, data: toLegacyRelation(res.data) };
+      return { ok: true, data: res.data };
     },
 
-    relationUpdate: async ({ relationId, patch }) => {
+    relationUpdate: async ({ id, patch }) => {
       const state = get();
       if (!state.projectId) {
         const error = missingProjectError();
@@ -422,10 +412,10 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
       const res = await deps.invoke("knowledge:relation:update", {
         projectId: state.projectId,
-        id: relationId,
+        id,
         patch: {
-          sourceEntityId: patch.fromEntityId,
-          targetEntityId: patch.toEntityId,
+          sourceEntityId: patch.sourceEntityId,
+          targetEntityId: patch.targetEntityId,
           relationType: patch.relationType,
         },
       });
@@ -435,10 +425,10 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
       }
 
       await get().refresh();
-      return { ok: true, data: toLegacyRelation(res.data) };
+      return { ok: true, data: res.data };
     },
 
-    relationDelete: async ({ relationId }) => {
+    relationDelete: async ({ id }) => {
       const state = get();
       if (!state.projectId) {
         const error = missingProjectError();
@@ -448,7 +438,7 @@ export function createKgStore(deps: { invoke: IpcInvoke }) {
 
       const res = await deps.invoke("knowledge:relation:delete", {
         projectId: state.projectId,
-        id: relationId,
+        id,
       });
       if (!res.ok) {
         set({ lastError: res.error });

--- a/apps/desktop/renderer/src/stores/memoryStore.ts
+++ b/apps/desktop/renderer/src/stores/memoryStore.ts
@@ -228,8 +228,6 @@ export type MemoryActions = {
     projectId: string | null,
     documentId: string | null,
   ) => Promise<void>;
-  /** @deprecated Use bootstrapForContext instead */
-  bootstrapForProject: (projectId: string | null) => Promise<void>;
   refresh: () => Promise<void>;
   create: (args: {
     type: MemoryItem["type"];
@@ -335,11 +333,6 @@ export function createMemoryStore(deps: { invoke: IpcInvoke }) {
         settings: settingsRes.data,
         items: listRes.data.items,
       });
-    },
-
-    bootstrapForProject: async (projectId) => {
-      // Backward compatible wrapper
-      await get().bootstrapForContext(projectId, null);
     },
 
     refresh: async () => {

--- a/openspec/_ops/task_runs/ISSUE-699.md
+++ b/openspec/_ops/task_runs/ISSUE-699.md
@@ -1,0 +1,37 @@
+# ISSUE-699
+
+更新时间：2026-02-27 21:00
+
+## Links
+
+- Issue: #699
+- Branch: `task/699-audit-legacy-adapter-retirement`
+- PR: TBD
+
+## Plan
+
+- [x] kgStore 移除 toLegacyEntity/toLegacyRelation，统一 IPC 原生字段
+- [x] normalizeEntityType 移除 "other"→"faction" 硬编码映射
+- [x] UI 类型列表移除 "other"，改为 faction
+- [x] 历史数据迁移 0023_kg_type_other_to_faction.sql 落地
+- [x] memoryStore 下线 bootstrapForProject，保留 bootstrapForContext
+- [x] 新增审计测试 S1-S6，修复快照漂移
+
+## Runs
+
+### 2026-02-27 验证全绿
+
+- pnpm typecheck: 通过
+- pnpm lint: 通过 (0 errors, 67 warnings)
+- pnpm -C apps/desktop test:run: 通过 (182 files, 1537 tests)
+- pnpm test:unit: 通过 (vitest 7 files, 24 tests)
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 50881d6423d72ab5d5c231f8c6452dc2483a2b58
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT


### PR DESCRIPTION
## Summary

Closes #699

- Remove `toLegacyEntity()`/`toLegacyRelation()` from kgStore, renderer uses IPC native fields directly
- Remove `normalizeEntityType()` "other"→"faction" hardcoded mapping, UI no longer offers "other" option
- Add DB migration `0023_kg_type_other_to_faction.sql` for historical data
- Retire `bootstrapForProject()` from memoryStore, migrate callers to `bootstrapForContext()`
- Add audit tests for S1-S6, fix snapshot drift

## Verification

- `pnpm typecheck`: pass
- `pnpm lint`: 0 errors, 67 warnings
- `pnpm -C apps/desktop test:run`: 182 files, 1537 tests pass
- `pnpm test:unit`: pass

## OpenSpec

- Change: `openspec/changes/audit-legacy-adapter-retirement/`
- RUN_LOG: `openspec/_ops/task_runs/ISSUE-699.md`

Closes #699