### PR TITLE
improve: split AppShell test suite to satisfy max-lines

### DIFF
--- a/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
@@ -269,6 +269,42 @@ describe("AppShell", () => {
       expect(sidebar.style.transition).toContain("var(--duration-slow)");
     });
   });
+});
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIpc = createMockIpc();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Render AppShell with all required providers.
+   *
+   * Why: Wraps render in act() and waits for initial bootstrap to complete,
+   * avoiding "not wrapped in act()" warnings from async state updates.
+   */
+  const renderWithWrapper = async (options?: {
+    layoutStoreOverride?: UseLayoutStore;
+  }) => {
+    let result: ReturnType<typeof render>;
+
+    await act(async () => {
+      result = render(
+        <AppShellTestWrapper layoutStoreOverride={options?.layoutStoreOverride}>
+          <AppShell />
+        </AppShellTestWrapper>,
+      );
+    });
+    await waitFor(() => {
+      expect(mockIpc.invoke).toHaveBeenCalled();
+    });
+
+    return result!;
+  };
 
   // ===========================================================================
   // 键盘快捷键测试


### PR DESCRIPTION
## 改了什么
将 `AppShell.test.tsx` 里过长的 `renderWithWrapper`（触发 `max-lines-per-function`）拆成两个 `describe("AppShell")` 分组，避免单个 `describe` block 内部 helper 过长。

注意：测试用例本身、断言逻辑不变，只是把测试分组拆开以满足 lint 约束。

## 为什么改
该测试文件存在 `max-lines-per-function` warning，属于纯质量债；拆分分组可降低 lint 噪音且不会改变测试行为。

## 验证
- [x] lint 通过（相关文件）
- [x] 相关测试通过

执行命令：
- `pnpm eslint apps/desktop/renderer/src/components/layout/AppShell.test.tsx`
- `pnpm -C apps/desktop test:run src/components/layout/AppShell.test.tsx`

---
🤖 by 天野 (automated iteration)
