### PR TITLE
Audit store provider style unification (#701)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -63,5 +63,25 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ["apps/desktop/renderer/src/stores/**/*.{ts,tsx}"],
+      rules: {
+        "no-restricted-syntax": [
+          "error",
+          {
+            selector:
+              "UnaryExpression[operator='void'][argument.type='CallExpression'][argument.callee.type='ArrowFunctionExpression'][argument.callee.async=true]",
+            message:
+              "Do not use bare void async IIFE. Use runFireAndForget() with explicit error handling.",
+          },
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='React'][callee.property.name='createElement']",
+            message:
+              "Use JSX syntax instead of React.createElement in stores.",
+          },
+        ],
+      },
+    },
   ],
 };

--- a/apps/desktop/renderer/src/stores/__tests__/kgStore.native-contract.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/kgStore.native-contract.test.ts
@@ -121,7 +121,7 @@ describe("kgStore native contract", () => {
 
   it("AUD-C11-S1/S2: source code must not keep toLegacy adapters", () => {
     const source = readFileSync(
-      resolve(process.cwd(), "renderer/src/stores/kgStore.ts"),
+      resolve(process.cwd(), "renderer/src/stores/kgStore.tsx"),
       "utf8",
     );
 

--- a/apps/desktop/renderer/src/stores/__tests__/memoryStore.bootstrap-retirement.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/memoryStore.bootstrap-retirement.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 describe("memoryStore bootstrap retirement", () => {
   it("AUD-C11-S5/S6: memoryStore must not define deprecated bootstrapForProject", () => {
     const source = readFileSync(
-      resolve(process.cwd(), "renderer/src/stores/memoryStore.ts"),
+      resolve(process.cwd(), "renderer/src/stores/memoryStore.tsx"),
       "utf8",
     );
 

--- a/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/store-refresh-governance.test.ts
@@ -77,11 +77,11 @@ describe("store refresh governance", () => {
 
   it("static scan clears void refresh patterns in critical stores (AUD-C9-S8)", () => {
     const kgStoreSource = readFileSync(
-      resolve(process.cwd(), "renderer/src/stores/kgStore.ts"),
+      resolve(process.cwd(), "renderer/src/stores/kgStore.tsx"),
       "utf8",
     );
     const memoryStoreSource = readFileSync(
-      resolve(process.cwd(), "renderer/src/stores/memoryStore.ts"),
+      resolve(process.cwd(), "renderer/src/stores/memoryStore.tsx"),
       "utf8",
     );
     const projectStoreSource = readFileSync(

--- a/apps/desktop/renderer/src/stores/aiStore.tsx
+++ b/apps/desktop/renderer/src/stores/aiStore.tsx
@@ -647,10 +647,10 @@ export function AiStoreProvider(props: {
   store: UseAiStore;
   children: React.ReactNode;
 }): React.ReactElement {
-  return React.createElement(
-    AiStoreContext.Provider,
-    { value: props.store },
-    props.children,
+  return (
+    <AiStoreContext.Provider value={props.store}>
+      {props.children}
+    </AiStoreContext.Provider>
   );
 }
 

--- a/apps/desktop/renderer/src/stores/fileStore.tsx
+++ b/apps/desktop/renderer/src/stores/fileStore.tsx
@@ -341,10 +341,10 @@ export function FileStoreProvider(props: {
   store: UseFileStore;
   children: React.ReactNode;
 }): JSX.Element {
-  return React.createElement(
-    FileStoreContext.Provider,
-    { value: props.store },
-    props.children,
+  return (
+    <FileStoreContext.Provider value={props.store}>
+      {props.children}
+    </FileStoreContext.Provider>
   );
 }
 

--- a/apps/desktop/renderer/src/stores/kgStore.tsx
+++ b/apps/desktop/renderer/src/stores/kgStore.tsx
@@ -458,10 +458,10 @@ export function KgStoreProvider(props: {
   store: UseKgStore;
   children: React.ReactNode;
 }): JSX.Element {
-  return React.createElement(
-    KgStoreContext.Provider,
-    { value: props.store },
-    props.children,
+  return (
+    <KgStoreContext.Provider value={props.store}>
+      {props.children}
+    </KgStoreContext.Provider>
   );
 }
 

--- a/apps/desktop/renderer/src/stores/memoryStore.tsx
+++ b/apps/desktop/renderer/src/stores/memoryStore.tsx
@@ -453,10 +453,10 @@ export function MemoryStoreProvider(props: {
   store: UseMemoryStore;
   children: React.ReactNode;
 }): JSX.Element {
-  return React.createElement(
-    MemoryStoreContext.Provider,
-    { value: props.store },
-    props.children,
+  return (
+    <MemoryStoreContext.Provider value={props.store}>
+      {props.children}
+    </MemoryStoreContext.Provider>
   );
 }
 

--- a/apps/desktop/renderer/src/stores/searchStore.tsx
+++ b/apps/desktop/renderer/src/stores/searchStore.tsx
@@ -153,10 +153,10 @@ export function SearchStoreProvider(props: {
   store: UseSearchStore;
   children: React.ReactNode;
 }): React.ReactElement {
-  return React.createElement(
-    SearchStoreContext.Provider,
-    { value: props.store },
-    props.children,
+  return (
+    <SearchStoreContext.Provider value={props.store}>
+      {props.children}
+    </SearchStoreContext.Provider>
   );
 }
 

--- a/apps/desktop/tests/lint/store-provider-style-unification.test.ts
+++ b/apps/desktop/tests/lint/store-provider-style-unification.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { spawnSync } from "node:child_process";
+import { readdir, readFile, stat } from "node:fs/promises";
+import * as path from "node:path";
+
+const TARGET_STORE_BASENAMES = [
+  "aiStore",
+  "fileStore",
+  "searchStore",
+  "kgStore",
+  "memoryStore",
+] as const;
+
+const STORE_ROOT_RELATIVE = "apps/desktop/renderer/src/stores";
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function toPosixRelative(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).split(path.sep).join("/");
+}
+
+async function walkFiles(rootDir: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "dist") {
+          continue;
+        }
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      out.push(fullPath);
+    }
+  }
+
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+function isStoreSourceFile(filePath: string): boolean {
+  const ext = path.extname(filePath);
+  return ext === ".ts" || ext === ".tsx";
+}
+
+async function collectCreateElementViolations(
+  storeRoot: string,
+  reportRoot: string,
+): Promise<string[]> {
+  const files = await walkFiles(storeRoot);
+  const violations: string[] = [];
+  for (const filePath of files) {
+    if (!isStoreSourceFile(filePath)) {
+      continue;
+    }
+
+    const source = await readFile(filePath, "utf8");
+    if (source.includes("React.createElement(")) {
+      violations.push(toPosixRelative(reportRoot, filePath));
+    }
+  }
+  return violations.sort((a, b) => a.localeCompare(b));
+}
+
+describe("AUD-C14 store provider style unification", () => {
+  it("AUD-C14-S1 target store files should all be .tsx and contain zero React.createElement", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+    const storeRoot = path.join(repoRoot, STORE_ROOT_RELATIVE);
+
+    const extensionViolations: string[] = [];
+    for (const baseName of TARGET_STORE_BASENAMES) {
+      const tsPath = path.join(storeRoot, `${baseName}.ts`);
+      const tsxPath = path.join(storeRoot, `${baseName}.tsx`);
+
+      if (await pathExists(tsPath)) {
+        extensionViolations.push(
+          `${toPosixRelative(repoRoot, tsPath)} should be renamed to .tsx`,
+        );
+      }
+
+      if (!(await pathExists(tsxPath))) {
+        extensionViolations.push(
+          `${toPosixRelative(repoRoot, tsxPath)} is missing`,
+        );
+      }
+    }
+
+    const createElementViolations = await collectCreateElementViolations(
+      storeRoot,
+      repoRoot,
+    );
+
+    if (extensionViolations.length > 0 || createElementViolations.length > 0) {
+      throw new Error(
+        `Store provider style violations (AUD-C14-S1):\n${[
+          ...extensionViolations.map((line) => `- ${line}`),
+          ...createElementViolations.map(
+            (line) => `- ${line} contains React.createElement`,
+          ),
+        ].join("\n")}`,
+      );
+    }
+
+    expect(extensionViolations).toEqual([]);
+    expect(createElementViolations).toEqual([]);
+  });
+
+  it("AUD-C14-S4 lint should reject React.createElement usage in store files", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+    const lintInput = `
+import React from "react";
+
+export function BrokenProvider(): JSX.Element {
+  return React.createElement("div", null, "x");
+}
+    `;
+
+    const lintResult = spawnSync(
+      "pnpm",
+      [
+        "exec",
+        "eslint",
+        "--stdin",
+        "--stdin-filename",
+        "apps/desktop/renderer/src/stores/__lint_fixture__.tsx",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        input: lintInput,
+        encoding: "utf8",
+      },
+    );
+
+    if (lintResult.error) {
+      throw lintResult.error;
+    }
+
+    expect(lintResult.status).toBe(1);
+
+    type LintMessage = {
+      ruleId: string | null;
+      message: string;
+    };
+
+    type LintReport = {
+      messages: LintMessage[];
+    };
+
+    const reports = JSON.parse(lintResult.stdout) as LintReport[];
+    const messages = reports.flatMap((report) => report.messages);
+    const hasGuardError = messages.some(
+      (message) =>
+        message.ruleId === "no-restricted-syntax" &&
+        message.message.includes("Use JSX"),
+    );
+
+    expect(hasGuardError).toBe(true);
+  });
+});

--- a/apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts
+++ b/apps/desktop/tests/unit/audit-type-contract-alignment.spec.ts
@@ -11,11 +11,11 @@ type Hit = {
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 
 const STORE_FILES = [
-  "apps/desktop/renderer/src/stores/aiStore.ts",
-  "apps/desktop/renderer/src/stores/fileStore.ts",
-  "apps/desktop/renderer/src/stores/searchStore.ts",
-  "apps/desktop/renderer/src/stores/kgStore.ts",
-  "apps/desktop/renderer/src/stores/memoryStore.ts",
+  "apps/desktop/renderer/src/stores/aiStore.tsx",
+  "apps/desktop/renderer/src/stores/fileStore.tsx",
+  "apps/desktop/renderer/src/stores/searchStore.tsx",
+  "apps/desktop/renderer/src/stores/kgStore.tsx",
+  "apps/desktop/renderer/src/stores/memoryStore.tsx",
   "apps/desktop/renderer/src/stores/editorStore.tsx",
   "apps/desktop/renderer/src/stores/versionStore.tsx",
   "apps/desktop/renderer/src/stores/projectStore.tsx",

--- a/openspec/_ops/task_runs/ISSUE-701.md
+++ b/openspec/_ops/task_runs/ISSUE-701.md
@@ -1,0 +1,81 @@
+# ISSUE-701
+
+更新时间：2026-02-27 21:40
+
+## Links
+
+- Issue: #701
+- Issue URL: https://github.com/Leeky1017/CreoNow/issues/701
+- Branch: `task/701-audit-store-provider-style-unification`
+- PR: NOT-CREATED（本次仅完成本地实现与验证，待创建后回填真实链接）
+
+## Plan
+
+- [x] 审阅 `audit-store-provider-style-unification` 的 proposal/spec/tasks 与交付规则
+- [x] Dependency Sync Check：核对 C8 依赖已完成且无漂移
+- [x] Red：新增 C14 lint+结构守卫测试并验证失败
+- [x] Green：5 个 store `.ts` 重命名为 `.tsx`，Provider 从 `React.createElement` 改为 JSX
+- [x] 防回归：新增 stores 目录 `React.createElement` lint 禁令
+- [x] 执行四门禁验证并记录真实结果
+
+## Runs
+
+### 2026-02-27 Dependency Sync Check（C8 上游）
+
+- Command: `ls -d openspec/changes/archive/audit-type-contract-alignment`
+- Exit code: `0`
+- Key output: `openspec/changes/archive/audit-type-contract-alignment`
+
+- Command: `rg -n "audit-type-contract-alignment|C8" openspec/changes/EXECUTION_ORDER.md openspec/changes/audit-store-provider-style-unification/proposal.md`
+- Exit code: `0`
+- Key output: `C8（audit-type-contract-alignment）在 EXECUTION_ORDER 标记 DONE，C14 依赖链 C8✅ 已满足`
+
+- Conclusion: `无漂移，可进入 Red/Green`
+
+### 2026-02-27 Red：C14 守卫测试（预期失败）
+
+- Command: `pnpm -C apps/desktop exec vitest run --config tests/unit/main/vitest.node.config.ts tests/lint/store-provider-style-unification.test.ts`
+- Exit code: `1`
+- Key output:
+  - `AUD-C14-S1 ... aiStore.ts/fileStore.ts/searchStore.ts/kgStore.ts/memoryStore.ts should be renamed to .tsx`
+  - `AUD-C14-S1 ... contains React.createElement`
+  - `AUD-C14-S4 ... expected false to be true`
+
+### 2026-02-27 Green：C14 守卫测试回归通过
+
+- Command: `pnpm -C apps/desktop exec vitest run --config tests/unit/main/vitest.node.config.ts tests/lint/store-provider-style-unification.test.ts`
+- Exit code: `0`
+- Key output: `2 tests passed（AUD-C14-S1 / AUD-C14-S4）`
+
+- Command: `rg -n "React\.createElement" apps/desktop/renderer/src/stores`
+- Exit code: `1`
+- Key output: `无匹配（store 目录搜索结果为零）`
+
+### 2026-02-27 四门禁验证（Fresh Verification）
+
+- Command: `pnpm typecheck`
+- Exit code: `0`
+
+- Command: `pnpm lint`
+- Exit code: `0`
+- Key output: `0 errors, 67 warnings`
+
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `182 files, 1537 tests passed`
+
+- Command: `pnpm test:unit`
+- Exit code: `0`
+- Key output:
+  - `[test-discovery] mode=unit tsx=243 vitest=8`
+  - `vitest bucket: 8 files, 26 tests passed`
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 86a69c59f5438661f23567260845af9e87f81175
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-701.md
+++ b/openspec/_ops/task_runs/ISSUE-701.md
@@ -1,13 +1,13 @@
 # ISSUE-701
 
-更新时间：2026-02-27 21:40
+更新时间：2026-02-27 21:45
 
 ## Links
 
 - Issue: #701
 - Issue URL: https://github.com/Leeky1017/CreoNow/issues/701
 - Branch: `task/701-audit-store-provider-style-unification`
-- PR: NOT-CREATED（本次仅完成本地实现与验证，待创建后回填真实链接）
+- PR: https://github.com/Leeky1017/CreoNow/pull/704
 
 ## Plan
 
@@ -70,10 +70,16 @@
   - `[test-discovery] mode=unit tsx=243 vitest=8`
   - `vitest bucket: 8 files, 26 tests passed`
 
+### 2026-02-27 GitHub 提交流程
+
+- Command: `gh pr create --base main --head task/701-audit-store-provider-style-unification --title "Audit store provider style unification (#701)" ...`
+- Exit code: `0`
+- Key output: `https://github.com/Leeky1017/CreoNow/pull/704`
+
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 86a69c59f5438661f23567260845af9e87f81175
+- Reviewed-HEAD-SHA: 756f3a84cf96c7e017ef7a7537b54685f44b4c4f
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS


### PR DESCRIPTION
## Summary
- rename five renderer store files from .ts to .tsx via git mv
- replace Provider React.createElement calls with equivalent JSX providers
- add lint guard to forbid React.createElement usage under renderer/src/stores and add AUD-C14 lint/spec tests
- sync file-path contract tests that reference explicit store file extensions

## Verification
- pnpm typecheck
- pnpm lint
- pnpm -C apps/desktop test:run
- pnpm test:unit

Closes #701