### PR TITLE
improve(main): extract record/object schema validators to reduce validateSchemaAtPath complexity

### DIFF
--- a/apps/desktop/main/src/ipc/runtime-validation.ts
+++ b/apps/desktop/main/src/ipc/runtime-validation.ts
@@ -129,6 +129,49 @@ function pushIssue(
   });
 }
 
+function validateRecordSchema(
+  schema: Extract<IpcSchema, { kind: "record" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  if (!isRecord(value) || Array.isArray(value)) {
+    pushIssue(issues, path, "must be object record", renderSchema(schema), value);
+    return;
+  }
+  for (const [key, recordValue] of Object.entries(value)) {
+    validateSchemaAtPath(schema.value, recordValue, `${path}.${key}`, issues);
+  }
+}
+
+function validateObjectSchema(
+  schema: Extract<IpcSchema, { kind: "object" }>,
+  value: unknown,
+  path: string,
+  issues: RuntimeValidationIssue[],
+): void {
+  if (!isRecord(value) || Array.isArray(value)) {
+    pushIssue(issues, path, "must be object", "object", value);
+    return;
+  }
+  for (const [fieldName, fieldSchema] of Object.entries(schema.fields)) {
+    const fieldPath = `${path}.${fieldName}`;
+    if (!(fieldName in value)) {
+      if (fieldSchema.kind !== "optional") {
+        pushIssue(issues, fieldPath, "is required", renderSchema(fieldSchema), undefined);
+      }
+      continue;
+    }
+    validateSchemaAtPath(fieldSchema, (value as Record<string, unknown>)[fieldName], fieldPath, issues);
+  }
+  const knownFields = new Set(Object.keys(schema.fields));
+  for (const fieldName of Object.keys(value)) {
+    if (!knownFields.has(fieldName)) {
+      pushIssue(issues, `${path}.${fieldName}`, "is not allowed", "no extra fields", (value as Record<string, unknown>)[fieldName]);
+    }
+  }
+}
+
 function validateSchemaAtPath(
   schema: IpcSchema,
   value: unknown,
@@ -172,24 +215,7 @@ function validateSchemaAtPath(
       });
       return;
     case "record":
-      if (!isRecord(value) || Array.isArray(value)) {
-        pushIssue(
-          issues,
-          path,
-          "must be object record",
-          renderSchema(schema),
-          value,
-        );
-        return;
-      }
-      for (const [key, recordValue] of Object.entries(value)) {
-        validateSchemaAtPath(
-          schema.value,
-          recordValue,
-          `${path}.${key}`,
-          issues,
-        );
-      }
+      validateRecordSchema(schema, value, path, issues);
       return;
     case "union": {
       const matchesVariant = schema.variants.some((variant) => {
@@ -214,43 +240,9 @@ function validateSchemaAtPath(
       }
       validateSchemaAtPath(schema.schema, value, path, issues);
       return;
-    case "object": {
-      if (!isRecord(value) || Array.isArray(value)) {
-        pushIssue(issues, path, "must be object", "object", value);
-        return;
-      }
-
-      for (const [fieldName, fieldSchema] of Object.entries(schema.fields)) {
-        const fieldPath = `${path}.${fieldName}`;
-        if (!(fieldName in value)) {
-          if (fieldSchema.kind !== "optional") {
-            pushIssue(
-              issues,
-              fieldPath,
-              "is required",
-              renderSchema(fieldSchema),
-              undefined,
-            );
-          }
-          continue;
-        }
-        validateSchemaAtPath(fieldSchema, value[fieldName], fieldPath, issues);
-      }
-
-      const knownFields = new Set(Object.keys(schema.fields));
-      for (const fieldName of Object.keys(value)) {
-        if (!knownFields.has(fieldName)) {
-          pushIssue(
-            issues,
-            `${path}.${fieldName}`,
-            "is not allowed",
-            "no extra fields",
-            value[fieldName],
-          );
-        }
-      }
+    case "object":
+      validateObjectSchema(schema, value, path, issues);
       return;
-    }
     default:
       pushIssue(
         issues,


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
从 validateSchemaAtPath 提取 validateRecordSchema/validateObjectSchema，将复杂度从 28 降至 25 以内

## 改动列表
- 新增 `validateRecordSchema`：封装 record case 的校验逻辑
- 新增 `validateObjectSchema`：封装 object case 的字段遍历和额外字段检查逻辑
- validateSchemaAtPath switch 中对应 case 缩减为单行调用

## 为什么改
`validateSchemaAtPath` 存在 `complexity: 28` lint 警告，超出 25 限制。

## 验证
- [x] pnpm eslint runtime-validation.ts 通过（0 warnings）
- [x] pnpm typecheck 通过
- [x] projectIpc.validation.test.ts 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)