### PR TITLE
improve(main): 搜索IPC异常兜底与回归覆盖

### DIFF
--- a/apps/desktop/main/src/ipc/search.ts
+++ b/apps/desktop/main/src/ipc/search.ts
@@ -13,6 +13,8 @@ import {
 } from "../services/search/hybridRankingService";
 import { createSearchReplaceService } from "../services/search/searchReplaceService";
 
+type SearchReplaceService = ReturnType<typeof createSearchReplaceService>;
+
 type DocumentIndexRow = {
   documentId: string;
   contentText: string;
@@ -91,6 +93,70 @@ function createSearchSemanticRetriever(args: {
   };
 }
 
+function toInternalSearchError(
+  logger: Logger,
+  event: string,
+  error: unknown,
+): IpcResponse<never> {
+  logger.error(event, {
+    message: error instanceof Error ? error.message : String(error),
+  });
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "Internal error",
+    },
+  };
+}
+
+function hasProjectId(payload: unknown): payload is { projectId: string } {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+  const projectId = (payload as { projectId?: unknown }).projectId;
+  return typeof projectId === "string" && projectId.trim().length > 0;
+}
+
+function registerSearchReplaceHandlers(
+  ipcMain: IpcMain,
+  db: Database.Database | null,
+  logger: Logger,
+  replaceService: SearchReplaceService | null,
+): void {
+  ipcMain.handle("search:replace:preview", async (_e, payload: Parameters<SearchReplaceService["preview"]>[0]) => {
+    if (!db || !replaceService) {
+      return { ok: false, error: { code: "DB_ERROR", message: "Database not ready" } };
+    }
+    try {
+      const res = replaceService.preview(payload);
+      if (!res.ok) {
+        logger.error("search_replace_preview_failed", { code: res.error.code, message: res.error.message });
+        return { ok: false, error: res.error };
+      }
+      return { ok: true, data: res.data };
+    } catch (error) {
+      return toInternalSearchError(logger, "search_replace_preview_exception", error);
+    }
+  });
+
+  ipcMain.handle("search:replace:execute", async (_e, payload: Parameters<SearchReplaceService["execute"]>[0]) => {
+    if (!db || !replaceService) {
+      return { ok: false, error: { code: "DB_ERROR", message: "Database not ready" } };
+    }
+    try {
+      const res = replaceService.execute(payload);
+      if (!res.ok) {
+        logger.error("search_replace_execute_failed", { code: res.error.code, message: res.error.message });
+        return { ok: false, error: res.error };
+      }
+      return { ok: true, data: res.data };
+    } catch (error) {
+      return toInternalSearchError(logger, "search_replace_execute_exception", error);
+    }
+  });
+}
+
 /**
  * Register `search:*` IPC handlers.
  *
@@ -131,12 +197,7 @@ export function registerSearchIpcHandlers(deps: {
     "search:fts:query",
     async (
       _e,
-      payload: {
-        projectId: string;
-        query: string;
-        limit?: number;
-        offset?: number;
-      },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         results: Array<{
@@ -161,46 +222,65 @@ export function registerSearchIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!hasProjectId(payload)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
         };
       }
 
-      const res = ftsService?.search({
-        projectId: payload.projectId,
-        query: payload.query,
-        limit: payload.limit,
-        offset: payload.offset,
-      });
-      if (!res) {
-        return {
-          ok: false,
-          error: { code: "DB_ERROR", message: "Database not ready" },
-        };
-      }
+      const safePayload = payload as {
+        projectId: string;
+        query: string;
+        limit?: number;
+        offset?: number;
+      };
+      const queryLength =
+        typeof safePayload.query === "string"
+          ? safePayload.query.trim().length
+          : 0;
 
-      if (!res.ok) {
-        if (res.error.code === "INVALID_ARGUMENT") {
-          deps.logger.info("search_fts_invalid_query", {
-            queryLength: payload.query.trim().length,
-          });
-        } else {
-          deps.logger.error("search_fts_failed", {
-            code: res.error.code,
-            message: res.error.message,
-          });
+      try {
+        const res = ftsService?.search({
+          projectId: safePayload.projectId,
+          query: safePayload.query,
+          limit: safePayload.limit,
+          offset: safePayload.offset,
+        });
+        if (!res) {
+          return {
+            ok: false,
+            error: { code: "DB_ERROR", message: "Database not ready" },
+          };
         }
-        return { ok: false, error: res.error };
-      }
 
-      deps.logger.info("search_fts_query", {
-        queryLength: payload.query.trim().length,
-        resultCount: res.data.results.length,
-        indexState: res.data.indexState,
-      });
-      return { ok: true, data: res.data };
+        if (!res.ok) {
+          if (res.error.code === "INVALID_ARGUMENT") {
+            deps.logger.info("search_fts_invalid_query", {
+              queryLength: queryLength,
+            });
+          } else {
+            deps.logger.error("search_fts_failed", {
+              code: res.error.code,
+              message: res.error.message,
+            });
+          }
+          return { ok: false, error: res.error };
+        }
+
+        deps.logger.info("search_fts_query", {
+          queryLength: queryLength,
+          resultCount: res.data.results.length,
+          indexState: res.data.indexState,
+        });
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          deps.logger,
+          "search_fts_query_exception",
+          error,
+        );
+      }
     },
   );
 
@@ -208,7 +288,7 @@ export function registerSearchIpcHandlers(deps: {
     "search:fts:reindex",
     async (
       _e,
-      payload: { projectId: string },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         indexState: "ready";
@@ -222,25 +302,42 @@ export function registerSearchIpcHandlers(deps: {
         };
       }
 
-      const res = ftsService?.reindex({ projectId: payload.projectId });
-      if (!res) {
+      if (!hasProjectId(payload)) {
         return {
           ok: false,
-          error: { code: "DB_ERROR", message: "Database not ready" },
+          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
         };
       }
-      if (!res.ok) {
-        deps.logger.error("search_fts_reindex_failed", {
-          code: res.error.code,
-          message: res.error.message,
-        });
-        return { ok: false, error: res.error };
-      }
 
-      deps.logger.info("search_fts_reindex", {
-        reindexed: res.data.reindexed,
-      });
-      return { ok: true, data: res.data };
+      const safePayload = payload as { projectId: string };
+
+      try {
+        const res = ftsService?.reindex({ projectId: safePayload.projectId });
+        if (!res) {
+          return {
+            ok: false,
+            error: { code: "DB_ERROR", message: "Database not ready" },
+          };
+        }
+        if (!res.ok) {
+          deps.logger.error("search_fts_reindex_failed", {
+            code: res.error.code,
+            message: res.error.message,
+          });
+          return { ok: false, error: res.error };
+        }
+
+        deps.logger.info("search_fts_reindex", {
+          reindexed: res.data.reindexed,
+        });
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          deps.logger,
+          "search_fts_reindex_exception",
+          error,
+        );
+      }
     },
   );
 
@@ -290,21 +387,29 @@ export function registerSearchIpcHandlers(deps: {
         };
       }
 
-      const res = hybridRankingService.queryByStrategy(payload);
-      if (!res.ok) {
-        deps.logger.error("search_query_strategy_failed", {
-          code: res.error.code,
-          message: res.error.message,
+      try {
+        const res = hybridRankingService.queryByStrategy(payload);
+        if (!res.ok) {
+          deps.logger.error("search_query_strategy_failed", {
+            code: res.error.code,
+            message: res.error.message,
+            strategy: payload.strategy,
+          });
+          return { ok: false, error: res.error };
+        }
+        deps.logger.info("search_query_strategy", {
           strategy: payload.strategy,
+          resultCount: res.data.results.length,
+          total: res.data.total,
         });
-        return { ok: false, error: res.error };
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          deps.logger,
+          "search_query_strategy_exception",
+          error,
+        );
       }
-      deps.logger.info("search_query_strategy", {
-        strategy: payload.strategy,
-        resultCount: res.data.results.length,
-        total: res.data.total,
-      });
-      return { ok: true, data: res.data };
     },
   );
 
@@ -351,114 +456,30 @@ export function registerSearchIpcHandlers(deps: {
         };
       }
 
-      const res = hybridRankingService.rankExplain(payload);
-      if (!res.ok) {
-        deps.logger.error("search_rank_explain_failed", {
-          code: res.error.code,
-          message: res.error.message,
+      try {
+        const res = hybridRankingService.rankExplain(payload);
+        if (!res.ok) {
+          deps.logger.error("search_rank_explain_failed", {
+            code: res.error.code,
+            message: res.error.message,
+            strategy: payload.strategy,
+          });
+          return { ok: false, error: res.error };
+        }
+        deps.logger.info("search_rank_explain", {
           strategy: payload.strategy,
+          explanationCount: res.data.explanations.length,
         });
-        return { ok: false, error: res.error };
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          deps.logger,
+          "search_rank_explain_exception",
+          error,
+        );
       }
-      deps.logger.info("search_rank_explain", {
-        strategy: payload.strategy,
-        explanationCount: res.data.explanations.length,
-      });
-      return { ok: true, data: res.data };
     },
   );
 
-  deps.ipcMain.handle(
-    "search:replace:preview",
-    async (
-      _e,
-      payload: {
-        projectId: string;
-        documentId?: string;
-        scope: "currentDocument" | "wholeProject";
-        query: string;
-        replaceWith: string;
-        regex?: boolean;
-        caseSensitive?: boolean;
-        wholeWord?: boolean;
-      },
-    ): Promise<
-      IpcResponse<{
-        affectedDocuments: number;
-        totalMatches: number;
-        items: Array<{
-          documentId: string;
-          title: string;
-          matchCount: number;
-          sample: string;
-        }>;
-        warnings: string[];
-        previewId?: string;
-      }>
-    > => {
-      if (!deps.db || !replaceService) {
-        return {
-          ok: false,
-          error: { code: "DB_ERROR", message: "Database not ready" },
-        };
-      }
-
-      const res = replaceService.preview(payload);
-      if (!res.ok) {
-        deps.logger.error("search_replace_preview_failed", {
-          code: res.error.code,
-          message: res.error.message,
-        });
-        return { ok: false, error: res.error };
-      }
-      return { ok: true, data: res.data };
-    },
-  );
-
-  deps.ipcMain.handle(
-    "search:replace:execute",
-    async (
-      _e,
-      payload: {
-        projectId: string;
-        documentId?: string;
-        scope: "currentDocument" | "wholeProject";
-        query: string;
-        replaceWith: string;
-        regex?: boolean;
-        caseSensitive?: boolean;
-        wholeWord?: boolean;
-        previewId?: string;
-        confirmed?: boolean;
-      },
-    ): Promise<
-      IpcResponse<{
-        replacedCount: number;
-        affectedDocumentCount: number;
-        snapshotIds: string[];
-        skipped: Array<{
-          documentId: string;
-          reason: string;
-          message?: string;
-        }>;
-      }>
-    > => {
-      if (!deps.db || !replaceService) {
-        return {
-          ok: false,
-          error: { code: "DB_ERROR", message: "Database not ready" },
-        };
-      }
-
-      const res = replaceService.execute(payload);
-      if (!res.ok) {
-        deps.logger.error("search_replace_execute_failed", {
-          code: res.error.code,
-          message: res.error.message,
-        });
-        return { ok: false, error: res.error };
-      }
-      return { ok: true, data: res.data };
-    },
-  );
+  registerSearchReplaceHandlers(deps.ipcMain, deps.db, deps.logger, replaceService);
 }

--- a/apps/desktop/main/src/services/ai/errorMapper.test.ts
+++ b/apps/desktop/main/src/services/ai/errorMapper.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildUpstreamHttpError,
+  mapUpstreamStatusToIpcErrorCode,
+} from "./errorMapper";
+
+function makeResponse(
+  status: number,
+  body: string,
+  contentType = "application/json",
+): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": contentType },
+  });
+}
+
+describe("mapUpstreamStatusToIpcErrorCode", () => {
+  it("maps auth statuses to AI_AUTH_FAILED", () => {
+    expect(mapUpstreamStatusToIpcErrorCode(401)).toBe("AI_AUTH_FAILED");
+    expect(mapUpstreamStatusToIpcErrorCode(403)).toBe("AI_AUTH_FAILED");
+  });
+
+  it("maps 429 to AI_RATE_LIMITED", () => {
+    expect(mapUpstreamStatusToIpcErrorCode(429)).toBe("AI_RATE_LIMITED");
+  });
+
+  it("maps all other statuses to LLM_API_ERROR", () => {
+    expect(mapUpstreamStatusToIpcErrorCode(400)).toBe("LLM_API_ERROR");
+    expect(mapUpstreamStatusToIpcErrorCode(500)).toBe("LLM_API_ERROR");
+  });
+});
+
+describe("buildUpstreamHttpError", () => {
+  it("reads nested JSON error.message", async () => {
+    const res = makeResponse(500, JSON.stringify({ error: { message: "internal error" } }));
+    const err = await buildUpstreamHttpError({ res, fallbackMessage: "fallback" });
+
+    expect(err.code).toBe("LLM_API_ERROR");
+    expect(err.message).toBe("internal error");
+    expect(err.details).toMatchObject({
+      status: 500,
+      upstreamMessage: "internal error",
+    });
+  });
+
+  it("falls back to top-level JSON message", async () => {
+    const res = makeResponse(500, JSON.stringify({ message: "top level error" }));
+    const err = await buildUpstreamHttpError({ res, fallbackMessage: "fallback" });
+
+    expect(err.message).toBe("top level error");
+    expect(err.details).toMatchObject({
+      status: 500,
+      upstreamMessage: "top level error",
+    });
+  });
+
+  it("falls back when JSON is invalid", async () => {
+    const res = makeResponse(500, "{invalid-json");
+    const err = await buildUpstreamHttpError({ res, fallbackMessage: "fallback" });
+
+    expect(err.message).toBe("fallback");
+    expect(err.details).toMatchObject({
+      status: 500,
+      upstreamMessage: "fallback",
+    });
+  });
+
+  it("falls back for non-JSON plain text body", async () => {
+    const res = makeResponse(500, "Internal Server Error", "text/plain");
+    const err = await buildUpstreamHttpError({ res, fallbackMessage: "fallback" });
+
+    expect(err.message).toBe("fallback");
+    expect(err.details).toMatchObject({
+      status: 500,
+      upstreamMessage: "fallback",
+    });
+  });
+
+  it("overrides message for auth and rate-limit statuses", async () => {
+    const authRes = makeResponse(401, JSON.stringify({ error: { message: "bad key" } }));
+    const authErr = await buildUpstreamHttpError({
+      res: authRes,
+      fallbackMessage: "fallback",
+    });
+    expect(authErr.code).toBe("AI_AUTH_FAILED");
+    expect(authErr.message).toBe("AI upstream unauthorized");
+    expect(authErr.details).toMatchObject({
+      status: 401,
+      upstreamMessage: "bad key",
+    });
+
+    const rateRes = makeResponse(429, JSON.stringify({ error: { message: "quota exceeded" } }));
+    const rateErr = await buildUpstreamHttpError({
+      res: rateRes,
+      fallbackMessage: "fallback",
+    });
+    expect(rateErr.code).toBe("AI_RATE_LIMITED");
+    expect(rateErr.message).toBe("AI upstream rate limited");
+    expect(rateErr.details).toMatchObject({
+      status: 429,
+      upstreamMessage: "quota exceeded",
+    });
+  });
+});

--- a/apps/desktop/tests/integration/search/search-fts-invalid-project-id.test.ts
+++ b/apps/desktop/tests/integration/search/search-fts-invalid-project-id.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+import { registerSearchIpcHandlers } from "../../../main/src/ipc/search";
+import type { Logger } from "../../../main/src/logging/logger";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+type FakeIpcMain = {
+  handle: (channel: string, handler: Handler) => void;
+};
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: FakeIpcMain;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain: FakeIpcMain = {
+    handle: (channel, handler) => {
+      handlers.set(channel, handler);
+    },
+  };
+  return { ipcMain, handlers };
+}
+
+function createDbStub(): Database.Database {
+  return {
+    prepare: () => {
+      throw new Error("db should not be touched for invalid payload");
+    },
+  } as unknown as Database.Database;
+}
+
+const malformedPayloads: unknown[] = [
+  undefined,
+  null,
+  {},
+  { projectId: 123 },
+  { projectId: "   " },
+];
+
+{
+  const logger = createLogger();
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerSearchIpcHandlers({
+    ipcMain: ipcMain as unknown as IpcMain,
+    db: createDbStub(),
+    logger,
+  });
+
+  const query = handlers.get("search:fts:query");
+  assert.ok(query, "Missing handler search:fts:query");
+  if (!query) {
+    throw new Error("Missing handler search:fts:query");
+  }
+
+  for (const payload of malformedPayloads) {
+    const response = (await query({}, payload)) as IpcResponse<unknown>;
+    assert.equal(response.ok, false);
+    if (!response.ok) {
+      assert.equal(response.error.code, "INVALID_ARGUMENT");
+      assert.equal(response.error.message, "projectId is required");
+    }
+  }
+}
+
+{
+  const logger = createLogger();
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerSearchIpcHandlers({
+    ipcMain: ipcMain as unknown as IpcMain,
+    db: createDbStub(),
+    logger,
+  });
+
+  const reindex = handlers.get("search:fts:reindex");
+  assert.ok(reindex, "Missing handler search:fts:reindex");
+  if (!reindex) {
+    throw new Error("Missing handler search:fts:reindex");
+  }
+
+  for (const payload of malformedPayloads) {
+    const response = (await reindex({}, payload)) as IpcResponse<unknown>;
+    assert.equal(response.ok, false);
+    if (!response.ok) {
+      assert.equal(response.error.code, "INVALID_ARGUMENT");
+      assert.equal(response.error.message, "projectId is required");
+    }
+  }
+}

--- a/apps/desktop/tests/integration/search/search-ipc-unexpected-error-guard.test.ts
+++ b/apps/desktop/tests/integration/search/search-ipc-unexpected-error-guard.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+import { registerSearchIpcHandlers } from "../../../main/src/ipc/search";
+import type { Logger } from "../../../main/src/logging/logger";
+import type { HybridRankingService } from "../../../main/src/services/search/hybridRankingService";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+type FakeIpcMain = {
+  handle: (channel: string, handler: Handler) => void;
+};
+
+type LoggedError = {
+  event: string;
+  payload: unknown;
+};
+
+function createLogger(loggedErrors: LoggedError[]): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: (event, payload) => {
+      loggedErrors.push({ event, payload });
+    },
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: FakeIpcMain;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain: FakeIpcMain = {
+    handle: (channel, handler) => {
+      handlers.set(channel, handler);
+    },
+  };
+  return { ipcMain, handlers };
+}
+
+function createThrowingDb(): Database.Database {
+  return {
+    prepare: () => {
+      throw new Error("unexpected sqlite failure");
+    },
+  } as unknown as Database.Database;
+}
+
+{
+  const loggedErrors: LoggedError[] = [];
+  const logger = createLogger(loggedErrors);
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerSearchIpcHandlers({
+    ipcMain: ipcMain as unknown as IpcMain,
+    db: createThrowingDb(),
+    logger,
+  });
+
+  const ftsQuery = handlers.get("search:fts:query");
+  assert.ok(ftsQuery, "Missing handler search:fts:query");
+  if (!ftsQuery) {
+    throw new Error("Missing handler search:fts:query");
+  }
+
+  const queryRes = (await ftsQuery(
+    {},
+    { projectId: "proj_1", query: "hero" },
+  )) as IpcResponse<unknown>;
+  assert.equal(queryRes.ok, false);
+  if (!queryRes.ok) {
+    assert.equal(queryRes.error.code, "DB_ERROR");
+  }
+
+  const ftsReindex = handlers.get("search:fts:reindex");
+  assert.ok(ftsReindex, "Missing handler search:fts:reindex");
+  if (!ftsReindex) {
+    throw new Error("Missing handler search:fts:reindex");
+  }
+
+  const reindexRes = (await ftsReindex(
+    {},
+    { projectId: "proj_1" },
+  )) as IpcResponse<unknown>;
+  assert.equal(reindexRes.ok, false);
+  if (!reindexRes.ok) {
+    assert.equal(reindexRes.error.code, "DB_ERROR");
+  }
+
+  const errorEvents = loggedErrors.map((item) => item.event);
+  assert.ok(errorEvents.includes("fts_search_failed"));
+  assert.ok(errorEvents.includes("search_fts_reindex_failed"));
+}
+
+{
+  const loggedErrors: LoggedError[] = [];
+  const logger = createLogger(loggedErrors);
+  const { ipcMain, handlers } = createIpcHarness();
+
+  const hybridRankingService: HybridRankingService = {
+    queryByStrategy: () => {
+      throw new Error("strategy failed unexpectedly");
+    },
+    rankExplain: () => {
+      throw new Error("explain failed unexpectedly");
+    },
+  };
+
+  registerSearchIpcHandlers({
+    ipcMain: ipcMain as unknown as IpcMain,
+    db: createThrowingDb(),
+    logger,
+    hybridRankingService,
+  });
+
+  const queryByStrategy = handlers.get("search:query:strategy");
+  assert.ok(queryByStrategy, "Missing handler search:query:strategy");
+  if (!queryByStrategy) {
+    throw new Error("Missing handler search:query:strategy");
+  }
+
+  const strategyRes = (await queryByStrategy(
+    {},
+    {
+      projectId: "proj_1",
+      query: "hero",
+      strategy: "hybrid",
+    },
+  )) as IpcResponse<unknown>;
+  assert.equal(strategyRes.ok, false);
+  if (!strategyRes.ok) {
+    assert.equal(strategyRes.error.code, "INTERNAL_ERROR");
+    assert.equal(strategyRes.error.message, "Internal error");
+  }
+
+  const rankExplain = handlers.get("search:rank:explain");
+  assert.ok(rankExplain, "Missing handler search:rank:explain");
+  if (!rankExplain) {
+    throw new Error("Missing handler search:rank:explain");
+  }
+
+  const explainRes = (await rankExplain(
+    {},
+    {
+      projectId: "proj_1",
+      query: "hero",
+      strategy: "hybrid",
+    },
+  )) as IpcResponse<unknown>;
+  assert.equal(explainRes.ok, false);
+  if (!explainRes.ok) {
+    assert.equal(explainRes.error.code, "INTERNAL_ERROR");
+    assert.equal(explainRes.error.message, "Internal error");
+  }
+
+  const errorEvents = loggedErrors.map((item) => item.event);
+  assert.ok(errorEvents.includes("search_query_strategy_exception"));
+  assert.ok(errorEvents.includes("search_rank_explain_exception"));
+}

--- a/apps/desktop/tests/integration/search/search-replace-ipc-unexpected-error-guard.test.ts
+++ b/apps/desktop/tests/integration/search/search-replace-ipc-unexpected-error-guard.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+import { registerSearchIpcHandlers } from "../../../main/src/ipc/search";
+import type { Logger } from "../../../main/src/logging/logger";
+import {
+  asIpcMain,
+  createIpcHarness,
+  createReplaceDbStub,
+} from "./replace-test-harness";
+
+type LoggedError = {
+  event: string;
+  payload: unknown;
+};
+
+function createErrorCollectingLogger(loggedErrors: LoggedError[]): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: (event, payload) => {
+      loggedErrors.push({ event, payload });
+    },
+  };
+}
+
+function createExplodingTrimError(message: string): string {
+  return {
+    trim: () => {
+      throw new Error(message);
+    },
+  } as unknown as string;
+}
+
+{
+  const loggedErrors: LoggedError[] = [];
+  const logger = createErrorCollectingLogger(loggedErrors);
+  const db = createReplaceDbStub({
+    projectId: "proj_1",
+    documents: [
+      {
+        documentId: "doc_1",
+        title: "Chapter One",
+        text: "warehouse hero warehouse",
+      },
+    ],
+  });
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerSearchIpcHandlers({
+    ipcMain: asIpcMain(ipcMain),
+    db,
+    logger,
+  });
+
+  const preview = handlers.get("search:replace:preview");
+  assert.ok(preview, "Missing handler search:replace:preview");
+  if (!preview) {
+    throw new Error("Missing handler search:replace:preview");
+  }
+
+  const previewRes = (await preview(
+    {},
+    {
+      projectId: "proj_1",
+      scope: "wholeProject",
+      query: createExplodingTrimError("preview query trim exploded"),
+      replaceWith: "factory",
+    },
+  )) as IpcResponse<unknown>;
+
+  assert.equal(previewRes.ok, false);
+  if (!previewRes.ok) {
+    assert.equal(previewRes.error.code, "INTERNAL_ERROR");
+    assert.equal(previewRes.error.message, "Internal error");
+  }
+
+  const execute = handlers.get("search:replace:execute");
+  assert.ok(execute, "Missing handler search:replace:execute");
+  if (!execute) {
+    throw new Error("Missing handler search:replace:execute");
+  }
+
+  const executeRes = (await execute(
+    {},
+    {
+      projectId: "proj_1",
+      documentId: "doc_1",
+      scope: "currentDocument",
+      query: createExplodingTrimError("execute query trim exploded"),
+      replaceWith: "factory",
+    },
+  )) as IpcResponse<unknown>;
+
+  assert.equal(executeRes.ok, false);
+  if (!executeRes.ok) {
+    assert.equal(executeRes.error.code, "INTERNAL_ERROR");
+    assert.equal(executeRes.error.message, "Internal error");
+  }
+
+  const errorEvents = loggedErrors.map((item) => item.event);
+  assert.ok(errorEvents.includes("search_replace_preview_exception"));
+  assert.ok(errorEvents.includes("search_replace_execute_exception"));
+
+  const previewException = loggedErrors.find(
+    (item) => item.event === "search_replace_preview_exception",
+  );
+  const executeException = loggedErrors.find(
+    (item) => item.event === "search_replace_execute_exception",
+  );
+
+  assert.deepEqual(previewException?.payload, {
+    message: "preview query trim exploded",
+  });
+  assert.deepEqual(executeException?.payload, {
+    message: "execute query trim exploded",
+  });
+}


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
加强搜索 IPC 的异常兜底与回归测试，避免畸形参数触发非预期内部错误。

## 改动列表
- commit 1: search IPC 增加 projectId payload 类型守卫，并统一 replace 通道异常兜底
- commit 2: 新增搜索异常与参数守卫集成测试（fts invalid projectId、replace 异常、unexpected error guard）
- commit 3: 新增 AI upstream 错误映射单元测试，补齐回退与 details 断言

## 为什么改
现有搜索通道在畸形 payload 和运行时异常场景下回归覆盖不足，容易把输入问题或异常路径漏成不稳定行为；本轮补齐守卫与测试，提升错误处理稳定性。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仅现有历史 warning，无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)