### PR TITLE
improve(main): 修复 hybrid 搜索超时降级与 IPC 边界测试

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/stats-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/stats-ipc.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+
+import { registerStatsIpcHandlers } from "../stats";
+
+type Handler = (event: unknown, payload?: unknown) => Promise<unknown>;
+
+type Harness = {
+  invoke: <T>(channel: string, payload?: unknown) => Promise<T>;
+};
+
+function createHarness(dbReady: boolean): Harness {
+  const handlers = new Map<string, Handler>();
+
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+
+  registerStatsIpcHandlers({
+    ipcMain,
+    db: dbReady ? ({} as never) : null,
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    } as never,
+  });
+
+  return {
+    invoke: async <T>(channel: string, payload: unknown = {}) => {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `expected IPC handler ${channel} to be registered`);
+      return (await handler({}, payload)) as T;
+    },
+  };
+}
+
+async function runScenario(
+  name: string,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    throw new Error(
+      `[${name}] ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  await runScenario("S1 DB 未就绪时返回 DB_ERROR", async () => {
+    const harness = createHarness(false);
+
+    const range = await harness.invoke<{
+      ok: boolean;
+      error?: { code: string; message: string };
+    }>("stats:range:get", { from: "2026-01-01", to: "2026-01-02" });
+
+    assert.equal(range.ok, false);
+    assert.equal(range.error?.code, "DB_ERROR");
+    assert.equal(range.error?.message, "Database not ready");
+  });
+
+  await runScenario("S2 from 非法格式应被拦截", async () => {
+    const harness = createHarness(true);
+
+    const res = await harness.invoke<{
+      ok: boolean;
+      error?: { code: string; message: string };
+    }>("stats:range:get", { from: "2026/01/01", to: "2026-01-02" });
+
+    assert.equal(res.ok, false);
+    assert.equal(res.error?.code, "INVALID_ARGUMENT");
+    assert.equal(res.error?.message, "from must be YYYY-MM-DD");
+  });
+
+  await runScenario("S3 to 非法格式应被拦截", async () => {
+    const harness = createHarness(true);
+
+    const res = await harness.invoke<{
+      ok: boolean;
+      error?: { code: string; message: string };
+    }>("stats:range:get", { from: "2026-01-01", to: "2026/01/02" });
+
+    assert.equal(res.ok, false);
+    assert.equal(res.error?.code, "INVALID_ARGUMENT");
+    assert.equal(res.error?.message, "to must be YYYY-MM-DD");
+  });
+
+  await runScenario("S4 from 晚于 to 应被拦截", async () => {
+    const harness = createHarness(true);
+
+    const res = await harness.invoke<{
+      ok: boolean;
+      error?: { code: string; message: string };
+    }>("stats:range:get", { from: "2026-01-03", to: "2026-01-02" });
+
+    assert.equal(res.ok, false);
+    assert.equal(res.error?.code, "INVALID_ARGUMENT");
+    assert.equal(res.error?.message, "from must be <= to");
+  });
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/services/search/hybridRankingService.ts
+++ b/apps/desktop/main/src/services/search/hybridRankingService.ts
@@ -357,17 +357,21 @@ function buildRankedItems(args: {
     });
     if (!semantic.ok) {
       if (isTimeoutCode(semantic.error.code)) {
-        const semanticNotice =
-          args.strategy === "hybrid"
-            ? "语义检索超时，已切换关键词检索"
-            : "语义检索超时，请稍后重试";
-        return ipcError("SEARCH_TIMEOUT", "Semantic search timed out", {
-          fallback: args.strategy === "hybrid" ? "fts" : "none",
-          notice: semanticNotice,
-          strategy: args.strategy,
-        });
-      }
-      if (args.strategy === "hybrid") {
+        if (args.strategy === "hybrid") {
+          args.logger.info("search_hybrid_semantic_degraded", {
+            projectId: args.projectId,
+            reason: semantic.error.code,
+          });
+          fallback = "fts";
+          notice = "语义检索超时，已切换关键词检索";
+        } else {
+          return ipcError("SEARCH_TIMEOUT", "Semantic search timed out", {
+            fallback: "none",
+            notice: "语义检索超时，请稍后重试",
+            strategy: args.strategy,
+          });
+        }
+      } else if (args.strategy === "hybrid") {
         args.logger.info("search_hybrid_semantic_degraded", {
           projectId: args.projectId,
           reason: semantic.error.code,

--- a/apps/desktop/tests/integration/search/search-timeout-visible-fallback.test.ts
+++ b/apps/desktop/tests/integration/search/search-timeout-visible-fallback.test.ts
@@ -9,8 +9,19 @@ import {
   createLogger,
 } from "./hybrid-ranking-test-harness";
 
-// Scenario Mapping: SR5-R1-S2
-{
+type QueryStrategyResponse = IpcResponse<{
+  strategy: "fts" | "semantic" | "hybrid";
+  fallback: "fts" | "none";
+  notice?: string;
+  results: Array<{
+    documentId: string;
+    chunkId: string;
+    snippet: string;
+  }>;
+  total: number;
+}>;
+
+function createTimeoutHarness() {
   const logger = createLogger();
   const db = createFtsDbStub({
     projectId: "proj_1",
@@ -47,6 +58,12 @@ import {
     throw new Error("Missing handler search:query:strategy");
   }
 
+  return queryByStrategy;
+}
+
+// Scenario Mapping: SR5-R1-S2
+{
+  const queryByStrategy = createTimeoutHarness();
   const res = (await queryByStrategy(
     {},
     {
@@ -56,7 +73,31 @@ import {
       limit: 20,
       offset: 0,
     },
-  )) as IpcResponse<unknown>;
+  )) as QueryStrategyResponse;
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.strategy, "hybrid");
+    assert.equal(res.data.fallback, "fts");
+    assert.ok((res.data.notice ?? "").includes("语义检索超时"));
+    assert.equal(res.data.total, 1);
+    assert.equal(res.data.results[0]?.documentId, "doc_1");
+  }
+}
+
+// Scenario Mapping: SR5-R1-S3
+{
+  const queryByStrategy = createTimeoutHarness();
+  const res = (await queryByStrategy(
+    {},
+    {
+      projectId: "proj_1",
+      query: "abandoned warehouse",
+      strategy: "semantic",
+      limit: 20,
+      offset: 0,
+    },
+  )) as QueryStrategyResponse;
 
   assert.equal(res.ok, false);
   if (!res.ok) {
@@ -66,8 +107,8 @@ import {
       notice?: string;
       strategy?: "fts" | "semantic" | "hybrid";
     };
-    assert.equal(details.fallback, "fts");
-    assert.equal(details.strategy, "hybrid");
+    assert.equal(details.fallback, "none");
+    assert.equal(details.strategy, "semantic");
     assert.ok((details.notice ?? "").includes("语义检索超时"));
   }
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 hybrid 搜索在语义超时时错误返回失败的问题，并补齐关键 IPC 输入边界测试。

## 改动列表
- commit 1: 修复 `hybridRankingService` 在 `strategy=hybrid` + 语义超时时的错误处理，改为降级返回 FTS 结果；同步更新 `search-timeout-visible-fallback` 回归测试，补充 semantic 策略超时断言
- commit 2: 新增 `stats-ipc.test.ts`，覆盖 DB 未就绪与 `stats:range:get` 的 `from/to` 参数边界校验

## 为什么改
hybrid 模式下语义检索超时本应降级为关键词检索，但原逻辑会直接返回 `SEARCH_TIMEOUT`，导致可用结果被丢弃；同时 stats IPC 缺少输入边界回归，容易在参数校验链路回归时放大风险。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库存量 warning 无新增错误）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更（仅修正 hybrid 超时降级为既定预期）
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
