### PR TITLE
improve(main): 强化 contextFs IPC 非法 payload 错误处理

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/contextFs-invalid-payload-guard.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/contextFs-invalid-payload-guard.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+
+import type { Logger } from "../../logging/logger";
+import type { CreonowWatchService } from "../../services/context/watchService";
+import { registerContextFsHandlers } from "../contextFs";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createDeps(args: {
+  handlers: Map<string, Handler>;
+  watchService: CreonowWatchService;
+}): {
+  ipcMain: IpcMain;
+  db: Database.Database;
+  logger: Logger;
+  userDataDir: string;
+  watchService: CreonowWatchService;
+} {
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      args.handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+
+  return {
+    ipcMain,
+    db: {} as Database.Database,
+    logger: createLogger(),
+    userDataDir: "<test-user-data>",
+    watchService: args.watchService,
+  };
+}
+
+const handlers = new Map<string, Handler>();
+let stopCalled = 0;
+
+registerContextFsHandlers(
+  createDeps({
+    handlers,
+    watchService: {
+      start: () => ({ ok: true, data: { watching: true } }),
+      stop: () => {
+        stopCalled += 1;
+        return { ok: true, data: { watching: false } };
+      },
+      isWatching: () => false,
+    },
+  }),
+);
+
+const watchStop = handlers.get("context:watch:stop");
+assert.ok(watchStop, "context:watch:stop handler should exist");
+let watchStopRejected = false;
+let watchStopResponse: unknown;
+try {
+  watchStopResponse = await watchStop!(
+    {},
+    { projectId: 42 } as unknown as { projectId: string },
+  );
+} catch {
+  watchStopRejected = true;
+}
+
+assert.equal(
+  watchStopRejected,
+  false,
+  "context:watch:stop should not reject on malformed projectId",
+);
+assert.deepEqual(watchStopResponse, {
+  ok: false,
+  error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+});
+assert.equal(stopCalled, 0, "watchService.stop should not run on invalid payload");
+
+const rulesRead = handlers.get("context:rules:read");
+assert.ok(rulesRead, "context:rules:read handler should exist");
+let rulesReadRejected = false;
+let rulesReadResponse: unknown;
+try {
+  rulesReadResponse = await rulesRead!(
+    {},
+    { projectId: "p-1", path: 42 } as unknown as {
+      projectId: string;
+      path: string;
+    },
+  );
+} catch {
+  rulesReadRejected = true;
+}
+
+assert.equal(
+  rulesReadRejected,
+  false,
+  "context:rules:read should not reject on malformed path",
+);
+assert.deepEqual(rulesReadResponse, {
+  ok: false,
+  error: { code: "INVALID_ARGUMENT", message: "Invalid rules path" },
+});

--- a/apps/desktop/main/src/ipc/contextFs.ts
+++ b/apps/desktop/main/src/ipc/contextFs.ts
@@ -31,9 +31,13 @@ type ContextFsRegistrarDeps = {
 
 function isReadWithinScope(args: {
   scope: "rules" | "settings";
-  p: string;
+  p: unknown;
 }): boolean {
-  return args.p.startsWith(`.creonow/${args.scope}/`);
+  return typeof args.p === "string" && args.p.startsWith(`.creonow/${args.scope}/`);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
@@ -69,7 +73,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -128,7 +132,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -192,7 +196,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -253,7 +257,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
       _e,
       payload: { projectId: string },
     ): Promise<IpcResponse<{ watching: false }>> => {
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -301,7 +305,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -363,7 +367,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -433,7 +437,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -532,7 +536,7 @@ export function registerContextFsHandlers(deps: ContextFsRegistrarDeps): void {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!isNonEmptyString(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 contextFs IPC 在收到非字符串 projectId/path 时可能抛出运行时异常的问题，并补齐回归测试。

## 改动列表
- commit 1: 在 contextFs.ts 新增运行时字符串守卫，避免对非法 payload 调用 .trim()/.startsWith() 直接抛错
- commit 2: 新增 contextFs-invalid-payload-guard.test.ts，覆盖 context:watch:stop 与 context:rules:read 的异常输入回归场景

## 为什么改
当前 IPC 入口虽然有 TypeScript 类型，但运行时仍可能收到畸形 payload。此前会在参数检查阶段直接抛异常并导致 Promise reject，前端拿不到结构化错误；本次改动将其收敛为 INVALID_ARGUMENT，让错误链路可预期、可观测。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库存在历史 warning，本次无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
