### PR TITLE
improve(main): 补齐窗口异常映射并收紧特权IPC来源校验

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/runtimeValidation.acl.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/runtimeValidation.acl.test.ts
@@ -18,9 +18,12 @@ function createLogger(): TestLogger {
   };
 }
 
-function createEvent(url: string, webContentsId: number): IpcMainInvokeEvent {
+function createEvent(
+  url: string | null | undefined,
+  webContentsId: number,
+): IpcMainInvokeEvent {
   return {
-    senderFrame: { url },
+    senderFrame: url == null ? undefined : { url },
     sender: { id: webContentsId },
   } as unknown as IpcMainInvokeEvent;
 }
@@ -58,6 +61,40 @@ async function main(): Promise<void> {
 
       const response = (await wrapped(
         createEvent("https://evil.com/admin", -1),
+        {},
+      )) as IpcResponse<unknown>;
+
+      assert.equal(called, false);
+      assert.equal(response.ok, false);
+      if (response.ok) {
+        assert.fail("expected FORBIDDEN response");
+      }
+      assert.equal(response.error.code, "FORBIDDEN");
+      assert.equal(
+        (response.error.details as { reason?: string } | undefined)?.reason,
+        "origin_not_allowed",
+      );
+    },
+  );
+  await runScenario(
+    "SIA-S4 should block privileged channel when sender origin is missing",
+    async () => {
+      let called = false;
+
+      const wrapped = wrapIpcRequestResponse({
+        channel: "db:debug:tablenames",
+        requestSchema: s.object({}),
+        responseSchema: s.object({ tableNames: s.array(s.string()) }),
+        logger: createLogger(),
+        timeoutMs: 5_000,
+        handler: async () => {
+          called = true;
+          return { ok: true, data: { tableNames: ["projects"] } };
+        },
+      });
+
+      const response = (await wrapped(
+        createEvent(undefined, 1),
         {},
       )) as IpcResponse<unknown>;
 

--- a/apps/desktop/main/src/ipc/__tests__/window-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/window-ipc.test.ts
@@ -16,6 +16,8 @@ type FakeWindow = {
   close: () => void;
 };
 
+type ThrowTargets = Partial<Record<keyof FakeWindow, string>>;
+
 type Harness = {
   handlers: Map<string, Handler>;
   calls: string[];
@@ -27,27 +29,48 @@ function createHarness(args?: {
   platform?: NodeJS.Platform;
   hasWindow?: boolean;
   initiallyMaximized?: boolean;
+  throwOn?: ThrowTargets;
 }): Harness {
   const handlers = new Map<string, Handler>();
   const calls: string[] = [];
   const maximizeState = { value: args?.initiallyMaximized ?? false };
 
+  const maybeThrow = (method: keyof FakeWindow): void => {
+    const message = args?.throwOn?.[method];
+    if (message) {
+      throw new Error(message);
+    }
+  };
+
   const win: FakeWindow = {
-    isMaximized: () => maximizeState.value,
-    isMinimized: () => false,
-    isFullScreen: () => false,
+    isMaximized: () => {
+      maybeThrow("isMaximized");
+      return maximizeState.value;
+    },
+    isMinimized: () => {
+      maybeThrow("isMinimized");
+      return false;
+    },
+    isFullScreen: () => {
+      maybeThrow("isFullScreen");
+      return false;
+    },
     minimize: () => {
+      maybeThrow("minimize");
       calls.push("minimize");
     },
     maximize: () => {
+      maybeThrow("maximize");
       calls.push("maximize");
       maximizeState.value = true;
     },
     unmaximize: () => {
+      maybeThrow("unmaximize");
       calls.push("unmaximize");
       maximizeState.value = false;
     },
     close: () => {
+      maybeThrow("close");
       calls.push("close");
     },
   };
@@ -183,6 +206,45 @@ async function main(): Promise<void> {
 
       assert.equal(response.ok, false);
       assert.equal(response.error?.code, "NOT_FOUND");
+    },
+  );
+
+  await runScenario(
+    "W5 should map getstate runtime exceptions to INTERNAL",
+    async () => {
+      const harness = createHarness({
+        platform: "win32",
+        throwOn: { isMaximized: "boom-state" },
+      });
+
+      const response = await harness.invoke<{
+        ok: boolean;
+        error?: { code: string; message: string };
+      }>("app:window:getstate");
+
+      assert.equal(response.ok, false);
+      assert.equal(response.error?.code, "INTERNAL");
+      assert.match(response.error?.message ?? "", /get window state/);
+    },
+  );
+
+  await runScenario(
+    "W6 should map action runtime exceptions to INTERNAL",
+    async () => {
+      const harness = createHarness({
+        platform: "win32",
+        throwOn: { minimize: "boom-minimize" },
+      });
+
+      const response = await harness.invoke<{
+        ok: boolean;
+        error?: { code: string; message: string };
+      }>("app:window:minimize");
+
+      assert.equal(response.ok, false);
+      assert.equal(response.error?.code, "INTERNAL");
+      assert.match(response.error?.message ?? "", /Failed to minimize window/);
+      assert.deepEqual(harness.calls, []);
     },
   );
 }

--- a/apps/desktop/main/src/ipc/ipcAcl.ts
+++ b/apps/desktop/main/src/ipc/ipcAcl.ts
@@ -97,6 +97,19 @@ export function createIpcAclEvaluator(
 
   return ({ channel, event }): IpcAclDecision => {
     const senderOrigin = resolveSenderOrigin(event);
+    const isPrivileged = isPrivilegedChannel(channel, privilegedPrefixes);
+
+    if (senderOrigin === null && isPrivileged) {
+      return {
+        allowed: false,
+        reason: "origin_not_allowed",
+        details: {
+          channel,
+          senderOrigin,
+        },
+      };
+    }
+
     if (
       senderOrigin !== null &&
       !isOriginAllowed({ senderOrigin, devServerOrigin })
@@ -111,7 +124,7 @@ export function createIpcAclEvaluator(
       };
     }
 
-    if (isPrivilegedChannel(channel, privilegedPrefixes)) {
+    if (isPrivileged) {
       const webContentsId = resolveWebContentsId(event);
       if (!Number.isInteger(webContentsId) || (webContentsId ?? 0) <= 0) {
         return {

--- a/apps/desktop/main/src/ipc/window.ts
+++ b/apps/desktop/main/src/ipc/window.ts
@@ -12,6 +12,8 @@ type WindowLike = {
   close: () => void;
 };
 
+type WindowAction = "minimize" | "togglemaximized" | "close";
+
 type WindowState = {
   controlsEnabled: boolean;
   isMaximized: boolean;
@@ -30,6 +32,12 @@ function toError(code: IpcError["code"], message: string): IpcResponse<never> {
 function isWindowControlsEnabled(platform: NodeJS.Platform): boolean {
   return platform === "win32";
 }
+
+function toInternalError(action: string, error: unknown): IpcResponse<never> {
+  const message = error instanceof Error ? error.message : String(error);
+  return toError("INTERNAL", `Failed to ${action} window: ${message}`);
+}
+
 
 export function registerWindowIpcHandlers(args: {
   ipcMain: IpcMain;
@@ -57,76 +65,89 @@ export function registerWindowIpcHandlers(args: {
     };
   }
 
-  function buildState(win: WindowLike | null): WindowState {
+  function buildState(win: WindowLike | null): IpcResponse<WindowState> {
     if (!controlsEnabled || !win) {
       return {
-        controlsEnabled,
-        isMaximized: false,
-        isMinimized: false,
-        isFullScreen: false,
-        platform: args.platform,
+        ok: true,
+        data: {
+          controlsEnabled,
+          isMaximized: false,
+          isMinimized: false,
+          isFullScreen: false,
+          platform: args.platform,
+        },
       };
     }
 
-    return {
-      controlsEnabled,
-      isMaximized: win.isMaximized(),
-      isMinimized: win.isMinimized(),
-      isFullScreen: win.isFullScreen(),
-      platform: args.platform,
-    };
+    try {
+      return {
+        ok: true,
+        data: {
+          controlsEnabled,
+          isMaximized: win.isMaximized(),
+          isMinimized: win.isMinimized(),
+          isFullScreen: win.isFullScreen(),
+          platform: args.platform,
+        },
+      };
+    } catch (error) {
+      return toInternalError("get window state", error);
+    }
+  }
+
+  function runWindowAction(
+    event: IpcMainInvokeEvent,
+    action: WindowAction,
+  ): IpcResponse<Record<string, never>> {
+    const resolved = resolveSupportedWindow(event);
+    if (!resolved.ok) {
+      return resolved;
+    }
+
+    try {
+      if (action === "minimize") {
+        resolved.data.minimize();
+      } else if (action === "togglemaximized") {
+        if (resolved.data.isMaximized()) {
+          resolved.data.unmaximize();
+        } else {
+          resolved.data.maximize();
+        }
+      } else {
+        resolved.data.close();
+      }
+      return { ok: true, data: {} };
+    } catch (error) {
+      return toInternalError(action, error);
+    }
   }
 
   args.ipcMain.handle(
     "app:window:getstate",
     async (event): Promise<IpcResponse<WindowState>> => {
       const win = controlsEnabled ? resolveWindow(event) : null;
-      return {
-        ok: true,
-        data: buildState(win),
-      };
+      return buildState(win);
     },
   );
 
   args.ipcMain.handle(
     "app:window:minimize",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
-      }
-      resolved.data.minimize();
-      return { ok: true, data: {} };
+      return runWindowAction(event, "minimize");
     },
   );
 
   args.ipcMain.handle(
     "app:window:togglemaximized",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
-      }
-
-      if (resolved.data.isMaximized()) {
-        resolved.data.unmaximize();
-      } else {
-        resolved.data.maximize();
-      }
-
-      return { ok: true, data: {} };
+      return runWindowAction(event, "togglemaximized");
     },
   );
 
   args.ipcMain.handle(
     "app:window:close",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
-      }
-      resolved.data.close();
-      return { ok: true, data: {} };
+      return runWindowAction(event, "close");
     },
   );
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
补齐 window IPC 的运行时异常错误闭环，并修复特权 IPC 在缺失 sender origin 时的放行漏洞。

## 改动列表
- commit 1: improve(main): 补齐 window IPC 运行时异常错误闭环
- commit 2: improve(main): 收紧特权IPC缺失来源的访问控制

## 为什么改
窗口状态读取与窗口动作在 Electron API 异常时会直接抛出，导致错误码不一致且可观测性差；同时特权通道在 senderFrame.url 缺失时未拒绝，存在 ACL 降级为放行的风险。本次改动统一把这些边界异常收敛为结构化错误并补回归测试，保证失败路径稳定可控。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（或相关文件无新增警告）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
