### PR TITLE
improve(renderer): 提升渲染层启动与命令历史容错

### DIFF
--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
@@ -30,6 +30,25 @@ describe("recentItems", () => {
     expect(ids[ids.length - 1]).toBe("command-3");
   });
 
+
+
+  it("should normalize command ids by trimming whitespace", () => {
+    recordRecentCommandId("  command-a  ");
+    recordRecentCommandId("command-a");
+    recordRecentCommandId("  command-b");
+
+    expect(readRecentCommandIds()).toEqual(["command-b", "command-a"]);
+  });
+
+  it("should ignore blank and non-string ids from storage payload", () => {
+    window.localStorage.setItem(
+      "creonow.commandPalette.recent",
+      JSON.stringify([" command-a ", "", "   ", 123, "command-b"]),
+    );
+
+    expect(readRecentCommandIds()).toEqual(["command-a", "command-b"]);
+  });
+
   it("should return empty list when storage payload is invalid", () => {
     window.localStorage.setItem("creonow.commandPalette.recent", "{bad-json");
 

--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
@@ -36,9 +36,10 @@ export function readRecentCommandIds(args?: {
     if (!Array.isArray(parsed)) {
       return [];
     }
-    const ids = parsed.filter(
-      (item): item is string => typeof item === "string",
-    );
+    const ids = parsed
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
     const uniqueIds = Array.from(new Set(ids));
     const limit = Math.max(0, args?.limit ?? MAX_RECENT_COMMANDS);
     return uniqueIds.slice(0, limit);
@@ -58,15 +59,16 @@ export function recordRecentCommandId(
   args?: { storage?: Storage; limit?: number },
 ): void {
   const storage = resolveStorage(args?.storage);
-  if (!storage || !commandId.trim()) {
+  const normalizedCommandId = commandId.trim();
+  if (!storage || normalizedCommandId.length === 0) {
     return;
   }
 
   try {
     const limit = Math.max(1, args?.limit ?? MAX_RECENT_COMMANDS);
     const existing = readRecentCommandIds({ storage, limit });
-    const withoutCurrent = existing.filter((item) => item !== commandId);
-    const next = [commandId, ...withoutCurrent].slice(0, limit);
+    const withoutCurrent = existing.filter((item) => item !== normalizedCommandId);
+    const next = [normalizedCommandId, ...withoutCurrent].slice(0, limit);
     storage.setItem(STORAGE_KEY, JSON.stringify(next));
   } catch (error) {
     console.error("COMMAND_PALETTE_RECENT_WRITE_FAILED", error);

--- a/apps/desktop/renderer/src/i18n/__tests__/i18n-init-failure.test.ts
+++ b/apps/desktop/renderer/src/i18n/__tests__/i18n-init-failure.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("i18n init failure recovery", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unmock("i18next");
+    vi.unmock("react-i18next");
+  });
+
+  it("retries initializeI18n after init rejection", async () => {
+    const initMock = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("init failed"))
+      .mockResolvedValue(undefined);
+
+    const instance = {
+      use: vi.fn(function use() {
+        return instance;
+      }),
+      init: initMock,
+    };
+
+    vi.doMock("i18next", () => ({
+      __esModule: true,
+      default: {
+        createInstance: () => instance,
+      },
+    }));
+
+    vi.doMock("react-i18next", () => ({
+      initReactI18next: {},
+    }));
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // noop for test output hygiene
+    });
+
+    const mod = await import("../index");
+    await Promise.resolve();
+
+    await expect(mod.initializeI18n()).resolves.toBe(mod.i18n);
+    expect(initMock).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith("I18N_INIT_FAILED", expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith(
+      "I18N_BOOTSTRAP_FAILED",
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/desktop/renderer/src/i18n/index.ts
+++ b/apps/desktop/renderer/src/i18n/index.ts
@@ -32,9 +32,16 @@ export function initializeI18n(): Promise<I18nInstance> {
       },
       returnNull: false,
     })
-    .then(() => i18n);
+    .then(() => i18n)
+    .catch((error: unknown) => {
+      initPromise = null;
+      console.error("I18N_INIT_FAILED", error);
+      throw error;
+    });
 
   return initPromise;
 }
 
-void initializeI18n();
+void initializeI18n().catch((error: unknown) => {
+  console.error("I18N_BOOTSTRAP_FAILED", error);
+});


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复渲染层两个高频边界错误：i18n 初始化失败后的不可恢复状态，以及命令面板历史被空白 ID 污染。

## 改动列表
- commit 1: 修复 i18n 初始化失败后会卡死在 rejected promise 的问题，补上失败日志与重试能力
- commit 2: 统一命令历史 ID 的 trim 规范，过滤空白与无效项，补充回归测试

## 为什么改
这两个问题都属于真实运行时边界场景：一旦 i18n 初始化异常会导致后续无法自恢复；命令历史一旦写入异常空白值会造成历史列表污染和去重失效。修复后能提升启动稳定性与命令面板数据质量。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库现存 warning 无新增）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)