### PR TITLE
improve(renderer): 强化项目引导与互斥锁异常可观测性

### DIFF
--- a/apps/desktop/main/src/__tests__/unit/keyed-mutex-error-observability.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/keyed-mutex-error-observability.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createKeyedMutex } from "../../services/shared/concurrency";
+
+describe("keyed mutex prior-task error observability", () => {
+  it("reports prior task failures on subsequent executions", async () => {
+    const onPriorTaskError = vi.fn<(args: { key: string; error: unknown }) => void>();
+    const mutex = createKeyedMutex({ onPriorTaskError });
+
+    let firstError: unknown = null;
+    await mutex.runExclusive("project-a", async () => {
+      throw new Error("first task failed");
+    }).catch((error: unknown) => {
+      firstError = error;
+    });
+
+    await expect(
+      mutex.runExclusive("project-a", async () => "second-ok"),
+    ).resolves.toBe("second-ok");
+    await expect(
+      mutex.runExclusive("project-a", async () => "third-ok"),
+    ).resolves.toBe("third-ok");
+
+    expect(firstError).toBeInstanceOf(Error);
+    expect((firstError as Error).message).toBe("first task failed");
+    expect(onPriorTaskError).toHaveBeenCalledTimes(1);
+    expect(onPriorTaskError).toHaveBeenCalledWith({
+      key: "project-a",
+      error: expect.any(Error),
+    });
+  });
+
+  it("falls back to console error when observer throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      return;
+    });
+
+    const mutex = createKeyedMutex({
+      onPriorTaskError: () => {
+        throw new Error("observer failed");
+      },
+    });
+
+    let firstError: unknown = null;
+    await mutex.runExclusive("project-b", async () => {
+      throw new Error("original task failed");
+    }).catch((error: unknown) => {
+      firstError = error;
+    });
+
+    await expect(
+      mutex.runExclusive("project-b", async () => "still-runs"),
+    ).resolves.toBe("still-runs");
+    await expect(
+      mutex.runExclusive("project-b", async () => "next-runs"),
+    ).resolves.toBe("next-runs");
+
+    expect(firstError).toBeInstanceOf(Error);
+    expect((firstError as Error).message).toBe("original task failed");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "KEYED_MUTEX_ERROR_HANDLER_FAILED",
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/desktop/main/src/services/shared/concurrency.ts
+++ b/apps/desktop/main/src/services/shared/concurrency.ts
@@ -4,6 +4,10 @@ export type KeyedMutex = {
   runExclusive: <T>(key: string, task: AsyncTask<T>) => Promise<T>;
 };
 
+export type KeyedMutexOptions = {
+  onPriorTaskError?: (args: { key: string; error: unknown }) => void;
+};
+
 export type KeyedSingleflight = {
   run: <T>(key: string, compute: AsyncTask<T>) => Promise<T>;
 };
@@ -12,8 +16,25 @@ function normalizeKey(key: string): string {
   return key.trim();
 }
 
-export function createKeyedMutex(): KeyedMutex {
+function reportPriorTaskError(
+  onPriorTaskError: NonNullable<KeyedMutexOptions["onPriorTaskError"]>,
+  args: { key: string; error: unknown },
+): void {
+  try {
+    onPriorTaskError(args);
+  } catch (callbackError: unknown) {
+    console.error("KEYED_MUTEX_ERROR_HANDLER_FAILED", callbackError);
+  }
+}
+
+export function createKeyedMutex(options?: KeyedMutexOptions): KeyedMutex {
   const tailByKey = new Map<string, Promise<void>>();
+  const priorTaskErrorByKey = new Map<string, unknown>();
+  const onPriorTaskError =
+    options?.onPriorTaskError ??
+    ((args: { key: string; error: unknown }) => {
+      console.error("KEYED_MUTEX_PRIOR_TASK_FAILED", args);
+    });
 
   return {
     runExclusive: async (key, task) => {
@@ -22,9 +43,16 @@ export function createKeyedMutex(): KeyedMutex {
         return await task();
       }
 
-      const previousTail = (
-        tailByKey.get(normalizedKey) ?? Promise.resolve()
-      ).catch(() => undefined);
+      if (priorTaskErrorByKey.has(normalizedKey)) {
+        const priorError = priorTaskErrorByKey.get(normalizedKey);
+        priorTaskErrorByKey.delete(normalizedKey);
+        reportPriorTaskError(onPriorTaskError, {
+          key: normalizedKey,
+          error: priorError,
+        });
+      }
+
+      const previousTail = tailByKey.get(normalizedKey) ?? Promise.resolve();
 
       let releaseCurrentTail: () => void = () => {};
       const currentTail = new Promise<void>((resolve) => {
@@ -38,6 +66,9 @@ export function createKeyedMutex(): KeyedMutex {
       await previousTail;
       try {
         return await task();
+      } catch (error: unknown) {
+        priorTaskErrorByKey.set(normalizedKey, error);
+        throw error;
       } finally {
         releaseCurrentTail();
         void queuedTail.finally(() => {

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -365,7 +365,9 @@ export function AppShell(): JSX.Element {
   // Bootstrap projects on mount
   React.useEffect(() => {
     if (bootstrapStatus === "idle") {
-      void bootstrapProjects();
+      runFireAndForget(() => bootstrapProjects(), {
+        label: "appShell.bootstrapProjects",
+      });
     }
   }, [bootstrapProjects, bootstrapStatus]);
 

--- a/apps/desktop/renderer/src/stores/__tests__/project-store-bootstrap-error.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/project-store-bootstrap-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { createProjectStore, type IpcInvoke } from "../projectStore";
+
+describe("project store bootstrap error boundary", () => {
+  it("captures invoke throw as INTERNAL error", async () => {
+    const invoke: IpcInvoke = async (channel) => {
+      if (channel === "project:project:getcurrent") {
+        throw new Error("ipc bridge unavailable");
+      }
+      throw new Error(`Unexpected channel: ${channel}`);
+    };
+
+    const store = createProjectStore({ invoke });
+
+    await store.getState().bootstrap();
+
+    const state = store.getState();
+    expect(state.bootstrapStatus).toBe("error");
+    expect(state.lastError).toMatchObject({
+      code: "INTERNAL",
+      message: "ipc bridge unavailable",
+    });
+  });
+});

--- a/apps/desktop/renderer/src/stores/projectStore.tsx
+++ b/apps/desktop/renderer/src/stores/projectStore.tsx
@@ -145,31 +145,44 @@ export function createProjectStore(deps: {
 
       set({ bootstrapStatus: "loading", lastError: null });
 
-      const currentRes = await deps.invoke("project:project:getcurrent", {});
-      const current = currentRes.ok
-        ? currentRes.data
-        : currentRes.error.code === "NOT_FOUND"
-          ? null
-          : null;
-      if (!currentRes.ok && currentRes.error.code !== "NOT_FOUND") {
-        set({ bootstrapStatus: "error", lastError: currentRes.error });
-        return;
-      }
+      try {
+        const currentRes = await deps.invoke("project:project:getcurrent", {});
+        const current = currentRes.ok
+          ? currentRes.data
+          : currentRes.error.code === "NOT_FOUND"
+            ? null
+            : null;
+        if (!currentRes.ok && currentRes.error.code !== "NOT_FOUND") {
+          set({ bootstrapStatus: "error", lastError: currentRes.error });
+          return;
+        }
 
-      const listRes = await deps.invoke("project:project:list", {
-        includeArchived: true,
-      });
-      if (!listRes.ok) {
-        set({ bootstrapStatus: "error", lastError: listRes.error, current });
-        return;
-      }
+        const listRes = await deps.invoke("project:project:list", {
+          includeArchived: true,
+        });
+        if (!listRes.ok) {
+          set({ bootstrapStatus: "error", lastError: listRes.error, current });
+          return;
+        }
 
-      set({
-        bootstrapStatus: "ready",
-        current,
-        items: listRes.data.items,
-        lastError: null,
-      });
+        set({
+          bootstrapStatus: "ready",
+          current,
+          items: listRes.data.items,
+          lastError: null,
+        });
+      } catch (error: unknown) {
+        set({
+          bootstrapStatus: "error",
+          lastError: {
+            code: "INTERNAL",
+            message:
+              error instanceof Error
+                ? error.message
+                : "project bootstrap failed unexpectedly",
+          },
+        });
+      }
     },
 
     createAndSetCurrent: async ({ name, type, description, template }) => {


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复项目引导与同键互斥执行中的异常可观测性缺口，避免静默失败并补齐回归测试。

## 改动列表
- commit 1: improve(renderer): 补齐项目引导异常链路
- commit 2: improve(tests): 增加并发锁与引导异常回归测试

## 为什么改
`projectStore.bootstrap` 在 `invoke` 抛异常时会产生未受控 reject，且 `AppShell` 以 `void` 触发引导缺少统一错误兜底；同时 keyed mutex 对前序任务失败缺少明确上报，容易形成隐性失败链路。此次改动统一把异常收口到显式错误状态/日志回调，并用回归测试固定行为。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库现存 warning 无新增）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
