### PR TITLE
improve(main): IPC 边界防护与回归测试

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/context-budget-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/context-budget-ipc.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+
+import { registerContextBudgetHandlers } from "../contextBudget";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+async function runScenario(
+  name: string,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    throw new Error(
+      `[${name}] ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const handlers = new Map<string, Handler>();
+
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+
+  const logger = {
+    info: () => {},
+    error: () => {},
+  };
+
+  registerContextBudgetHandlers({
+    ipcMain,
+    logger: logger as never,
+    contextAssemblyService: {
+      getBudgetProfile: () => ({
+        version: 1,
+        tokenizerId: "gpt-tokenizer",
+        tokenizerVersion: "1",
+        layers: {
+          rules: { ratio: 0.25, minimumTokens: 50 },
+          settings: { ratio: 0.25, minimumTokens: 50 },
+          retrieved: { ratio: 0.25, minimumTokens: 50 },
+          immediate: { ratio: 0.25, minimumTokens: 50 },
+        },
+      }),
+      updateBudgetProfile: () => {
+        throw new Error("should not be called for invalid payload");
+      },
+    } as never,
+  });
+
+  const updateHandler = handlers.get("context:budget:update");
+  assert.ok(updateHandler, "expected context:budget:update to be registered");
+
+  await runScenario("CB1 null payload should return INVALID_ARGUMENT", async () => {
+    const response = (await updateHandler({}, null)) as {
+      ok: boolean;
+      error?: { code?: string };
+    };
+
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  });
+
+  await runScenario(
+    "CB2 malformed nested field should return INVALID_ARGUMENT",
+    async () => {
+      const response = (await updateHandler({}, {
+        version: 1,
+        tokenizerId: "gpt-tokenizer",
+        tokenizerVersion: "1",
+        layers: {
+          rules: { ratio: 0.25, minimumTokens: 50 },
+          settings: { ratio: 0.25, minimumTokens: 50 },
+          retrieved: { ratio: 0.25, minimumTokens: "50" },
+          immediate: { ratio: 0.25, minimumTokens: 50 },
+        },
+      })) as {
+        ok: boolean;
+        error?: { code?: string };
+      };
+
+      assert.equal(response.ok, false);
+      assert.equal(response.error?.code, "INVALID_ARGUMENT");
+    },
+  );
+}
+
+void main();

--- a/apps/desktop/main/src/ipc/__tests__/ipc-boundary-regression.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ipc-boundary-regression.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+
+import Database from "better-sqlite3";
+import type { IpcMain, IpcMainInvokeEvent } from "electron";
+
+import { registerProjectIpcHandlers } from "../project";
+import { registerSearchIpcHandlers } from "../search";
+import { registerStatsIpcHandlers } from "../stats";
+import {
+  createNoopLogger,
+  createProjectTestDb,
+} from "../../../../tests/unit/projectService.test-helpers";
+
+type Handler = (
+  event: IpcMainInvokeEvent,
+  payload: unknown,
+) => Promise<unknown> | unknown;
+
+function createIpcHarness() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+
+  return {
+    ipcMain,
+    invoke: async (channel: string, payload: unknown) => {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `missing handler ${channel}`);
+      return await handler({} as IpcMainInvokeEvent, payload);
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const logger = createNoopLogger();
+
+  {
+    const harness = createIpcHarness();
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE stats_daily (
+        date TEXT PRIMARY KEY,
+        words_written INTEGER NOT NULL DEFAULT 0,
+        writing_seconds INTEGER NOT NULL DEFAULT 0,
+        skills_used INTEGER NOT NULL DEFAULT 0,
+        documents_created INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+
+    registerStatsIpcHandlers({ ipcMain: harness.ipcMain, db, logger });
+
+    const res = (await harness.invoke("stats:range:get", {
+      from: "2026-02-30",
+      to: "2026-03-01",
+    })) as { ok: boolean; error?: { code?: string } };
+
+    assert.equal(res.ok, false);
+    assert.equal(res.error?.code, "INVALID_ARGUMENT");
+    db.close();
+  }
+
+  {
+    const harness = createIpcHarness();
+    const db = new Database(":memory:");
+    registerSearchIpcHandlers({ ipcMain: harness.ipcMain, db, logger });
+
+    const res = (await harness.invoke("search:fts:query", null)) as {
+      ok: boolean;
+      error?: { code?: string };
+    };
+
+    assert.equal(res.ok, false);
+    assert.equal(res.error?.code, "INVALID_ARGUMENT");
+    db.close();
+  }
+
+  {
+    const harness = createIpcHarness();
+    const db = createProjectTestDb();
+
+    registerProjectIpcHandlers({
+      ipcMain: harness.ipcMain,
+      db,
+      userDataDir: "/tmp",
+      logger,
+    });
+
+    const res = (await harness.invoke("project:project:list", undefined)) as {
+      ok: boolean;
+      data?: { items?: unknown[] };
+    };
+
+    assert.equal(res.ok, true);
+    assert.deepEqual(res.data?.items, []);
+    db.close();
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/ipc/contextBudget.ts
+++ b/apps/desktop/main/src/ipc/contextBudget.ts
@@ -14,6 +14,44 @@ type ContextBudgetRegistrarDeps = {
   contextAssemblyService: ContextLayerAssemblyService;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isBudgetLayerPayload(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.ratio === "number" && typeof value.minimumTokens === "number"
+  );
+}
+
+function isContextBudgetUpdatePayload(
+  payload: unknown,
+): payload is ContextBudgetUpdateRequest {
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  if (
+    typeof payload.version !== "number" ||
+    typeof payload.tokenizerId !== "string" ||
+    typeof payload.tokenizerVersion !== "string" ||
+    !isRecord(payload.layers)
+  ) {
+    return false;
+  }
+
+  return (
+    isBudgetLayerPayload(payload.layers.rules) &&
+    isBudgetLayerPayload(payload.layers.settings) &&
+    isBudgetLayerPayload(payload.layers.retrieved) &&
+    isBudgetLayerPayload(payload.layers.immediate)
+  );
+}
+
 export function registerContextBudgetHandlers(
   deps: ContextBudgetRegistrarDeps,
 ): void {
@@ -40,10 +78,17 @@ export function registerContextBudgetHandlers(
 
   deps.ipcMain.handle(
     "context:budget:update",
-    async (
-      _e,
-      payload: ContextBudgetUpdateRequest,
-    ): Promise<IpcResponse<ContextBudgetProfile>> => {
+    async (_e, payload: unknown): Promise<IpcResponse<ContextBudgetProfile>> => {
+      if (!isContextBudgetUpdatePayload(payload)) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "Invalid context budget update payload",
+          },
+        };
+      }
+
       const updated = deps.contextAssemblyService.updateBudgetProfile(payload);
       if (!updated.ok) {
         deps.logger.error("context_budget_update_failed", {

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -101,7 +101,7 @@ export function registerProjectIpcHandlers(deps: {
     "project:project:list",
     async (
       _e,
-      payload: { includeArchived?: boolean },
+      payload: { includeArchived?: boolean } = {},
     ): Promise<
       IpcResponse<{
         items: Array<{

--- a/apps/desktop/main/src/ipc/search.ts
+++ b/apps/desktop/main/src/ipc/search.ts
@@ -31,6 +31,55 @@ function listProjectDocuments(args: {
     .all(args.projectId);
 }
 
+
+type SearchFtsQueryPayload = {
+  projectId: string;
+  query: string;
+  limit?: number;
+  offset?: number;
+};
+
+function normalizeSearchFtsQueryPayload(
+  payload: unknown,
+): IpcResponse<SearchFtsQueryPayload> {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {
+      ok: false,
+      error: { code: "INVALID_ARGUMENT", message: "payload must be an object" },
+    };
+  }
+
+  const raw = payload as {
+    projectId?: unknown;
+    query?: unknown;
+    limit?: unknown;
+    offset?: unknown;
+  };
+
+  if (typeof raw.projectId !== "string" || raw.projectId.trim().length === 0) {
+    return {
+      ok: false,
+      error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
+    };
+  }
+  if (typeof raw.query !== "string") {
+    return {
+      ok: false,
+      error: { code: "INVALID_ARGUMENT", message: "query is required" },
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      projectId: raw.projectId,
+      query: raw.query,
+      limit: typeof raw.limit === "number" ? raw.limit : undefined,
+      offset: typeof raw.offset === "number" ? raw.offset : undefined,
+    },
+  };
+}
+
 /**
  * Create semantic retriever for hybrid ranking.
  *
@@ -131,12 +180,7 @@ export function registerSearchIpcHandlers(deps: {
     "search:fts:query",
     async (
       _e,
-      payload: {
-        projectId: string;
-        query: string;
-        limit?: number;
-        offset?: number;
-      },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         results: Array<{
@@ -161,19 +205,12 @@ export function registerSearchIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-        };
+      const normalizedPayload = normalizeSearchFtsQueryPayload(payload);
+      if (!normalizedPayload.ok) {
+        return normalizedPayload;
       }
 
-      const res = ftsService?.search({
-        projectId: payload.projectId,
-        query: payload.query,
-        limit: payload.limit,
-        offset: payload.offset,
-      });
+      const res = ftsService?.search(normalizedPayload.data);
       if (!res) {
         return {
           ok: false,
@@ -184,7 +221,7 @@ export function registerSearchIpcHandlers(deps: {
       if (!res.ok) {
         if (res.error.code === "INVALID_ARGUMENT") {
           deps.logger.info("search_fts_invalid_query", {
-            queryLength: payload.query.trim().length,
+            queryLength: normalizedPayload.data.query.trim().length,
           });
         } else {
           deps.logger.error("search_fts_failed", {
@@ -196,7 +233,7 @@ export function registerSearchIpcHandlers(deps: {
       }
 
       deps.logger.info("search_fts_query", {
-        queryLength: payload.query.trim().length,
+        queryLength: normalizedPayload.data.query.trim().length,
         resultCount: res.data.results.length,
         indexState: res.data.indexState,
       });

--- a/apps/desktop/main/src/ipc/stats.ts
+++ b/apps/desktop/main/src/ipc/stats.ts
@@ -28,8 +28,20 @@ function isValidDateKey(x: string): boolean {
   if (!DATE_RE.test(x)) {
     return false;
   }
-  const t = Date.parse(`${x}T00:00:00Z`);
-  return Number.isFinite(t);
+  const [yearRaw, monthRaw, dayRaw] = x.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return false;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 }
 
 /**

--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
@@ -30,6 +30,23 @@ describe("recentItems", () => {
     expect(ids[ids.length - 1]).toBe("command-3");
   });
 
+
+  it("should normalize command id whitespace to prevent duplicated history records", () => {
+    recordRecentCommandId("command-a");
+    recordRecentCommandId("  command-a  ");
+
+    expect(readRecentCommandIds()).toEqual(["command-a"]);
+  });
+
+  it("should ignore blank ids and sanitize polluted storage payload", () => {
+    window.localStorage.setItem(
+      "creonow.commandPalette.recent",
+      JSON.stringify(["   ", " command-a ", "command-a", "", 1, null]),
+    );
+
+    expect(readRecentCommandIds()).toEqual(["command-a"]);
+  });
+
   it("should return empty list when storage payload is invalid", () => {
     window.localStorage.setItem("creonow.commandPalette.recent", "{bad-json");
 

--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
@@ -2,6 +2,15 @@ const STORAGE_KEY = "creonow.commandPalette.recent";
 
 export const MAX_RECENT_COMMANDS = 20;
 
+function normalizeCommandId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 function resolveStorage(provided?: Storage): Storage | null {
   if (provided) {
     return provided;
@@ -36,9 +45,9 @@ export function readRecentCommandIds(args?: {
     if (!Array.isArray(parsed)) {
       return [];
     }
-    const ids = parsed.filter(
-      (item): item is string => typeof item === "string",
-    );
+    const ids = parsed
+      .map((item) => normalizeCommandId(item))
+      .filter((item): item is string => item !== null);
     const uniqueIds = Array.from(new Set(ids));
     const limit = Math.max(0, args?.limit ?? MAX_RECENT_COMMANDS);
     return uniqueIds.slice(0, limit);
@@ -58,15 +67,18 @@ export function recordRecentCommandId(
   args?: { storage?: Storage; limit?: number },
 ): void {
   const storage = resolveStorage(args?.storage);
-  if (!storage || !commandId.trim()) {
+  const normalizedCommandId = normalizeCommandId(commandId);
+  if (!storage || !normalizedCommandId) {
     return;
   }
 
   try {
     const limit = Math.max(1, args?.limit ?? MAX_RECENT_COMMANDS);
     const existing = readRecentCommandIds({ storage, limit });
-    const withoutCurrent = existing.filter((item) => item !== commandId);
-    const next = [commandId, ...withoutCurrent].slice(0, limit);
+    const withoutCurrent = existing.filter(
+      (item) => item !== normalizedCommandId,
+    );
+    const next = [normalizedCommandId, ...withoutCurrent].slice(0, limit);
     storage.setItem(STORAGE_KEY, JSON.stringify(next));
   } catch (error) {
     console.error("COMMAND_PALETTE_RECENT_WRITE_FAILED", error);


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 IPC 入口在非法 payload 与日期边界下的真实崩溃风险，并补回归测试。

## 改动列表
- commit 1: fix(command-palette): 修复 recent 命令记录被空白和空字符串污染
- commit 2: fix(main): 修复 context budget IPC 非法 payload 未守卫问题
- commit 3: fix(ipc): 修复参数边界崩溃与日期校验漏洞

## 为什么改
这些入口位于高频调用链路，异常 payload 会导致未预期分支或错误语义不一致；补齐守卫和回归测试能稳定主流程并避免隐性数据污染。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（相关文件无新增错误）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
