### PR TITLE
improve(shared): 收敛 UTF-8 截断与交互错误处理稳定性

### DIFF
--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.filter.test.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.filter.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+import { GraphCanvas } from "./GraphCanvas";
+import type { GraphData } from "./types";
+
+const data: GraphData = {
+  nodes: [
+    {
+      id: "n1",
+      label: "Hero",
+      type: "character",
+      position: { x: 10, y: 20 },
+    },
+    {
+      id: "n2",
+      label: "Town",
+      type: "location",
+      position: { x: 200, y: 220 },
+    },
+  ],
+  edges: [{ id: "e1", source: "n1", target: "n2", label: "arrives" }],
+};
+
+const baseProps = {
+  data,
+  selectedNodeId: null,
+  transform: { scale: 1, translateX: 0, translateY: 0 },
+  onNodeSelect: vi.fn(),
+  onNodeMove: vi.fn(),
+  onCanvasPan: vi.fn(),
+  onCanvasZoom: vi.fn(),
+};
+
+describe("GraphCanvas filter", () => {
+  it("过滤后只保留两端都可见的边", () => {
+    const { container, rerender } = render(
+      <GraphCanvas {...baseProps} filter="all" />,
+    );
+
+    expect(container.querySelector('[data-edge-id="e1"]')).toBeInTheDocument();
+
+    rerender(<GraphCanvas {...baseProps} filter="location" />);
+
+    expect(container.querySelector('[data-node-id="n2"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-node-id="n1"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-edge-id="e1"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphCanvas.tsx
@@ -67,15 +67,21 @@ export function GraphCanvas({
     [data.nodes],
   );
 
-  // Filter visible nodes
-  const visibleNodes = data.nodes.filter((node) => isNodeVisible(node, filter));
-  const visibleNodeIds = new Set(visibleNodes.map((n) => n.id));
+  const { visibleNodes, visibleEdges } = useMemo(() => {
+    const nextVisibleNodes = data.nodes.filter((node) =>
+      isNodeVisible(node, filter),
+    );
+    const visibleNodeIds = new Set(nextVisibleNodes.map((node) => node.id));
+    const nextVisibleEdges = data.edges.filter(
+      (edge) =>
+        visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
+    );
 
-  // Filter edges to only show those connecting visible nodes
-  const visibleEdges = data.edges.filter(
-    (edge) =>
-      visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
-  );
+    return {
+      visibleNodes: nextVisibleNodes,
+      visibleEdges: nextVisibleEdges,
+    };
+  }, [data.edges, data.nodes, filter]);
 
   /**
    * Handle node drag start

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -247,13 +247,18 @@ export function CodeBlock(props: {
   const [copied, setCopied] = React.useState(false);
 
   function handleCopy(): void {
-    void navigator.clipboard.writeText(props.code);
-
-    setCopied(true);
-
-    setTimeout(() => setCopied(false), 2000);
-
-    props.onCopy?.();
+    runFireAndForget(async () => {
+      try {
+        await navigator.clipboard.writeText(props.code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        props.onCopy?.();
+      } catch (error) {
+        console.error("CodeBlock copy failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
   }
 
   return (

--- a/apps/desktop/renderer/src/features/ai/CodeBlock.copy.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/CodeBlock.copy.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CodeBlock } from "./AiPanel";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function setClipboardWriteText(
+  writeText: (text: string) => Promise<void>,
+): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+}
+
+describe("CodeBlock copy", () => {
+  it("复制成功后显示 Copied!", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboardWriteText(writeText);
+
+    render(<CodeBlock code="const a = 1;" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(writeText).toHaveBeenCalledWith("const a = 1;");
+    expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+  });
+
+  it("复制失败时保持 Copy 文案并记录错误", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setClipboardWriteText(writeText);
+
+    render(<CodeBlock code="const b = 2;" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith("const b = 2;");
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalledWith("CodeBlock copy failed", {
+      error: "denied",
+    });
+  });
+});

--- a/apps/desktop/tests/unit/shared-token-budget.test.ts
+++ b/apps/desktop/tests/unit/shared-token-budget.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import {
+  estimateUtf8TokenCount,
+  tokenBudgetToUtf8ByteLimit,
+  trimUtf8ToTokenBudget,
+} from "@shared/tokenBudget";
+
+{
+  assert.equal(tokenBudgetToUtf8ByteLimit(0), 0);
+  assert.equal(tokenBudgetToUtf8ByteLimit(1.5), 6);
+}
+
+{
+  const input = "hello";
+  assert.equal(trimUtf8ToTokenBudget(input, 10), input);
+  assert.equal(estimateUtf8TokenCount(input), 2);
+}
+
+{
+  const input = "你";
+  const trimmed = trimUtf8ToTokenBudget(input, 0.5);
+  assert.equal(trimmed.includes("�"), false);
+  assert.equal(trimmed, "");
+}
+
+{
+  const input = "你";
+  const trimmed = trimUtf8ToTokenBudget(input, 0.75);
+  assert.equal(trimmed, input);
+}
+
+{
+  assert.equal(trimUtf8ToTokenBudget("abc", 0), "");
+  assert.equal(trimUtf8ToTokenBudget("abc", -1), "");
+}

--- a/packages/shared/tokenBudget.ts
+++ b/packages/shared/tokenBudget.ts
@@ -38,5 +38,14 @@ export function trimUtf8ToTokenBudget(
     return text;
   }
 
-  return new TextDecoder().decode(encoded.slice(0, maxBytes));
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let end = maxBytes; end > 0; end -= 1) {
+    try {
+      return decoder.decode(encoded.slice(0, end));
+    } catch {
+      continue;
+    }
+  }
+
+  return "";
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 UTF-8 截断边界、补齐复制失败错误处理，并优化知识图谱过滤计算的渲染开销。

## 改动列表
- commit 1: improve(shared): 修复 UTF-8 截断半字符并补回归测试
- commit 2: improve(renderer): 修复代码块复制失败的错误处理链路
- commit 3: improve(renderer): 缓存图谱可见节点边计算并补过滤测试

## 为什么改
这组改动集中处理高价值稳定性问题：避免 token 截断生成乱码字符、避免复制失败静默、并减少图谱在过滤场景下的重复计算，提升可靠性与交互流畅度。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库既有 warning 无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)