### PR TITLE
improve(renderer): 错误处理闭环（解析兜底 + 异步任务防崩）

### DIFF
--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -499,6 +499,16 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
       setContentReady(false);
       suppressAutosaveRef.current = true;
       editor.commands.setContent(JSON.parse(activeContentJson));
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("[editor-pane] failed to parse active content", {
+        documentId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      editor.commands.setContent({
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      });
     } finally {
       window.setTimeout(() => {
         suppressAutosaveRef.current = false;

--- a/apps/desktop/renderer/src/lib/fireAndForget.ts
+++ b/apps/desktop/renderer/src/lib/fireAndForget.ts
@@ -64,7 +64,12 @@ export function runFireAndForget(
     }
   };
 
-  void task().catch((error) => {
+  try {
+    const result = task();
+    void result.catch((error) => {
+      safeHandleError(error);
+    });
+  } catch (error) {
     safeHandleError(error);
-  });
+  }
 }

--- a/apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts
+++ b/apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts
@@ -45,3 +45,39 @@ function flushMicrotasks(): Promise<void> {
   assert.ok(captured instanceof Error);
   assert.equal((captured as Error).message, "handled");
 }
+
+{
+  const original = console.error;
+  const calls: unknown[][] = [];
+  console.error = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  let captured: unknown = null;
+  assert.doesNotThrow(() => {
+    runFireAndForget(
+      () => {
+        throw new Error("sync boom");
+      },
+      {
+        label: "sync-task",
+        onError: (error) => {
+          captured = error;
+        },
+      },
+    );
+  });
+
+  console.error = original;
+
+  assert.ok(captured instanceof Error);
+  assert.equal((captured as Error).message, "sync boom");
+  assert.equal(calls.length, 1, "expected sync throws to be logged once");
+  assert.equal(calls[0][0], "[fire-and-forget][critical] task failed");
+  assert.deepEqual(calls[0][1], {
+    label: "sync-task",
+    errorType: "Error",
+    message: "sync boom",
+    critical: true,
+  });
+}


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
补齐渲染层两个高风险错误处理缺口：编辑器内容解析兜底 + fire-and-forget 同步异常兜底，并补回归测试。

## 改动列表
- commit 1: 修复 `runFireAndForget` 未处理同步 throw 的缺陷，并在 `apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts` 增加回归断言
- commit 2: 修复 `EditorPane` 解析 `activeContentJson` 失败会直接抛错的问题，增加显式错误日志与空文档回退

## 为什么改
- 真实 bug：`runFireAndForget` 仅处理 Promise reject，任务函数同步抛错时会逃逸到调用栈，破坏“fire-and-forget 不阻塞主流程”的契约
- 真实 bug：编辑器载入时对 `activeContentJson` 直接 `JSON.parse`，脏数据会导致编辑器加载链路中断
- 稳定性收益：统一变成“可观测 + 可恢复”错误链路，避免用户侧白屏/中断

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（无新增 error，保留仓库既有 warning）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
