### PR TITLE
improve(main): 加固 RAG 与 Embedding IPC 异常 payload 守卫

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/embedding-runtime-guards.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/embedding-runtime-guards.contract.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { EmbeddingService } from "../../services/embedding/embeddingService";
+import { registerEmbeddingIpcHandlers } from "../embedding";
+
+function createIpcHarness(): {
+  ipcMain: IpcMain;
+  handlers: Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >;
+} {
+  const handlers = new Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >();
+
+  const ipcMain = {
+    handle: (channel: string, handler: unknown) => {
+      handlers.set(
+        channel,
+        handler as (event: unknown, payload: unknown) => Promise<unknown>,
+      );
+    },
+  };
+
+  return {
+    ipcMain: ipcMain as unknown as IpcMain,
+    handlers,
+  };
+}
+
+async function main(): Promise<void> {
+  const { ipcMain, handlers } = createIpcHarness();
+  const embedding: EmbeddingService = {
+    encode: () => ({
+      ok: true,
+      data: {
+        vectors: [[0.1, 0.2]],
+        dimension: 2,
+      },
+    }),
+  };
+
+  registerEmbeddingIpcHandlers({
+    ipcMain,
+    db: {} as Database.Database,
+    logger: {
+      logPath: "<test>",
+      info: () => {},
+      error: () => {},
+    },
+    embedding,
+  });
+
+  const generateHandler = handlers.get("embedding:text:generate");
+  assert.ok(generateHandler, "embedding:text:generate handler should exist");
+
+  const invalidGeneratePayloads: unknown[] = [
+    null,
+    1,
+    { texts: "x" },
+    { texts: ["ok", 1] },
+    { texts: ["ok"], model: 2 },
+  ];
+
+  for (const payload of invalidGeneratePayloads) {
+    const response = (await generateHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+
+  const semanticHandler = handlers.get("embedding:semantic:search");
+  assert.ok(semanticHandler, "embedding:semantic:search handler should exist");
+
+  const invalidSemanticPayloads: unknown[] = [
+    null,
+    1,
+    { projectId: 1, queryText: "hello" },
+    { projectId: "p1", queryText: 2 },
+    { projectId: "p1", queryText: "hello", topK: "3" },
+    { projectId: "p1", queryText: "hello", minScore: "0.5" },
+    { projectId: "p1", queryText: "hello", model: 3 },
+  ];
+
+  for (const payload of invalidSemanticPayloads) {
+    const response = (await semanticHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/ipc/__tests__/rag-runtime-guards.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/rag-runtime-guards.contract.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../logging/logger";
+import type { EmbeddingService } from "../../services/embedding/embeddingService";
+import { registerRagIpcHandlers } from "../rag";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createDbStub(): Database.Database {
+  return {
+    prepare: () => {
+      throw new Error("db should not be used in runtime-guard invalid payload test");
+    },
+  } as unknown as Database.Database;
+}
+
+function createEmbeddingStub(): EmbeddingService {
+  return {
+    encode: () => ({
+      ok: false,
+      error: {
+        code: "MODEL_NOT_READY",
+        message: "embedding not needed in runtime-guard test",
+      },
+    }),
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: IpcMain;
+  handlers: Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >;
+} {
+  const handlers = new Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >();
+
+  const ipcMain = {
+    handle: (channel: string, handler: unknown) => {
+      handlers.set(
+        channel,
+        handler as (event: unknown, payload: unknown) => Promise<unknown>,
+      );
+    },
+  };
+
+  return {
+    ipcMain: ipcMain as unknown as IpcMain,
+    handlers,
+  };
+}
+
+async function main(): Promise<void> {
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerRagIpcHandlers({
+    ipcMain,
+    db: createDbStub(),
+    logger: createLogger(),
+    embedding: createEmbeddingStub(),
+    ragRerank: { enabled: false },
+  } as unknown as Parameters<typeof registerRagIpcHandlers>[0]);
+
+  const configUpdateHandler = handlers.get("rag:config:update");
+  assert.ok(configUpdateHandler, "rag:config:update handler should be registered");
+
+  const invalidConfigPayloads: unknown[] = [null, 3, { model: 9 }, { topK: "2" }];
+  for (const payload of invalidConfigPayloads) {
+    const response = (await configUpdateHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+
+  const validConfigResponse = (await configUpdateHandler?.({}, { model: "text-embedding" })) as {
+    ok: boolean;
+    data?: { model?: string };
+  };
+  assert.equal(validConfigResponse.ok, true);
+  assert.equal(validConfigResponse.data?.model, "text-embedding");
+
+  const retrieveHandler = handlers.get("rag:context:retrieve");
+  assert.ok(retrieveHandler, "rag:context:retrieve handler should be registered");
+
+  const invalidRetrievePayloads: unknown[] = [
+    null,
+    1,
+    { projectId: 1, queryText: "query" },
+    { projectId: "project-1", queryText: 2 },
+    { projectId: "project-1", queryText: "query", model: 1 },
+  ];
+
+  for (const payload of invalidRetrievePayloads) {
+    const response = (await retrieveHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/ipc/embedding.ts
+++ b/apps/desktop/main/src/ipc/embedding.ts
@@ -61,6 +61,77 @@ function hasCorruptedOffsets(chunk: {
   return chunk.startOffset < 0 || chunk.endOffset < chunk.startOffset;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidArgument(message: string): IpcResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_ARGUMENT",
+      message,
+    },
+  };
+}
+
+function parseTextGeneratePayload(payload: unknown): {
+  texts: string[];
+  model?: string;
+} | null {
+  if (!isRecord(payload) || !Array.isArray(payload.texts)) {
+    return null;
+  }
+  if (!payload.texts.every((text) => typeof text === "string")) {
+    return null;
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return null;
+  }
+
+  return {
+    texts: payload.texts,
+    ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+  };
+}
+
+function parseSemanticSearchPayload(payload: unknown): {
+  projectId: string;
+  queryText: string;
+  topK?: number;
+  minScore?: number;
+  model?: string;
+} | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (typeof payload.projectId !== "string") {
+    return null;
+  }
+  if (typeof payload.queryText !== "string") {
+    return null;
+  }
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return null;
+  }
+  if (payload.minScore !== undefined && typeof payload.minScore !== "number") {
+    return null;
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return null;
+  }
+
+  return {
+    projectId: payload.projectId,
+    queryText: payload.queryText,
+    ...(typeof payload.topK === "number" ? { topK: payload.topK } : {}),
+    ...(typeof payload.minScore === "number"
+      ? { minScore: payload.minScore }
+      : {}),
+    ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+  };
+}
+
 /**
  * Register `embedding:*` IPC handlers.
  *
@@ -99,7 +170,7 @@ export function registerEmbeddingIpcHandlers(deps: {
     "embedding:text:generate",
     async (
       _e,
-      payload: { texts: string[]; model?: string },
+      payload: unknown,
       signal?: AbortSignal,
     ): Promise<IpcResponse<{ vectors: number[][]; dimension: number }>> => {
       if (!deps.db) {
@@ -109,17 +180,22 @@ export function registerEmbeddingIpcHandlers(deps: {
         };
       }
 
+      const parsedPayload = parseTextGeneratePayload(payload);
+      if (!parsedPayload) {
+        return invalidArgument("payload must include texts:string[] and optional model:string");
+      }
+
       if (embeddingTextOffload) {
         return await embeddingTextOffload.encode({
-          texts: payload.texts,
-          model: payload.model,
+          texts: parsedPayload.texts,
+          model: parsedPayload.model,
           signal,
         });
       }
 
       const encoded = deps.embedding.encode({
-        texts: payload.texts,
-        model: payload.model,
+        texts: parsedPayload.texts,
+        model: parsedPayload.model,
       });
       return encoded.ok
         ? { ok: true, data: encoded.data }
@@ -131,13 +207,7 @@ export function registerEmbeddingIpcHandlers(deps: {
     "embedding:semantic:search",
     async (
       _e,
-      payload: {
-        projectId: string;
-        queryText: string;
-        topK?: number;
-        minScore?: number;
-        model?: string;
-      },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         mode: "semantic" | "fts-fallback";
@@ -167,33 +237,34 @@ export function registerEmbeddingIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-        };
+
+      const parsedPayload = parseSemanticSearchPayload(payload);
+      if (!parsedPayload) {
+        return invalidArgument(
+          "payload must include projectId:string, queryText:string, and optional topK/minScore/model",
+        );
       }
-      if (payload.queryText.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "queryText is required" },
-        };
+      if (parsedPayload.projectId.trim().length === 0) {
+        return invalidArgument("projectId is required");
+      }
+      if (parsedPayload.queryText.trim().length === 0) {
+        return invalidArgument("queryText is required");
       }
 
-      const topK = normalizeTopK(payload.topK);
-      const minScore = normalizeMinScore(payload.minScore);
+      const topK = normalizeTopK(parsedPayload.topK);
+      const minScore = normalizeMinScore(parsedPayload.minScore);
 
       const docs = listProjectDocuments({
         db: deps.db,
-        projectId: payload.projectId,
+        projectId: parsedPayload.projectId,
       });
       for (const doc of docs) {
         const upserted = semanticIndex.upsertDocument({
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           documentId: doc.documentId,
           contentText: doc.contentText,
           updatedAt: doc.updatedAt,
-          model: payload.model,
+          model: parsedPayload.model,
         });
         if (
           !upserted.ok &&
@@ -205,11 +276,11 @@ export function registerEmbeddingIpcHandlers(deps: {
       }
 
       const semantic = semanticIndex.search({
-        projectId: payload.projectId,
-        queryText: payload.queryText,
+        projectId: parsedPayload.projectId,
+        queryText: parsedPayload.queryText,
         topK,
         minScore,
-        model: payload.model,
+        model: parsedPayload.model,
       });
 
       if (!semantic.ok) {
@@ -222,8 +293,8 @@ export function registerEmbeddingIpcHandlers(deps: {
 
         const fts = createFtsService({ db: deps.db, logger: deps.logger });
         const ftsRes = fts.searchFulltext({
-          projectId: payload.projectId,
-          query: payload.queryText,
+          projectId: parsedPayload.projectId,
+          query: parsedPayload.queryText,
           limit: topK,
         });
         if (!ftsRes.ok) {
@@ -231,12 +302,12 @@ export function registerEmbeddingIpcHandlers(deps: {
         }
 
         const crossProjectItem = ftsRes.data.items.find(
-          (item) => item.projectId !== payload.projectId,
+          (item) => item.projectId !== parsedPayload.projectId,
         );
         if (crossProjectItem) {
           deps.logger.error("embedding_project_forbidden_audit", {
             operation: "embedding:semantic:search",
-            requestedProjectId: payload.projectId,
+            requestedProjectId: parsedPayload.projectId,
             rowProjectId: crossProjectItem.projectId,
             documentId: crossProjectItem.documentId,
           });
@@ -246,7 +317,7 @@ export function registerEmbeddingIpcHandlers(deps: {
               code: "SEARCH_PROJECT_FORBIDDEN",
               message: "Cross-project semantic retrieval is forbidden",
               details: {
-                requestedProjectId: payload.projectId,
+                requestedProjectId: parsedPayload.projectId,
                 rowProjectId: crossProjectItem.projectId,
               },
             },
@@ -254,9 +325,9 @@ export function registerEmbeddingIpcHandlers(deps: {
         }
 
         deps.logger.info("embedding_search_fallback_fts", {
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           reason: semantic.error.code,
-          queryLength: payload.queryText.trim().length,
+          queryLength: parsedPayload.queryText.trim().length,
           resultCount: ftsRes.data.items.length,
         });
 
@@ -283,12 +354,12 @@ export function registerEmbeddingIpcHandlers(deps: {
       }
 
       const crossProjectChunk = semantic.data.chunks.find(
-        (chunk) => chunk.projectId !== payload.projectId,
+        (chunk) => chunk.projectId !== parsedPayload.projectId,
       );
       if (crossProjectChunk) {
         deps.logger.error("embedding_project_forbidden_audit", {
           operation: "embedding:semantic:search",
-          requestedProjectId: payload.projectId,
+          requestedProjectId: parsedPayload.projectId,
           rowProjectId: crossProjectChunk.projectId,
           documentId: crossProjectChunk.documentId,
         });
@@ -298,7 +369,7 @@ export function registerEmbeddingIpcHandlers(deps: {
             code: "SEARCH_PROJECT_FORBIDDEN",
             message: "Cross-project semantic retrieval is forbidden",
             details: {
-              requestedProjectId: payload.projectId,
+              requestedProjectId: parsedPayload.projectId,
               rowProjectId: crossProjectChunk.projectId,
             },
           },
@@ -316,14 +387,14 @@ export function registerEmbeddingIpcHandlers(deps: {
 
       if (isolatedChunkIds.length > 0) {
         deps.logger.error("embedding_data_corrupted_isolated", {
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           isolatedChunkIds,
         });
       }
 
       deps.logger.info("embedding_search_semantic", {
-        projectId: payload.projectId,
-        queryLength: payload.queryText.trim().length,
+        projectId: parsedPayload.projectId,
+        queryLength: parsedPayload.queryText.trim().length,
         resultCount: validChunks.length,
       });
 

--- a/apps/desktop/main/src/ipc/rag.ts
+++ b/apps/desktop/main/src/ipc/rag.ts
@@ -46,6 +46,8 @@ type RagRetrievePayload = {
   model?: string;
 };
 
+type RuntimeRecord = Record<string, unknown>;
+
 const DEFAULT_RAG_CONFIG: RagConfig = {
   topK: 5,
   minScore: 0.7,
@@ -91,20 +93,82 @@ function normalizeMaxTokens(value: number, fallback: number): number {
   return Math.floor(value);
 }
 
-function validateRagRetrievePayload(
-  payload: RagRetrievePayload,
+function isRuntimeRecord(value: unknown): value is RuntimeRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function toInvalidPayloadError(message: string): IpcResponse<never> {
+  return {
+    ok: false,
+    error: { code: "INVALID_ARGUMENT", message },
+  };
+}
+
+function validateRagConfigUpdatePayload(
+  payload: unknown,
 ): IpcResponse<never> | null {
+  if (!isRuntimeRecord(payload)) {
+    return toInvalidPayloadError("payload must be an object");
+  }
+
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return toInvalidPayloadError("topK must be a number");
+  }
+  if (
+    payload.minScore !== undefined &&
+    typeof payload.minScore !== "number"
+  ) {
+    return toInvalidPayloadError("minScore must be a number");
+  }
+  if (
+    payload.maxTokens !== undefined &&
+    typeof payload.maxTokens !== "number"
+  ) {
+    return toInvalidPayloadError("maxTokens must be a number");
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return toInvalidPayloadError("model must be a string");
+  }
+
+  return null;
+}
+
+function validateRagRetrievePayload(
+  payload: unknown,
+): IpcResponse<never> | null {
+  if (!isRuntimeRecord(payload)) {
+    return toInvalidPayloadError("payload must be an object");
+  }
+  if (typeof payload.projectId !== "string") {
+    return toInvalidPayloadError("projectId must be a string");
+  }
+  if (typeof payload.queryText !== "string") {
+    return toInvalidPayloadError("queryText must be a string");
+  }
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return toInvalidPayloadError("topK must be a number");
+  }
+  if (
+    payload.minScore !== undefined &&
+    typeof payload.minScore !== "number"
+  ) {
+    return toInvalidPayloadError("minScore must be a number");
+  }
+  if (
+    payload.maxTokens !== undefined &&
+    typeof payload.maxTokens !== "number"
+  ) {
+    return toInvalidPayloadError("maxTokens must be a number");
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return toInvalidPayloadError("model must be a string");
+  }
+
   if (payload.projectId.trim().length === 0) {
-    return {
-      ok: false,
-      error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-    };
+    return toInvalidPayloadError("projectId is required");
   }
   if (payload.queryText.trim().length === 0) {
-    return {
-      ok: false,
-      error: { code: "INVALID_ARGUMENT", message: "queryText is required" },
-    };
+    return toInvalidPayloadError("queryText is required");
   }
   return null;
 }
@@ -219,17 +283,23 @@ export function registerRagIpcHandlers(deps: {
     "rag:config:update",
     async (
       _e,
-      payload: Partial<RagConfig>,
+      payload: unknown,
     ): Promise<IpcResponse<RagConfig>> => {
-      ragConfig.topK = normalizeTopK(payload.topK ?? ragConfig.topK);
+      const payloadError = validateRagConfigUpdatePayload(payload);
+      if (payloadError) {
+        return payloadError;
+      }
+      const validPayload = payload as Partial<RagConfig>;
+
+      ragConfig.topK = normalizeTopK(validPayload.topK ?? ragConfig.topK);
       ragConfig.minScore = normalizeMinScore(
-        payload.minScore ?? ragConfig.minScore,
+        validPayload.minScore ?? ragConfig.minScore,
       );
       ragConfig.maxTokens = normalizeMaxTokens(
-        payload.maxTokens ?? ragConfig.maxTokens,
+        validPayload.maxTokens ?? ragConfig.maxTokens,
         ragConfig.maxTokens,
       );
-      ragConfig.model = payload.model?.trim() || ragConfig.model;
+      ragConfig.model = validPayload.model?.trim() || ragConfig.model;
 
       return {
         ok: true,
@@ -242,7 +312,7 @@ export function registerRagIpcHandlers(deps: {
     "rag:context:retrieve",
     async (
       _e,
-      payload: RagRetrievePayload,
+      payload: unknown,
       signal?: AbortSignal,
     ): Promise<
       IpcResponse<{
@@ -267,16 +337,17 @@ export function registerRagIpcHandlers(deps: {
       if (payloadError) {
         return payloadError;
       }
+      const validPayload = payload as RagRetrievePayload;
 
-      const topK = normalizeTopK(payload.topK ?? ragConfig.topK);
+      const topK = normalizeTopK(validPayload.topK ?? ragConfig.topK);
       const minScore = normalizeMinScore(
-        payload.minScore ?? ragConfig.minScore,
+        validPayload.minScore ?? ragConfig.minScore,
       );
       const maxTokens = normalizeMaxTokens(
-        payload.maxTokens ?? ragConfig.maxTokens,
+        validPayload.maxTokens ?? ragConfig.maxTokens,
         ragConfig.maxTokens,
       );
-      const model = payload.model ?? ragConfig.model;
+      const model = validPayload.model ?? ragConfig.model;
 
       const retrieveWithCurrentConfig = async (
         runtimeSignal?: AbortSignal,
@@ -298,7 +369,7 @@ export function registerRagIpcHandlers(deps: {
 
         const semanticPrepareError = prepareSemanticDocuments({
           db,
-          projectId: payload.projectId,
+          projectId: validPayload.projectId,
           model,
           semanticIndex,
         });
@@ -310,8 +381,8 @@ export function registerRagIpcHandlers(deps: {
         }
 
         const semantic = semanticIndex.search({
-          projectId: payload.projectId,
-          queryText: payload.queryText,
+          projectId: validPayload.projectId,
+          queryText: validPayload.queryText,
           topK,
           minScore,
           model,
@@ -339,8 +410,8 @@ export function registerRagIpcHandlers(deps: {
 
           const fts = createFtsService({ db, logger: deps.logger });
           const ftsRes = fts.searchFulltext({
-            projectId: payload.projectId,
-            query: payload.queryText,
+            projectId: validPayload.projectId,
+            query: validPayload.queryText,
             limit: topK,
           });
           if (!ftsRes.ok) {
@@ -348,12 +419,12 @@ export function registerRagIpcHandlers(deps: {
           }
 
           const crossProjectItem = ftsRes.data.items.find(
-            (item) => item.projectId !== payload.projectId,
+            (item) => item.projectId !== validPayload.projectId,
           );
           if (crossProjectItem) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectItem.projectId,
               documentId: crossProjectItem.documentId,
             });
@@ -363,7 +434,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectItem.projectId,
                 },
               },
@@ -384,12 +455,12 @@ export function registerRagIpcHandlers(deps: {
           }));
         } else {
           const crossProjectChunk = semantic.data.chunks.find(
-            (chunk) => chunk.projectId !== payload.projectId,
+            (chunk) => chunk.projectId !== validPayload.projectId,
           );
           if (crossProjectChunk) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectChunk.projectId,
               documentId: crossProjectChunk.documentId,
             });
@@ -399,7 +470,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectChunk.projectId,
                 },
               },
@@ -408,8 +479,8 @@ export function registerRagIpcHandlers(deps: {
 
           const fts = createFtsService({ db, logger: deps.logger });
           const ftsRes = fts.searchFulltext({
-            projectId: payload.projectId,
-            query: payload.queryText,
+            projectId: validPayload.projectId,
+            query: validPayload.queryText,
             limit: topK,
           });
           if (!ftsRes.ok) {
@@ -417,12 +488,12 @@ export function registerRagIpcHandlers(deps: {
           }
 
           const crossProjectItem = ftsRes.data.items.find(
-            (item) => item.projectId !== payload.projectId,
+            (item) => item.projectId !== validPayload.projectId,
           );
           if (crossProjectItem) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectItem.projectId,
               documentId: crossProjectItem.documentId,
             });
@@ -432,7 +503,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectItem.projectId,
                 },
               },
@@ -465,8 +536,8 @@ export function registerRagIpcHandlers(deps: {
           });
 
           deps.logger.info("rag_retrieve_complete", {
-            projectId: payload.projectId,
-            queryLength: payload.queryText.trim().length,
+            projectId: validPayload.projectId,
+            queryLength: validPayload.queryText.trim().length,
             topK,
             minScore,
             maxTokens,
@@ -513,8 +584,8 @@ export function registerRagIpcHandlers(deps: {
         }
 
         deps.logger.info("rag_retrieve_complete", {
-          projectId: payload.projectId,
-          queryLength: payload.queryText.trim().length,
+          projectId: validPayload.projectId,
+          queryLength: validPayload.queryText.trim().length,
           topK,
           minScore,
           maxTokens,


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
加固 RAG 与 Embedding IPC 在异常 payload 输入下的错误处理闭环，避免主进程因非法入参崩溃。

## 改动列表
- commit 1: 为 `rag:config:update` / `rag:context:retrieve` 增加运行时 payload 校验，并补充回归契约测试
- commit 2: 为 `embedding:text:generate` / `embedding:semantic:search` 增加运行时 payload 校验，并补充回归契约测试

## 为什么改
这些 IPC handler 之前默认 payload 类型正确，遇到 null、数字、字段类型错误等输入时会直接触发属性访问异常，导致错误链路中断。改动后统一返回 `INVALID_ARGUMENT`，保证错误可控、可观测，且不改变合法输入行为。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库已有存量 warning，无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
