### PR TITLE
improve(main): IPC payload 运行时守卫补齐（constraints/rag/embedding）

### DIFF
--- a/apps/desktop/main/src/ipc/constraints.ts
+++ b/apps/desktop/main/src/ipc/constraints.ts
@@ -64,6 +64,232 @@ function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null;
 }
 
+function invalidArgument(message: string): Err {
+  return ipcError("INVALID_ARGUMENT", message);
+}
+
+function readPayloadObject(payload: unknown): ServiceResult<Record<string, unknown>> {
+  if (!isRecord(payload)) {
+    return invalidArgument("payload must be an object");
+  }
+  return { ok: true, data: payload };
+}
+
+function readStringField(args: {
+  payload: Record<string, unknown>;
+  field: string;
+}): ServiceResult<string> {
+  const value = args.payload[args.field];
+  if (typeof value !== "string") {
+    return invalidArgument(`${args.field} must be a string`);
+  }
+  return { ok: true, data: value };
+}
+
+function readObjectField(args: {
+  payload: Record<string, unknown>;
+  field: string;
+}): ServiceResult<Record<string, unknown>> {
+  const value = args.payload[args.field];
+  if (!isRecord(value)) {
+    return invalidArgument(`${args.field} must be an object`);
+  }
+  return { ok: true, data: value };
+}
+
+function parsePolicyListPayload(
+  payload: unknown,
+): ServiceResult<{ projectId: string }> {
+  const payloadObj = readPayloadObject(payload);
+  if (!payloadObj.ok) {
+    return payloadObj;
+  }
+
+  const projectId = readStringField({
+    payload: payloadObj.data,
+    field: "projectId",
+  });
+  if (!projectId.ok) {
+    return projectId;
+  }
+
+  return { ok: true, data: { projectId: projectId.data } };
+}
+
+function parsePolicyCreatePayload(payload: unknown): ServiceResult<{
+  projectId: string;
+  constraint: ConstraintCreateInput;
+}> {
+  const payloadObj = readPayloadObject(payload);
+  if (!payloadObj.ok) {
+    return payloadObj;
+  }
+
+  const projectId = readStringField({
+    payload: payloadObj.data,
+    field: "projectId",
+  });
+  if (!projectId.ok) {
+    return projectId;
+  }
+
+  const constraintObj = readObjectField({
+    payload: payloadObj.data,
+    field: "constraint",
+  });
+  if (!constraintObj.ok) {
+    return constraintObj;
+  }
+
+  if (typeof constraintObj.data.text !== "string") {
+    return invalidArgument("constraint.text must be a string");
+  }
+  if (
+    constraintObj.data.source !== undefined &&
+    typeof constraintObj.data.source !== "string"
+  ) {
+    return invalidArgument("constraint.source must be a string");
+  }
+  if (
+    constraintObj.data.priority !== undefined &&
+    typeof constraintObj.data.priority !== "number"
+  ) {
+    return invalidArgument("constraint.priority must be a number");
+  }
+  if (
+    constraintObj.data.degradable !== undefined &&
+    typeof constraintObj.data.degradable !== "boolean"
+  ) {
+    return invalidArgument("constraint.degradable must be a boolean");
+  }
+
+  return {
+    ok: true,
+    data: {
+      projectId: projectId.data,
+      constraint: constraintObj.data as ConstraintCreateInput,
+    },
+  };
+}
+
+function parsePolicyUpdatePayload(payload: unknown): ServiceResult<{
+  projectId: string;
+  constraintId: string;
+  patch: ConstraintPatchInput;
+}> {
+  const payloadObj = readPayloadObject(payload);
+  if (!payloadObj.ok) {
+    return payloadObj;
+  }
+
+  const projectId = readStringField({
+    payload: payloadObj.data,
+    field: "projectId",
+  });
+  if (!projectId.ok) {
+    return projectId;
+  }
+  const constraintId = readStringField({
+    payload: payloadObj.data,
+    field: "constraintId",
+  });
+  if (!constraintId.ok) {
+    return constraintId;
+  }
+
+  const patchObj = readObjectField({
+    payload: payloadObj.data,
+    field: "patch",
+  });
+  if (!patchObj.ok) {
+    return patchObj;
+  }
+  if (patchObj.data.text !== undefined && typeof patchObj.data.text !== "string") {
+    return invalidArgument("patch.text must be a string");
+  }
+  if (
+    patchObj.data.priority !== undefined &&
+    typeof patchObj.data.priority !== "number"
+  ) {
+    return invalidArgument("patch.priority must be a number");
+  }
+  if (
+    patchObj.data.degradable !== undefined &&
+    typeof patchObj.data.degradable !== "boolean"
+  ) {
+    return invalidArgument("patch.degradable must be a boolean");
+  }
+
+  return {
+    ok: true,
+    data: {
+      projectId: projectId.data,
+      constraintId: constraintId.data,
+      patch: patchObj.data as ConstraintPatchInput,
+    },
+  };
+}
+
+function parsePolicyDeletePayload(payload: unknown): ServiceResult<{
+  projectId: string;
+  constraintId: string;
+}> {
+  const payloadObj = readPayloadObject(payload);
+  if (!payloadObj.ok) {
+    return payloadObj;
+  }
+
+  const projectId = readStringField({
+    payload: payloadObj.data,
+    field: "projectId",
+  });
+  if (!projectId.ok) {
+    return projectId;
+  }
+  const constraintId = readStringField({
+    payload: payloadObj.data,
+    field: "constraintId",
+  });
+  if (!constraintId.ok) {
+    return constraintId;
+  }
+
+  return {
+    ok: true,
+    data: { projectId: projectId.data, constraintId: constraintId.data },
+  };
+}
+
+function parsePolicySetPayload(payload: unknown): ServiceResult<{
+  projectId: string;
+  constraints: LegacyConstraintsConfig;
+}> {
+  const payloadObj = readPayloadObject(payload);
+  if (!payloadObj.ok) {
+    return payloadObj;
+  }
+
+  const projectId = readStringField({
+    payload: payloadObj.data,
+    field: "projectId",
+  });
+  if (!projectId.ok) {
+    return projectId;
+  }
+
+  if (!isRecord(payloadObj.data.constraints)) {
+    return invalidArgument("constraints must be an object");
+  }
+
+  return {
+    ok: true,
+    data: {
+      projectId: projectId.data,
+      constraints: payloadObj.data.constraints as LegacyConstraintsConfig,
+    },
+  };
+}
+
 /**
  * Validate allowed constraint source values.
  */
@@ -482,8 +708,13 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:list",
     async (
       _e,
-      payload: { projectId: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ constraints: ConstraintItem[] }>> => {
+      const parsedPayload = parsePolicyListPayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
@@ -491,7 +722,7 @@ export function registerConstraintsIpcHandlers(deps: {
         };
       }
 
-      const projectIdValidation = validateProjectId(payload.projectId);
+      const projectIdValidation = validateProjectId(projectId);
       if (projectIdValidation) {
         return projectIdValidation;
       }
@@ -499,7 +730,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -509,7 +740,7 @@ export function registerConstraintsIpcHandlers(deps: {
         const res = await readConstraintsFile(constraintsPath);
         if (!res.ok) {
           deps.logger.error("constraints_list_failed", {
-            projectId: payload.projectId,
+            projectId,
             code: res.error.code,
           });
           return { ok: false, error: res.error };
@@ -538,8 +769,13 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:create",
     async (
       _e,
-      payload: { projectId: string; constraint: ConstraintCreateInput },
+      payload: unknown,
     ): Promise<IpcResponse<{ constraint: ConstraintItem }>> => {
+      const parsedPayload = parsePolicyCreatePayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId, constraint } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
@@ -547,12 +783,12 @@ export function registerConstraintsIpcHandlers(deps: {
         };
       }
 
-      const projectIdValidation = validateProjectId(payload.projectId);
+      const projectIdValidation = validateProjectId(projectId);
       if (projectIdValidation) {
         return projectIdValidation;
       }
 
-      const createValidation = validateCreatePayload(payload.constraint);
+      const createValidation = validateCreatePayload(constraint);
       if (!createValidation.ok) {
         return createValidation;
       }
@@ -560,7 +796,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -610,7 +846,7 @@ export function registerConstraintsIpcHandlers(deps: {
         }
 
         deps.logger.info("constraints_created", {
-          projectId: payload.projectId,
+          projectId,
           constraintId: created.id,
           source: created.source,
           priority: created.priority,
@@ -634,12 +870,13 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:update",
     async (
       _e,
-      payload: {
-        projectId: string;
-        constraintId: string;
-        patch: ConstraintPatchInput;
-      },
+      payload: unknown,
     ): Promise<IpcResponse<{ constraint: ConstraintItem }>> => {
+      const parsedPayload = parsePolicyUpdatePayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId, constraintId, patch } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
@@ -647,19 +884,19 @@ export function registerConstraintsIpcHandlers(deps: {
         };
       }
 
-      const projectIdValidation = validateProjectId(payload.projectId);
+      const projectIdValidation = validateProjectId(projectId);
       if (projectIdValidation) {
         return projectIdValidation;
       }
 
-      if (payload.constraintId.trim().length === 0) {
+      if (constraintId.trim().length === 0) {
         return ipcError(
           "CONSTRAINT_VALIDATION_ERROR",
           "constraintId is required",
         );
       }
 
-      const patchValidation = validatePatchPayload(payload.patch);
+      const patchValidation = validatePatchPayload(patch);
       if (!patchValidation.ok) {
         return patchValidation;
       }
@@ -667,7 +904,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -685,7 +922,7 @@ export function registerConstraintsIpcHandlers(deps: {
         }
 
         const index = readRes.data.items.findIndex(
-          (item) => item.id === payload.constraintId,
+          (item) => item.id === constraintId,
         );
         if (index < 0) {
           return ipcError("CONSTRAINT_NOT_FOUND", "Constraint not found");
@@ -739,7 +976,7 @@ export function registerConstraintsIpcHandlers(deps: {
         }
 
         deps.logger.info("constraints_updated", {
-          projectId: payload.projectId,
+          projectId,
           constraintId: updated.id,
         });
 
@@ -761,8 +998,13 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:delete",
     async (
       _e,
-      payload: { projectId: string; constraintId: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ deletedConstraintId: string }>> => {
+      const parsedPayload = parsePolicyDeletePayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId, constraintId } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
@@ -770,12 +1012,12 @@ export function registerConstraintsIpcHandlers(deps: {
         };
       }
 
-      const projectIdValidation = validateProjectId(payload.projectId);
+      const projectIdValidation = validateProjectId(projectId);
       if (projectIdValidation) {
         return projectIdValidation;
       }
 
-      if (payload.constraintId.trim().length === 0) {
+      if (constraintId.trim().length === 0) {
         return ipcError(
           "CONSTRAINT_VALIDATION_ERROR",
           "constraintId is required",
@@ -785,7 +1027,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -803,7 +1045,7 @@ export function registerConstraintsIpcHandlers(deps: {
         }
 
         const current = readRes.data.items.find(
-          (item) => item.id === payload.constraintId,
+          (item) => item.id === constraintId,
         );
         if (!current) {
           return ipcError("CONSTRAINT_NOT_FOUND", "Constraint not found");
@@ -821,7 +1063,7 @@ export function registerConstraintsIpcHandlers(deps: {
           constraints: {
             version: 2,
             items: readRes.data.items.filter(
-              (item) => item.id !== payload.constraintId,
+              (item) => item.id !== constraintId,
             ),
           },
         });
@@ -830,13 +1072,13 @@ export function registerConstraintsIpcHandlers(deps: {
         }
 
         deps.logger.info("constraints_deleted", {
-          projectId: payload.projectId,
-          constraintId: payload.constraintId,
+          projectId,
+          constraintId,
         });
 
         return {
           ok: true,
-          data: { deletedConstraintId: payload.constraintId },
+          data: { deletedConstraintId: constraintId },
         };
       } catch (error) {
         deps.logger.error("constraints_delete_unhandled", {
@@ -856,8 +1098,13 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:get",
     async (
       _e,
-      payload: { projectId: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ constraints: LegacyConstraintsConfig }>> => {
+      const parsedPayload = parsePolicyListPayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
@@ -865,7 +1112,7 @@ export function registerConstraintsIpcHandlers(deps: {
         };
       }
 
-      if (payload.projectId.trim().length === 0) {
+      if (projectId.trim().length === 0) {
         return {
           ok: false,
           error: {
@@ -878,7 +1125,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -888,7 +1135,7 @@ export function registerConstraintsIpcHandlers(deps: {
         const readRes = await readConstraintsFile(constraintsPath);
         if (!readRes.ok) {
           deps.logger.error("constraints_read_failed", {
-            projectId: payload.projectId,
+            projectId,
             code: readRes.error.code,
           });
           return { ok: false, error: toLegacyError(readRes.error) };
@@ -915,21 +1162,26 @@ export function registerConstraintsIpcHandlers(deps: {
     "constraints:policy:set",
     async (
       _e,
-      payload: { projectId: string; constraints: LegacyConstraintsConfig },
+      payload: unknown,
     ): Promise<IpcResponse<{ constraints: LegacyConstraintsConfig }>> => {
+      const parsedPayload = parsePolicySetPayload(payload);
+      if (!parsedPayload.ok) {
+        return parsedPayload;
+      }
+      const { projectId, constraints } = parsedPayload.data;
       if (!deps.db) {
         return {
           ok: false,
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (projectId.trim().length === 0) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
         };
       }
-      if (!isLegacyConstraintsConfig(payload.constraints)) {
+      if (!isLegacyConstraintsConfig(constraints)) {
         return {
           ok: false,
           error: {
@@ -942,7 +1194,7 @@ export function registerConstraintsIpcHandlers(deps: {
       try {
         const rootRes = getProjectRootPath({
           db: deps.db,
-          projectId: payload.projectId,
+          projectId,
         });
         if (!rootRes.ok) {
           return rootRes;
@@ -951,32 +1203,32 @@ export function registerConstraintsIpcHandlers(deps: {
         const ensured = ensureCreonowDirStructure(rootRes.data);
         if (!ensured.ok) {
           deps.logger.error("constraints_ensure_creonow_failed", {
-            projectId: payload.projectId,
+            projectId,
             code: ensured.error.code,
           });
           return { ok: false, error: ensured.error };
         }
 
         const constraintsPath = getConstraintsPath(rootRes.data);
-        const store = fromLegacyConstraintsConfig(payload.constraints);
+        const store = fromLegacyConstraintsConfig(constraints);
         const writeRes = await writeConstraintsFile({
           constraintsPath,
           constraints: store,
         });
         if (!writeRes.ok) {
           deps.logger.error("constraints_write_failed", {
-            projectId: payload.projectId,
+            projectId,
             code: writeRes.error.code,
           });
           return { ok: false, error: toLegacyError(writeRes.error) };
         }
 
         deps.logger.info("constraints_updated", {
-          projectId: payload.projectId,
-          items_count: payload.constraints.items.length,
+          projectId,
+          items_count: constraints.items.length,
         });
 
-        return { ok: true, data: { constraints: payload.constraints } };
+        return { ok: true, data: { constraints } };
       } catch (error) {
         deps.logger.error("constraints_set_failed", {
           code: "IO_ERROR",

--- a/apps/desktop/main/src/ipc/embedding.ts
+++ b/apps/desktop/main/src/ipc/embedding.ts
@@ -61,6 +61,103 @@ function hasCorruptedOffsets(chunk: {
   return chunk.startOffset < 0 || chunk.endOffset < chunk.startOffset;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidArgument(message: string): IpcResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_ARGUMENT",
+      message,
+    },
+  };
+}
+
+function parseTextGeneratePayload(payload: unknown): {
+  texts: string[];
+  model?: string;
+} | null {
+  if (!isRecord(payload) || !Array.isArray(payload.texts)) {
+    return null;
+  }
+  if (!payload.texts.every((text) => typeof text === "string")) {
+    return null;
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return null;
+  }
+
+  return {
+    texts: payload.texts,
+    ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+  };
+}
+
+function parseSemanticSearchPayload(payload: unknown): {
+  projectId: string;
+  queryText: string;
+  topK?: number;
+  minScore?: number;
+  model?: string;
+} | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (typeof payload.projectId !== "string") {
+    return null;
+  }
+  if (typeof payload.queryText !== "string") {
+    return null;
+  }
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return null;
+  }
+  if (payload.minScore !== undefined && typeof payload.minScore !== "number") {
+    return null;
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return null;
+  }
+
+  return {
+    projectId: payload.projectId,
+    queryText: payload.queryText,
+    ...(typeof payload.topK === "number" ? { topK: payload.topK } : {}),
+    ...(typeof payload.minScore === "number"
+      ? { minScore: payload.minScore }
+      : {}),
+    ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+  };
+}
+
+
+function parseReindexPayload(payload: unknown): {
+  projectId: string;
+  batchSize?: number;
+  model?: string;
+} | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (typeof payload.projectId !== "string") {
+    return null;
+  }
+  if (payload.batchSize !== undefined && typeof payload.batchSize !== "number") {
+    return null;
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return null;
+  }
+
+  return {
+    projectId: payload.projectId,
+    ...(typeof payload.batchSize === "number" ? { batchSize: payload.batchSize } : {}),
+    ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+  };
+}
+
 /**
  * Register `embedding:*` IPC handlers.
  *
@@ -99,7 +196,7 @@ export function registerEmbeddingIpcHandlers(deps: {
     "embedding:text:generate",
     async (
       _e,
-      payload: { texts: string[]; model?: string },
+      payload: unknown,
       signal?: AbortSignal,
     ): Promise<IpcResponse<{ vectors: number[][]; dimension: number }>> => {
       if (!deps.db) {
@@ -109,17 +206,22 @@ export function registerEmbeddingIpcHandlers(deps: {
         };
       }
 
+      const parsedPayload = parseTextGeneratePayload(payload);
+      if (!parsedPayload) {
+        return invalidArgument("payload must include texts:string[] and optional model:string");
+      }
+
       if (embeddingTextOffload) {
         return await embeddingTextOffload.encode({
-          texts: payload.texts,
-          model: payload.model,
+          texts: parsedPayload.texts,
+          model: parsedPayload.model,
           signal,
         });
       }
 
       const encoded = deps.embedding.encode({
-        texts: payload.texts,
-        model: payload.model,
+        texts: parsedPayload.texts,
+        model: parsedPayload.model,
       });
       return encoded.ok
         ? { ok: true, data: encoded.data }
@@ -131,13 +233,7 @@ export function registerEmbeddingIpcHandlers(deps: {
     "embedding:semantic:search",
     async (
       _e,
-      payload: {
-        projectId: string;
-        queryText: string;
-        topK?: number;
-        minScore?: number;
-        model?: string;
-      },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         mode: "semantic" | "fts-fallback";
@@ -167,33 +263,34 @@ export function registerEmbeddingIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-        };
+
+      const parsedPayload = parseSemanticSearchPayload(payload);
+      if (!parsedPayload) {
+        return invalidArgument(
+          "payload must include projectId:string, queryText:string, and optional topK/minScore/model",
+        );
       }
-      if (payload.queryText.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "queryText is required" },
-        };
+      if (parsedPayload.projectId.trim().length === 0) {
+        return invalidArgument("projectId is required");
+      }
+      if (parsedPayload.queryText.trim().length === 0) {
+        return invalidArgument("queryText is required");
       }
 
-      const topK = normalizeTopK(payload.topK);
-      const minScore = normalizeMinScore(payload.minScore);
+      const topK = normalizeTopK(parsedPayload.topK);
+      const minScore = normalizeMinScore(parsedPayload.minScore);
 
       const docs = listProjectDocuments({
         db: deps.db,
-        projectId: payload.projectId,
+        projectId: parsedPayload.projectId,
       });
       for (const doc of docs) {
         const upserted = semanticIndex.upsertDocument({
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           documentId: doc.documentId,
           contentText: doc.contentText,
           updatedAt: doc.updatedAt,
-          model: payload.model,
+          model: parsedPayload.model,
         });
         if (
           !upserted.ok &&
@@ -205,11 +302,11 @@ export function registerEmbeddingIpcHandlers(deps: {
       }
 
       const semantic = semanticIndex.search({
-        projectId: payload.projectId,
-        queryText: payload.queryText,
+        projectId: parsedPayload.projectId,
+        queryText: parsedPayload.queryText,
         topK,
         minScore,
-        model: payload.model,
+        model: parsedPayload.model,
       });
 
       if (!semantic.ok) {
@@ -222,8 +319,8 @@ export function registerEmbeddingIpcHandlers(deps: {
 
         const fts = createFtsService({ db: deps.db, logger: deps.logger });
         const ftsRes = fts.searchFulltext({
-          projectId: payload.projectId,
-          query: payload.queryText,
+          projectId: parsedPayload.projectId,
+          query: parsedPayload.queryText,
           limit: topK,
         });
         if (!ftsRes.ok) {
@@ -231,12 +328,12 @@ export function registerEmbeddingIpcHandlers(deps: {
         }
 
         const crossProjectItem = ftsRes.data.items.find(
-          (item) => item.projectId !== payload.projectId,
+          (item) => item.projectId !== parsedPayload.projectId,
         );
         if (crossProjectItem) {
           deps.logger.error("embedding_project_forbidden_audit", {
             operation: "embedding:semantic:search",
-            requestedProjectId: payload.projectId,
+            requestedProjectId: parsedPayload.projectId,
             rowProjectId: crossProjectItem.projectId,
             documentId: crossProjectItem.documentId,
           });
@@ -246,7 +343,7 @@ export function registerEmbeddingIpcHandlers(deps: {
               code: "SEARCH_PROJECT_FORBIDDEN",
               message: "Cross-project semantic retrieval is forbidden",
               details: {
-                requestedProjectId: payload.projectId,
+                requestedProjectId: parsedPayload.projectId,
                 rowProjectId: crossProjectItem.projectId,
               },
             },
@@ -254,9 +351,9 @@ export function registerEmbeddingIpcHandlers(deps: {
         }
 
         deps.logger.info("embedding_search_fallback_fts", {
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           reason: semantic.error.code,
-          queryLength: payload.queryText.trim().length,
+          queryLength: parsedPayload.queryText.trim().length,
           resultCount: ftsRes.data.items.length,
         });
 
@@ -283,12 +380,12 @@ export function registerEmbeddingIpcHandlers(deps: {
       }
 
       const crossProjectChunk = semantic.data.chunks.find(
-        (chunk) => chunk.projectId !== payload.projectId,
+        (chunk) => chunk.projectId !== parsedPayload.projectId,
       );
       if (crossProjectChunk) {
         deps.logger.error("embedding_project_forbidden_audit", {
           operation: "embedding:semantic:search",
-          requestedProjectId: payload.projectId,
+          requestedProjectId: parsedPayload.projectId,
           rowProjectId: crossProjectChunk.projectId,
           documentId: crossProjectChunk.documentId,
         });
@@ -298,7 +395,7 @@ export function registerEmbeddingIpcHandlers(deps: {
             code: "SEARCH_PROJECT_FORBIDDEN",
             message: "Cross-project semantic retrieval is forbidden",
             details: {
-              requestedProjectId: payload.projectId,
+              requestedProjectId: parsedPayload.projectId,
               rowProjectId: crossProjectChunk.projectId,
             },
           },
@@ -316,14 +413,14 @@ export function registerEmbeddingIpcHandlers(deps: {
 
       if (isolatedChunkIds.length > 0) {
         deps.logger.error("embedding_data_corrupted_isolated", {
-          projectId: payload.projectId,
+          projectId: parsedPayload.projectId,
           isolatedChunkIds,
         });
       }
 
       deps.logger.info("embedding_search_semantic", {
-        projectId: payload.projectId,
-        queryLength: payload.queryText.trim().length,
+        projectId: parsedPayload.projectId,
+        queryLength: parsedPayload.queryText.trim().length,
         resultCount: validChunks.length,
       });
 
@@ -356,7 +453,7 @@ export function registerEmbeddingIpcHandlers(deps: {
     "embedding:index:reindex",
     async (
       _e,
-      payload: { projectId: string; batchSize?: number; model?: string },
+      payload: unknown,
     ): Promise<
       IpcResponse<{
         indexedDocuments: number;
@@ -370,28 +467,29 @@ export function registerEmbeddingIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
-        return {
-          ok: false,
-          error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-        };
+      const parsedPayload = parseReindexPayload(payload);
+      if (!parsedPayload) {
+        return invalidArgument("payload must include projectId:string and optional batchSize/model");
+      }
+      if (parsedPayload.projectId.trim().length === 0) {
+        return invalidArgument("projectId is required");
       }
 
       const docs = listProjectDocuments({
         db: deps.db,
-        projectId: payload.projectId,
+        projectId: parsedPayload.projectId,
       });
       const reindexed = semanticIndex.reindexProject({
-        projectId: payload.projectId,
+        projectId: parsedPayload.projectId,
         documents: docs,
-        model: payload.model,
+        model: parsedPayload.model,
       });
       if (!reindexed.ok) {
         return { ok: false, error: reindexed.error };
       }
 
       deps.logger.info("embedding_reindex", {
-        projectId: payload.projectId,
+        projectId: parsedPayload.projectId,
         indexedDocuments: reindexed.data.indexedDocuments,
         indexedChunks: reindexed.data.indexedChunks,
       });

--- a/apps/desktop/main/src/ipc/rag.ts
+++ b/apps/desktop/main/src/ipc/rag.ts
@@ -46,6 +46,8 @@ type RagRetrievePayload = {
   model?: string;
 };
 
+type RuntimeRecord = Record<string, unknown>;
+
 const DEFAULT_RAG_CONFIG: RagConfig = {
   topK: 5,
   minScore: 0.7,
@@ -91,20 +93,82 @@ function normalizeMaxTokens(value: number, fallback: number): number {
   return Math.floor(value);
 }
 
-function validateRagRetrievePayload(
-  payload: RagRetrievePayload,
+function isRuntimeRecord(value: unknown): value is RuntimeRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function toInvalidPayloadError(message: string): IpcResponse<never> {
+  return {
+    ok: false,
+    error: { code: "INVALID_ARGUMENT", message },
+  };
+}
+
+function validateRagConfigUpdatePayload(
+  payload: unknown,
 ): IpcResponse<never> | null {
+  if (!isRuntimeRecord(payload)) {
+    return toInvalidPayloadError("payload must be an object");
+  }
+
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return toInvalidPayloadError("topK must be a number");
+  }
+  if (
+    payload.minScore !== undefined &&
+    typeof payload.minScore !== "number"
+  ) {
+    return toInvalidPayloadError("minScore must be a number");
+  }
+  if (
+    payload.maxTokens !== undefined &&
+    typeof payload.maxTokens !== "number"
+  ) {
+    return toInvalidPayloadError("maxTokens must be a number");
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return toInvalidPayloadError("model must be a string");
+  }
+
+  return null;
+}
+
+function validateRagRetrievePayload(
+  payload: unknown,
+): IpcResponse<never> | null {
+  if (!isRuntimeRecord(payload)) {
+    return toInvalidPayloadError("payload must be an object");
+  }
+  if (typeof payload.projectId !== "string") {
+    return toInvalidPayloadError("projectId must be a string");
+  }
+  if (typeof payload.queryText !== "string") {
+    return toInvalidPayloadError("queryText must be a string");
+  }
+  if (payload.topK !== undefined && typeof payload.topK !== "number") {
+    return toInvalidPayloadError("topK must be a number");
+  }
+  if (
+    payload.minScore !== undefined &&
+    typeof payload.minScore !== "number"
+  ) {
+    return toInvalidPayloadError("minScore must be a number");
+  }
+  if (
+    payload.maxTokens !== undefined &&
+    typeof payload.maxTokens !== "number"
+  ) {
+    return toInvalidPayloadError("maxTokens must be a number");
+  }
+  if (payload.model !== undefined && typeof payload.model !== "string") {
+    return toInvalidPayloadError("model must be a string");
+  }
+
   if (payload.projectId.trim().length === 0) {
-    return {
-      ok: false,
-      error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
-    };
+    return toInvalidPayloadError("projectId is required");
   }
   if (payload.queryText.trim().length === 0) {
-    return {
-      ok: false,
-      error: { code: "INVALID_ARGUMENT", message: "queryText is required" },
-    };
+    return toInvalidPayloadError("queryText is required");
   }
   return null;
 }
@@ -219,17 +283,23 @@ export function registerRagIpcHandlers(deps: {
     "rag:config:update",
     async (
       _e,
-      payload: Partial<RagConfig>,
+      payload: unknown,
     ): Promise<IpcResponse<RagConfig>> => {
-      ragConfig.topK = normalizeTopK(payload.topK ?? ragConfig.topK);
+      const payloadError = validateRagConfigUpdatePayload(payload);
+      if (payloadError) {
+        return payloadError;
+      }
+      const validPayload = payload as Partial<RagConfig>;
+
+      ragConfig.topK = normalizeTopK(validPayload.topK ?? ragConfig.topK);
       ragConfig.minScore = normalizeMinScore(
-        payload.minScore ?? ragConfig.minScore,
+        validPayload.minScore ?? ragConfig.minScore,
       );
       ragConfig.maxTokens = normalizeMaxTokens(
-        payload.maxTokens ?? ragConfig.maxTokens,
+        validPayload.maxTokens ?? ragConfig.maxTokens,
         ragConfig.maxTokens,
       );
-      ragConfig.model = payload.model?.trim() || ragConfig.model;
+      ragConfig.model = validPayload.model?.trim() || ragConfig.model;
 
       return {
         ok: true,
@@ -242,7 +312,7 @@ export function registerRagIpcHandlers(deps: {
     "rag:context:retrieve",
     async (
       _e,
-      payload: RagRetrievePayload,
+      payload: unknown,
       signal?: AbortSignal,
     ): Promise<
       IpcResponse<{
@@ -267,16 +337,17 @@ export function registerRagIpcHandlers(deps: {
       if (payloadError) {
         return payloadError;
       }
+      const validPayload = payload as RagRetrievePayload;
 
-      const topK = normalizeTopK(payload.topK ?? ragConfig.topK);
+      const topK = normalizeTopK(validPayload.topK ?? ragConfig.topK);
       const minScore = normalizeMinScore(
-        payload.minScore ?? ragConfig.minScore,
+        validPayload.minScore ?? ragConfig.minScore,
       );
       const maxTokens = normalizeMaxTokens(
-        payload.maxTokens ?? ragConfig.maxTokens,
+        validPayload.maxTokens ?? ragConfig.maxTokens,
         ragConfig.maxTokens,
       );
-      const model = payload.model ?? ragConfig.model;
+      const model = validPayload.model ?? ragConfig.model;
 
       const retrieveWithCurrentConfig = async (
         runtimeSignal?: AbortSignal,
@@ -298,7 +369,7 @@ export function registerRagIpcHandlers(deps: {
 
         const semanticPrepareError = prepareSemanticDocuments({
           db,
-          projectId: payload.projectId,
+          projectId: validPayload.projectId,
           model,
           semanticIndex,
         });
@@ -310,8 +381,8 @@ export function registerRagIpcHandlers(deps: {
         }
 
         const semantic = semanticIndex.search({
-          projectId: payload.projectId,
-          queryText: payload.queryText,
+          projectId: validPayload.projectId,
+          queryText: validPayload.queryText,
           topK,
           minScore,
           model,
@@ -339,8 +410,8 @@ export function registerRagIpcHandlers(deps: {
 
           const fts = createFtsService({ db, logger: deps.logger });
           const ftsRes = fts.searchFulltext({
-            projectId: payload.projectId,
-            query: payload.queryText,
+            projectId: validPayload.projectId,
+            query: validPayload.queryText,
             limit: topK,
           });
           if (!ftsRes.ok) {
@@ -348,12 +419,12 @@ export function registerRagIpcHandlers(deps: {
           }
 
           const crossProjectItem = ftsRes.data.items.find(
-            (item) => item.projectId !== payload.projectId,
+            (item) => item.projectId !== validPayload.projectId,
           );
           if (crossProjectItem) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectItem.projectId,
               documentId: crossProjectItem.documentId,
             });
@@ -363,7 +434,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectItem.projectId,
                 },
               },
@@ -384,12 +455,12 @@ export function registerRagIpcHandlers(deps: {
           }));
         } else {
           const crossProjectChunk = semantic.data.chunks.find(
-            (chunk) => chunk.projectId !== payload.projectId,
+            (chunk) => chunk.projectId !== validPayload.projectId,
           );
           if (crossProjectChunk) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectChunk.projectId,
               documentId: crossProjectChunk.documentId,
             });
@@ -399,7 +470,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectChunk.projectId,
                 },
               },
@@ -408,8 +479,8 @@ export function registerRagIpcHandlers(deps: {
 
           const fts = createFtsService({ db, logger: deps.logger });
           const ftsRes = fts.searchFulltext({
-            projectId: payload.projectId,
-            query: payload.queryText,
+            projectId: validPayload.projectId,
+            query: validPayload.queryText,
             limit: topK,
           });
           if (!ftsRes.ok) {
@@ -417,12 +488,12 @@ export function registerRagIpcHandlers(deps: {
           }
 
           const crossProjectItem = ftsRes.data.items.find(
-            (item) => item.projectId !== payload.projectId,
+            (item) => item.projectId !== validPayload.projectId,
           );
           if (crossProjectItem) {
             deps.logger.error("rag_project_forbidden_audit", {
               operation: "rag:context:retrieve",
-              requestedProjectId: payload.projectId,
+              requestedProjectId: validPayload.projectId,
               rowProjectId: crossProjectItem.projectId,
               documentId: crossProjectItem.documentId,
             });
@@ -432,7 +503,7 @@ export function registerRagIpcHandlers(deps: {
                 code: "SEARCH_PROJECT_FORBIDDEN",
                 message: "Cross-project rag retrieval is forbidden",
                 details: {
-                  requestedProjectId: payload.projectId,
+                  requestedProjectId: validPayload.projectId,
                   rowProjectId: crossProjectItem.projectId,
                 },
               },
@@ -465,8 +536,8 @@ export function registerRagIpcHandlers(deps: {
           });
 
           deps.logger.info("rag_retrieve_complete", {
-            projectId: payload.projectId,
-            queryLength: payload.queryText.trim().length,
+            projectId: validPayload.projectId,
+            queryLength: validPayload.queryText.trim().length,
             topK,
             minScore,
             maxTokens,
@@ -513,8 +584,8 @@ export function registerRagIpcHandlers(deps: {
         }
 
         deps.logger.info("rag_retrieve_complete", {
-          projectId: payload.projectId,
-          queryLength: payload.queryText.trim().length,
+          projectId: validPayload.projectId,
+          queryLength: validPayload.queryText.trim().length,
           topK,
           minScore,
           maxTokens,

--- a/apps/desktop/tests/unit/context/constraints-ipc-payload-guard.test.ts
+++ b/apps/desktop/tests/unit/context/constraints-ipc-payload-guard.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+import { registerConstraintsIpcHandlers } from "../../../main/src/ipc/constraints";
+import type { Logger } from "../../../main/src/logging/logger";
+
+import type Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+type FakeIpcMain = {
+  handle: (channel: string, handler: Handler) => void;
+};
+
+async function createTempDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "CreoNow constraints payload "));
+}
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createDbStub(args: {
+  projectId: string;
+  rootPath: string;
+}): Database.Database {
+  const row = { rootPath: args.rootPath };
+  const prepare = () => {
+    return {
+      get: (projectId: string) => {
+        return projectId === args.projectId ? row : undefined;
+      },
+    };
+  };
+  return { prepare } as unknown as Database.Database;
+}
+
+function createIpcHarness(): {
+  ipcMain: FakeIpcMain;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain: FakeIpcMain = {
+    handle: (channel, handler) => {
+      handlers.set(channel, handler);
+    },
+  };
+  return { ipcMain, handlers };
+}
+
+const projectId = `proj_${randomUUID()}`;
+const projectRoot = await createTempDir();
+const db = createDbStub({ projectId, rootPath: projectRoot });
+const logger = createLogger();
+const { ipcMain, handlers } = createIpcHarness();
+
+registerConstraintsIpcHandlers({
+  ipcMain: ipcMain as unknown as IpcMain,
+  db,
+  logger,
+});
+
+const cases: Array<{
+  channel:
+    | "constraints:policy:list"
+    | "constraints:policy:create"
+    | "constraints:policy:update"
+    | "constraints:policy:delete"
+    | "constraints:policy:get"
+    | "constraints:policy:set";
+  payload: unknown;
+}> = [
+  { channel: "constraints:policy:list", payload: null },
+  { channel: "constraints:policy:list", payload: { projectId: 1 } },
+  { channel: "constraints:policy:create", payload: [] },
+  {
+    channel: "constraints:policy:create",
+    payload: { projectId, constraint: { text: 123 } },
+  },
+  { channel: "constraints:policy:update", payload: "oops" },
+  {
+    channel: "constraints:policy:update",
+    payload: { projectId, constraintId: "c1", patch: { priority: "100" } },
+  },
+  { channel: "constraints:policy:delete", payload: 42 },
+  {
+    channel: "constraints:policy:delete",
+    payload: { projectId, constraintId: false },
+  },
+  { channel: "constraints:policy:get", payload: undefined },
+  { channel: "constraints:policy:get", payload: { projectId: {} } },
+  { channel: "constraints:policy:set", payload: true },
+  {
+    channel: "constraints:policy:set",
+    payload: { projectId, constraints: "bad" },
+  },
+];
+
+for (const testCase of cases) {
+  const handler = handlers.get(testCase.channel);
+  assert.ok(handler, `Missing handler ${testCase.channel}`);
+
+  const result = (await handler({}, testCase.payload)) as IpcResponse<unknown>;
+  assert.equal(result.ok, false, `${testCase.channel} should reject payload`);
+  if (!result.ok) {
+    assert.equal(
+      result.error.code,
+      "INVALID_ARGUMENT",
+      `${testCase.channel} should return INVALID_ARGUMENT`,
+    );
+  }
+}
+
+await fs.rm(projectRoot, { recursive: true, force: true });

--- a/apps/desktop/tests/unit/embedding-ipc-runtime-guards.test.ts
+++ b/apps/desktop/tests/unit/embedding-ipc-runtime-guards.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../main/src/logging/logger";
+import type { EmbeddingService } from "../../main/src/services/embedding/embeddingService";
+import { registerEmbeddingIpcHandlers } from "../../main/src/ipc/embedding";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createDbStub(): Database.Database {
+  return {
+    prepare: () => {
+      throw new Error("db should not be used in invalid payload guard test");
+    },
+  } as unknown as Database.Database;
+}
+
+function createEmbeddingStub(): EmbeddingService {
+  return {
+    encode: () => ({
+      ok: false,
+      error: {
+        code: "MODEL_NOT_READY",
+        message: "embedding should not be used in invalid payload guard test",
+      },
+    }),
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: IpcMain;
+  handlers: Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >;
+} {
+  const handlers = new Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >();
+
+  const ipcMain = {
+    handle: (channel: string, handler: unknown) => {
+      handlers.set(
+        channel,
+        handler as (event: unknown, payload: unknown) => Promise<unknown>,
+      );
+    },
+  };
+
+  return {
+    ipcMain: ipcMain as unknown as IpcMain,
+    handlers,
+  };
+}
+
+async function main(): Promise<void> {
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerEmbeddingIpcHandlers({
+    ipcMain,
+    db: createDbStub(),
+    logger: createLogger(),
+    embedding: createEmbeddingStub(),
+  } as unknown as Parameters<typeof registerEmbeddingIpcHandlers>[0]);
+
+  const generateHandler = handlers.get("embedding:text:generate");
+  assert.ok(generateHandler, "embedding:text:generate handler should be registered");
+
+  for (const payload of [null, 1, { texts: [1] }, { texts: ["ok"], model: 1 }] as unknown[]) {
+    const response = (await generateHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+
+  const searchHandler = handlers.get("embedding:semantic:search");
+  assert.ok(searchHandler, "embedding:semantic:search handler should be registered");
+
+  for (const payload of [null, 1, { projectId: 1, queryText: "q" }, { projectId: "p1", queryText: 2 }] as unknown[]) {
+    const response = (await searchHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+
+  const reindexHandler = handlers.get("embedding:index:reindex");
+  assert.ok(reindexHandler, "embedding:index:reindex handler should be registered");
+
+  for (const payload of [null, 1, { projectId: 1 }, { projectId: "p1", model: 2 }] as unknown[]) {
+    const response = (await reindexHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/unit/rag-ipc-runtime-guards.test.ts
+++ b/apps/desktop/tests/unit/rag-ipc-runtime-guards.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../main/src/logging/logger";
+import type { EmbeddingService } from "../../main/src/services/embedding/embeddingService";
+import { registerRagIpcHandlers } from "../../main/src/ipc/rag";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createDbStub(): Database.Database {
+  return {
+    prepare: () => {
+      throw new Error("db should not be used in invalid payload guard test");
+    },
+  } as unknown as Database.Database;
+}
+
+function createEmbeddingStub(): EmbeddingService {
+  return {
+    encode: () => ({
+      ok: false,
+      error: {
+        code: "MODEL_NOT_READY",
+        message: "embedding should not be used in invalid payload guard test",
+      },
+    }),
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: IpcMain;
+  handlers: Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >;
+} {
+  const handlers = new Map<
+    string,
+    (event: unknown, payload: unknown, signal?: AbortSignal) => Promise<unknown>
+  >();
+
+  const ipcMain = {
+    handle: (channel: string, handler: unknown) => {
+      handlers.set(
+        channel,
+        handler as (event: unknown, payload: unknown) => Promise<unknown>,
+      );
+    },
+  };
+
+  return {
+    ipcMain: ipcMain as unknown as IpcMain,
+    handlers,
+  };
+}
+
+async function main(): Promise<void> {
+  const { ipcMain, handlers } = createIpcHarness();
+
+  registerRagIpcHandlers({
+    ipcMain,
+    db: createDbStub(),
+    logger: createLogger(),
+    embedding: createEmbeddingStub(),
+    ragRerank: { enabled: false },
+  } as unknown as Parameters<typeof registerRagIpcHandlers>[0]);
+
+  const configUpdateHandler = handlers.get("rag:config:update");
+  assert.ok(configUpdateHandler, "rag:config:update handler should be registered");
+
+  const invalidConfigPayloads: unknown[] = [null, 3, { model: 9 }, { topK: "2" }];
+  for (const payload of invalidConfigPayloads) {
+    const response = (await configUpdateHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+
+  const retrieveHandler = handlers.get("rag:context:retrieve");
+  assert.ok(retrieveHandler, "rag:context:retrieve handler should be registered");
+
+  const invalidRetrievePayloads: unknown[] = [
+    null,
+    1,
+    { projectId: 1, queryText: "query" },
+    { projectId: "project-1", queryText: 2 },
+    { projectId: "project-1", queryText: "query", model: 1 },
+  ];
+
+  for (const payload of invalidRetrievePayloads) {
+    const response = (await retrieveHandler?.({}, payload)) as {
+      ok: boolean;
+      error?: { code: string };
+    };
+    assert.equal(response.ok, false);
+    assert.equal(response.error?.code, "INVALID_ARGUMENT");
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
补齐 constraints/rag/embedding IPC 的 payload 运行时守卫，并补回归单测，防止非法 payload 导致主进程 TypeError。

## 改动列表
- commit 1: improve(main): 为 constraints IPC 增加 payload 运行时守卫
- commit 2: improve(main): 为 rag 与 embedding IPC 增加 payload 运行时守卫

## 为什么改
Renderer 侧入参在运行时可能不符合 TypeScript 静态类型，之前多个 IPC handler 会直接访问 payload 字段并调用 `trim`，遇到 `null`/数字/错类型对象会抛异常。此次统一加运行时校验并返回 `INVALID_ARGUMENT`，把崩溃路径收敛为可观测、可处理的错误响应。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（无新增 error，仓库既有 warning 保持不变）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
