### PR TITLE
improve(renderer): 编辑器错误处理闭环与崩溃兜底

### DIFF
--- a/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
@@ -31,6 +31,7 @@ import {
   EDITOR_DOCUMENT_CHARACTER_LIMIT,
   LARGE_PASTE_THRESHOLD_CHARS,
   chunkLargePasteText,
+  parseEditorContentJsonSafely,
   sanitizePastedHtml,
   shouldConfirmOverflowPaste,
   shouldWarnDocumentCapacity,
@@ -240,6 +241,13 @@ describe("EditorPane", () => {
     expect(shouldWarnDocumentCapacity(EDITOR_DOCUMENT_CHARACTER_LIMIT)).toBe(
       true,
     );
+  });
+
+  it("should fallback to empty doc when persisted content is invalid JSON", () => {
+    expect(parseEditorContentJsonSafely("{invalid")).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
   });
 
   it("S2-BA-1 should show Bubble Menu with inline actions when selection is non-empty", async () => {

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -44,6 +44,10 @@ const CAPACITY_WARNING_TEXT =
 const WRITE_CONTEXT_WINDOW = 240;
 const ENTITY_COMPLETION_LOOKBACK_CHARS = 96;
 const ENTITY_COMPLETION_TRIGGER = "@";
+const EMPTY_EDITOR_DOC: ReturnType<Editor["getJSON"]> = {
+  type: "doc",
+  content: [{ type: "paragraph" }],
+};
 
 type EntityListItem = IpcResponseData<"knowledge:entity:list">["items"][number];
 
@@ -197,6 +201,19 @@ function buildWriteInput(editor: Editor): string {
     return `Continue writing from cursor context:\n${fallback.slice(-WRITE_CONTEXT_WINDOW)}`;
   }
   return "Continue writing from cursor context:";
+}
+
+/**
+ * Parse persisted editor JSON with fail-safe fallback.
+ */
+export function parseEditorContentJsonSafely(
+  contentJson: string,
+): ReturnType<Editor["getJSON"]> {
+  try {
+    return JSON.parse(contentJson) as ReturnType<Editor["getJSON"]>;
+  } catch {
+    return EMPTY_EDITOR_DOC;
+  }
 }
 
 /**
@@ -498,7 +515,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
     try {
       setContentReady(false);
       suppressAutosaveRef.current = true;
-      editor.commands.setContent(JSON.parse(activeContentJson));
+      editor.commands.setContent(parseEditorContentJsonSafely(activeContentJson));
     } finally {
       window.setTimeout(() => {
         suppressAutosaveRef.current = false;

--- a/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
@@ -132,4 +132,28 @@ describe("editorSaveQueue", () => {
 
     expect(order).toEqual(["fail", "after-1", "after-2"]);
   });
+
+  it("should report unexpected save errors while keeping the queue alive", async () => {
+    const onUnexpectedError = vi.fn();
+
+    const queue = createEditorSaveQueue({
+      executeSave: async (request) => {
+        if (request.contentJson === "broken") {
+          throw new Error("unexpected");
+        }
+      },
+      onUnexpectedError,
+    });
+
+    const broken = queue.enqueue(makeRequest({ contentJson: "broken" }));
+    const next = queue.enqueue(makeRequest({ contentJson: "next" }));
+
+    await Promise.all([broken, next]);
+
+    expect(onUnexpectedError).toHaveBeenCalledTimes(1);
+    expect(onUnexpectedError).toHaveBeenCalledWith({
+      request: expect.objectContaining({ contentJson: "broken" }),
+      error: expect.any(Error),
+    });
+  });
 });

--- a/apps/desktop/renderer/src/stores/editorSaveQueue.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.ts
@@ -8,6 +8,10 @@ export type EditorSaveRequest = {
 
 export type EditorSaveQueueDeps = {
   executeSave: (request: EditorSaveRequest) => Promise<void>;
+  onUnexpectedError?: (args: {
+    request: EditorSaveRequest;
+    error: unknown;
+  }) => void;
 };
 
 export type EditorSaveQueue = {
@@ -36,8 +40,11 @@ export function createEditorSaveQueue(
 
         try {
           await deps.executeSave(current.request);
-        } catch {
-          // Keep queue alive after unexpected failures from one task.
+        } catch (error) {
+          deps.onUnexpectedError?.({
+            request: current.request,
+            error,
+          });
         }
 
         current.resolve();

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -126,6 +126,25 @@ function createInitialEntityCompletionSession(): EntityCompletionSession {
 export function createEditorStore(deps: { invoke: IpcInvoke }) {
   return create<EditorStore>((set, get) => {
     const saveQueue = createEditorSaveQueue({
+      onUnexpectedError: ({ request, error }) => {
+        const stillCurrent =
+          get().projectId === request.projectId &&
+          get().documentId === request.documentId;
+        if (!stillCurrent) {
+          return;
+        }
+
+        set({
+          autosaveStatus: "error",
+          autosaveError: {
+            code: "INTERNAL_ERROR",
+            message:
+              error instanceof Error
+                ? error.message
+                : "editor save queue failed unexpectedly",
+          },
+        });
+      },
       executeSave: async (request: EditorSaveRequest) => {
         const isCurrent =
           get().projectId === request.projectId &&

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -117,6 +117,31 @@ function createInitialEntityCompletionSession(): EntityCompletionSession {
   };
 }
 
+function createSaveQueueUnexpectedErrorHandler(deps: {
+  get: () => EditorStore;
+  set: (patch: Partial<EditorStore>) => void;
+}) {
+  return ({ request, error }: { request: EditorSaveRequest; error: unknown }) => {
+    const stillCurrent =
+      deps.get().projectId === request.projectId &&
+      deps.get().documentId === request.documentId;
+    if (!stillCurrent) {
+      return;
+    }
+
+    deps.set({
+      autosaveStatus: "error",
+      autosaveError: {
+        code: "INTERNAL_ERROR",
+        message:
+          error instanceof Error
+            ? error.message
+            : "editor save queue failed unexpectedly",
+      },
+    });
+  };
+}
+
 /**
  * Create a zustand store for editor/document state.
  *
@@ -126,25 +151,10 @@ function createInitialEntityCompletionSession(): EntityCompletionSession {
 export function createEditorStore(deps: { invoke: IpcInvoke }) {
   return create<EditorStore>((set, get) => {
     const saveQueue = createEditorSaveQueue({
-      onUnexpectedError: ({ request, error }) => {
-        const stillCurrent =
-          get().projectId === request.projectId &&
-          get().documentId === request.documentId;
-        if (!stillCurrent) {
-          return;
-        }
-
-        set({
-          autosaveStatus: "error",
-          autosaveError: {
-            code: "INTERNAL_ERROR",
-            message:
-              error instanceof Error
-                ? error.message
-                : "editor save queue failed unexpectedly",
-          },
-        });
-      },
+      onUnexpectedError: createSaveQueueUnexpectedErrorHandler({
+        get,
+        set: (patch) => set(patch),
+      }),
       executeSave: async (request: EditorSaveRequest) => {
         const isCurrent =
           get().projectId === request.projectId &&


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
补齐编辑器保存异常链路，并修复损坏文档内容导致的编辑器崩溃。

## 改动列表
- commit 1: 保存队列在执行保存任务异常时不再 silent failure，统一上报到 editorStore 并写入 autosaveError，同时补充队列异常回归测试
- commit 2: EditorPane 读取持久化内容时增加安全解析兜底，非法 JSON 自动回退为空文档，并补充对应单测

## 为什么改
这两个问题都属于高价值稳定性缺口：一个会吞掉保存异常导致用户感知不到失败，另一个会在坏数据场景直接触发编辑器初始化异常。补齐后可保证错误可见且界面可恢复。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库存在历史 warning，无新增 warning）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
