### PR TITLE
improve(main): 加固 version/skills/export IPC 入参守卫

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import type { IpcMain } from "electron";
+
+import type { Logger } from "../../logging/logger";
+import { registerExportIpcHandlers } from "../export";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createMockIpcMain(): {
+  ipcMain: IpcMain;
+  invoke: (channel: string, payload: unknown) => Promise<unknown>;
+} {
+  const handlers = new Map<string, Handler>();
+  return {
+    ipcMain: {
+      handle: (channel: string, listener: Handler) => {
+        handlers.set(channel, listener);
+      },
+    } as unknown as IpcMain,
+    invoke: async (channel: string, payload: unknown) => {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `expected handler ${channel}`);
+      return handler({}, payload);
+    },
+  };
+}
+
+function createLogger(): { logger: Logger; errors: string[] } {
+  const errors: string[] = [];
+  return {
+    errors,
+    logger: {
+      logPath: path.join(process.cwd(), "tmp.log"),
+      info: () => {},
+      error: (event) => {
+        errors.push(event);
+      },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const dbReadyHarness = createMockIpcMain();
+  const dbReadyLogger = createLogger();
+
+  registerExportIpcHandlers({
+    ipcMain: dbReadyHarness.ipcMain,
+    db: {} as never,
+    logger: dbReadyLogger.logger,
+    userDataDir: process.cwd(),
+  });
+
+  const invalidPayload = (await dbReadyHarness.invoke(
+    "export:document:markdown",
+    null,
+  )) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(invalidPayload.ok, false);
+  assert.equal(invalidPayload.error?.code, "INVALID_ARGUMENT");
+
+  const invalidDocumentId = (await dbReadyHarness.invoke(
+    "export:document:pdf",
+    { projectId: "p1", documentId: 42 },
+  )) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(invalidDocumentId.ok, false);
+  assert.equal(invalidDocumentId.error?.code, "INVALID_ARGUMENT");
+
+  const invalidBundlePayload = (await dbReadyHarness.invoke(
+    "export:project:bundle",
+    { projectId: 7 },
+  )) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(invalidBundlePayload.ok, false);
+  assert.equal(invalidBundlePayload.error?.code, "INVALID_ARGUMENT");
+
+  const dbMissingHarness = createMockIpcMain();
+  const dbMissingLogger = createLogger();
+
+  registerExportIpcHandlers({
+    ipcMain: dbMissingHarness.ipcMain,
+    db: null,
+    logger: dbMissingLogger.logger,
+    userDataDir: process.cwd(),
+  });
+
+  const dbMissing = (await dbMissingHarness.invoke("export:document:txt", {
+    projectId: 1,
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(dbMissing.ok, false);
+  assert.equal(dbMissing.error?.code, "DB_ERROR");
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/ipc/__tests__/skills-ipc-runtime-validation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/skills-ipc-runtime-validation.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+
+import { registerSkillIpcHandlers } from "../skills";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createHarness() {
+  const handlers = new Map<string, Handler>();
+
+  const ipcMain = {
+    handle: (channel: string, handler: Handler) => {
+      handlers.set(channel, handler);
+    },
+  } as unknown as IpcMain;
+
+  registerSkillIpcHandlers({
+    ipcMain,
+    db: {} as never,
+    userDataDir: "/tmp/user",
+    builtinSkillsDir: "/tmp/builtin",
+    logger: {
+      logPath: "<test>",
+      info: () => {},
+      error: () => {},
+    },
+  });
+
+  return handlers;
+}
+
+async function main(): Promise<void> {
+  const handlers = createHarness();
+
+  const listHandler = handlers.get("skill:registry:list");
+  assert.ok(listHandler, "skill:registry:list should be registered");
+  const listResponse = (await listHandler?.({}, undefined)) as {
+    ok: boolean;
+    error?: { code: string };
+  };
+  assert.equal(listResponse.ok, false);
+  assert.equal(listResponse.error?.code, "INVALID_ARGUMENT");
+
+  const readHandler = handlers.get("skill:registry:read");
+  assert.ok(readHandler, "skill:registry:read should be registered");
+  const readResponse = (await readHandler?.({}, null)) as {
+    ok: boolean;
+    error?: { code: string };
+  };
+  assert.equal(readResponse.ok, false);
+  assert.equal(readResponse.error?.code, "INVALID_ARGUMENT");
+
+  const toggleHandler = handlers.get("skill:registry:toggle");
+  assert.ok(toggleHandler, "skill:registry:toggle should be registered");
+  const toggleResponse = (await toggleHandler?.({}, { enabled: "yes" })) as {
+    ok: boolean;
+    error?: { code: string };
+  };
+  assert.equal(toggleResponse.ok, false);
+  assert.equal(toggleResponse.error?.code, "INVALID_ARGUMENT");
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/main/src/ipc/export.ts
+++ b/apps/desktop/main/src/ipc/export.ts
@@ -1,9 +1,73 @@
 import type { IpcMain } from "electron";
 import type Database from "better-sqlite3";
 
-import type { IpcResponse } from "@shared/types/ipc-generated";
+import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
 import { createExportService } from "../services/export/exportService";
+
+type ExportPayloadError = IpcError;
+
+type DocumentExportPayload = {
+  projectId: string;
+  documentId?: string;
+};
+
+function invalidPayload(message: string): ExportPayloadError {
+  return { code: "INVALID_ARGUMENT", message };
+}
+
+function parseDocumentExportPayload(payload: unknown):
+  | { ok: true; data: DocumentExportPayload }
+  | { ok: false; error: ExportPayloadError } {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: invalidPayload("payload must be an object") };
+  }
+
+  const projectId = (payload as { projectId?: unknown }).projectId;
+  if (typeof projectId !== "string") {
+    return { ok: false, error: invalidPayload("projectId must be a string") };
+  }
+
+  const documentId = (payload as { documentId?: unknown }).documentId;
+  if (documentId !== undefined && typeof documentId !== "string") {
+    return { ok: false, error: invalidPayload("documentId must be a string") };
+  }
+
+  return { ok: true, data: { projectId, documentId } };
+}
+
+function parseProjectBundlePayload(payload: unknown):
+  | { ok: true; data: { projectId: string } }
+  | { ok: false; error: ExportPayloadError } {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: invalidPayload("payload must be an object") };
+  }
+
+  const projectId = (payload as { projectId?: unknown }).projectId;
+  if (typeof projectId !== "string") {
+    return { ok: false, error: invalidPayload("projectId must be a string") };
+  }
+
+  return { ok: true, data: { projectId } };
+}
+
+function toUnexpectedExportError(error: unknown): ExportPayloadError {
+  return {
+    code: "INTERNAL_ERROR",
+    message:
+      error instanceof Error ? error.message : "Unexpected export IPC error",
+  };
+}
+
+function resolveExportResponse(
+  result:
+    | { ok: true; data: { relativePath: string; bytesWritten: number } }
+    | { ok: false; error: ExportPayloadError },
+): IpcResponse<{ relativePath: string; bytesWritten: number }> {
+  return result.ok
+    ? { ok: true, data: result.data }
+    : { ok: false, error: result.error };
+}
 
 /**
  * Register `export:*` IPC handlers.
@@ -17,11 +81,36 @@ export function registerExportIpcHandlers(deps: {
   logger: Logger;
   userDataDir: string;
 }): void {
+  const invokeDocumentExport = async (
+    channel: string,
+    payload: unknown,
+    run: (args: DocumentExportPayload) => Promise<
+      | { ok: true; data: { relativePath: string; bytesWritten: number } }
+      | { ok: false; error: ExportPayloadError }
+    >,
+  ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
+    const parsed = parseDocumentExportPayload(payload);
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error };
+    }
+
+    try {
+      const result = await run(parsed.data);
+      return resolveExportResponse(result);
+    } catch (error) {
+      deps.logger.error("ipc_export_unexpected_error", {
+        channel,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return { ok: false, error: toUnexpectedExportError(error) };
+    }
+  };
+
   deps.ipcMain.handle(
     "export:document:markdown",
     async (
       _e,
-      payload: { projectId: string; documentId?: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
       if (!deps.db) {
         return {
@@ -35,10 +124,11 @@ export function registerExportIpcHandlers(deps: {
         logger: deps.logger,
         userDataDir: deps.userDataDir,
       });
-      const res = await svc.exportMarkdown(payload);
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      return invokeDocumentExport(
+        "export:document:markdown",
+        payload,
+        async (args) => svc.exportMarkdown(args),
+      );
     },
   );
 
@@ -46,7 +136,7 @@ export function registerExportIpcHandlers(deps: {
     "export:document:pdf",
     async (
       _e,
-      payload: { projectId: string; documentId?: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
       if (!deps.db) {
         return {
@@ -59,10 +149,11 @@ export function registerExportIpcHandlers(deps: {
         logger: deps.logger,
         userDataDir: deps.userDataDir,
       });
-      const res = await svc.exportPdf(payload);
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      return invokeDocumentExport(
+        "export:document:pdf",
+        payload,
+        async (args) => svc.exportPdf(args),
+      );
     },
   );
 
@@ -70,7 +161,7 @@ export function registerExportIpcHandlers(deps: {
     "export:document:docx",
     async (
       _e,
-      payload: { projectId: string; documentId?: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
       if (!deps.db) {
         return {
@@ -83,10 +174,11 @@ export function registerExportIpcHandlers(deps: {
         logger: deps.logger,
         userDataDir: deps.userDataDir,
       });
-      const res = await svc.exportDocx(payload);
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      return invokeDocumentExport(
+        "export:document:docx",
+        payload,
+        async (args) => svc.exportDocx(args),
+      );
     },
   );
 
@@ -94,7 +186,7 @@ export function registerExportIpcHandlers(deps: {
     "export:document:txt",
     async (
       _e,
-      payload: { projectId: string; documentId?: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
       if (!deps.db) {
         return {
@@ -108,10 +200,11 @@ export function registerExportIpcHandlers(deps: {
         logger: deps.logger,
         userDataDir: deps.userDataDir,
       });
-      const res = await svc.exportTxt(payload);
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      return invokeDocumentExport(
+        "export:document:txt",
+        payload,
+        async (args) => svc.exportTxt(args),
+      );
     },
   );
 
@@ -119,7 +212,7 @@ export function registerExportIpcHandlers(deps: {
     "export:project:bundle",
     async (
       _e,
-      payload: { projectId: string },
+      payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
       if (!deps.db) {
         return {
@@ -128,15 +221,27 @@ export function registerExportIpcHandlers(deps: {
         };
       }
 
+      const parsed = parseProjectBundlePayload(payload);
+      if (!parsed.ok) {
+        return { ok: false, error: parsed.error };
+      }
+
       const svc = createExportService({
         db: deps.db,
         logger: deps.logger,
         userDataDir: deps.userDataDir,
       });
-      const res = await svc.exportProjectBundle(payload);
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+
+      try {
+        const result = await svc.exportProjectBundle(parsed.data);
+        return resolveExportResponse(result);
+      } catch (error) {
+        deps.logger.error("ipc_export_unexpected_error", {
+          channel: "export:project:bundle",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return { ok: false, error: toUnexpectedExportError(error) };
+      }
     },
   );
 }

--- a/apps/desktop/main/src/ipc/skills.ts
+++ b/apps/desktop/main/src/ipc/skills.ts
@@ -10,6 +10,20 @@ import {
 } from "../services/skills/skillService";
 import { createDbNotReadyError } from "./dbError";
 
+function createInvalidArgument(message: string) {
+  return {
+    ok: false as const,
+    error: {
+      code: "INVALID_ARGUMENT" as const,
+      message,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 /**
  * Register `skill:*` IPC handlers.
  *
@@ -35,6 +49,15 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
+      }
+      if (
+        "includeDisabled" in payload &&
+        typeof payload.includeDisabled !== "boolean"
+      ) {
+        return createInvalidArgument("includeDisabled must be a boolean");
       }
 
       const svc = createSkillService({
@@ -62,6 +85,12 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
+      }
+      if (typeof payload.id !== "string") {
+        return createInvalidArgument("id must be a string");
       }
 
       const svc = createSkillService({
@@ -96,6 +125,15 @@ export function registerSkillIpcHandlers(deps: {
           error: createDbNotReadyError(),
         };
       }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
+      }
+      if (typeof payload.id !== "string") {
+        return createInvalidArgument("id must be a string");
+      }
+      if (typeof payload.content !== "string") {
+        return createInvalidArgument("content must be a string");
+      }
 
       const svc = createSkillService({
         db: deps.db,
@@ -122,6 +160,22 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
+      }
+      if (typeof payload.enabled !== "boolean") {
+        return createInvalidArgument("enabled must be a boolean");
+      }
+      if ("id" in payload && payload.id !== undefined && typeof payload.id !== "string") {
+        return createInvalidArgument("id must be a string");
+      }
+      if (
+        "skillId" in payload &&
+        payload.skillId !== undefined &&
+        typeof payload.skillId !== "string"
+      ) {
+        return createInvalidArgument("skillId must be a string");
       }
 
       const svc = createSkillService({
@@ -168,6 +222,9 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
       }
 
       const svc = createSkillService({
@@ -218,6 +275,9 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
       }
 
       const svc = createSkillService({
@@ -284,6 +344,12 @@ export function registerSkillIpcHandlers(deps: {
           ok: false,
           error: createDbNotReadyError(),
         };
+      }
+      if (!isRecord(payload)) {
+        return createInvalidArgument("payload must be an object");
+      }
+      if (typeof payload.id !== "string") {
+        return createInvalidArgument("id must be a string");
       }
 
       const svc = createSkillService({

--- a/apps/desktop/main/src/ipc/version.ts
+++ b/apps/desktop/main/src/ipc/version.ts
@@ -58,6 +58,20 @@ function sleep(ms?: number): Promise<void> {
   });
 }
 
+function readNonEmptyStringField(
+  payload: unknown,
+  key: string,
+): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const value = (payload as Record<string, unknown>)[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  return value;
+}
+
 async function withTimeout<T>(
   run: () => Promise<T>,
   timeoutMs: number,
@@ -257,16 +271,7 @@ export function registerVersionIpcHandlers(deps: {
 
   deps.ipcMain.handle(
     "version:snapshot:create",
-    async (
-      _e,
-      payload: {
-        projectId: string;
-        documentId: string;
-        contentJson: string;
-        actor: VersionSnapshotActor;
-        reason: VersionSnapshotReason;
-      },
-    ): Promise<
+    async (_e, payload: unknown): Promise<
       IpcResponse<{
         versionId: string;
         contentHash: string;
@@ -281,10 +286,10 @@ export function registerVersionIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
-      ) {
+
+      const projectId = readNonEmptyStringField(payload, "projectId");
+      const documentId = readNonEmptyStringField(payload, "documentId");
+      if (!projectId || !documentId) {
         return {
           ok: false,
           error: {
@@ -294,9 +299,23 @@ export function registerVersionIpcHandlers(deps: {
         };
       }
 
+      const contentJson =
+        payload && typeof payload === "object"
+          ? (payload as { contentJson?: unknown }).contentJson
+          : undefined;
+      if (typeof contentJson !== "string") {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "contentJson must be valid JSON",
+          },
+        };
+      }
+
       let parsed: unknown;
       try {
-        parsed = JSON.parse(payload.contentJson);
+        parsed = JSON.parse(contentJson);
       } catch {
         return {
           ok: false,
@@ -307,13 +326,22 @@ export function registerVersionIpcHandlers(deps: {
         };
       }
 
+      const actor =
+        payload && typeof payload === "object"
+          ? (payload as { actor?: VersionSnapshotActor }).actor
+          : undefined;
+      const reason =
+        payload && typeof payload === "object"
+          ? (payload as { reason?: VersionSnapshotReason }).reason
+          : undefined;
+
       return coordinator.withSerializedDocument(
-        payload.documentId,
+        documentId,
         async () => {
           await sleep(deps.simulateLatencyMs?.snapshot);
           return withIoRetry({
             operation: "version:snapshot:create",
-            documentId: payload.documentId,
+            documentId,
             run: async (): Promise<
               IpcResponse<{
                 versionId: string;
@@ -325,18 +353,18 @@ export function registerVersionIpcHandlers(deps: {
             > => {
               const svc = createService();
               const saved = svc.save({
-                projectId: payload.projectId,
-                documentId: payload.documentId,
+                projectId,
+                documentId,
                 contentJson: parsed,
-                actor: payload.actor,
-                reason: payload.reason,
+                actor: actor as VersionSnapshotActor,
+                reason: reason as VersionSnapshotReason,
               });
               if (!saved.ok) {
                 return { ok: false, error: saved.error };
               }
 
               const listed = svc.listVersions({
-                documentId: payload.documentId,
+                documentId,
               });
               if (!listed.ok) {
                 return { ok: false, error: listed.error };

--- a/apps/desktop/tests/unit/version-hardening-boundary.ipc.test.ts
+++ b/apps/desktop/tests/unit/version-hardening-boundary.ipc.test.ts
@@ -458,6 +458,53 @@ async function testConcurrentRollbackConflict(): Promise<void> {
   db.close();
 }
 
+
+async function testSnapshotCreateRejectsNonStringIdsWithoutThrowing(): Promise<void> {
+  const db = createVersionDb();
+  const now = Date.now();
+  seedProjectAndDocument(db, {
+    projectId: "proj-invalid-payload",
+    documentId: "doc-invalid-payload",
+    text: "seed",
+    createdAt: now - 10_000,
+  });
+
+  const { ipcMain, handlers } = createIpcHarness();
+  registerVersionIpcHandlers({ ipcMain, db, logger: createNoopLogger() });
+
+  const createHandler = handlers.get("version:snapshot:create");
+  assert.ok(
+    createHandler,
+    "version:snapshot:create handler should be registered",
+  );
+  if (!createHandler) {
+    throw new Error("missing version:snapshot:create handler");
+  }
+
+  const res = (await createHandler(
+    {},
+    {
+      projectId: 1,
+      documentId: "doc-invalid-payload",
+      contentJson: toContentJson("payload"),
+      actor: "user",
+      reason: "manual-save",
+    },
+  )) as IpcResult<unknown>;
+
+  assert.equal(
+    res.ok,
+    false,
+    "snapshot create should map invalid payload to INVALID_ARGUMENT",
+  );
+  if (!res.ok) {
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+    assert.equal(res.error.message, "projectId/documentId is required");
+  }
+
+  db.close();
+}
+
 async function testSnapshotCreateIoRetry(): Promise<void> {
   const db = createVersionDb();
   const now = Date.now();
@@ -554,6 +601,10 @@ const checks: Array<{ name: string; run: () => Promise<void> }> = [
   {
     name: "snapshot create io retry",
     run: testSnapshotCreateIoRetry,
+  },
+  {
+    name: "snapshot create rejects non-string ids without throwing",
+    run: testSnapshotCreateRejectsNonStringIdsWithoutThrowing,
   },
 ];
 


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
加固 main 层 version/skills/export 三组 IPC 的 runtime payload 守卫，统一异常入参返回 INVALID_ARGUMENT，并补齐回归测试。

## 改动列表
- commit 1: improve(main): 修复 version 快照创建异常 payload 未映射异常
- commit 2: improve(main): 收紧 skills IPC 异常入参为显式参数错误
- commit 3: improve(main): 收紧 export IPC 异常入参并补回归测试

## 为什么改
这三组通道在异常 payload（非对象、字段类型错误）下会走到未映射异常路径，存在主进程抛错或错误码不稳定风险。统一做 runtime guard 后，边界输入可预测失败并维持 IPC 契约稳定性。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（无新增 error，仓库既有 warning 保持不变）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
