### PR TITLE
improve(shared): 修复UTF-8截断与本地存储异常兜底

### DIFF
--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   MAX_RECENT_COMMANDS,
@@ -34,5 +34,31 @@ describe("recentItems", () => {
     window.localStorage.setItem("creonow.commandPalette.recent", "{bad-json");
 
     expect(readRecentCommandIds()).toEqual([]);
+  });
+
+  it("should fail closed when localStorage is unavailable", () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("blocked", "SecurityError");
+      },
+    });
+
+    try {
+      expect(readRecentCommandIds()).toEqual([]);
+      expect(() => recordRecentCommandId("command-a")).not.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "COMMAND_PALETTE_STORAGE_UNAVAILABLE",
+        expect.any(DOMException),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      if (originalDescriptor) {
+        Object.defineProperty(window, "localStorage", originalDescriptor);
+      }
+    }
   });
 });

--- a/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
+++ b/apps/desktop/renderer/src/features/commandPalette/recentItems.ts
@@ -9,7 +9,12 @@ function resolveStorage(provided?: Storage): Storage | null {
   if (typeof window === "undefined") {
     return null;
   }
-  return window.localStorage;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.error("COMMAND_PALETTE_STORAGE_UNAVAILABLE", error);
+    return null;
+  }
 }
 
 /**

--- a/apps/desktop/tests/unit/token-budget-utf8-trim-boundary.spec.ts
+++ b/apps/desktop/tests/unit/token-budget-utf8-trim-boundary.spec.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+
+import { trimUtf8ToTokenBudget } from "@shared/tokenBudget";
+
+{
+  const trimmed = trimUtf8ToTokenBudget("😀", 0.75);
+  assert.equal(trimmed, "");
+  assert.equal(trimmed.includes("\uFFFD"), false);
+}
+
+{
+  const trimmed = trimUtf8ToTokenBudget("a😀b", 1);
+  assert.equal(trimmed, "a");
+  assert.equal(trimmed.includes("\uFFFD"), false);
+}
+
+{
+  const trimmed = trimUtf8ToTokenBudget("a😀b", 1.25);
+  assert.equal(trimmed, "a😀");
+}

--- a/packages/shared/tokenBudget.ts
+++ b/packages/shared/tokenBudget.ts
@@ -1,5 +1,52 @@
 const UTF8_BYTES_PER_TOKEN = 4;
 
+function isContinuationByte(byte: number): boolean {
+  return (byte & 0b1100_0000) === 0b1000_0000;
+}
+
+function utf8SequenceLength(leadByte: number): number {
+  if ((leadByte & 0b1000_0000) === 0) {
+    return 1;
+  }
+  if ((leadByte & 0b1110_0000) === 0b1100_0000) {
+    return 2;
+  }
+  if ((leadByte & 0b1111_0000) === 0b1110_0000) {
+    return 3;
+  }
+  if ((leadByte & 0b1111_1000) === 0b1111_0000) {
+    return 4;
+  }
+  return 0;
+}
+
+function alignUtf8Boundary(bytes: Uint8Array, endExclusive: number): number {
+  if (endExclusive <= 0 || endExclusive > bytes.length) {
+    return 0;
+  }
+
+  let leadIndex = endExclusive - 1;
+  while (leadIndex >= 0 && isContinuationByte(bytes[leadIndex] ?? 0)) {
+    leadIndex -= 1;
+  }
+
+  if (leadIndex < 0) {
+    return 0;
+  }
+
+  const expectedLength = utf8SequenceLength(bytes[leadIndex] ?? 0);
+  if (expectedLength === 0) {
+    return leadIndex;
+  }
+
+  const availableLength = endExclusive - leadIndex;
+  if (availableLength < expectedLength) {
+    return leadIndex;
+  }
+
+  return endExclusive;
+}
+
 /**
  * Convert token budget into a byte limit using the shared UTF-8 estimator.
  *
@@ -38,5 +85,6 @@ export function trimUtf8ToTokenBudget(
     return text;
   }
 
-  return new TextDecoder().decode(encoded.slice(0, maxBytes));
+  const safeEnd = alignUtf8Boundary(encoded, maxBytes);
+  return new TextDecoder().decode(encoded.slice(0, safeEnd));
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复共享 UTF-8 截断边界 bug，并补齐命令面板 recent storage 在受限环境下的错误处理闭环。

## 改动列表
- commit 1: improve(shared): 修复UTF-8截断边界并补本地存储异常兜底测试

## 为什么改
`trimUtf8ToTokenBudget` 在字节边界切到多字节字符中间时会产生替代字符，导致文本被污染；同时 command palette 读取 `window.localStorage` 在安全受限环境可能直接抛异常，现有逻辑未兜底。该批改动让两处都 fail-closed，并用回归测试固化边界行为。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库现存 warnings 无新增）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
