### PR TITLE
improve(renderer): 偏好迁移存储异常兜底与回归测试

### DIFF
--- a/apps/desktop/renderer/src/lib/preferences.test.ts
+++ b/apps/desktop/renderer/src/lib/preferences.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPreferenceStore } from "./preferences";
+
+type StoreRecord = Record<string, string>;
+
+function createMockStorage(
+  seed: StoreRecord = {},
+  overrides: {
+    getItem?: (key: string) => string | null;
+    setItem?: (key: string, value: string) => void;
+    removeItem?: (key: string) => void;
+  } = {},
+): Storage {
+  const store: StoreRecord = { ...seed };
+
+  const defaultGetItem = (key: string) => store[key] ?? null;
+  const defaultSetItem = (key: string, value: string) => {
+    store[key] = value;
+  };
+  const defaultRemoveItem = (key: string) => {
+    delete store[key];
+  };
+
+  return {
+    getItem: (key: string) => (overrides.getItem ?? defaultGetItem)(key),
+    setItem: (key: string, value: string) => (overrides.setItem ?? defaultSetItem)(key, value),
+    removeItem: (key: string) => (overrides.removeItem ?? defaultRemoveItem)(key),
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
+describe("createPreferenceStore", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("迁移写入版本失败时不应抛出异常", () => {
+    const migrationError = new Error("quota exceeded");
+    const storage = createMockStorage({}, {
+      setItem: (key, value) => {
+        if (key === "creonow.version") {
+          throw migrationError;
+        }
+        void value;
+      },
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(() => createPreferenceStore(storage)).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledWith("PreferenceStore.migrate failed", {
+      error: migrationError,
+    });
+  });
+
+  it("迁移时只清理 creonow 键并写入最新版本", () => {
+    const storage = createMockStorage({
+      "creonow.version": '"0"',
+      "creonow.layout.sidebarWidth": "320",
+      "other.app.key": "keep",
+    });
+
+    createPreferenceStore(storage);
+
+    expect(storage.getItem("creonow.layout.sidebarWidth")).toBeNull();
+    expect(storage.getItem("other.app.key")).toBe("keep");
+    expect(storage.getItem("creonow.version")).toBe("1");
+  });
+});

--- a/apps/desktop/renderer/src/lib/preferences.ts
+++ b/apps/desktop/renderer/src/lib/preferences.ts
@@ -87,10 +87,14 @@ export function createPreferenceStore(storage: Storage): PreferenceStore {
 
   function migrate(): void {
     const versionKey = `${APP_ID}.version` as const;
-    const storedVersion = parseVersion(storage.getItem(versionKey));
-    if (storedVersion !== CURRENT_VERSION) {
-      clearCreonowKeys();
-      storage.setItem(versionKey, CURRENT_VERSION);
+    try {
+      const storedVersion = parseVersion(storage.getItem(versionKey));
+      if (storedVersion !== CURRENT_VERSION) {
+        clearCreonowKeys();
+        storage.setItem(versionKey, CURRENT_VERSION);
+      }
+    } catch (error) {
+      console.error("PreferenceStore.migrate failed", { error });
     }
   }
 


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复偏好存储迁移在 localStorage 写入失败时可能导致初始化崩溃的问题，并补齐回归测试。

## 改动列表
- commit 1: 为 `createPreferenceStore` 的 `migrate()` 增加异常兜底与显式错误日志，避免存储异常导致 renderer 初始化中断
- commit 1: 新增 `preferences.test.ts`，覆盖迁移写入失败不崩溃与迁移仅清理 creonow 命名空间键两个关键场景

## 为什么改
在受限存储环境（配额耗尽/隐私模式）下，迁移阶段 `storage.setItem` 可能抛错；此前该异常会直接冒泡，导致应用启动链路不稳定。此次改动把该失败纳入可观测错误链路，并用测试锁定预期行为，降低真实环境启动失败风险。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（项目存在历史 warning，无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
