### PR TITLE
improve(main): 收紧项目访问守卫并补齐 KG 存储兜底

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts
@@ -108,3 +108,29 @@ function createEvent(webContentsId: number): { sender: { id: number } } {
   assert.equal(knowledgeDenied.ok, false);
   assert.equal(knowledgeDenied.error?.code, "FORBIDDEN");
 }
+
+// Scenario: project-scoped payloads are fail-closed when renderer session is not bound
+{
+  const binding = createProjectSessionBindingRegistry();
+  const logger = createLogger();
+
+  const memoryHarness = createIpcHarness();
+  registerMemoryIpcHandlers({
+    ipcMain: memoryHarness.ipcMain,
+    db: null,
+    logger,
+    projectSessionBinding: binding,
+  });
+
+  const memoryList = memoryHarness.handlers.get("memory:entry:list");
+  assert.ok(memoryList, "expected memory:entry:list handler");
+
+  const unboundDenied = (await memoryList!(createEvent(88), {
+    projectId: "project-rogue",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+  assert.equal(unboundDenied.ok, false);
+  assert.equal(unboundDenied.error?.code, "FORBIDDEN");
+}

--- a/apps/desktop/main/src/ipc/projectAccessGuard.ts
+++ b/apps/desktop/main/src/ipc/projectAccessGuard.ts
@@ -50,7 +50,16 @@ export function guardAndNormalizeProjectAccess(args: {
     webContentsId,
   });
   if (!boundProjectId) {
-    return { ok: true };
+    return {
+      ok: false,
+      response: {
+        ok: false,
+        error: {
+          code: "FORBIDDEN",
+          message: "renderer session is not bound to an active project",
+        },
+      },
+    };
   }
 
   const requestedProjectId =

--- a/apps/desktop/renderer/src/features/kg/kgViewPreferences.test.ts
+++ b/apps/desktop/renderer/src/features/kg/kgViewPreferences.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadKgViewPreferences,
+  saveKgViewPreferences,
+  type KgViewPreferences,
+} from "./kgViewPreferences";
+
+const projectId = "project-1";
+
+const DEFAULT_PREFERENCES: KgViewPreferences = {
+  graphTransform: {
+    scale: 1,
+    translateX: 0,
+    translateY: 0,
+  },
+  timelineOrder: [],
+  lastDraggedNodeId: null,
+};
+
+describe("kgViewPreferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns default preferences when localStorage.getItem throws", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    expect(loadKgViewPreferences(projectId)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("keeps current preferences when localStorage.setItem throws", () => {
+    const stored: KgViewPreferences = {
+      graphTransform: {
+        scale: 1.25,
+        translateX: 12,
+        translateY: -4,
+      },
+      timelineOrder: ["node-a"],
+      lastDraggedNodeId: "node-a",
+    };
+
+    window.localStorage.setItem(
+      `creonow.kg.view.${projectId}`,
+      JSON.stringify(stored),
+    );
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    const result = saveKgViewPreferences(projectId, {
+      graphTransform: { scale: 2, translateX: 99, translateY: 99 },
+    });
+
+    expect(result).toEqual(stored);
+    expect(loadKgViewPreferences(projectId)).toEqual(stored);
+  });
+});

--- a/apps/desktop/renderer/src/features/kg/kgViewPreferences.ts
+++ b/apps/desktop/renderer/src/features/kg/kgViewPreferences.ts
@@ -34,7 +34,13 @@ export function loadKgViewPreferences(projectId: string): KgViewPreferences {
     return DEFAULT_PREFERENCES;
   }
 
-  const raw = window.localStorage.getItem(storageKey(projectId));
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(storageKey(projectId));
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+
   if (!raw) {
     return DEFAULT_PREFERENCES;
   }
@@ -79,7 +85,11 @@ export function saveKgViewPreferences(
   };
 
   if (canUseStorage()) {
-    window.localStorage.setItem(storageKey(projectId), JSON.stringify(next));
+    try {
+      window.localStorage.setItem(storageKey(projectId), JSON.stringify(next));
+    } catch {
+      return current;
+    }
   }
 
   return next;


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
收紧项目访问守卫与 KG 视图偏好存储异常兜底，补齐对应回归测试。

## 改动列表
- commit 1: 收紧 project session 未绑定时的项目级 IPC 访问策略，`projectId` 入参改为 fail-closed（FORBIDDEN）
- commit 2: 加固 KG 视图偏好读写的 localStorage 异常处理，避免 `getItem/setItem` 抛错导致页面异常或状态错写

## 为什么改
当前项目级 IPC 在 renderer 尚未绑定项目会话时对 `projectId` 存在放行窗口，存在越权风险；同时 KG 偏好读写对浏览器存储异常缺少兜底，可能引发用户可见异常。本次改动统一收敛为显式拒绝/安全回退，并用回归测试固化边界行为。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（无新增 error，保留仓库既有 warning 基线）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
