### PR TITLE
improve(main): 运行时容错与存储边界修复

### DIFF
--- a/apps/desktop/main/src/__tests__/unit/token-budget-utf8-boundary.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/token-budget-utf8-boundary.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+
+import { trimUtf8ToTokenBudget } from "@shared/tokenBudget";
+
+const splitEmojiInput = "ab🙂cd";
+const splitEmojiTrimmed = trimUtf8ToTokenBudget(splitEmojiInput, 1);
+assert.equal(
+  splitEmojiTrimmed,
+  "ab",
+  "trimUtf8ToTokenBudget should drop incomplete UTF-8 tail instead of injecting replacement char",
+);
+assert.equal(
+  splitEmojiTrimmed.includes("\uFFFD"),
+  false,
+  "trimUtf8ToTokenBudget should never emit replacement char for valid input",
+);
+
+const exactEmojiBoundary = trimUtf8ToTokenBudget("🙂a", 1);
+assert.equal(
+  exactEmojiBoundary,
+  "🙂",
+  "trimUtf8ToTokenBudget should preserve a complete multibyte character at byte boundary",
+);
+
+console.log("token-budget-utf8-boundary.test.ts: all assertions passed");

--- a/apps/desktop/main/src/ipc/runtime-validation.ts
+++ b/apps/desktop/main/src/ipc/runtime-validation.ts
@@ -371,15 +371,17 @@ function sanitizeErrorEnvelope(rawError: IpcError): IpcError {
     code: rawError.code,
     message: rawError.message,
   };
+
   if ("details" in rawError) {
     sanitized.details = rawError.details;
   }
-  if ("retryable" in rawError) {
+  if (typeof rawError.retryable === "boolean") {
     sanitized.retryable = rawError.retryable;
   }
-  if ("traceId" in rawError) {
+  if (typeof rawError.traceId === "string") {
     sanitized.traceId = rawError.traceId;
   }
+
   return sanitized;
 }
 

--- a/apps/desktop/renderer/src/stores/templateStore.test.ts
+++ b/apps/desktop/renderer/src/stores/templateStore.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { STORAGE_KEY, useTemplateStore } from "./templateStore";
+
+const validTemplate = {
+  id: "custom-valid",
+  name: "Valid",
+  type: "custom" as const,
+  structure: {
+    folders: ["chapters"],
+    files: [{ path: "chapters/ch1.md", content: "# Ch1" }],
+  },
+  createdAt: 1,
+};
+
+describe("templateStore", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTemplateStore.setState({
+      customs: [],
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("loads only valid custom templates and repairs corrupted storage", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        validTemplate,
+        {
+          id: "broken",
+          type: "custom",
+          structure: { folders: [], files: [] },
+        },
+      ]),
+    );
+
+    await useTemplateStore.getState().loadTemplates();
+
+    const customs = useTemplateStore.getState().customs;
+    expect(customs).toHaveLength(1);
+    expect(customs[0]?.id).toBe("custom-valid");
+
+    const repaired = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]") as unknown[];
+    expect(repaired).toHaveLength(1);
+  });
+
+  it("clears malformed JSON from storage instead of keeping broken state", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "{bad-json");
+
+    await useTemplateStore.getState().loadTemplates();
+
+    expect(useTemplateStore.getState().customs).toEqual([]);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/desktop/renderer/src/stores/templateStore.ts
+++ b/apps/desktop/renderer/src/stores/templateStore.ts
@@ -140,7 +140,53 @@ function generateTemplateId(): string {
 /**
  * Storage key for persisting custom templates
  */
-const STORAGE_KEY = "creonow.templates.customs";
+export const STORAGE_KEY = "creonow.templates.customs";
+
+function isTemplateStructure(value: unknown): value is TemplateStructure {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<TemplateStructure>;
+  const { folders, files } = candidate;
+
+  if (!Array.isArray(folders) || !folders.every((folder) => typeof folder === "string")) {
+    return false;
+  }
+
+  if (!Array.isArray(files)) {
+    return false;
+  }
+
+  return files.every((file) => {
+    if (typeof file !== "object" || file === null) {
+      return false;
+    }
+    const candidateFile = file as { path?: unknown; content?: unknown };
+    return (
+      typeof candidateFile.path === "string" &&
+      (candidateFile.content === undefined || typeof candidateFile.content === "string")
+    );
+  });
+}
+
+function isCustomTemplate(value: unknown): value is ProjectTemplate {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<ProjectTemplate>;
+
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.name === "string" &&
+    candidate.type === "custom" &&
+    isTemplateStructure(candidate.structure) &&
+    (candidate.icon === undefined || typeof candidate.icon === "string") &&
+    (candidate.description === undefined || typeof candidate.description === "string") &&
+    (candidate.createdAt === undefined || typeof candidate.createdAt === "number")
+  );
+}
 
 /**
  * Load custom templates from localStorage
@@ -149,9 +195,25 @@ function loadCustomTemplatesFromStorage(): ProjectTemplate[] {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return [];
-    return JSON.parse(stored) as ProjectTemplate[];
-  } catch {
-    console.error("Failed to load custom templates from storage");
+
+    const parsed = JSON.parse(stored) as unknown;
+    if (!Array.isArray(parsed)) {
+      localStorage.removeItem(STORAGE_KEY);
+      return [];
+    }
+
+    const customs = parsed.filter(isCustomTemplate);
+    if (customs.length !== parsed.length) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(customs));
+    }
+
+    return customs;
+  } catch (error) {
+    console.error("Failed to load custom templates from storage", {
+      storageKey: STORAGE_KEY,
+      error,
+    });
+    localStorage.removeItem(STORAGE_KEY);
     return [];
   }
 }
@@ -162,8 +224,11 @@ function loadCustomTemplatesFromStorage(): ProjectTemplate[] {
 function saveCustomTemplatesToStorage(templates: ProjectTemplate[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
-  } catch {
-    console.error("Failed to save custom templates to storage");
+  } catch (error) {
+    console.error("Failed to save custom templates to storage", {
+      storageKey: STORAGE_KEY,
+      error,
+    });
   }
 }
 

--- a/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
+++ b/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
@@ -168,3 +168,37 @@ async function invokeWrapped(
   assert.equal(res.error.code, "IPC_TIMEOUT");
   assert.equal(cleaned, true);
 }
+
+// S6: 非法错误字段类型会被清洗，避免错误映射漂移 [ADDED]
+{
+  const logger = createTestLogger();
+
+  const wrapped = wrapIpcRequestResponse({
+    channel: "test:error:sanitize-optional-fields",
+    requestSchema: s.object({}),
+    responseSchema: s.object({ ok: s.literal(true) }),
+    logger,
+    timeoutMs: 30_000,
+    handler: async () =>
+      ({
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "missing",
+          traceId: 123,
+          retryable: "yes",
+          details: { source: "test" },
+        },
+      }) as unknown as IpcResponse<unknown>,
+  });
+
+  const res = await invokeWrapped(wrapped, {});
+  assert.equal(res.ok, false);
+  if (res.ok) {
+    assert.fail("expected error envelope");
+  }
+  assert.equal(res.error.code, "NOT_FOUND");
+  assert.equal("traceId" in res.error, false);
+  assert.equal("retryable" in res.error, false);
+  assert.deepEqual(res.error.details, { source: "test" });
+}

--- a/packages/shared/tokenBudget.ts
+++ b/packages/shared/tokenBudget.ts
@@ -1,4 +1,5 @@
 const UTF8_BYTES_PER_TOKEN = 4;
+const UTF8_FATAL_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 /**
  * Convert token budget into a byte limit using the shared UTF-8 estimator.
@@ -38,5 +39,13 @@ export function trimUtf8ToTokenBudget(
     return text;
   }
 
-  return new TextDecoder().decode(encoded.slice(0, maxBytes));
+  for (let end = maxBytes; end > 0; end -= 1) {
+    try {
+      return UTF8_FATAL_DECODER.decode(encoded.slice(0, end));
+    } catch {
+      continue;
+    }
+  }
+
+  return "";
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复三处高价值边界问题：IPC 错误包清洗、UTF-8 截断边界、模板存储损坏数据恢复。

## 改动列表
- commit 1: improve(main): 修正IPC错误可选字段类型清洗
- commit 2: improve(shared): 修复 UTF-8 截断边界并补回归测试
- commit 3: improve(renderer): 加固模板存储损坏数据容错

## 为什么改
这三处都属于线上易触发但难排查的稳定性问题：错误字段类型漂移会污染调用方判断；UTF-8 截断落在多字节中间会产生替换字符；本地模板存储被污染后会导致加载状态异常。统一补齐防护和回归测试后，能显著降低异常输入导致的不可预期行为。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库既有 warnings 未新增 errors）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
