### PR TITLE
improve(main): 强化运行时异常防护并补关键回归测试

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/window-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/window-ipc.test.ts
@@ -27,13 +27,19 @@ function createHarness(args?: {
   platform?: NodeJS.Platform;
   hasWindow?: boolean;
   initiallyMaximized?: boolean;
+  throwOnIsMaximized?: boolean;
 }): Harness {
   const handlers = new Map<string, Handler>();
   const calls: string[] = [];
   const maximizeState = { value: args?.initiallyMaximized ?? false };
 
   const win: FakeWindow = {
-    isMaximized: () => maximizeState.value,
+    isMaximized: () => {
+      if (args?.throwOnIsMaximized) {
+        throw new Error("window_state_unavailable");
+      }
+      return maximizeState.value;
+    },
     isMinimized: () => false,
     isFullScreen: () => false,
     minimize: () => {
@@ -185,6 +191,34 @@ async function main(): Promise<void> {
       assert.equal(response.error?.code, "NOT_FOUND");
     },
   );
+  await runScenario(
+    "W5 should map unexpected window runtime errors to INTERNAL response",
+    async () => {
+      const harness = createHarness({
+        platform: "win32",
+        throwOnIsMaximized: true,
+      });
+
+      const getStateResponse = await harness.invoke<{
+        ok: boolean;
+        error?: { code: string; message: string };
+      }>("app:window:getstate");
+
+      assert.equal(getStateResponse.ok, false);
+      assert.equal(getStateResponse.error?.code, "INTERNAL");
+      assert.equal(getStateResponse.error?.message, "window_state_unavailable");
+
+      const toggleResponse = await harness.invoke<{
+        ok: boolean;
+        error?: { code: string; message: string };
+      }>("app:window:togglemaximized");
+
+      assert.equal(toggleResponse.ok, false);
+      assert.equal(toggleResponse.error?.code, "INTERNAL");
+      assert.equal(toggleResponse.error?.message, "window_state_unavailable");
+    },
+  );
+
 }
 
 void main().catch((error) => {

--- a/apps/desktop/main/src/ipc/window.ts
+++ b/apps/desktop/main/src/ipc/window.ts
@@ -27,6 +27,10 @@ function toError(code: IpcError["code"], message: string): IpcResponse<never> {
   };
 }
 
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function isWindowControlsEnabled(platform: NodeJS.Platform): boolean {
   return platform === "win32";
 }
@@ -80,53 +84,69 @@ export function registerWindowIpcHandlers(args: {
   args.ipcMain.handle(
     "app:window:getstate",
     async (event): Promise<IpcResponse<WindowState>> => {
-      const win = controlsEnabled ? resolveWindow(event) : null;
-      return {
-        ok: true,
-        data: buildState(win),
-      };
+      try {
+        const win = controlsEnabled ? resolveWindow(event) : null;
+        return {
+          ok: true,
+          data: buildState(win),
+        };
+      } catch (error) {
+        return toError("INTERNAL", toErrorMessage(error));
+      }
     },
   );
 
   args.ipcMain.handle(
     "app:window:minimize",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
+      try {
+        const resolved = resolveSupportedWindow(event);
+        if (!resolved.ok) {
+          return resolved;
+        }
+        resolved.data.minimize();
+        return { ok: true, data: {} };
+      } catch (error) {
+        return toError("INTERNAL", toErrorMessage(error));
       }
-      resolved.data.minimize();
-      return { ok: true, data: {} };
     },
   );
 
   args.ipcMain.handle(
     "app:window:togglemaximized",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
-      }
+      try {
+        const resolved = resolveSupportedWindow(event);
+        if (!resolved.ok) {
+          return resolved;
+        }
 
-      if (resolved.data.isMaximized()) {
-        resolved.data.unmaximize();
-      } else {
-        resolved.data.maximize();
-      }
+        if (resolved.data.isMaximized()) {
+          resolved.data.unmaximize();
+        } else {
+          resolved.data.maximize();
+        }
 
-      return { ok: true, data: {} };
+        return { ok: true, data: {} };
+      } catch (error) {
+        return toError("INTERNAL", toErrorMessage(error));
+      }
     },
   );
 
   args.ipcMain.handle(
     "app:window:close",
     async (event): Promise<IpcResponse<Record<string, never>>> => {
-      const resolved = resolveSupportedWindow(event);
-      if (!resolved.ok) {
-        return resolved;
+      try {
+        const resolved = resolveSupportedWindow(event);
+        if (!resolved.ok) {
+          return resolved;
+        }
+        resolved.data.close();
+        return { ok: true, data: {} };
+      } catch (error) {
+        return toError("INTERNAL", toErrorMessage(error));
       }
-      resolved.data.close();
-      return { ok: true, data: {} };
     },
   );
 }

--- a/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   act,
 } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   IpcChannel,
   IpcInvokeResult,
@@ -156,6 +156,42 @@ async function waitForEditorInstance(
 }
 
 describe("EditorPane", () => {
+  it("should fallback to empty document when activeContentJson is invalid JSON", async () => {
+    const store = createReadyEditorStore({
+      onSave: () => undefined,
+    });
+    const versionStore = createVersionStoreForEditorPaneTests();
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    store.setState({
+      documentContentJson: "{bad-json",
+    });
+
+    render(
+      <VersionStoreProvider store={versionStore}>
+        <EditorStoreProvider store={store}>
+          <EditorPane projectId="project-1" />
+        </EditorStoreProvider>
+      </VersionStoreProvider>,
+    );
+
+    await screen.findByTestId("editor-pane");
+    await screen.findByTestId("tiptap-editor");
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "EditorPane document JSON parse failed",
+        expect.objectContaining({
+          documentId: "doc-1",
+        }),
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it("should trigger manual save with actor=user reason=manual-save on Ctrl/Cmd+S", async () => {
     const saveCalls: Array<{ actor: string; reason: string }> = [];
     const store = createReadyEditorStore({

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -44,6 +44,7 @@ const CAPACITY_WARNING_TEXT =
 const WRITE_CONTEXT_WINDOW = 240;
 const ENTITY_COMPLETION_LOOKBACK_CHARS = 96;
 const ENTITY_COMPLETION_TRIGGER = "@";
+const EMPTY_EDITOR_DOCUMENT = { type: "doc", content: [{ type: "paragraph" }] };
 
 type EntityListItem = IpcResponseData<"knowledge:entity:list">["items"][number];
 
@@ -468,7 +469,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
         class: "h-full outline-none p-4 text-[var(--color-fg-default)]",
       },
     },
-    content: { type: "doc", content: [{ type: "paragraph" }] },
+    content: EMPTY_EDITOR_DOCUMENT,
   });
 
   React.useEffect(() => {
@@ -498,7 +499,16 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
     try {
       setContentReady(false);
       suppressAutosaveRef.current = true;
-      editor.commands.setContent(JSON.parse(activeContentJson));
+      const parsedContent = JSON.parse(activeContentJson) as Parameters<
+        Editor["commands"]["setContent"]
+      >[0];
+      editor.commands.setContent(parsedContent);
+    } catch (error) {
+      console.error("EditorPane document JSON parse failed", {
+        documentId,
+        error,
+      });
+      editor.commands.setContent(EMPTY_EDITOR_DOCUMENT);
     } finally {
       window.setTimeout(() => {
         suppressAutosaveRef.current = false;

--- a/apps/desktop/tests/unit/token-budget-invalid-input.spec.ts
+++ b/apps/desktop/tests/unit/token-budget-invalid-input.spec.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+
+import {
+  tokenBudgetToUtf8ByteLimit,
+  trimUtf8ToTokenBudget,
+} from "@shared/tokenBudget";
+
+// Scenario Mapping: AUD-M3-S4 Edge Case (NaN budget should not create accidental empty output) [ADDED]
+{
+  const text = "hello";
+  assert.equal(tokenBudgetToUtf8ByteLimit(Number.NaN), 0);
+  assert.equal(trimUtf8ToTokenBudget(text, Number.NaN), "");
+}
+
+// Scenario Mapping: AUD-M3-S5 Core Path (Infinity budget keeps text unchanged) [ADDED]
+{
+  const text = "你好，world";
+  assert.equal(tokenBudgetToUtf8ByteLimit(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY);
+  assert.equal(trimUtf8ToTokenBudget(text, Number.POSITIVE_INFINITY), text);
+}

--- a/packages/shared/tokenBudget.ts
+++ b/packages/shared/tokenBudget.ts
@@ -6,7 +6,11 @@ const UTF8_BYTES_PER_TOKEN = 4;
  * Why: token budget math must stay identical across renderer/main/test paths.
  */
 export function tokenBudgetToUtf8ByteLimit(tokenBudget: number): number {
-  return Math.max(0, Math.floor(tokenBudget * UTF8_BYTES_PER_TOKEN));
+  const byteLimit = Math.floor(tokenBudget * UTF8_BYTES_PER_TOKEN);
+  if (Number.isNaN(byteLimit)) {
+    return 0;
+  }
+  return Math.max(0, byteLimit);
 }
 
 /**


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复主进程与渲染层的运行时异常边界，并补齐共享预算工具的异常输入回归测试。

## 改动列表
- commit 1: improve(main): 修复窗口IPC运行时异常映射并补回归测试
- commit 2: improve(renderer): 修复编辑器JSON解析失败崩溃并补回归测试
- commit 3: improve(shared): 修复NaN token预算边界并补单测

## 为什么改
当前存在异常输入/运行时异常导致的潜在崩溃或错误响应缺口，这些问题直接影响稳定性与可恢复性；本次统一补上错误映射与回归测试，降低线上不可控失败风险。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库现存 warnings 无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
