### PR TITLE
improve(main): 修复UTF-8截断边界与SSE CRLF流解析

### DIFF
--- a/apps/desktop/main/src/__tests__/unit/ai-service-sse-crlf.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/ai-service-sse-crlf.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+
+import type { Logger } from "../../logging/logger";
+import type {
+  AiStreamDoneEvent,
+  AiStreamEvent,
+  AiStreamChunkEvent,
+} from "@shared/types/ai";
+import { createAiService } from "../../services/ai/aiService";
+
+type LogEntry = {
+  event: string;
+  data: Record<string, unknown> | undefined;
+};
+
+function createDoneWaiter(): {
+  setExecutionId: (executionId: string) => void;
+  onEvent: (event: AiStreamEvent) => void;
+  getChunks: () => string[];
+  promise: Promise<AiStreamDoneEvent>;
+} {
+  let expectedExecutionId: string | null = null;
+  let bufferedDone: AiStreamDoneEvent | null = null;
+  const chunkEvents: AiStreamChunkEvent[] = [];
+  let resolvePromise: (event: AiStreamDoneEvent) => void = () => undefined;
+
+  const promise = new Promise<AiStreamDoneEvent>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  const maybeResolve = () => {
+    if (!expectedExecutionId || !bufferedDone) {
+      return;
+    }
+    if (bufferedDone.executionId !== expectedExecutionId) {
+      return;
+    }
+    resolvePromise(bufferedDone);
+  };
+
+  return {
+    promise,
+    setExecutionId: (executionId) => {
+      expectedExecutionId = executionId;
+      maybeResolve();
+    },
+    onEvent: (event) => {
+      if (event.type === "chunk") {
+        chunkEvents.push(event);
+        return;
+      }
+      if (event.type !== "done") {
+        return;
+      }
+      bufferedDone = event;
+      maybeResolve();
+    },
+    getChunks: () =>
+      expectedExecutionId
+        ? chunkEvents
+            .filter((event) => event.executionId === expectedExecutionId)
+            .map((event) => event.chunk)
+        : [],
+  };
+}
+
+function createLogger(logs: LogEntry[]): Logger & {
+  warn: (event: string, data?: Record<string, unknown>) => void;
+} {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    warn: (event, data) => {
+      logs.push({ event, data });
+    },
+    error: () => {},
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+try {
+  const logs: LogEntry[] = [];
+  const logger = createLogger(logs);
+
+  globalThis.fetch = (async () => {
+    return new Response(
+      "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\r\n\r\n" +
+        "data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\r\n\r\n" +
+        "data: [DONE]\r\n\r\n",
+      {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      },
+    );
+  }) as typeof fetch;
+
+  const service = createAiService({
+    logger,
+    env: {
+      CREONOW_AI_PROVIDER: "openai",
+      CREONOW_AI_BASE_URL: "https://api.openai.com",
+      CREONOW_AI_API_KEY: "sk-test",
+    },
+    sleep: async () => {},
+    rateLimitPerMinute: 1_000,
+  });
+
+  const doneWaiter = createDoneWaiter();
+  const result = await service.runSkill({
+    skillId: "builtin:polish",
+    input: "stream crlf",
+    mode: "ask",
+    model: "gpt-5.2",
+    stream: true,
+    ts: 1_700_000_000_000,
+    emitEvent: doneWaiter.onEvent,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) {
+    throw new Error("AUD-C3-S8: expected stream run success");
+  }
+
+  doneWaiter.setExecutionId(result.data.executionId);
+  const done = await doneWaiter.promise;
+  assert.equal(done.terminal, "completed");
+  assert.equal(done.error, undefined);
+  assert.equal(doneWaiter.getChunks().join(""), "hello world");
+  assert.equal(
+    logs.some((entry) => entry.event === "ai_sse_parse_failure"),
+    false,
+  );
+} finally {
+  globalThis.fetch = originalFetch;
+}
+
+console.log("ai-service-sse-crlf.test.ts: all assertions passed");

--- a/apps/desktop/main/src/__tests__/unit/token-budget-utf8-boundary.test.ts
+++ b/apps/desktop/main/src/__tests__/unit/token-budget-utf8-boundary.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+
+import {
+  estimateUtf8TokenCount,
+  trimUtf8ToTokenBudget,
+} from "@shared/tokenBudget";
+
+{
+  const trimmed = trimUtf8ToTokenBudget("你你", 1);
+  assert.equal(trimmed, "你");
+  assert.equal(trimmed.includes("\uFFFD"), false);
+  assert.equal(estimateUtf8TokenCount(trimmed), 1);
+}
+
+{
+  const trimmed = trimUtf8ToTokenBudget("ab你cd", 1);
+  assert.equal(trimmed, "ab");
+  assert.equal(trimmed.includes("\uFFFD"), false);
+  assert.equal(estimateUtf8TokenCount(trimmed) <= 1, true);
+}
+
+console.log("token-budget-utf8-boundary.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -205,15 +205,24 @@ async function* readSse(args: {
     buffer += decoder.decode(value, { stream: true });
 
     while (true) {
-      const sepIndex = buffer.indexOf("\n\n");
-      if (sepIndex < 0) {
+      const lfSeparator = buffer.indexOf("\n\n");
+      const crlfSeparator = buffer.indexOf("\r\n\r\n");
+      const hasLfSeparator = lfSeparator >= 0;
+      const hasCrlfSeparator = crlfSeparator >= 0;
+      if (!hasLfSeparator && !hasCrlfSeparator) {
         break;
       }
 
-      const rawEvent = buffer.slice(0, sepIndex);
-      buffer = buffer.slice(sepIndex + 2);
+      const useLfSeparator =
+        hasLfSeparator &&
+        (!hasCrlfSeparator || lfSeparator < crlfSeparator);
+      const sepIndex = useLfSeparator ? lfSeparator : crlfSeparator;
+      const sepLength = useLfSeparator ? 2 : 4;
 
-      const lines = rawEvent.split("\n");
+      const rawEvent = buffer.slice(0, sepIndex);
+      buffer = buffer.slice(sepIndex + sepLength);
+
+      const lines = rawEvent.split(/\r?\n/);
       let event: string | null = null;
       const dataLines: string[] = [];
 

--- a/packages/shared/tokenBudget.ts
+++ b/packages/shared/tokenBudget.ts
@@ -38,5 +38,15 @@ export function trimUtf8ToTokenBudget(
     return text;
   }
 
-  return new TextDecoder().decode(encoded.slice(0, maxBytes));
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  const minBytes = Math.max(0, maxBytes - 3);
+  for (let byteCount = maxBytes; byteCount >= minBytes; byteCount -= 1) {
+    try {
+      return decoder.decode(encoded.subarray(0, byteCount));
+    } catch {
+      // Continue rolling back to reach a valid UTF-8 boundary.
+    }
+  }
+
+  return "";
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复共享 token budget UTF-8 截断边界与 AI 流式 SSE 的 CRLF 解析稳定性问题。

## 改动列表
- commit 1: 修复 `trimUtf8ToTokenBudget` 在多字节边界可能引入替代字符（`�`）的数据污染问题，并新增 UTF-8 边界回归测试
- commit 1: 修复 `readSse` 仅支持 `\n\n` 分隔导致 CRLF 流式响应被误判中断的问题，并新增 CRLF SSE 回归测试

## 为什么改
这两处都属于高价值稳定性缺陷：前者会污染上下文内容并影响 token 预算一致性，后者会在标准 CRLF SSE 响应下触发流式中断，直接影响 AI 流式能力可用性。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库现存 warning 无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
