### PR TITLE
improve(renderer): 修复项目切换 bootstrap 竞态覆盖

### DIFF
--- a/apps/desktop/renderer/src/stores/__tests__/fileStore.race.test.ts
+++ b/apps/desktop/renderer/src/stores/__tests__/fileStore.race.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  IpcChannel,
+  IpcInvokeResult,
+  IpcRequest,
+  IpcResponseData,
+} from "@shared/types/ipc-generated";
+import { createFileStore, type IpcInvoke } from "../fileStore";
+
+function ok<C extends IpcChannel>(
+  _channel: C,
+  data: IpcResponseData<C>,
+): IpcInvokeResult<C> {
+  return { ok: true, data };
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("fileStore race scenarios", () => {
+  it("WB-S2-SRF-S3 ignores stale file bootstrap result after rapid project switch", async () => {
+    const pendingListByProject = new Map<
+      string,
+      Deferred<IpcInvokeResult<"file:document:list">>
+    >([
+      ["project-a", deferred<IpcInvokeResult<"file:document:list">>()],
+      ["project-b", deferred<IpcInvokeResult<"file:document:list">>()],
+    ]);
+
+    const invoke: IpcInvoke = async (channel, payload) => {
+      if (channel === "file:document:list") {
+        const request = payload as IpcRequest<"file:document:list">;
+        const pending = pendingListByProject.get(request.projectId);
+        if (!pending) {
+          throw new Error(`Unexpected projectId: ${request.projectId}`);
+        }
+        return await pending.promise;
+      }
+
+      if (channel === "file:document:getcurrent") {
+        const request = payload as IpcRequest<"file:document:getcurrent">;
+        return ok(channel, { documentId: `doc-${request.projectId}` });
+      }
+
+      throw new Error(`Unexpected channel: ${channel}`);
+    };
+
+    const store = createFileStore({ invoke });
+
+    const firstBootstrap = store.getState().bootstrapForProject("project-a");
+    await vi.waitFor(() => {
+      expect(store.getState().projectId).toBe("project-a");
+    });
+
+    const secondBootstrap = store.getState().bootstrapForProject("project-b");
+    await vi.waitFor(() => {
+      expect(store.getState().projectId).toBe("project-b");
+    });
+
+    pendingListByProject.get("project-b")!.resolve(
+      ok("file:document:list", {
+        items: [
+          {
+            documentId: "doc-project-b",
+            title: "Doc B",
+            type: "chapter",
+            status: "draft",
+            parentId: undefined,
+            sortOrder: 0,
+            updatedAt: 1,
+          },
+        ],
+      }),
+    );
+    await secondBootstrap;
+
+    expect(store.getState().items.map((item) => item.documentId)).toEqual([
+      "doc-project-b",
+    ]);
+
+    pendingListByProject.get("project-a")!.resolve(
+      ok("file:document:list", {
+        items: [
+          {
+            documentId: "doc-project-a",
+            title: "Doc A",
+            type: "chapter",
+            status: "draft",
+            parentId: undefined,
+            sortOrder: 0,
+            updatedAt: 1,
+          },
+        ],
+      }),
+    );
+    await firstBootstrap;
+
+    const state = store.getState();
+    expect(state.projectId).toBe("project-b");
+    expect(state.items.map((item) => item.documentId)).toEqual([
+      "doc-project-b",
+    ]);
+    expect(state.currentDocumentId).toBe("doc-project-b");
+    expect(state.bootstrapStatus).toBe("ready");
+    expect(state.lastError).toBeNull();
+  });
+});

--- a/apps/desktop/renderer/src/stores/editorStore.test.ts
+++ b/apps/desktop/renderer/src/stores/editorStore.test.ts
@@ -31,10 +31,11 @@ function err<C extends IpcChannel>(
 
 function createReadPayload(
   documentId: string,
+  projectId = "project-1",
 ): IpcResponseData<"file:document:read"> {
   return {
     documentId,
-    projectId: "project-1",
+    projectId,
     title: "Doc",
     type: "chapter",
     status: "draft",
@@ -248,4 +249,79 @@ describe("editorStore bootstrap and autosave scenarios", () => {
     expect(store.getState().autosaveStatus).toBe("saved");
     expect(store.getState().autosaveError).toBeNull();
   });
+  it("should ignore stale bootstrap responses after rapid project switch", async () => {
+    type Deferred<T> = {
+      promise: Promise<T>;
+      resolve: (value: T) => void;
+    };
+
+    function deferred<T>(): Deferred<T> {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    }
+
+    const pendingCurrentByProject = new Map<
+      string,
+      Deferred<IpcInvokeResult<"file:document:getcurrent">>
+    >([
+      ["project-a", deferred<IpcInvokeResult<"file:document:getcurrent">>()],
+      ["project-b", deferred<IpcInvokeResult<"file:document:getcurrent">>()],
+    ]);
+
+    const invoke: IpcInvoke = async (channel, payload) => {
+      if (channel === "file:document:getcurrent") {
+        const request = payload as { projectId: string };
+        const pending = pendingCurrentByProject.get(request.projectId);
+        if (!pending) {
+          throw new Error("Unexpected projectId: " + request.projectId);
+        }
+        return await pending.promise;
+      }
+
+      if (channel === "file:document:read") {
+        const request = payload as { projectId: string; documentId: string };
+        return ok(
+          channel,
+          createReadPayload(request.documentId, request.projectId),
+        );
+      }
+
+      throw new Error("Unexpected channel: " + channel);
+    };
+
+    const store = createEditorStore({ invoke });
+
+    const firstBootstrap = store.getState().bootstrapForProject("project-a");
+    await vi.waitFor(() => {
+      expect(store.getState().projectId).toBe("project-a");
+      expect(store.getState().bootstrapStatus).toBe("loading");
+    });
+
+    const secondBootstrap = store.getState().bootstrapForProject("project-b");
+    await vi.waitFor(() => {
+      expect(store.getState().projectId).toBe("project-b");
+      expect(store.getState().bootstrapStatus).toBe("loading");
+    });
+
+    pendingCurrentByProject
+      .get("project-b")!
+      .resolve(ok("file:document:getcurrent", { documentId: "doc-b" }));
+    await secondBootstrap;
+
+    expect(store.getState().documentId).toBe("doc-b");
+
+    pendingCurrentByProject
+      .get("project-a")!
+      .resolve(ok("file:document:getcurrent", { documentId: "doc-a" }));
+    await firstBootstrap;
+
+    const state = store.getState();
+    expect(state.projectId).toBe("project-b");
+    expect(state.documentId).toBe("doc-b");
+    expect(state.bootstrapStatus).toBe("ready");
+  });
+
 });

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -124,6 +124,8 @@ function createInitialEntityCompletionSession(): EntityCompletionSession {
  * and StatusBar, and must be driven through typed IPC.
  */
 export function createEditorStore(deps: { invoke: IpcInvoke }) {
+  let latestBootstrapRequestId = 0;
+
   return create<EditorStore>((set, get) => {
     const saveQueue = createEditorSaveQueue({
       executeSave: async (request: EditorSaveRequest) => {
@@ -228,17 +230,26 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
         }),
 
       bootstrapForProject: async (projectId) => {
-        set({ bootstrapStatus: "loading" });
+        const requestId = ++latestBootstrapRequestId;
+        const shouldCommit = () => requestId === latestBootstrapRequestId;
+
+        set({ bootstrapStatus: "loading", projectId });
 
         let documentId: string | null = null;
 
         const currentRes = await deps.invoke("file:document:getcurrent", {
           projectId,
         });
+        if (!shouldCommit()) {
+          return;
+        }
         if (currentRes.ok) {
           documentId = currentRes.data.documentId;
         } else if (currentRes.error.code === "NOT_FOUND") {
           const listRes = await deps.invoke("file:document:list", { projectId });
+          if (!shouldCommit()) {
+            return;
+          }
           if (!listRes.ok) {
             set({ bootstrapStatus: "error" });
             return;
@@ -249,6 +260,9 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
             const created = await deps.invoke("file:document:create", {
               projectId,
             });
+            if (!shouldCommit()) {
+              return;
+            }
             if (!created.ok) {
               set({ bootstrapStatus: "error" });
               return;
@@ -260,6 +274,9 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
             projectId,
             documentId,
           });
+          if (!shouldCommit()) {
+            return;
+          }
           if (!setRes.ok) {
             set({ bootstrapStatus: "error" });
             return;
@@ -283,6 +300,9 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
           projectId,
           documentId,
         });
+        if (!shouldCommit()) {
+          return;
+        }
         if (!readRes.ok) {
           set({ bootstrapStatus: "error" });
           return;

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -232,24 +232,17 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
       bootstrapForProject: async (projectId) => {
         const requestId = ++latestBootstrapRequestId;
         const shouldCommit = () => requestId === latestBootstrapRequestId;
-
         set({ bootstrapStatus: "loading", projectId });
-
         let documentId: string | null = null;
-
         const currentRes = await deps.invoke("file:document:getcurrent", {
           projectId,
         });
-        if (!shouldCommit()) {
-          return;
-        }
+        if (!shouldCommit()) return;
         if (currentRes.ok) {
           documentId = currentRes.data.documentId;
         } else if (currentRes.error.code === "NOT_FOUND") {
           const listRes = await deps.invoke("file:document:list", { projectId });
-          if (!shouldCommit()) {
-            return;
-          }
+          if (!shouldCommit()) return;
           if (!listRes.ok) {
             set({ bootstrapStatus: "error" });
             return;
@@ -260,9 +253,7 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
             const created = await deps.invoke("file:document:create", {
               projectId,
             });
-            if (!shouldCommit()) {
-              return;
-            }
+            if (!shouldCommit()) return;
             if (!created.ok) {
               set({ bootstrapStatus: "error" });
               return;
@@ -274,9 +265,7 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
             projectId,
             documentId,
           });
-          if (!shouldCommit()) {
-            return;
-          }
+          if (!shouldCommit()) return;
           if (!setRes.ok) {
             set({ bootstrapStatus: "error" });
             return;
@@ -300,9 +289,7 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
           projectId,
           documentId,
         });
-        if (!shouldCommit()) {
-          return;
-        }
+        if (!shouldCommit()) return;
         if (!readRes.ok) {
           set({ bootstrapStatus: "error" });
           return;

--- a/apps/desktop/renderer/src/stores/fileStore.tsx
+++ b/apps/desktop/renderer/src/stores/fileStore.tsx
@@ -78,6 +78,8 @@ const FileStoreContext = React.createContext<UseFileStore | null>(null);
  * testable state machine, and `currentDocumentId` must persist per project.
  */
 export function createFileStore(deps: { invoke: IpcInvoke }) {
+  let latestBootstrapRequestId = 0;
+
   async function loadDocuments(
     projectId: string,
   ): Promise<IpcInvokeResult<"file:document:list">> {
@@ -149,6 +151,10 @@ export function createFileStore(deps: { invoke: IpcInvoke }) {
         return;
       }
 
+      const requestId = ++latestBootstrapRequestId;
+      const shouldCommit = () =>
+        requestId === latestBootstrapRequestId && get().projectId === projectId;
+
       set({
         projectId,
         bootstrapStatus: "loading",
@@ -158,12 +164,18 @@ export function createFileStore(deps: { invoke: IpcInvoke }) {
       });
 
       const listRes = await loadDocuments(projectId);
+      if (!shouldCommit()) {
+        return;
+      }
       if (!listRes.ok) {
         set({ bootstrapStatus: "error", lastError: listRes.error });
         return;
       }
 
       const currentRes = await loadCurrent(projectId);
+      if (!shouldCommit()) {
+        return;
+      }
       if (currentRes.ok) {
         set({
           bootstrapStatus: "ready",
@@ -185,6 +197,9 @@ export function createFileStore(deps: { invoke: IpcInvoke }) {
       const firstExisting = listRes.data.items[0]?.documentId ?? null;
       if (firstExisting) {
         const setRes = await persistCurrent(projectId, firstExisting);
+        if (!shouldCommit()) {
+          return;
+        }
         if (!setRes.ok) {
           set({
             bootstrapStatus: "error",
@@ -203,18 +218,27 @@ export function createFileStore(deps: { invoke: IpcInvoke }) {
       }
 
       const created = await createDocument(projectId);
+      if (!shouldCommit()) {
+        return;
+      }
       if (!created.ok) {
         set({ bootstrapStatus: "error", lastError: created.error });
         return;
       }
 
       const setRes = await persistCurrent(projectId, created.data.documentId);
+      if (!shouldCommit()) {
+        return;
+      }
       if (!setRes.ok) {
         set({ bootstrapStatus: "error", lastError: setRes.error });
         return;
       }
 
       const listRes2 = await loadDocuments(projectId);
+      if (!shouldCommit()) {
+        return;
+      }
       if (!listRes2.ok) {
         set({ bootstrapStatus: "error", lastError: listRes2.error });
         return;


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 renderer 在快速切换项目时 bootstrap 异步结果乱序回写导致状态被旧项目覆盖的问题。

## 改动列表
- commit 1: 在 fileStore/bootstrapForProject 增加请求代次守卫，确保仅最新项目切换请求可落盘状态
- commit 1: 在 editorStore/bootstrapForProject 增加同类守卫，阻断旧请求覆盖当前项目文档状态
- commit 1: 新增 fileStore 竞态回归测试，并在 editorStore.test 补充快速切项目乱序返回用例

## 为什么改
当前 AppShell 会在切换项目时触发异步 bootstrap 链路；在快速连续切换场景下，旧请求可能晚于新请求返回并覆盖当前 store，造成“项目B界面被项目A文档回写”的一致性缺陷。本次改动通过请求代次校验把 bootstrap 写入收敛到“最后一次请求”，消除该真实竞态 bug。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仓库已有历史 warning，无新增 error）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)
