### PR TITLE
improve(main): IPC 校验与保存错误处理闭环加固

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ipcAcl.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ipcAcl.test.ts
@@ -18,10 +18,15 @@ function createLogger(): TestLogger {
   };
 }
 
-function createEvent(url: string, webContentsId = 1): IpcMainInvokeEvent {
+function createEvent(args: {
+  url?: string;
+  webContentsId?: number;
+} = {}): IpcMainInvokeEvent {
+  const senderFrame = args.url === undefined ? {} : { url: args.url };
+
   return {
-    senderFrame: { url },
-    sender: { id: webContentsId },
+    senderFrame,
+    sender: { id: args.webContentsId ?? 1 },
   } as unknown as IpcMainInvokeEvent;
 }
 
@@ -62,7 +67,27 @@ async function main(): Promise<void> {
     "SIA-S1 should reject non-allowlisted origin with FORBIDDEN/origin_not_allowed",
     async () => {
       const response = await invokeWrapped({
-        event: createEvent("https://evil.com"),
+        event: createEvent({ url: "https://evil.com" }),
+        channel: "file:document:list",
+      });
+
+      assert.equal(response.ok, false);
+      if (response.ok) {
+        assert.fail("expected FORBIDDEN response");
+      }
+      assert.equal(response.error.code, "FORBIDDEN");
+      assert.equal(
+        (response.error.details as { reason?: string } | undefined)?.reason,
+        "origin_not_allowed",
+      );
+    },
+  );
+
+  await runScenario(
+    "SIA-S1 should reject caller when senderFrame.url is missing",
+    async () => {
+      const response = await invokeWrapped({
+        event: createEvent(),
         channel: "file:document:list",
       });
 
@@ -80,7 +105,7 @@ async function main(): Promise<void> {
 
   await runScenario("SIA-S2 should allow localhost dev origin", async () => {
     const response = await invokeWrapped({
-      event: createEvent("http://localhost:5173/index.html"),
+      event: createEvent({ url: "http://localhost:5173/index.html" }),
       channel: "file:document:list",
     });
 
@@ -91,7 +116,7 @@ async function main(): Promise<void> {
     "SIA-S2 should allow VITE_DEV_SERVER_URL origin",
     async () => {
       const response = await invokeWrapped({
-        event: createEvent("http://127.0.0.1:4173/editor"),
+        event: createEvent({ url: "http://127.0.0.1:4173/editor" }),
         channel: "file:document:list",
       });
 
@@ -101,12 +126,35 @@ async function main(): Promise<void> {
 
   await runScenario("SIA-S2 should allow production file origin", async () => {
     const response = await invokeWrapped({
-      event: createEvent("file:///Applications/CreoNow/index.html"),
+      event: createEvent({ url: "file:///Applications/CreoNow/index.html" }),
       channel: "file:document:list",
     });
 
     assert.equal(response.ok, true);
   });
+
+  await runScenario(
+    "SIA-S3 should reject privileged channel with illegal webContentsId",
+    async () => {
+      const response = await invokeWrapped({
+        event: createEvent({
+          url: "http://localhost:5173/index.html",
+          webContentsId: 0,
+        }),
+        channel: "db:debug:tablenames",
+      });
+
+      assert.equal(response.ok, false);
+      if (response.ok) {
+        assert.fail("expected FORBIDDEN response");
+      }
+      assert.equal(response.error.code, "FORBIDDEN");
+      assert.equal(
+        (response.error.details as { reason?: string } | undefined)?.reason,
+        "web_contents_not_allowed",
+      );
+    },
+  );
 }
 
 process.env.VITE_DEV_SERVER_URL = "http://127.0.0.1:4173";

--- a/apps/desktop/main/src/ipc/file.ts
+++ b/apps/desktop/main/src/ipc/file.ts
@@ -169,6 +169,10 @@ function estimateWritingSeconds(wordsAdded: number): number {
   return words === 0 ? 0 : Math.max(1, Math.ceil(words / WORDS_PER_SECOND));
 }
 
+function hasNonEmptyText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 /**
  * Register `file:document:*` IPC handlers.
  *
@@ -203,7 +207,7 @@ export function registerFileIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!hasNonEmptyText(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -261,7 +265,7 @@ export function registerFileIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!hasNonEmptyText(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -305,8 +309,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,
@@ -349,8 +353,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,
@@ -396,8 +400,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,
@@ -542,7 +546,7 @@ export function registerFileIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!hasNonEmptyText(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -570,8 +574,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,
@@ -605,7 +609,7 @@ export function registerFileIpcHandlers(deps: {
           error: { code: "DB_ERROR", message: "Database not ready" },
         };
       }
-      if (payload.projectId.trim().length === 0) {
+      if (!hasNonEmptyText(payload.projectId)) {
         return {
           ok: false,
           error: { code: "INVALID_ARGUMENT", message: "projectId is required" },
@@ -640,8 +644,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,
@@ -692,8 +696,8 @@ export function registerFileIpcHandlers(deps: {
         };
       }
       if (
-        payload.projectId.trim().length === 0 ||
-        payload.documentId.trim().length === 0
+        !hasNonEmptyText(payload.projectId) ||
+        !hasNonEmptyText(payload.documentId)
       ) {
         return {
           ok: false,

--- a/apps/desktop/main/src/ipc/ipcAcl.ts
+++ b/apps/desktop/main/src/ipc/ipcAcl.ts
@@ -98,7 +98,7 @@ export function createIpcAclEvaluator(
   return ({ channel, event }): IpcAclDecision => {
     const senderOrigin = resolveSenderOrigin(event);
     if (
-      senderOrigin !== null &&
+      senderOrigin === null ||
       !isOriginAllowed({ senderOrigin, devServerOrigin })
     ) {
       return {

--- a/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.test.ts
@@ -111,8 +111,9 @@ describe("editorSaveQueue", () => {
     expect(maxActive).toBe(1);
   });
 
-  it("should continue processing tasks after a task throws", async () => {
+  it("should continue processing tasks after a task throws and report the error", async () => {
     const order: string[] = [];
+    const onExecuteSaveError = vi.fn();
 
     const queue = createEditorSaveQueue({
       executeSave: async (request) => {
@@ -121,6 +122,7 @@ describe("editorSaveQueue", () => {
           throw new Error("save failed");
         }
       },
+      onExecuteSaveError,
     });
 
     const failed = queue.enqueue(makeRequest({ contentJson: "fail" }));
@@ -131,5 +133,10 @@ describe("editorSaveQueue", () => {
     await Promise.all([failed, after1, after2]);
 
     expect(order).toEqual(["fail", "after-1", "after-2"]);
+    expect(onExecuteSaveError).toHaveBeenCalledTimes(1);
+    expect(onExecuteSaveError).toHaveBeenCalledWith({
+      request: makeRequest({ contentJson: "fail" }),
+      error: expect.any(Error),
+    });
   });
 });

--- a/apps/desktop/renderer/src/stores/editorSaveQueue.ts
+++ b/apps/desktop/renderer/src/stores/editorSaveQueue.ts
@@ -8,6 +8,10 @@ export type EditorSaveRequest = {
 
 export type EditorSaveQueueDeps = {
   executeSave: (request: EditorSaveRequest) => Promise<void>;
+  onExecuteSaveError?: (args: {
+    request: EditorSaveRequest;
+    error: unknown;
+  }) => void;
 };
 
 export type EditorSaveQueue = {
@@ -36,8 +40,11 @@ export function createEditorSaveQueue(
 
         try {
           await deps.executeSave(current.request);
-        } catch {
-          // Keep queue alive after unexpected failures from one task.
+        } catch (error) {
+          deps.onExecuteSaveError?.({
+            request: current.request,
+            error,
+          });
         }
 
         current.resolve();

--- a/apps/desktop/renderer/src/stores/editorStore.saveQueue.test.ts
+++ b/apps/desktop/renderer/src/stores/editorStore.saveQueue.test.ts
@@ -1,6 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { enqueueMock, createEditorSaveQueueMock } = vi.hoisted(() => {
+  type CreateQueueOptions = {
+    executeSave: (request: {
+      projectId: string;
+      documentId: string;
+      contentJson: string;
+      actor: "user" | "auto";
+      reason: "manual-save" | "autosave";
+    }) => Promise<void>;
+    onExecuteSaveError?: (args: {
+      request: {
+        projectId: string;
+        documentId: string;
+        contentJson: string;
+        actor: "user" | "auto";
+        reason: "manual-save" | "autosave";
+      };
+      error: unknown;
+    }) => void;
+  };
   const enqueue = vi.fn<
     (request: {
       projectId: string;
@@ -11,7 +30,7 @@ const { enqueueMock, createEditorSaveQueueMock } = vi.hoisted(() => {
     }) => Promise<void>
   >();
 
-  const createQueue = vi.fn(() => ({
+  const createQueue = vi.fn((_: CreateQueueOptions) => ({
     enqueue,
   }));
 
@@ -53,5 +72,38 @@ describe("editorStore save queue delegation", () => {
     expect(createEditorSaveQueueMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledWith(request);
+  });
+  it("should map queue executeSave throw to autosaveError", () => {
+    const invoke: IpcInvoke = async (channel) => {
+      throw new Error(`Unexpected invoke in mocked queue test: ${channel}`);
+    };
+
+    const store = createEditorStore({ invoke });
+    store.setState({
+      projectId: "project-1",
+      documentId: "doc-1",
+      autosaveStatus: "idle",
+      autosaveError: null,
+    });
+
+    const queueOptions = createEditorSaveQueueMock.mock.calls[0]?.[0];
+    expect(queueOptions).toBeTruthy();
+
+    queueOptions?.onExecuteSaveError?.({
+      request: {
+        projectId: "project-1",
+        documentId: "doc-1",
+        contentJson: '{"v":1}',
+        actor: "auto",
+        reason: "autosave",
+      },
+      error: new Error("save exploded"),
+    });
+
+    expect(store.getState().autosaveStatus).toBe("error");
+    expect(store.getState().autosaveError).toEqual({
+      code: "INTERNAL_ERROR",
+      message: "save exploded",
+    });
   });
 });

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -137,51 +137,52 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
           });
         }
 
-        try {
-          const res = await deps.invoke("file:document:save", {
-            projectId: request.projectId,
-            documentId: request.documentId,
-            contentJson: request.contentJson,
-            actor: request.actor,
-            reason: request.reason,
-          });
+        const res = await deps.invoke("file:document:save", {
+          projectId: request.projectId,
+          documentId: request.documentId,
+          contentJson: request.contentJson,
+          actor: request.actor,
+          reason: request.reason,
+        });
 
-          if (!res.ok) {
-            const stillCurrent =
-              get().projectId === request.projectId &&
-              get().documentId === request.documentId;
-            if (stillCurrent) {
-              set({ autosaveStatus: "error", autosaveError: res.error });
-            }
-            return;
-          }
-
+        if (!res.ok) {
           const stillCurrent =
             get().projectId === request.projectId &&
             get().documentId === request.documentId;
           if (stillCurrent) {
-            set({
-              autosaveStatus: "saved",
-              autosaveError: null,
-            });
+            set({ autosaveStatus: "error", autosaveError: res.error });
           }
-        } catch (error) {
-          const stillCurrent =
-            get().projectId === request.projectId &&
-            get().documentId === request.documentId;
-          if (stillCurrent) {
-            set({
-              autosaveStatus: "error",
-              autosaveError: {
-                code: "INTERNAL_ERROR",
-                message:
-                  error instanceof Error
-                    ? error.message
-                    : "file:document:save threw unexpectedly",
-              },
-            });
-          }
+          return;
         }
+
+        const stillCurrent =
+          get().projectId === request.projectId &&
+          get().documentId === request.documentId;
+        if (stillCurrent) {
+          set({
+            autosaveStatus: "saved",
+            autosaveError: null,
+          });
+        }
+      },
+      onExecuteSaveError: ({ request, error }) => {
+        const stillCurrent =
+          get().projectId === request.projectId &&
+          get().documentId === request.documentId;
+        if (!stillCurrent) {
+          return;
+        }
+
+        set({
+          autosaveStatus: "error",
+          autosaveError: {
+            code: "INTERNAL_ERROR",
+            message:
+              error instanceof Error
+                ? error.message
+                : "file:document:save threw unexpectedly",
+          },
+        });
       },
     });
 

--- a/apps/desktop/tests/unit/file-ipc-runtime-boundary.test.ts
+++ b/apps/desktop/tests/unit/file-ipc-runtime-boundary.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+
+import { registerFileIpcHandlers } from "../../main/src/ipc/file";
+import type { Logger } from "../../main/src/logging/logger";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+type IpcErrorPayload = {
+  code: string;
+  message: string;
+};
+
+type IpcResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: IpcErrorPayload };
+
+function createNoopLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createIpcHarness(): {
+  ipcMain: IpcMain;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle(channel: string, handler: Handler) {
+      handlers.set(channel, handler);
+    },
+  } as unknown as IpcMain;
+
+  return { ipcMain, handlers };
+}
+
+async function testCreateRejectsNonStringProjectId(): Promise<void> {
+  const { ipcMain, handlers } = createIpcHarness();
+  registerFileIpcHandlers({
+    ipcMain,
+    db: {} as Database.Database,
+    logger: createNoopLogger(),
+  });
+
+  const createHandler = handlers.get("file:document:create");
+  assert.ok(createHandler, "file:document:create handler should be registered");
+  if (!createHandler) {
+    throw new Error("missing file:document:create handler");
+  }
+
+  const response = (await createHandler({}, { projectId: null })) as IpcResult<
+    unknown
+  >;
+
+  assert.equal(response.ok, false, "non-string projectId should be rejected");
+  if (!response.ok) {
+    assert.equal(response.error.code, "INVALID_ARGUMENT");
+    assert.equal(response.error.message, "projectId is required");
+  }
+}
+
+const checks: Array<{ name: string; run: () => Promise<void> }> = [
+  {
+    name: "create rejects non-string projectId without throwing",
+    run: testCreateRejectsNonStringProjectId,
+  },
+];
+
+const failures: Array<{ name: string; error: unknown }> = [];
+for (const check of checks) {
+  try {
+    await check.run();
+    console.log(`[PASS] ${check.name}`);
+  } catch (error) {
+    failures.push({ name: check.name, error });
+    console.error(`[FAIL] ${check.name}`);
+    console.error(error);
+  }
+}
+
+if (failures.length > 0) {
+  const names = failures.map((item) => item.name).join(", ");
+  throw new Error(`file IPC runtime boundary checks failed: ${names}`);
+}
+
+console.log("file-ipc-runtime-boundary.test.ts: all assertions passed");

--- a/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
+++ b/apps/desktop/tests/unit/ipc-runtime-validation.spec.ts
@@ -33,7 +33,10 @@ async function invokeWrapped(
   payload: unknown,
 ): Promise<IpcResponse<unknown>> {
   return (await wrapped(
-    {} as Parameters<typeof wrapped>[0],
+    {
+      senderFrame: { url: "file:///index.html" },
+      sender: { id: 1 },
+    } as Parameters<typeof wrapped>[0],
     payload,
   )) as IpcResponse<unknown>;
 }

--- a/apps/desktop/tests/unit/kg/entity-list-runtime-contract-aliases.test.ts
+++ b/apps/desktop/tests/unit/kg/entity-list-runtime-contract-aliases.test.ts
@@ -28,7 +28,13 @@ function createMockIpcMain() {
       if (!listener) {
         throw new Error(`Missing handler: ${channel}`);
       }
-      return await listener({} as IpcMainInvokeEvent, payload);
+      return await listener(
+        {
+          senderFrame: { url: "file:///index.html" },
+          sender: { id: 1 },
+        } as IpcMainInvokeEvent,
+        payload,
+      );
     },
   };
 }

--- a/apps/desktop/tests/unit/projectIpc.validation.test.ts
+++ b/apps/desktop/tests/unit/projectIpc.validation.test.ts
@@ -29,7 +29,13 @@ function createMockIpcMain() {
       if (!listener) {
         throw new Error(`Missing handler: ${channel}`);
       }
-      return await listener({} as IpcMainInvokeEvent, payload);
+      return await listener(
+        {
+          senderFrame: { url: "file:///index.html" },
+          sender: { id: 1 },
+        } as IpcMainInvokeEvent,
+        payload,
+      );
     },
   };
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
收紧 IPC 入口安全边界并补齐保存链路异常上报，形成更完整的错误处理闭环。

## 改动列表
- commit 1: improve(main): 修复 file IPC 非字符串 payload 的参数校验边界
- commit 2: improve(main): 收紧 IPC ACL 缺失来源时默认拒绝
- commit 3: improve(renderer): 补齐 editorSaveQueue 抛错上报并透传 autosaveError
- commit 4: improve(tests): 对齐 IPC ACL 来源校验后的事件夹具

## 为什么改
现有 IPC 处理在边界输入和来源缺失时存在可触发的异常/放行风险，且编辑器保存队列抛错时可观测性不足；本轮将这三类高价值问题联动修复，并用回归测试固化。

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仅历史 warnings，无新增 errors）
- [x] pnpm test:unit 通过

## 注意
- 不涉及业务行为变更
- 不涉及架构变更

---
🤖 by 天野 (automated iteration)