### PR TITLE
improve(tests): 稳定 Markdown 导出 E2E 同步判定

### DIFF
--- a/apps/desktop/tests/e2e/export-markdown.spec.ts
+++ b/apps/desktop/tests/e2e/export-markdown.spec.ts
@@ -1,4 +1,4 @@
-import { _electron as electron, expect, test } from "@playwright/test";
+import { _electron as electron, expect, test, type Page } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -44,6 +44,64 @@ async function fileExists(p: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+type ExportOutcome =
+  | { kind: "success" }
+  | { kind: "error"; code: string; message: string }
+  | {
+      kind: "timeout";
+      successVisible: boolean;
+      errorVisible: boolean;
+      fileWritten: boolean;
+    };
+
+async function waitForExportOutcome(args: {
+  page: Page;
+  expectedAbsPath: string;
+  timeoutMs?: number;
+}): Promise<ExportOutcome> {
+  const timeoutMs = args.timeoutMs ?? 30_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() <= deadline) {
+    const [successVisible, errorVisible, fileWritten] = await Promise.all([
+      args.page.getByTestId("export-success").isVisible(),
+      args.page.getByTestId("export-error").isVisible(),
+      fileExists(args.expectedAbsPath),
+    ]);
+
+    if (errorVisible) {
+      const [codeText, messageText] = await Promise.all([
+        args.page.getByTestId("export-error-code").textContent(),
+        args.page.getByTestId("export-error-message").textContent(),
+      ]);
+      return {
+        kind: "error",
+        code: codeText?.trim() || "<missing code>",
+        message: messageText?.trim() || "<missing message>",
+      };
+    }
+
+    if (successVisible && fileWritten) {
+      return { kind: "success" };
+    }
+
+    await args.page.waitForTimeout(250);
+  }
+
+  const [successVisible, errorVisible, fileWritten] = await Promise.all([
+    args.page.getByTestId("export-success").isVisible(),
+    args.page.getByTestId("export-error").isVisible(),
+    fileExists(args.expectedAbsPath),
+  ]);
+
+  return {
+    kind: "timeout",
+    successVisible,
+    errorVisible,
+    fileWritten,
+  };
 }
 
 test("export: markdown writes deterministic file under userData exports", async () => {
@@ -111,51 +169,6 @@ test("export: markdown writes deterministic file under userData exports", async 
     "checked",
   );
 
-  // Click Export button to start export
-  await page.getByTestId("export-submit").click();
-
-  // Wait for success (or a surfaced error) and print diagnostics on failure.
-  try {
-    await expect(page.getByTestId("export-success")).toBeVisible({
-      timeout: 10_000,
-    });
-  } catch (error) {
-    const errorVisible = await page.getByTestId("export-error").isVisible();
-    if (errorVisible) {
-      const code = await page.getByTestId("export-error-code").textContent();
-      const message = await page
-        .getByTestId("export-error-message")
-        .textContent();
-      const mainLogTail = await readMainLogTail({ userDataDir });
-      throw new Error(
-        [
-          "Export failed:",
-          `${code ?? "<missing code>"}: ${message ?? "<missing message>"}`,
-          "--- main.log tail ---",
-          mainLogTail,
-          "--- original error ---",
-          error instanceof Error ? error.message : String(error),
-        ].join("\n"),
-      );
-    }
-
-    const mainLogTail = await readMainLogTail({ userDataDir });
-    throw new Error(
-      [
-        "Export did not reach success view within timeout.",
-        "--- main.log tail ---",
-        mainLogTail,
-        "--- original error ---",
-        error instanceof Error ? error.message : String(error),
-      ].join("\n"),
-    );
-  }
-
-  // Verify result fields are displayed
-  await expect(page.getByTestId("export-success-relative-path")).toBeVisible();
-  await expect(page.getByTestId("export-success-bytes-written")).toBeVisible();
-
-  // Verify file was actually written
   const expectedRelPath = path.join(
     "exports",
     current.projectId,
@@ -163,7 +176,43 @@ test("export: markdown writes deterministic file under userData exports", async 
   );
   const expectedAbsPath = path.join(userDataDir, expectedRelPath);
 
-  await expect.poll(async () => await fileExists(expectedAbsPath)).toBe(true);
+  // Click Export button to start export
+  await page.getByTestId("export-submit").click();
+
+  // Require dual evidence: success UI + exported file written.
+  const outcome = await waitForExportOutcome({
+    page,
+    expectedAbsPath,
+    timeoutMs: 30_000,
+  });
+
+  if (outcome.kind === "error") {
+    const mainLogTail = await readMainLogTail({ userDataDir });
+    throw new Error(
+      [
+        "Export failed:",
+        `${outcome.code}: ${outcome.message}`,
+        "--- main.log tail ---",
+        mainLogTail,
+      ].join("\n"),
+    );
+  }
+
+  if (outcome.kind === "timeout") {
+    const mainLogTail = await readMainLogTail({ userDataDir });
+    throw new Error(
+      [
+        "Export did not reach stable success state within timeout.",
+        `state: successVisible=${outcome.successVisible}, errorVisible=${outcome.errorVisible}, fileWritten=${outcome.fileWritten}`,
+        "--- main.log tail ---",
+        mainLogTail,
+      ].join("\n"),
+    );
+  }
+
+  // Verify result fields are displayed
+  await expect(page.getByTestId("export-success-relative-path")).toBeVisible();
+  await expect(page.getByTestId("export-success-bytes-written")).toBeVisible();
 
   const exported = await fs.readFile(expectedAbsPath, "utf8");
   expect(exported).toContain("Export me");


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

Fixes #751

## 主题
稳定 Windows 环境下 Markdown 导出 E2E 的完成判定，降低 `export-success` 单点等待带来的间歇性失败。

## 改动列表
- `apps/desktop/tests/e2e/export-markdown.spec.ts`：新增 `waitForExportOutcome`，统一等待导出结果
- 将导出完成判定从“仅成功 UI 可见”改为“成功 UI 可见 + 文件落盘双证据”
- 超时诊断补充当前状态快照（successVisible/errorVisible/fileWritten）和 main.log tail

## 用户影响
- CI 对 Markdown 导出主路径的回归信号更稳定，减少假阴性红灯导致的发布阻塞。
- 对真实失败仍会保留明确错误信息与日志线索，排障更快。

## 不修最坏后果
- Windows E2E 会持续出现间歇性超时红灯，主干合并与发布节奏被反复打断。
- 导出链路的真实回归可能被 flaky 噪音掩盖，风险在后续版本累积。

## 验证证据
- 本地：`pnpm -C apps/desktop typecheck` 通过。
- 本地：`pnpm -C apps/desktop lint -- tests/e2e/export-markdown.spec.ts` 通过（仓库既有 warning，无新增 error）。
- CI：`https://github.com/Leeky1017/CreoNow/actions/runs/22512415619` 全绿，`windows-e2e` 通过（3m24s）。
- 环境说明：本地 WSL 直接运行 `pnpm -C apps/desktop test:e2e -- tests/e2e/export-markdown.spec.ts` 会因 `Missing X server or $DISPLAY` 无法执行 Electron 窗口测试。

## 回滚点
- 单提交回滚：`git revert 4e195301`
- 分支回滚：关闭该 PR 即可完全撤销本次测试同步点调整。

## Open PR 排重检查
- 扫描时间：2026-02-28 11:32 (Asia/Shanghai)
- 当前 open PR 概览：无
- 文件重叠检查：无重叠风险
- 处理决策：独立新开 PR

## 注意
- 仅调整 E2E 同步与诊断逻辑，不涉及业务功能与 IPC 契约变更。
