### PR TITLE
fix(ci): 为非 task 分支补齐 Skip-Reason 引导

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Skip-Reason: <non-task 分支必填；task/* 分支填写 N/A>
+
+## 主题
+- 简要说明本次改动解决的问题
+
+## 关联 Issue
+- Fixes #<issue_number>
+
+## 用户影响
+- 本次改动对用户/交付链路的影响
+
+## 不修最坏后果
+- 若不合入该 PR，最坏会发生什么
+
+## 验证证据
+- [ ] `pnpm typecheck`
+- [ ] `pnpm lint`
+- [ ] `pnpm test:unit`
+- 其他补充验证：
+
+## 回滚点
+- 回滚 commit/分支：
+- 回滚后需要恢复的数据或配置：

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -87,7 +87,10 @@ jobs:
             if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then
               echo "✅ Non-task branch with required Skip-Reason"
             else
-              echo "❌ Non-task branch '$BRANCH' must include 'Skip-Reason:' in PR body"
+              echo "::error title=Missing Skip-Reason::Non-task branch '$BRANCH' must include a 'Skip-Reason:' line in PR body. Add for example: Skip-Reason: non-task branch delivery without openspec task run log"
+              echo "❌ Missing Skip-Reason in PR body"
+              echo "Please update PR description with a line like:"
+              echo "Skip-Reason: <why this branch is not task/* and has no RUN_LOG>"
               exit 1
             fi
           fi


### PR DESCRIPTION
Skip-Reason: non-task 分支交付，本次修复 CI 失败提示与 PR 模板提示入口

Fixes #762

## 用户影响
- 非 `task/*` 分支创建 PR 时会直接看到 `Skip-Reason` 模板入口，减少因为遗漏字段导致的 required check 阻断。
- `openspec-log-guard` 失败信息新增可复制示例，提交者可在一次修订内完成修复。

## 不修最坏后果
- 非 task 分支会持续因缺失 `Skip-Reason` 硬失败，紧急修复/清理类 PR 反复卡在 CI，造成交付延迟和 CI 资源浪费。

## 验证证据
- `pnpm typecheck`：通过。
- `pnpm lint`：通过（仓库既有 68 条 warning，无新增 error）。
- `pnpm test:unit`：失败，原因为本地 `better-sqlite3` 二进制与当前 Node ABI 不匹配（`NODE_MODULE_VERSION 143` vs `127`），属于环境问题，非本次改动引入。
- 手动校验：`Skip-Reason` 正则分支分别验证了缺失/存在两条路径，结果符合预期。

## 回滚点
- 单提交回滚：`git revert 3d9b2910`
- 分支回滚：关闭并删除 `amano/fix-asuka-762-skip-reason` 即可恢复到改动前状态。
