### PR TITLE
improve(ci): 明确并发运行标识并收敛OpenSpec旧run噪声

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+run-name: >-
+  CI / ${{ github.event_name == 'pull_request' && format('PR #{0} @ {1}', github.event.pull_request.number, github.event.pull_request.head.sha) || format('push @ {0}', github.sha) }}
 
 on:
   pull_request:

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -1,8 +1,14 @@
 name: OpenSpec Log Guard
+run-name: >-
+  OpenSpec Log Guard / PR #${{ github.event.pull_request.number }} @ ${{ github.event.pull_request.head.sha }}
 
 on:
   pull_request:
     branches: [main]
+
+concurrency:
+  group: openspec-log-guard-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   openspec-log-guard:


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

Fixes #760

## 主题
降低连续推送时 CI 结果解读噪声，让 PR 视图更容易定位当前有效 run。

## 改动列表
- 在 `CI` workflow 增加 `run-name`，把 PR 编号和 head SHA 放到运行标题中。
- 在 `OpenSpec Log Guard` workflow 增加 `run-name`，并为同一 PR 启用并发组（`cancel-in-progress: true`）只保留最新校验。

## 用户影响
- 连续推送时，PR/Actions 列表能直接看到对应提交 SHA，减少“哪条是当前有效结果”的人工辨识成本。
- 旧的 OpenSpec 校验会被新提交替换，避免旧提交失败结果长期挂在列表里干扰回归判断。

## 不修最坏后果
- CI 历史会持续出现“旧提交失败 + 新提交取消/成功”混杂，审阅者容易误判当前提交状态，增加漏看真实失败信号的风险。

## 验证证据
- `pnpm typecheck` 通过。
- `pnpm lint` 通过（仅存在仓库基线 warning，无新增 error）。
- `pnpm test:unit` 失败：本地 `better-sqlite3` 二进制与当前 Node ABI 不匹配（`NODE_MODULE_VERSION 143` vs `127`），属于环境问题，和本次 workflow YAML 改动无关。

## 回滚点
- 可直接回滚提交 `87f23543`，或恢复到基线 `origin/main@831ada22`。
