### PR TITLE
fix(build): 修复 Windows 打包 tar 导入不兼容

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,13 +46,14 @@
   "packageManager": "pnpm@8.15.0",
   "pnpm": {
     "overrides": {
+      "@electron/rebuild": "4.0.3",
       "@isaacs/brace-expansion@<=5.0.0": "5.0.1",
       "ajv@<6.14.0": "6.14.0",
       "markdown-it@>=13.0.0 <14.1.1": "14.1.1",
       "minimatch@<3.1.4": "3.1.4",
+      "minimatch@>=10.0.0 <10.2.3": "10.2.4",
       "minimatch@>=5.0.0 <5.1.8": "5.1.8",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-      "minimatch@>=10.0.0 <10.2.3": "10.2.4",
       "rollup@>=4.0.0 <4.59.0": "4.59.0",
       "storybook@>=8.1.0 <8.6.17": "8.6.17",
       "tar@<7.5.8": "7.5.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@electron/rebuild': 4.0.3
   '@isaacs/brace-expansion@<=5.0.0': 5.0.1
   ajv@<6.14.0: 6.14.0
   markdown-it@>=13.0.0 <14.1.1: 14.1.1
   minimatch@<3.1.4: 3.1.4
+  minimatch@>=10.0.0 <10.2.3: 10.2.4
   minimatch@>=5.0.0 <5.1.8: 5.1.8
   minimatch@>=9.0.0 <9.0.7: 9.0.7
-  minimatch@>=10.0.0 <10.2.3: 10.2.4
   rollup@>=4.0.0 <4.59.0: 4.59.0
   storybook@>=8.1.0 <8.6.17: 8.6.17
   tar@<7.5.8: 7.5.9
@@ -576,13 +577,12 @@ packages:
       - supports-color
     dev: true
 
-  /@electron/rebuild@4.0.1:
-    resolution: {integrity: sha512-iMGXb6Ib7H/Q3v+BKZJoETgF9g6KMNZVbsO4b7Dmpgb5qTFqyFTzqW9F3TOSHdybv2vKYKzSS9OiZL+dcJb+1Q==}
+  /@electron/rebuild@4.0.3:
+    resolution: {integrity: sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      chalk: 4.1.2
       debug: 4.4.3
       detect-libc: 2.1.2
       got: 11.8.6
@@ -3923,7 +3923,7 @@ packages:
       '@electron/fuses': 1.8.0
       '@electron/notarize': 2.5.0
       '@electron/osx-sign': 1.3.3
-      '@electron/rebuild': 4.0.1
+      '@electron/rebuild': 4.0.3
       '@electron/universal': 2.0.3
       '@malept/flatpak-bundler': 0.4.0
       '@types/fs-extra': 9.0.13


### PR DESCRIPTION
Fixes #765
Skip-Reason: non-task branch delivery for dependency hotfix; no openspec task run log

## 改动说明
- 在根 `package.json` 增加 `pnpm.overrides["@electron/rebuild"] = "4.0.3"`，强制构建链路使用已修复 tar 导入方式的版本。
- 更新 `pnpm-lock.yaml`，将 `@electron/rebuild` 从 `4.0.1` 提升到 `4.0.3`。

## 用户影响
- Windows CI 的 `build:win` 阶段不再命中 `The requested module 'tar' does not provide an export named 'default'`，可稳定产出 NSIS 与 zip 工件。

## 不修最坏后果
- 主干会持续出现 Windows 打包红灯，阻断发布工件生成，拖慢版本交付与回归验证；安全修复合入后也无法通过完整构建链路验证。

## 验证证据
- `pnpm install`：依赖图已应用 override，锁文件显示 `@electron/rebuild@4.0.3`。
- `node -e "import('file://' + process.cwd() + '/node_modules/.pnpm/@electron+rebuild@4.0.3/node_modules/@electron/rebuild/lib/clang-fetcher.js')..."`：可成功导入（`clang-fetcher import ok`），确认不再触发 tar default export 异常。
- `pnpm typecheck`：通过。
- `pnpm lint`：通过（仅现存历史 warning，无新增 error）。
- `pnpm test:unit`：未通过，失败原因为当前环境 `better-sqlite3` 的 Node ABI 不匹配（`NODE_MODULE_VERSION 143 vs 127`），与本次依赖修复无关。

## 回滚点
- 若需快速回滚，可执行 `git revert 09324921` 撤销本次 override 与锁文件更新，恢复到修复前依赖解析结果。



- 审计补充：已添加 Skip-Reason 以满足 openspec-log-guard 门禁。
