### PR TITLE
fix(tests): 修复 desktop native rebuild 后 unit ABI 冲突

### DIFF
--- a/apps/desktop/tests/unit/test-runner-discovery.spec.ts
+++ b/apps/desktop/tests/unit/test-runner-discovery.spec.ts
@@ -14,8 +14,12 @@ const runnerScript = readFileSync(runnerScriptPath, "utf8");
 
 // S1: unit/integration must use discovery runner entrypoint [ADDED]
 assert.equal(
+  packageJson.scripts?.["desktop:ensure-native-node-abi"],
+  "tsx scripts/ensure-desktop-native-node-abi.ts",
+);
+assert.equal(
   packageJson.scripts?.["test:unit"],
-  "tsx scripts/run-discovered-tests.ts --mode unit",
+  "pnpm desktop:ensure-native-node-abi && tsx scripts/run-discovered-tests.ts --mode unit",
 );
 assert.equal(
   packageJson.scripts?.["test:integration"],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cross-module:check": "tsx scripts/cross-module-contract-gate.ts",
     "cross-module:autofix": "tsx scripts/cross-module-contract-autofix.ts",
     "test:ipc:acceptance": "tsx apps/desktop/tests/perf/ipc-request-response.acceptance.spec.ts && tsx apps/desktop/tests/perf/ipc-push.acceptance.spec.ts && tsx apps/desktop/tests/perf/ipc-validation.acceptance.spec.ts && tsx apps/desktop/tests/perf/ipc-acceptance-gate.spec.ts && tsx scripts/ipc-acceptance-gate.ts",
-    "test:unit": "tsx scripts/run-discovered-tests.ts --mode unit",
+    "test:unit": "pnpm desktop:ensure-native-node-abi && tsx scripts/run-discovered-tests.ts --mode unit",
     "test:integration": "tsx scripts/run-discovered-tests.ts --mode integration",
     "test:discovery:consistency": "tsx scripts/test-discovery-consistency-gate.ts",
     "test:coverage:desktop": "pnpm -C apps/desktop test:coverage",
@@ -25,7 +25,9 @@
     "lint:ratchet:update": "tsx scripts/lint-ratchet.ts --write-baseline",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "desktop:ensure-native-node-abi": "tsx scripts/ensure-desktop-native-node-abi.ts",
+    "test:unit:after-desktop-rebuild": "pnpm -C apps/desktop rebuild:native && pnpm test:unit"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/scripts/ensure-desktop-native-node-abi.ts
+++ b/scripts/ensure-desktop-native-node-abi.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const DESKTOP_PACKAGE_JSON = path.join(REPO_ROOT, "apps/desktop/package.json");
+const PNPM = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+const RECOVERABLE_MARKERS = [
+  "node_module_version",
+  "compiled against a different node.js version",
+  "could not locate the bindings file",
+  "better_sqlite3.node",
+  "cannot find module",
+];
+
+type ProbeResult = {
+  ok: boolean;
+  output: string;
+};
+
+function runProbe(): ProbeResult {
+  const probeScript = `
+const { createRequire } = require("node:module");
+const requireFromDesktop = createRequire(${JSON.stringify(DESKTOP_PACKAGE_JSON)});
+
+try {
+  const Database = requireFromDesktop("better-sqlite3");
+  const db = new Database(":memory:");
+  db.close();
+  process.exit(0);
+} catch (error) {
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(detail);
+  process.exit(1);
+}
+`;
+
+  const result = spawnSync(process.execPath, ["-e", probeScript], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+
+  return {
+    ok: result.status === 0,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim(),
+  };
+}
+
+function isRecoverable(output: string): boolean {
+  const lowered = output.toLowerCase();
+  return RECOVERABLE_MARKERS.some((marker) => lowered.includes(marker));
+}
+
+function rebuildForNodeAbi(): void {
+  const result = spawnSync(PNPM, ["-C", "apps/desktop", "rebuild", "better-sqlite3"], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    throw new Error("Failed to rebuild better-sqlite3 for Node runtime ABI");
+  }
+}
+
+function ensureDesktopNativeNodeAbi(): void {
+  const initialProbe = runProbe();
+  if (initialProbe.ok) {
+    return;
+  }
+
+  if (!isRecoverable(initialProbe.output)) {
+    throw new Error(
+      [
+        "Unable to load apps/desktop better-sqlite3 for an unknown reason.",
+        initialProbe.output,
+      ].join("\n"),
+    );
+  }
+
+  console.log("[native-abi] detected better-sqlite3 ABI drift, rebuilding for Node runtime...");
+  rebuildForNodeAbi();
+
+  const verifyProbe = runProbe();
+  if (!verifyProbe.ok) {
+    throw new Error(
+      [
+        "better-sqlite3 still failed to load after Node ABI rebuild.",
+        verifyProbe.output,
+      ].join("\n"),
+    );
+  }
+
+  console.log("[native-abi] better-sqlite3 Node ABI restored.");
+}
+
+ensureDesktopNativeNodeAbi();


### PR DESCRIPTION
Fixes #768
Skip-Reason: non-task branch delivery without openspec task run log

## 问题
`pnpm -C apps/desktop rebuild:native` 会把 `better-sqlite3` 重编译成 Electron ABI，随后直接执行根级 `pnpm test:unit` 时，Node 运行时加载数据库原生模块会报 `NODE_MODULE_VERSION` 不匹配并中断单测链路。

## 改动
- 新增 `scripts/ensure-desktop-native-node-abi.ts`：在单测前实际创建 `:memory:` 数据库探测 `better-sqlite3` 可用性；若检测到 ABI 漂移/绑定缺失，自动执行 `pnpm -C apps/desktop rebuild better-sqlite3` 并二次校验。
- 根级 `test:unit` 改为先执行 `desktop:ensure-native-node-abi` 再跑测试发现器，避免被 Electron rebuild 污染。
- 新增 `test:unit:after-desktop-rebuild` 门禁脚本，固化“rebuild 后再跑 unit”的可复现检查路径。
- 更新 `apps/desktop/tests/unit/test-runner-discovery.spec.ts`，把新脚本链路纳入约束，防止后续回退。

## 用户影响
开发者在同一工作区执行 `rebuild:native` 后，不再需要手动修复 `better-sqlite3` ABI；`pnpm test:unit` 会自动恢复 Node ABI 并继续执行回归测试，避免测试链路被中断。

## 不修的最坏后果
如果不修，任何触发 Electron native rebuild 的流程（如 e2e/build）都会让后续根级单测稳定失败，导致本地/预检回归链路失效，提升未充分验证变更进入主干的风险。

## 验证证据
- `pnpm test:unit:after-desktop-rebuild` 通过（覆盖 `rebuild:native -> test:unit` 全链路）
- `pnpm typecheck` 通过
- `pnpm lint` 通过（仅仓库既有 warning，无新增 error）

## 回滚点
- 单提交回滚：`git revert b802a9df`
- 若需临时回退行为，可恢复 `package.json` 中旧版 `test:unit` 脚本并删除 `scripts/ensure-desktop-native-node-abi.ts`
