### PR TITLE
fix(ci): 避免 windows 打包阶段重复触发 native rebuild

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -5,6 +5,7 @@
     "output": "dist-electron"
   },
   "files": ["dist/**", "package.json"],
+  "npmRebuild": false,
   "asar": true,
   "asarUnpack": ["**/*.node", "**/*.dll"],
   "win": {


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 Windows 打包阶段因 `@electron/rebuild` 导入 `tar` 失败导致的构建中断。

## 改动列表
- 在 `apps/desktop/electron-builder.json` 增加 `"npmRebuild": false`，禁止 `electron-builder` 在打包阶段再次触发 native rebuild。
- 保留 `build:win` 里已有的 `pnpm rebuild:native` 作为唯一 native 依赖重建入口，避免重复重建路径触发 `@electron/rebuild` 兼容性问题。

## Fixes
Fixes #770

## 用户影响
- Windows 发布链路恢复稳定：`build:win` 不再在 `electron-builder` 阶段二次触发失败路径。
- Windows 用户可以继续获得 `nsis/zip` 安装包，紧急修复发布通道恢复可用。

## 不修最坏后果
- `main` 仍可能在 Windows CI 上间歇性卡死于打包阶段，导致安装包无法产出。
- 遇到安全热修时，Windows 用户侧修复交付会继续被阻断，风险暴露时间拉长。

## 验证证据
- 本地验证（Linux 开发环境）：
  - `pnpm -C apps/desktop rebuild:native` 通过（`Rebuild Complete`）
  - `pnpm -C apps/desktop build` 通过（main/preload/renderer 全部构建成功）
- 变更逻辑验证：
  - 该改动移除了 `electron-builder` 阶段对 `@electron/rebuild` 的重复调用，直接规避 issue 中报错堆栈对应的触发点。

## 回滚点
- 单文件配置改动，可通过回滚提交 `c0a81501` 恢复（`apps/desktop/electron-builder.json`）。

## Open PR 排重检查
- 扫描时间：2026-02-28 14:20 (Asia/Shanghai)
- 当前 open PR：#755 清理审计相关文件和目录
- 文件重叠：无（本 PR 仅改 `apps/desktop/electron-builder.json`）
- 处理决策：新开 PR，主题与文件均独立。
