### PR TITLE
fix(ci): 补齐 Skip-Reason 前置提示与机器人评论引导

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,9 @@
-Skip-Reason: <non-task 分支必填；task/* 分支填写 N/A>
+> 非 `task/*` 分支：请先填写 `Skip-Reason:`（必须保留该前缀）
+> 示例：`Skip-Reason: automated quality iteration by 天野 (non-task branch)`
+>
+> `task/*` 分支：填写 `Skip-Reason: N/A (task branch)`，并补齐对应 RUN_LOG。
+
+Skip-Reason: <必填，按上方示例替换>
 
 ## 主题
 - 简要说明本次改动解决的问题

--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -56,30 +56,30 @@ jobs:
           PY
 
       - name: Validate RUN_LOG or Skip-Reason
+        id: validate_run_log_or_skip_reason
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           BRANCH="${{ github.head_ref }}"
+          echo "skip_reason_missing=false" >> "$GITHUB_OUTPUT"
 
           if [[ "$BRANCH" =~ ^task/([0-9]+)- ]]; then
             ISSUE_NUM="${BASH_REMATCH[1]}"
             RUN_LOG="openspec/_ops/task_runs/ISSUE-${ISSUE_NUM}.md"
 
-            # Check file exists
             if [ ! -f "$RUN_LOG" ]; then
               echo "❌ RUN_LOG not found: $RUN_LOG"
               exit 1
             fi
             echo "✅ RUN_LOG found: $RUN_LOG"
 
-            # Validate required fields
             MISSING=""
-            grep -q "^- Issue:" "$RUN_LOG"   || MISSING="${MISSING} Issue"
-            grep -q "^- Branch:" "$RUN_LOG"  || MISSING="${MISSING} Branch"
-            grep -q "^- PR:" "$RUN_LOG"      || MISSING="${MISSING} PR"
-            grep -q "^## Plan" "$RUN_LOG"    || MISSING="${MISSING} Plan"
-            grep -q "^## Runs" "$RUN_LOG"    || MISSING="${MISSING} Runs"
+            grep -q "^- Issue:" "$RUN_LOG" || MISSING="${MISSING} Issue"
+            grep -q "^- Branch:" "$RUN_LOG" || MISSING="${MISSING} Branch"
+            grep -q "^- PR:" "$RUN_LOG" || MISSING="${MISSING} PR"
+            grep -q "^## Plan" "$RUN_LOG" || MISSING="${MISSING} Plan"
+            grep -q "^## Runs" "$RUN_LOG" || MISSING="${MISSING} Runs"
 
             if [ -n "$MISSING" ]; then
               echo "❌ RUN_LOG missing required fields:${MISSING}"
@@ -88,15 +88,90 @@ jobs:
             echo "✅ RUN_LOG format validated"
 
             python3 scripts/validate_main_session_audit_ci.py "$RUN_LOG"
-
           else
             if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then
               echo "✅ Non-task branch with required Skip-Reason"
             else
-              echo "::error title=Missing Skip-Reason::Non-task branch '$BRANCH' must include a 'Skip-Reason:' line in PR body. Add for example: Skip-Reason: non-task branch delivery without openspec task run log"
+              FIX_LINE="Skip-Reason: automated quality iteration by 天野 (non-task branch)"
+              echo "skip_reason_missing=true" >> "$GITHUB_OUTPUT"
+
+              echo "::error title=Missing Skip-Reason::Non-task branch '$BRANCH' must include a 'Skip-Reason:' line in PR body."
               echo "❌ Missing Skip-Reason in PR body"
-              echo "Please update PR description with a line like:"
-              echo "Skip-Reason: <why this branch is not task/* and has no RUN_LOG>"
+              echo "Fix suggestion (copy one line): $FIX_LINE"
+              echo "Minimal example:"
+              echo "$FIX_LINE"
+              echo "## 主题"
+              echo "- 简要说明本次改动解决的问题"
+
+              {
+                echo "### Missing Skip-Reason"
+                echo
+                echo "Non-task branch \`$BRANCH\` must include a \`Skip-Reason:\` line in PR body."
+                echo
+                echo "Copy one line:"
+                echo "\`$FIX_LINE\`"
+                echo
+                echo "Minimal example:"
+                echo '```markdown'
+                echo "$FIX_LINE"
+                echo "## 主题"
+                echo "- 简要说明本次改动解决的问题"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+
               exit 1
             fi
           fi
+
+      - name: Comment Skip-Reason guidance on PR
+        if: ${{ failure() && steps.validate_run_log_or_skip_reason.outputs.skip_reason_missing == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = '<!-- openspec-skip-reason-guidance -->';
+            const fixLine = 'Skip-Reason: automated quality iteration by 天野 (non-task branch)';
+            const body = [
+              marker,
+              'OpenSpec Log Guard 检测到当前分支不是 `task/*`，但 PR 描述缺少 `Skip-Reason:`。',
+              '',
+              '可直接复制这一行到 PR 描述顶部：',
+              `\`${fixLine}\``,
+              '',
+              '最小示例：',
+              '```markdown',
+              fixLine,
+              '## 主题',
+              '- 简要说明本次改动解决的问题',
+              '```',
+            ].join('\n');
+
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
- 为非 `task/*` 分支补齐更靠前的 `Skip-Reason` 提示，并在缺失时由 CI 机器人自动评论可复制修复示例。

## 关联 Issue
- Fixes #773

## 用户影响
- 非 `task/*` 分支提 PR 时，在模板顶部即可看到必填说明与可复制示例，降低遗漏概率。
- 若仍遗漏，`OpenSpec Log Guard` 会在失败时自动留下机器人评论，提交者无需翻日志即可快速修复并重跑。

## 不修最坏后果
- 提交者会继续在代码本身正确的情况下被流程字段拦截，反复编辑 PR 才能过 CI，增加交付时延和无效沟通成本。

## 验证证据
- [x] `pnpm typecheck`
- [x] `pnpm lint`（通过，仓库现存 68 条 warning，无新增 error）
- [x] `pnpm test:unit`
- 补充：工作流新增 `skip_reason_missing` 输出与 `actions/github-script` 评论更新逻辑，仅在缺失 `Skip-Reason` 时触发。

## 回滚点
- 回滚 commit/分支：`git revert 4dab41ce` 或回滚分支 `amano/asuka-773-skip-reason`
- 回滚后需要恢复的数据或配置：无（仅 PR 模板与 CI 工作流文案/提示逻辑变更）
