### PR TITLE
fix(ci): 修复 OpenSpec Log Guard 缺少补救评论闭环

### DIFF
--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -10,6 +10,11 @@ concurrency:
   group: openspec-log-guard-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   openspec-log-guard:
     runs-on: ubuntu-latest
@@ -95,9 +100,9 @@ jobs:
               FIX_LINE="Skip-Reason: automated quality iteration by 天野 (non-task branch)"
               echo "skip_reason_missing=true" >> "$GITHUB_OUTPUT"
 
-              echo "::error title=Missing Skip-Reason::Non-task branch '$BRANCH' must include a 'Skip-Reason:' line in PR body."
               echo "❌ Missing Skip-Reason in PR body"
               echo "Fix suggestion (copy one line): $FIX_LINE"
+              echo "After updating the PR body, re-run OpenSpec Log Guard from Checks tab."
               echo "Minimal example:"
               echo "$FIX_LINE"
               echo "## 主题"
@@ -111,6 +116,8 @@ jobs:
                 echo "Copy one line:"
                 echo "\`$FIX_LINE\`"
                 echo
+                echo "更新 PR 描述后，请在 Checks 页面点击 \`Re-run jobs\`（或 push 任意新 commit）重新触发 OpenSpec Log Guard。"
+                echo
                 echo "Minimal example:"
                 echo '```markdown'
                 echo "$FIX_LINE"
@@ -118,13 +125,11 @@ jobs:
                 echo "- 简要说明本次改动解决的问题"
                 echo '```'
               } >> "$GITHUB_STEP_SUMMARY"
-
-              exit 1
             fi
           fi
 
       - name: Comment Skip-Reason guidance on PR
-        if: ${{ failure() && steps.validate_run_log_or_skip_reason.outputs.skip_reason_missing == 'true' }}
+        if: ${{ steps.validate_run_log_or_skip_reason.outputs.skip_reason_missing == 'true' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -137,6 +142,8 @@ jobs:
               '',
               '可直接复制这一行到 PR 描述顶部：',
               `\`${fixLine}\``,
+              '',
+              '更新 PR 描述后，请在 Checks 页面点击 `Re-run jobs`（或 push 任意新 commit）重新触发 OpenSpec Log Guard。',
               '',
               '最小示例：',
               '```markdown',
@@ -175,3 +182,12 @@ jobs:
                 body,
               });
             }
+
+      - name: Fail when Skip-Reason is missing
+        if: ${{ steps.validate_run_log_or_skip_reason.outputs.skip_reason_missing == 'true' }}
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          echo "::error title=Missing Skip-Reason::Non-task branch '$BRANCH' must include a 'Skip-Reason:' line in PR body."
+          echo "❌ Missing Skip-Reason in PR body"
+          echo "请按机器人评论指引补齐 Skip-Reason 后重跑 OpenSpec Log Guard。"
+          exit 1


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

Fixes #776

## 用户影响
- 非 `task/*` 分支在缺少 `Skip-Reason:` 时，PR 会自动收到可直接复制的修复指引，并明确提示需要重跑检查。
- 现有被阻断 PR 作者不需要翻 CI 原始日志即可自助解除阻断。

## 不修最坏后果
- PR 会持续被 OpenSpec Log Guard 阻断但无页面级补救提示，作者容易长时间卡在失败状态，发布节奏被反复拖慢。

## 改动说明
- 给 `OpenSpec Log Guard` 工作流增加显式 `issues/pull-requests` 写权限，避免评论步骤因权限不足静默失效。
- 把“缺少 Skip-Reason”的失败路径改为：先写 Step Summary + 发/更评论，再统一 fail，确保闭环提示一定落到 PR 页面。
- 在评论和 Summary 中补充 “更新描述后需 Re-run jobs（或 push 任意 commit）” 指引。
- 已对存量失败 PR #755 补发一次指引评论进行兜底验证：
  https://github.com/Leeky1017/CreoNow/pull/755#issuecomment-3976611041

## 验证证据
- `pnpm typecheck` 通过。
- `pnpm lint` 通过（仓库现存 68 条 warning，无新增 error）。
- `pnpm test:unit` 通过（10 files / 36 tests）。

## 回滚点
- 回滚 commit `1669dc04` 即可恢复旧逻辑。
- 回滚影响面仅 `.github/workflows/openspec-log-guard.yml`。
