### PR TITLE
fix(renderer): 修复 fire-and-forget 已处理异常的 critical 误报

### DIFF
--- a/apps/desktop/renderer/src/lib/__tests__/fireAndForget.test.ts
+++ b/apps/desktop/renderer/src/lib/__tests__/fireAndForget.test.ts
@@ -94,6 +94,8 @@ describe("runFireAndForget", () => {
 
   it("keeps backward-compat function options signature", async () => {
     const handler = vi.fn();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     runFireAndForget(
       async () => {
@@ -107,5 +109,17 @@ describe("runFireAndForget", () => {
     expect(handler).toHaveBeenCalledTimes(1);
     const [error] = handler.mock.calls[0];
     expect(error).toBeInstanceOf(Error);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const [message, details] = consoleWarnSpy.mock.calls[0];
+    expect(message).toContain("[fire-and-forget][non-critical] task failed");
+    expect(details).toMatchObject({
+      errorType: "Error",
+      message: "boom",
+      critical: false,
+    });
+
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/desktop/renderer/src/lib/fireAndForget.ts
+++ b/apps/desktop/renderer/src/lib/fireAndForget.ts
@@ -15,7 +15,7 @@ export function runFireAndForget(
 ): void {
   const normalized: FireAndForgetOptions =
     typeof options === "function"
-      ? { onError: options }
+      ? { onError: options, critical: false }
       : options ?? {};
 
   const { label, onError, critical = true } = normalized;

--- a/apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts
+++ b/apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts
@@ -31,6 +31,17 @@ function flushMicrotasks(): Promise<void> {
 }
 
 {
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const errorCalls: unknown[][] = [];
+  const warnCalls: unknown[][] = [];
+  console.error = (...args: unknown[]) => {
+    errorCalls.push(args);
+  };
+  console.warn = (...args: unknown[]) => {
+    warnCalls.push(args);
+  };
+
   let captured: unknown = null;
   runFireAndForget(
     async () => {
@@ -42,6 +53,13 @@ function flushMicrotasks(): Promise<void> {
   );
 
   await flushMicrotasks();
+
+  console.error = originalError;
+  console.warn = originalWarn;
+
   assert.ok(captured instanceof Error);
   assert.equal((captured as Error).message, "handled");
+  assert.equal(errorCalls.length, 0, "expected handled errors to avoid critical logs");
+  assert.equal(warnCalls.length, 1, "expected handled errors to emit non-critical warning");
+  assert.equal(warnCalls[0][0], "[fire-and-forget][non-critical] task failed");
 }


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 `runFireAndForget` 在“错误已由调用方 onError 处理”场景下仍输出 `critical` 级日志的误报。

## 改动列表
- 调整 `runFireAndForget` 的函数签名兼容分支：当第二参数为回调函数时，默认按 `critical: false` 记录。
- 补充 `fireAndForget` 单元测试：验证函数签名兼容路径不会再打 `console.error`，改为非关键告警。
- 更新 `renderer-fireforget-helper.spec.ts`：覆盖并断言“自定义 `onError` + 预期异常”路径不会产出 `critical` 日志。

## 用户影响
- `pnpm test:unit` 全绿场景下，不再因为“已捕获并断言的预期异常”出现 `[fire-and-forget][critical]` 噪音。
- CI `unit-test-core` 日志信噪比提升，值班排障时更容易识别真正故障。

## 不修复的最坏后果
如果不修，这类预期异常会持续以 `critical` 级别污染成功构建日志，告警系统可能被误触发并稀释真实事故信号，影响对真实故障/安全异常的响应效率。

## 验证证据
- `pnpm typecheck` 通过。
- `pnpm lint` 通过（仅存在仓库既有 68 条 warning，无新增 error）。
- `pnpm test:unit` 通过。
- `pnpm tsx apps/desktop/tests/unit/renderer-fireforget-helper.spec.ts` 通过，且无 `critical` 误报输出。

## 回滚点
- 回滚提交：`222cdb1f`。
- 回滚方式：`git revert 222cdb1f`（仅撤销本次 fire-and-forget 日志级别与测试改动）。

Fixes #778
