### PR TITLE
improve(tests): 修复 renderer 单测 act 告警噪音。

### DIFF
--- a/apps/desktop/renderer/src/features/ai/AiPanel.selection-reference.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.selection-reference.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 type SelectionSnapshot = {
@@ -165,6 +165,18 @@ vi.mock("../../lib/ipcClient", () => ({
   }),
 }));
 
+async function renderAiPanel(): Promise<void> {
+  const { AiPanel } = await import("./AiPanel");
+
+  await act(async () => {
+    render(<AiPanel />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("ai-panel")).toBeInTheDocument();
+  });
+}
+
 describe("AiPanel selection reference card", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -179,11 +191,10 @@ describe("AiPanel selection reference card", () => {
   });
 
   it("should render selection reference card with preview when selection exists", async () => {
-    const { AiPanel } = await import("./AiPanel");
     mocks.aiState.selectionRef = mocks.selectionA.selectionRef;
     mocks.aiState.selectionText = mocks.selectionA.selectionText;
 
-    render(<AiPanel />);
+    await renderAiPanel();
 
     expect(
       screen.getByTestId("ai-selection-reference-card"),
@@ -198,11 +209,10 @@ describe("AiPanel selection reference card", () => {
 
   it("should clear selection snapshot when user closes reference card", async () => {
     const user = userEvent.setup();
-    const { AiPanel } = await import("./AiPanel");
     mocks.aiState.selectionRef = mocks.selectionA.selectionRef;
     mocks.aiState.selectionText = mocks.selectionA.selectionText;
 
-    render(<AiPanel />);
+    await renderAiPanel();
 
     await user.click(screen.getByTestId("ai-selection-reference-close"));
 
@@ -210,12 +220,11 @@ describe("AiPanel selection reference card", () => {
   });
 
   it("should send with selection context and clear reference after Enter", async () => {
-    const { AiPanel } = await import("./AiPanel");
     mocks.aiState.input = "润色这段话";
     mocks.aiState.selectionRef = mocks.selectionA.selectionRef;
     mocks.aiState.selectionText = mocks.selectionA.selectionText;
 
-    render(<AiPanel />);
+    await renderAiPanel();
 
     fireEvent.keyDown(screen.getByTestId("ai-input"), {
       key: "Enter",
@@ -238,11 +247,10 @@ describe("AiPanel selection reference card", () => {
   });
 
   it("should replace existing reference when a new selection is made", async () => {
-    const { AiPanel } = await import("./AiPanel");
     mocks.aiState.selectionRef = mocks.selectionA.selectionRef;
     mocks.aiState.selectionText = mocks.selectionA.selectionText;
 
-    render(<AiPanel />);
+    await renderAiPanel();
 
     captureSelectionRefMock.mockReturnValueOnce({
       ok: true,
@@ -259,11 +267,10 @@ describe("AiPanel selection reference card", () => {
   });
 
   it("should not render reference card when no selection exists", async () => {
-    const { AiPanel } = await import("./AiPanel");
     mocks.aiState.selectionRef = null;
     mocks.aiState.selectionText = "";
 
-    render(<AiPanel />);
+    await renderAiPanel();
 
     expect(
       screen.queryByTestId("ai-selection-reference-card"),

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.context-menu.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.context-menu.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { FileTreePanel } from "./FileTreePanel";
 
@@ -56,6 +56,23 @@ vi.mock("../../stores/editorStore", () => ({
   ),
 }));
 
+async function renderFileTreePanel(projectId = "proj-1"): Promise<void> {
+  await act(async () => {
+    render(<FileTreePanel projectId={projectId} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("sidebar-files")).toBeInTheDocument();
+  });
+}
+
+async function flushFileTreeAsyncUpdates(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe("FileTreePanel context menu actions", () => {
   beforeEach(() => {
     fileItems = [
@@ -97,9 +114,11 @@ describe("FileTreePanel context menu actions", () => {
   });
 
   it("should show rename/delete/copy/move/status actions and invoke corresponding operations", async () => {
-    render(<FileTreePanel projectId="proj-1" />);
+    await renderFileTreePanel("proj-1");
 
-    fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
+    await act(async () => {
+      fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
+    });
 
     const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
     const deleteItem = await screen.findByRole("menuitem", { name: "Delete" });
@@ -122,16 +141,20 @@ describe("FileTreePanel context menu actions", () => {
     expect(statusItem).toBeInTheDocument();
 
     fireEvent.click(copyItem);
+    await flushFileTreeAsyncUpdates();
+
     expect(createAndSetCurrent).toHaveBeenCalledWith({
       projectId: "proj-1",
       type: "chapter",
       title: "未命名章节 Copy",
     });
 
-    fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Move to Folder" }),
-    );
+    await act(async () => {
+      fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
+    });
+
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Folder" }));
+    await flushFileTreeAsyncUpdates();
 
     expect(moveToFolder).toHaveBeenCalledWith({
       projectId: "proj-1",

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.drag-drop.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.drag-drop.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { FileTreePanel } from "./FileTreePanel";
 
@@ -57,6 +57,23 @@ vi.mock("../../stores/editorStore", () => ({
       }),
   ),
 }));
+
+async function renderFileTreePanel(projectId = "proj-1"): Promise<void> {
+  await act(async () => {
+    render(<FileTreePanel projectId={projectId} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("sidebar-files")).toBeInTheDocument();
+  });
+}
+
+async function flushFileTreeAsyncUpdates(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
 
 describe("FileTreePanel drag and folder hierarchy", () => {
   beforeEach(() => {
@@ -125,15 +142,18 @@ describe("FileTreePanel drag and folder hierarchy", () => {
     openCurrentDocumentForProject.mockReset().mockResolvedValue({ ok: true });
   });
 
-  it("should reorder sibling documents and persist via file:document:reorder", () => {
-    render(<FileTreePanel projectId="proj-1" />);
+  it("should reorder sibling documents and persist via file:document:reorder", async () => {
+    await renderFileTreePanel("proj-1");
 
     const source = screen.getByTestId("file-row-doc-3");
     const target = screen.getByTestId("file-row-doc-1");
 
     fireEvent.dragStart(source);
+    await flushFileTreeAsyncUpdates();
     fireEvent.dragOver(target);
+    await flushFileTreeAsyncUpdates();
     fireEvent.drop(target);
+    await flushFileTreeAsyncUpdates();
 
     expect(reorder).toHaveBeenCalledWith({
       projectId: "proj-1",
@@ -141,15 +161,18 @@ describe("FileTreePanel drag and folder hierarchy", () => {
     });
   });
 
-  it("should move document into target folder and persist parentId", () => {
-    render(<FileTreePanel projectId="proj-1" />);
+  it("should move document into target folder and persist parentId", async () => {
+    await renderFileTreePanel("proj-1");
 
     const source = screen.getByTestId("file-row-doc-side");
     const targetFolder = screen.getByTestId("file-row-folder-1");
 
     fireEvent.dragStart(source);
+    await flushFileTreeAsyncUpdates();
     fireEvent.dragOver(targetFolder);
+    await flushFileTreeAsyncUpdates();
     fireEvent.drop(targetFolder);
+    await flushFileTreeAsyncUpdates();
 
     expect(moveToFolder).toHaveBeenCalledWith({
       projectId: "proj-1",

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.empty-state.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.empty-state.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { FileTreePanel } from "./FileTreePanel";
 
@@ -39,6 +39,23 @@ vi.mock("../../stores/editorStore", () => ({
   ),
 }));
 
+async function renderFileTreePanel(projectId: string): Promise<void> {
+  await act(async () => {
+    render(<FileTreePanel projectId={projectId} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("sidebar-files")).toBeInTheDocument();
+  });
+}
+
+async function flushFileTreeAsyncUpdates(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe("FileTreePanel empty state", () => {
   beforeEach(() => {
     createAndSetCurrent.mockReset().mockResolvedValue({
@@ -57,8 +74,8 @@ describe("FileTreePanel empty state", () => {
     openCurrentDocumentForProject.mockReset().mockResolvedValue({ ok: true });
   });
 
-  it("should render empty state message and new file entry action when no documents exist", () => {
-    render(<FileTreePanel projectId="proj-empty" />);
+  it("should render empty state message and new file entry action when no documents exist", async () => {
+    await renderFileTreePanel("proj-empty");
 
     expect(
       screen.getByText("暂无文件，开始创建你的第一个文件"),
@@ -66,6 +83,7 @@ describe("FileTreePanel empty state", () => {
 
     const createButton = screen.getByRole("button", { name: "新建文件" });
     fireEvent.click(createButton);
+    await flushFileTreeAsyncUpdates();
 
     expect(createAndSetCurrent).toHaveBeenCalledWith({
       projectId: "proj-empty",

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.types-status.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.types-status.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { FileTreePanel } from "./FileTreePanel";
 
@@ -52,6 +52,23 @@ vi.mock("../../stores/editorStore", () => ({
   ),
 }));
 
+async function renderFileTreePanel(projectId = "proj-1"): Promise<void> {
+  await act(async () => {
+    render(<FileTreePanel projectId={projectId} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId("sidebar-files")).toBeInTheDocument();
+  });
+}
+
+async function flushFileTreeAsyncUpdates(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe("FileTreePanel type/status baseline", () => {
   beforeEach(() => {
     fileItems = [];
@@ -71,10 +88,11 @@ describe("FileTreePanel type/status baseline", () => {
     openCurrentDocumentForProject.mockReset().mockResolvedValue({ ok: true });
   });
 
-  it("should create chapter document from default create button", () => {
-    render(<FileTreePanel projectId="proj-1" />);
+  it("should create chapter document from default create button", async () => {
+    await renderFileTreePanel("proj-1");
 
     fireEvent.click(screen.getByTestId("file-create"));
+    await flushFileTreeAsyncUpdates();
 
     expect(createAndSetCurrent).toHaveBeenCalledWith({
       projectId: "proj-1",
@@ -82,7 +100,7 @@ describe("FileTreePanel type/status baseline", () => {
     });
   });
 
-  it("should render note type icon in file row", () => {
+  it("should render note type icon in file row", async () => {
     fileItems = [
       {
         documentId: "doc-note",
@@ -93,12 +111,12 @@ describe("FileTreePanel type/status baseline", () => {
       },
     ];
 
-    render(<FileTreePanel projectId="proj-1" />);
+    await renderFileTreePanel("proj-1");
 
     expect(screen.getByTestId("file-type-icon-doc-note")).toBeInTheDocument();
   });
 
-  it("should render final status indicator in file row", () => {
+  it("should render final status indicator in file row", async () => {
     fileItems = [
       {
         documentId: "doc-final",
@@ -109,7 +127,7 @@ describe("FileTreePanel type/status baseline", () => {
       },
     ];
 
-    render(<FileTreePanel projectId="proj-1" />);
+    await renderFileTreePanel("proj-1");
 
     expect(
       screen.getByTestId("file-status-final-doc-final"),


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

Fixes #780

## 用户影响
- 清理 AiPanel / FileTreePanel 相关单测中的 React `act(...)` 告警噪音，测试输出更聚焦真实失败。
- 仅修改测试代码，不触碰业务实现，降低回归风险。

## 不修复的最坏后果
- 单测日志持续被告警淹没，真实错误信号被稀释；长期会放大定位成本，并可能掩盖异步交互带来的潜在超时问题。

## 变更内容
- `apps/desktop/renderer/src/features/ai/AiPanel.selection-reference.test.tsx`
- `apps/desktop/renderer/src/features/files/FileTreePanel.context-menu.test.tsx`
- `apps/desktop/renderer/src/features/files/FileTreePanel.drag-drop.test.tsx`
- `apps/desktop/renderer/src/features/files/FileTreePanel.empty-state.test.tsx`
- `apps/desktop/renderer/src/features/files/FileTreePanel.types-status.test.tsx`

## 验证证据
- `pnpm -C apps/desktop test:run renderer/src/features/ai/AiPanel.selection-reference.test.tsx renderer/src/features/files/FileTreePanel.context-menu.test.tsx renderer/src/features/files/FileTreePanel.drag-drop.test.tsx`
  - 3 files, 8 tests passed；未出现 React `act(...)` 告警。
- `pnpm -C apps/desktop test:run renderer/src/features/files/FileTreePanel.empty-state.test.tsx renderer/src/features/files/FileTreePanel.types-status.test.tsx`
  - 2 files, 4 tests passed；未出现 React `act(...)` 告警。
- `pnpm typecheck` 通过。
- `pnpm lint` 通过（0 errors，存在仓库基线 68 warnings）。

## 回滚点
- 可回滚至父提交 `925f2ffacb5cab27c5f3fae4087ea4632748e83d`（本次提交 `3186f99a2628d0a588477fb6a553837dbc6858a1`）。

## Open PR 排重检查
- `gh pr list --state open --limit 100` 当前仅有 `#755`（`issue-754-cleanup-audit-files -> main`）。
- 分支 `amano/fix-issue-780-act-warnings` 无已存在 open PR，未发现重复提交。
