### PR TITLE
fix(search): SearchPanel open 短路 + backdrop 关闭语义 (#786)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/desktop/renderer/src/components/layout/Sidebar.tsx
@@ -59,6 +59,7 @@ export function Sidebar(props: {
   onSwitchProject?: (projectId: string) => Promise<void>;
   onCreateProject?: () => void;
   onOpenVersionHistoryDocument?: (documentId: string) => void;
+  onCloseSearch?: () => void;
 }): JSX.Element {
 
   if (props.collapsed) {
@@ -91,7 +92,11 @@ export function Sidebar(props: {
 
       case "search":
         return props.projectId ? (
-          <SearchPanel projectId={props.projectId} />
+          <SearchPanel
+            projectId={props.projectId}
+            open={true}
+            onClose={props.onCloseSearch}
+          />
         ) : (
           <div className="p-3 text-xs text-[var(--color-fg-muted)]">
             Open a project to search

--- a/apps/desktop/renderer/src/features/search/SearchPanel.close.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.close.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchPanel } from "./SearchPanel";
+
+vi.mock("../../stores/searchStore", () => ({
+  useSearchStore: vi.fn((selector) => {
+    const state = {
+      query: "",
+      items: [],
+      status: "idle" as const,
+      indexState: "ready" as const,
+      total: 0,
+      hasMore: false,
+      lastError: null,
+      setQuery: vi.fn(),
+      runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+      clearResults: vi.fn(),
+      clearError: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("../../stores/fileStore", () => ({
+  useFileStore: vi.fn((selector) => {
+    const state = { setCurrent: vi.fn().mockResolvedValue({ ok: true }) };
+    return selector(state);
+  }),
+}));
+
+// WB-FE-HF-SP-S2 + S2b
+describe("SearchPanel close", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls onClose when clicking backdrop", () => {
+    const onClose = vi.fn();
+    render(
+      <SearchPanel projectId="test-project" open={true} onClose={onClose} />,
+    );
+    const backdrop = screen.getByTestId("search-backdrop");
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when pressing Escape", () => {
+    const onClose = vi.fn();
+    render(
+      <SearchPanel projectId="test-project" open={true} onClose={onClose} />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.stories.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.stories.tsx
@@ -51,7 +51,7 @@ type Story = StoryObj<typeof meta>;
  */
 function SearchPanelWithQuery(props: {
   projectId: string;
-  open?: boolean;
+  open: boolean;
   onClose?: () => void;
   mockResults?: SearchResultItem[];
   initialQuery?: string;

--- a/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
@@ -41,14 +41,14 @@ describe("SearchPanel", () => {
   // ===========================================================================
   describe("渲染", () => {
     it("应该渲染 SearchPanel 组件", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const panel = screen.getByTestId("search-panel");
       expect(panel).toBeInTheDocument();
     });
 
     it("应该显示搜索输入框带有 placeholder", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const input = screen.getByTestId("search-input");
       expect(input).toBeInTheDocument();
@@ -59,14 +59,14 @@ describe("SearchPanel", () => {
     });
 
     it("应该显示分类过滤按钮", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       // 组件使用分类过滤器（All, Documents, Memories, Knowledge, Assets）
       expect(screen.getByText("All")).toBeInTheDocument();
     });
 
     it("应该有模态背景遮罩", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       // 检查模态框结构
       const panel = screen.getByTestId("search-panel");
@@ -80,7 +80,7 @@ describe("SearchPanel", () => {
   // ===========================================================================
   describe("交互", () => {
     it("输入框应可输入", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const input = screen.getByTestId("search-input");
       expect(input).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe("SearchPanel", () => {
     });
 
     it("点击分类按钮应切换分类", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const allButton = screen.getByText("All");
       expect(allButton).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe("SearchPanel", () => {
   // ===========================================================================
   describe("搜索结果展示", () => {
     it("输入搜索词后应显示相关结果", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const input = screen.getByTestId("search-input");
       fireEvent.change(input, { target: { value: "design" } });
@@ -136,7 +136,7 @@ describe("SearchPanel", () => {
         return selector(state);
       });
 
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       // 组件可能显示 Spinner 或其他加载指示器
       // 基于当前实现，loading 状态由 store 管理
@@ -148,7 +148,7 @@ describe("SearchPanel", () => {
   // ===========================================================================
   describe("样式", () => {
     it("应该是 div 元素（模态框样式）", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const panel = screen.getByTestId("search-panel");
       // 组件使用 div 作为模态框容器，不是 section
@@ -156,7 +156,7 @@ describe("SearchPanel", () => {
     });
 
     it("应该有固定定位和全屏覆盖", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const panel = screen.getByTestId("search-panel");
       expect(panel).toHaveClass("fixed");
@@ -165,7 +165,7 @@ describe("SearchPanel", () => {
     });
 
     it("应该居中显示搜索面板", () => {
-      render(<SearchPanel projectId="test-project" />);
+      render(<SearchPanel projectId="test-project" open={true} />);
 
       const panel = screen.getByTestId("search-panel");
       expect(panel).toHaveClass("items-start");
@@ -179,7 +179,7 @@ describe("SearchPanel", () => {
   describe("关闭功能", () => {
     it("点击背景遮罩应触发关闭", () => {
       const onClose = vi.fn();
-      render(<SearchPanel projectId="test-project" onClose={onClose} />);
+      render(<SearchPanel projectId="test-project" open={true} onClose={onClose} />);
 
       // 点击背景遮罩
       const backdrop = document.querySelector(".backdrop-blur-sm");

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -497,7 +497,7 @@ function KeyHint(props: {
  */
 export function SearchPanel(props: {
   projectId: string;
-  open?: boolean;
+  open: boolean;
   onClose?: () => void;
   /** Mock results for storybook demonstration */
   mockResults?: SearchResultItem[];
@@ -507,7 +507,7 @@ export function SearchPanel(props: {
   mockStatus?: SearchStatus;
   /** Mock index state for storybook demonstration */
   mockIndexState?: "ready" | "rebuilding";
-}): JSX.Element {
+}): JSX.Element | null {
   const {
     projectId,
     open,
@@ -619,6 +619,8 @@ export function SearchPanel(props: {
     void runFulltext({ projectId, limit: 20 });
   }
 
+  if (!open) return null;
+
   return (
     <div
       data-testid="search-panel"
@@ -626,6 +628,7 @@ export function SearchPanel(props: {
     >
       {/* Backdrop with blur */}
       <div
+        data-testid="search-backdrop"
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onClose}
       />

--- a/apps/desktop/renderer/src/features/search/SearchPanel.visibility.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.visibility.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchPanel } from "./SearchPanel";
+
+vi.mock("../../stores/searchStore", () => ({
+  useSearchStore: vi.fn((selector) => {
+    const state = {
+      query: "",
+      items: [],
+      status: "idle" as const,
+      indexState: "ready" as const,
+      total: 0,
+      hasMore: false,
+      lastError: null,
+      setQuery: vi.fn(),
+      runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+      clearResults: vi.fn(),
+      clearError: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("../../stores/fileStore", () => ({
+  useFileStore: vi.fn((selector) => {
+    const state = { setCurrent: vi.fn().mockResolvedValue({ ok: true }) };
+    return selector(state);
+  }),
+}));
+
+// WB-FE-HF-SP-S1
+describe("SearchPanel visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render overlay when open is false", () => {
+    render(<SearchPanel projectId="test-project" open={false} />);
+    expect(screen.queryByTestId("search-panel")).not.toBeInTheDocument();
+  });
+
+  it("renders overlay when open is true", () => {
+    render(<SearchPanel projectId="test-project" open={true} />);
+    expect(screen.getByTestId("search-panel")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/search/__tests__/search-panel-empty.test.tsx
+++ b/apps/desktop/renderer/src/features/search/__tests__/search-panel-empty.test.tsx
@@ -31,7 +31,7 @@ vi.mock("../../../stores/fileStore", () => ({
 
 describe("search panel empty state (SR1-R1-S3)", () => {
   it("should render empty hint when no fts match exists", () => {
-    render(<SearchPanel projectId="proj_1" />);
+    render(<SearchPanel projectId="proj_1" open={true} />);
 
     expect(screen.getByText("未找到匹配结果")).toBeInTheDocument();
     expect(

--- a/apps/desktop/renderer/src/features/search/__tests__/search-panel-navigation.test.tsx
+++ b/apps/desktop/renderer/src/features/search/__tests__/search-panel-navigation.test.tsx
@@ -70,7 +70,7 @@ describe("Search Panel navigation (S3-SEARCH-PANEL-S2)", () => {
 
   it("navigates editor to selected search hit", async () => {
     const onClose = vi.fn();
-    render(<SearchPanel projectId="proj_1" onClose={onClose} />);
+    render(<SearchPanel projectId="proj_1" open={true} onClose={onClose} />);
 
     fireEvent.click(screen.getByTestId("search-result-item-doc_target"));
 

--- a/apps/desktop/renderer/src/features/search/__tests__/search-panel-query.test.tsx
+++ b/apps/desktop/renderer/src/features/search/__tests__/search-panel-query.test.tsx
@@ -79,7 +79,7 @@ describe("Search Panel query rendering (S3-SEARCH-PANEL-S1)", () => {
       total: 2,
     });
 
-    render(<SearchPanel projectId="proj_1" />);
+    render(<SearchPanel projectId="proj_1" open={true} />);
 
     fireEvent.change(screen.getByTestId("search-input"), {
       target: { value: "design systems" },

--- a/apps/desktop/renderer/src/features/search/__tests__/search-panel-status.test.tsx
+++ b/apps/desktop/renderer/src/features/search/__tests__/search-panel-status.test.tsx
@@ -45,7 +45,7 @@ describe("Search Panel status rendering (S3-SEARCH-PANEL-S3)", () => {
   });
 
   it("renders distinct empty and error states", async () => {
-    const { rerender } = render(<SearchPanel projectId="proj_1" />);
+    const { rerender } = render(<SearchPanel projectId="proj_1" open={true} />);
 
     expect(screen.getByText("未找到匹配结果")).toBeInTheDocument();
     expect(screen.queryByText("搜索失败，请重试")).not.toBeInTheDocument();
@@ -57,7 +57,7 @@ describe("Search Panel status rendering (S3-SEARCH-PANEL-S3)", () => {
         message: "fts query failed",
       },
     });
-    rerender(<SearchPanel projectId="proj_1" />);
+    rerender(<SearchPanel projectId="proj_1" open={true} />);
 
     expect(screen.queryByText("未找到匹配结果")).not.toBeInTheDocument();
     expect(screen.getByText("搜索失败，请重试")).toBeInTheDocument();

--- a/openspec/_ops/task_runs/ISSUE-786.md
+++ b/openspec/_ops/task_runs/ISSUE-786.md
@@ -4,7 +4,8 @@
 
 - Issue: #786
 - Branch: task/786-fe-hotfix-searchpanel-backdrop-close
-- PR: <fill-after-created>
+- PR: https://github.com/Leeky1017/CreoNow/pull/787
+- Reviewed-HEAD-SHA: 0225d27ee6aa03473a4e4507a2a908f8f965e784
 
 ## Plan
 
@@ -13,3 +14,36 @@
 - Refactor：open 改为必选 prop；验证全量测试通过
 
 ## Runs
+
+### 2026-02-28 20:39 Red — visibility test
+- Command: `pnpm -C apps/desktop test:run features/search/SearchPanel.visibility`
+- Key output: `1 failed | 1 passed` — `does not render overlay when open is false` FAIL（overlay 始终渲染）
+- Evidence: open=false 无短路，search-panel 仍在 DOM
+
+### 2026-02-28 20:39 Red — close test
+- Command: `pnpm -C apps/desktop test:run features/search/SearchPanel.close`
+- Key output: `1 failed | 1 passed` — `calls onClose when clicking backdrop` FAIL（无 data-testid="search-backdrop"）
+- Evidence: backdrop 无 testid，getByTestId 抛出
+
+### 2026-02-28 20:41 Green — visibility + close
+- Command: `pnpm -C apps/desktop test:run features/search/SearchPanel.visibility features/search/SearchPanel.close`
+- Key output: `2 passed (4 tests)` — 全绿
+- Changes: SearchPanel.tsx 加 `if (!open) return null` + `data-testid="search-backdrop"`；Sidebar.tsx 传入 `open={true} onClose={props.onCloseSearch}`
+
+### 2026-02-28 20:42 Refactor — open 改为必选
+- Command: `pnpm typecheck`
+- Key output: 无错误（修复 stories + 现有测试补 open={true}）
+
+### 2026-02-28 20:43 Full regression
+- Command: `pnpm -C apps/desktop test:run`
+- Key output: `187 passed (1549 tests)` — 无新增失败
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 0225d27ee6aa03473a4e4507a2a908f8f965e784
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-786.md
+++ b/openspec/_ops/task_runs/ISSUE-786.md
@@ -1,0 +1,15 @@
+# ISSUE-786
+
+更新时间：2026-02-28 20:00
+
+- Issue: #786
+- Branch: task/786-fe-hotfix-searchpanel-backdrop-close
+- PR: <fill-after-created>
+
+## Plan
+
+- Red：写 SearchPanel.visibility.test.tsx + SearchPanel.close.test.tsx，确认失败
+- Green：SearchPanel.tsx 加 open 短路 + backdrop data-testid；Sidebar.tsx 传入 open/onClose
+- Refactor：open 改为必选 prop；验证全量测试通过
+
+## Runs


### PR DESCRIPTION
Closes #786

## Summary

- `SearchPanel.tsx`：`open=false` 时 `return null` 短路，不渲染任何 overlay/backdrop
- `SearchPanel.tsx`：backdrop 容器加 `data-testid="search-backdrop"`（已有 `onClick={onClose}`）
- `SearchPanel.tsx`：`open` 改为必选 prop（`boolean`），强制调用方传入
- `Sidebar.tsx`：挂载 SearchPanel 时传入 `open={true}` 与 `onClose={props.onCloseSearch}`
- 现有测试文件补 `open={true}`；stories 包装器 `open` 改为必选

## Test Plan

- [x] `SearchPanel.visibility.test.tsx`：`open=false` 不渲染 overlay（WB-FE-HF-SP-S1）
- [x] `SearchPanel.close.test.tsx`：backdrop 点击触发 `onClose`（WB-FE-HF-SP-S2）
- [x] `SearchPanel.close.test.tsx`：Esc 触发 `onClose`（WB-FE-HF-SP-S2b）
- [x] `pnpm typecheck` 通过
- [x] `pnpm -C apps/desktop test:run` 187 files / 1549 tests 全绿

RUN_LOG: `openspec/_ops/task_runs/ISSUE-786.md`