### PR TITLE
fix(ci): 改进 OpenSpec 归档门禁可执行修复提示

### DIFF
--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -50,11 +50,19 @@ jobs:
               completed_active.append(change_dir.name)
 
           if completed_active:
+            fix_commands = [
+              f"mv openspec/changes/{change} openspec/changes/archive/{change}"
+              for change in completed_active
+            ]
             print(
               "❌ tasks.md checkboxes are all checked, so completed changes must be archived to "
               "openspec/changes/archive/: "
               + ", ".join(completed_active)
             )
+            print("Fix suggestion (copy & run):")
+            for command in fix_commands:
+              print(command)
+            print("Then rerun checks: scripts/agent_pr_preflight.sh --mode fast")
             sys.exit(1)
 
           print("✅ Completed active change archive guard passed")

--- a/scripts/agent_pr_preflight.py
+++ b/scripts/agent_pr_preflight.py
@@ -375,6 +375,13 @@ def parse_markdown_checkbox_states(content: str) -> list[bool]:
     return states
 
 
+def build_archive_fix_commands(change_names: list[str]) -> list[str]:
+    return [
+        f"mv openspec/changes/{change_name} openspec/changes/archive/{change_name}"
+        for change_name in sorted(change_names)
+    ]
+
+
 def validate_no_completed_active_changes(repo: str) -> None:
     active_changes = list_active_changes(repo)
     if not active_changes:
@@ -396,10 +403,12 @@ def validate_no_completed_active_changes(repo: str) -> None:
 
     if completed_active:
         joined = ", ".join(sorted(completed_active))
+        fix_commands = build_archive_fix_commands(completed_active)
+        rerun_hint = "scripts/agent_pr_preflight.sh --mode fast"
         raise RuntimeError(
             "[OPENSPEC_CHANGE] change tasks.md checkboxes are all checked, so the change is completed "
             "and must be archived from openspec/changes/ to openspec/changes/archive/: "
-            f"{joined}"
+            f"{joined}. Fix (copy & run): {' ; '.join(fix_commands)}. Then rerun: {rerun_hint}"
         )
 
 

--- a/scripts/tests/test_agent_pr_preflight.py
+++ b/scripts/tests/test_agent_pr_preflight.py
@@ -66,6 +66,45 @@ class RulebookTaskResolutionTests(unittest.TestCase):
             agent_pr_preflight.resolve_rulebook_task_location(self.repo, task_id)
 
 
+class OpenSpecCompletedActiveChangeGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = self.tmp.name
+        os.makedirs(os.path.join(self.repo, "openspec", "changes", "archive"), exist_ok=True)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_change_tasks(self, change_name: str, body: str) -> None:
+        change_dir = os.path.join(self.repo, "openspec", "changes", change_name)
+        os.makedirs(change_dir, exist_ok=True)
+        with open(os.path.join(change_dir, "tasks.md"), "w", encoding="utf-8") as fp:
+            fp.write(body)
+
+    def test_validate_no_completed_active_changes_should_include_actionable_archive_command(self) -> None:
+        change_name = "issue-792-openspec-archive-guard"
+        self._write_change_tasks(
+            change_name,
+            "- [x] all done\n- [x] another done\n",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            rf"mv openspec/changes/{change_name} openspec/changes/archive/{change_name}",
+        ) as exc:
+            agent_pr_preflight.validate_no_completed_active_changes(self.repo)
+
+        self.assertIn("scripts/agent_pr_preflight.sh --mode fast", str(exc.exception))
+
+    def test_validate_no_completed_active_changes_should_pass_when_not_all_checked(self) -> None:
+        self._write_change_tasks(
+            "issue-792-openspec-archive-guard",
+            "- [x] done\n- [ ] pending\n",
+        )
+
+        agent_pr_preflight.validate_no_completed_active_changes(self.repo)
+
+
 class MainSessionAuditValidationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

Fixes #792

## 主题
修复 OpenSpec 归档门禁报错不可执行的问题：当 active change 的 `tasks.md` 全勾选时，CI 与本地 preflight 都会给出可直接复制执行的归档命令。

## 用户影响
- PR 触发 `OpenSpec Log Guard` 失败时，提交者可直接复制命令修复，不再需要手动推断归档动作。
- 降低跨 PR 被同一门禁阻塞时的排障成本与重复沟通成本。

## 不修最坏后果
当门禁再次命中“已完成但未归档”的 change 时，开发者仍只能看到目录名，容易出现修复路径不一致、反复重跑 CI、多个无关 PR 持续阻塞。

## 改动列表
- `.github/workflows/openspec-log-guard.yml`：失败输出新增逐条 `mv openspec/changes/<change> openspec/changes/archive/<change>` 命令及本地重跑提示。
- `scripts/agent_pr_preflight.py`：同类校验异常文案新增可复制执行命令与 `scripts/agent_pr_preflight.sh --mode fast` 指引。
- `scripts/tests/test_agent_pr_preflight.py`：新增回归测试，覆盖“全勾选时报错含可执行命令”和“未全勾选通过”两类场景。

## Open PR 排重检查
- 扫描时间：2026-02-28 21:39 (Asia/Shanghai)
- 当前相关 open PR：#794 docs: 同步 EO 到当前活跃变更状态 (#792)
- 文件重叠检查：无重叠（本 PR 改 `.github/workflows/openspec-log-guard.yml`、`scripts/*`；#794 仅改 `openspec/changes/EXECUTION_ORDER.md`）
- 处理决策：新开 PR，聚焦门禁可执行修复指引，不并入文档同步 PR。

## 验证证据
- `python3 -m unittest scripts.tests.test_agent_pr_preflight` 通过（26 tests, OK）。
- 新增测试 `OpenSpecCompletedActiveChangeGuardTests` 覆盖报错提示包含 `mv` 指令。

## 回滚点
- 单提交回滚：`git revert 9dc08691`

## 注意
- 不涉及业务逻辑变更。
- 不涉及架构变更。
