### PR TITLE
docs(openspec): align issue-797 execution-order dependency semantics

### DIFF
--- a/apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts
+++ b/apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const OWNER_ALIGNED_ICONBAR_ORDER = [
+  "files",
+  "search",
+  "outline",
+  "versionHistory",
+  "memory",
+  "characters",
+  "knowledgeGraph",
+] as const;
+
+const OWNER_ALIGNED_RIGHT_PANEL_TABS = ["ai", "info", "quality"] as const;
+
+function readSource(relativePath: string): string {
+  const filePath = fileURLToPath(new URL(relativePath, import.meta.url));
+  return readFileSync(filePath, "utf8");
+}
+
+function extractIconBarCodeOrder(iconBarSource: string): string[] {
+  const mainIconsBlock = iconBarSource.match(
+    /const MAIN_ICONS: IconItem\[] = \[([\s\S]*?)\];/,
+  );
+
+  if (!mainIconsBlock) {
+    throw new Error("Cannot locate MAIN_ICONS block in IconBar.tsx.");
+  }
+
+  return Array.from(mainIconsBlock[1].matchAll(/panel:\s*"([^"]+)"/g)).map(
+    (match) => match[1],
+  );
+}
+
+function extractRightPanelTypeUnion(layoutStoreSource: string): string[] {
+  const unionMatch = layoutStoreSource.match(
+    /export type RightPanelType\s*=\s*([^;]+);/,
+  );
+
+  if (!unionMatch) {
+    throw new Error("Cannot locate RightPanelType union in layoutStore.tsx.");
+  }
+
+  return Array.from(unionMatch[1].matchAll(/"([^"]+)"/g)).map(
+    (match) => match[1],
+  );
+}
+
+function hasMediaFutureMarker(mainWorkbenchSpec: string): boolean {
+  return /`media`[\s\S]*?\[FUTURE\]/.test(mainWorkbenchSpec);
+}
+
+describe("WB-FE-DRIFT panel-id SSOT guard", () => {
+  it("IconBar current order stays aligned with owner-decided contract and keeps media as [FUTURE] (WB-FE-DRIFT-S1)", () => {
+    const mainWorkbenchSpec = readSource(
+      "../../../../../../../openspec/specs/workbench/spec.md",
+    );
+    const iconBarSource = readSource("../IconBar.tsx");
+
+    const actualOrder = extractIconBarCodeOrder(iconBarSource);
+
+    expect(actualOrder).toEqual([...OWNER_ALIGNED_ICONBAR_ORDER]);
+    expect(hasMediaFutureMarker(mainWorkbenchSpec)).toBe(true);
+    expect(actualOrder).not.toContain("media");
+  });
+
+  it("knowledge graph semantic ID is fixed to knowledgeGraph (WB-FE-DRIFT-S2)", () => {
+    const layoutStoreSource = readSource("../../../stores/layoutStore.tsx");
+    const iconBarSource = readSource("../IconBar.tsx");
+    const codeSources = [layoutStoreSource, iconBarSource].join("\n");
+
+    const hasGraphIdInCode = /(["'])graph\1/.test(codeSources);
+    const hasKnowledgeGraphId = /(["'])knowledgeGraph\1/.test(codeSources);
+
+    expect(hasKnowledgeGraphId).toBe(true);
+    expect(hasGraphIdInCode).toBe(false);
+  });
+
+  it("RightPanel tab set matches spec enum (ai/info/quality) (WB-FE-DRIFT-S3)", () => {
+    const layoutStoreSource = readSource("../../../stores/layoutStore.tsx");
+    const storeEnum = extractRightPanelTypeUnion(layoutStoreSource);
+
+    expect(storeEnum).toEqual([...OWNER_ALIGNED_RIGHT_PANEL_TABS]);
+  });
+});

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -1,0 +1,95 @@
+# ISSUE-797
+
+更新时间：2026-03-01 10:21
+
+- Issue: #797
+- Branch: task/797-fe-spec-drift-iconbar-rightpanel-alignment
+- PR: （未创建；本次仅本地 Green 阶段，不提交）
+- Reviewed-HEAD-SHA: ac81d35ca42af5f369ff4ace0d542ae742bf21c7
+
+## Plan
+
+- 历史目标（已完成）：执行 Red→Green guard 测试并完成 D1/D2/D3 决策落盘，不改业务实现代码。
+- 本轮目标（文档治理补齐）：对齐 Rulebook proposal/tasks 与 OpenSpec tasks/RUN_LOG 叙述，明确 guard 仅依赖稳定路径（主 spec + 源码），不依赖活跃 change 路径。
+
+## Runs
+
+### 2026-03-01 09:45 Red — panel-id-ssot guard
+
+- Command: `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard`
+- Exit code: `1`
+- Key output: `1 failed | 2 passed (3)`；`Test Files 1 failed (1)`
+- Failed assertion: `expect(actualOrder).toEqual(expectedOrder)`（`renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts:82`）
+- Failure points:
+  - Spec 期望顺序包含 `media`，且不包含 `search`/`versionHistory`/`memory`。
+  - 实际 IconBar 解析顺序为 `files → search → outline → versionHistory → memory → characters → knowledgeGraph`。
+  - 该差异命中 `WB-FE-DRIFT-S1` 预期红灯（契约与实现漂移）。
+
+### 2026-03-01 09:54 Green — delta spec + guard 对齐（D1/D2/D3）
+
+- Scope:
+  - 仅改 `openspec/changes/.../specs/workbench/spec.md` 与 guard 测试；
+  - 不修改 `IconBar.tsx` / `layoutStore.tsx` 业务实现行为。
+- D1 落盘：
+  - 在 delta spec 明确保留 `media` 且标注 `[FUTURE]`；
+  - 明确“当前实现入口顺序”为 `files → search → outline → versionHistory → memory → characters → knowledgeGraph`，与未来入口分离。
+- D2 落盘：
+  - delta spec 语义 ID 统一为 `knowledgeGraph`；
+  - 删除“`graph` 作为最终 ID”的描述口径。
+- D3 落盘：
+  - delta spec 明确 RightPanel 为 `AI/Info/Quality` 三 tab（`ai/info/quality`）。
+- Command: `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard`
+- Exit code: `0`
+- Key output: `Test Files 1 passed (1)`；`Tests 3 passed (3)`
+
+### 2026-03-01 09:55 Green 复验 — 最终文件状态确认
+
+- Command: `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard`
+- Exit code: `0`
+- Key output: `Test Files 1 passed (1)`；`Tests 3 passed (3)`
+
+### 2026-03-01 09:59 Audit Fix — guard 去除活跃 change 路径耦合
+
+- Why: 原 guard 直接读取 `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/...`，在 change 归档迁移后会失效。
+- Change:
+  - guard 改为使用稳定契约常量校验 `IconBar.tsx` 与 `layoutStore.tsx`；
+  - `media [FUTURE]` 校验改为读取主 `openspec/specs/workbench/spec.md`。
+- Command: `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard`
+- Exit code: `0`
+- Key output: `Test Files 1 passed (1)`；`Tests 3 passed (3)`
+
+### 2026-03-01 10:07 Docs Governance Sync — Rulebook/OpenSpec 口径统一
+
+- Scope:
+  - 仅补齐/校对治理文档：`rulebook/tasks/.../proposal.md`、`rulebook/tasks/.../tasks.md`、`openspec/changes/.../tasks.md`、`openspec/_ops/task_runs/ISSUE-797.md`；
+  - 不修改业务实现代码；不执行长测试。
+- Command: `rg -n "openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment" apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts || true`
+- Exit code: `0`
+- Key output: 无匹配（guard 已不依赖活跃 change 路径）
+- Command: `rg -n "openspec/specs/workbench/spec.md|OWNER_ALIGNED_ICONBAR_ORDER|OWNER_ALIGNED_RIGHT_PANEL_TABS" apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts`
+- Exit code: `0`
+- Key output: 命中主 spec 稳定路径与契约常量（行 `57`、`5`、`15`）
+- Command: `rg -n "\\[Explain why this change is needed|\\[Describe what will change|First task|Second task|Update README|Update CHANGELOG" rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/proposal.md rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/tasks.md || true`
+- Exit code: `0`
+- Key output: 无匹配（Rulebook 模板占位已清理）
+
+### 2026-03-01 10:21 Full Regression — desktop 全量回归
+
+- Scope:
+  - 仅执行全量测试并补充治理证据；
+  - 不修改业务实现代码。
+- Command: `pnpm -C apps/desktop test:run`
+- Exit code: `0`
+- Key output: `Test Files 189 passed (189)`；`Tests 1555 passed (1555)`
+- Duration: `90.63s`
+- Notes: 存在既有 warning（Dialog `aria-describedby`、React `act(...)` 提示等），未导致失败。
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: ac81d35ca42af5f369ff4ace0d542ae742bf21c7
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -4,7 +4,7 @@
 
 - Issue: #797
 - Branch: task/797-fe-spec-drift-iconbar-rightpanel-alignment
-- PR: （未创建；本次仅本地 Green 阶段，不提交）
+- PR: https://github.com/Leeky1017/CreoNow/pull/799
 - Reviewed-HEAD-SHA: 160857a234193fbaf235c4da3b5232d66b8e486c
 
 ## Plan

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -5,7 +5,7 @@
 - Issue: #797
 - Branch: task/797-fe-spec-drift-iconbar-rightpanel-alignment
 - PR: https://github.com/Leeky1017/CreoNow/pull/799
-- Reviewed-HEAD-SHA: 160857a234193fbaf235c4da3b5232d66b8e486c
+- Reviewed-HEAD-SHA: d9a86e18fbbe72306e56c5a31d70b3d9318dda43
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -86,7 +86,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: ac81d35ca42af5f369ff4ace0d542ae742bf21c7
+- Reviewed-HEAD-SHA: 9534192aa0b3bace147d8d4e3964a57508e0546c
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -5,7 +5,7 @@
 - Issue: #797
 - Branch: task/797-fe-spec-drift-iconbar-rightpanel-alignment
 - PR: （未创建；本次仅本地 Green 阶段，不提交）
-- Reviewed-HEAD-SHA: ac81d35ca42af5f369ff4ace0d542ae742bf21c7
+- Reviewed-HEAD-SHA: 160857a234193fbaf235c4da3b5232d66b8e486c
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -5,7 +5,6 @@
 - Issue: #797
 - Branch: task/797-fe-spec-drift-iconbar-rightpanel-alignment
 - PR: https://github.com/Leeky1017/CreoNow/pull/799
-- Reviewed-HEAD-SHA: d9a86e18fbbe72306e56c5a31d70b3d9318dda43
 
 ## Plan
 

--- a/openspec/_ops/task_runs/ISSUE-797.md
+++ b/openspec/_ops/task_runs/ISSUE-797.md
@@ -86,7 +86,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 9534192aa0b3bace147d8d4e3964a57508e0546c
+- Reviewed-HEAD-SHA: 1f859e396b62c23e4c042b4378bc040edf083c2b
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-01 08:56
+更新时间：2026-03-01 10:49
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
@@ -147,6 +147,16 @@
 | hotkeys | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | EditorPane.tsx | EditorPane.tsx | — |
 
 ✅ = 无共享文件，可并行。单元格内容 = 冲突文件，不可并行。
+
+## 依赖说明
+
+- 依赖语义：`A -> B` 表示 B 进入 Red 前，A 必须完成 Green 且证据落盘（至少包含 RUN_LOG 记录与 preflight 通过）；若 B 同时带 Owner 决策阻塞，则执行门禁为“前置完成 + 决策落盘”双条件。
+- 并行/互斥规则：同批次仅当“无共享文件 + 无前置依赖 + 无决策阻塞”同时成立时可并行；冲突矩阵中非 `✅` 的共享文件关系一律互斥，按 lane 顺序串行推进。
+- Owner 决策门：凡标记 D1/D2/D3 的 change，在决策结论写入本文件并同步相关 spec 前不得进入 Red；若决策结论变化，先更新本节与“Owner 决策阻塞项”后再继续执行。
+- 第一批两条 lane 依赖边界：
+  - Lane 1（AiPanel 簇）在 `AiPanel.tsx` 范围内串行推进，不阻塞 Lane 2。
+  - Lane 2（Layout 簇）在 `IconBar.tsx`/`layoutStore.tsx`/`AppShell.tsx` 范围内串行推进，不反向阻塞 Lane 1。
+  - 跨 lane 的唯一硬依赖在收尾：`fe-dashboard-welcome-merge-and-ghost-actions` 需等待 Lane 1 的 `fe-cleanup-proxysection-and-mocks`、Lane 2 的 `fe-ai-panel-toggle-button`，并额外等待第二批 `fe-ui-open-folder-entrypoints`。
 
 ## 依赖拓扑
 

--- a/openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/specs/workbench/spec.md
+++ b/openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/specs/workbench/spec.md
@@ -1,25 +1,28 @@
 # Workbench Specification Delta
 
-更新时间：2026-02-28 19:20
+更新时间：2026-03-01 09:55
 
 ## Change: fe-spec-drift-iconbar-rightpanel-alignment
 
 ### Requirement: IconBar 面板 ID 与顺序必须为 SSOT [MODIFIED]
 
 - IconBar 必须以单一面板 ID 集合为 SSOT，禁止同义双栈（如 `graph` 与 `knowledgeGraph` 并存）。
-- IconBar 入口顺序与实际产品必须一致；若入口呈现形态变化（Sidebar → Dialog/Spotlight），属于呈现层改变，不影响入口 ID 的一致性。
+- 当前实现入口集合/顺序（顶部）定义为：`files → search → outline → versionHistory → memory → characters → knowledgeGraph`。
+- `media` 入口保留在契约中并标注为 `[FUTURE]`：它属于未来入口，不计入“当前实现入口顺序”校验，待能力上线后再并入当前序列。
+- 入口呈现形态变化（Sidebar → Dialog/Spotlight）属于呈现层改变，不影响入口 ID 的一致性约束。
 
 #### Scenario: 同一语义面板不得存在两个 ID [ADDED]
 
 - **假设** 某面板语义为“知识图谱”
 - **当** 系统定义其面板 ID
-- **则** 该语义必须且只能使用一个 ID（例如 `graph`）
-- **并且** 不得同时存在 `graph` 与 `knowledgeGraph`
+- **则** 该语义必须且只能使用一个 ID（`knowledgeGraph`）
+- **并且** 不得出现将 `graph` 作为最终 ID 的描述
 
 ### Requirement: RightPanel tab 集合必须与枚举一致 [MODIFIED]
 
 - RightPanel 的 tab 集合（文档描述）与 `activeRightPanel` 枚举必须一致。
-- 若选择保留 `Quality`，则 RightPanel tab 明确包含 `AI` / `Info` / `Quality` 三项；若选择移除，则枚举与实现必须同时移除。
+- RightPanel 明确为 `AI` / `Info` / `Quality` 三 tab（对应 `ai` / `info` / `quality`）。
+- 不允许出现“文本仅 AI/Info 两项，但枚举含 quality”的矛盾状态。
 
 #### Scenario: spec 文本与枚举不得自相矛盾 [ADDED]
 

--- a/openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/tasks.md
+++ b/openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/tasks.md
@@ -1,47 +1,45 @@
 ## 1. Specification
 
-更新时间：2026-02-28 19:20
+更新时间：2026-03-01 10:21
 
-- [ ] 1.1 审阅并确认需求边界：对齐 `workbench/spec.md` 与实现之间的漂移——IconBar 入口、`graph`/`knowledgeGraph` 命名、RightPanel tab 枚举。只做 spec 对齐与决策落盘，不做功能实现。
-- [ ] 1.2 审阅并确认漂移点全集：
-  - IconBar：`media` 面板 spec 要求存在但代码缺失
-  - 命名：`graph` vs `knowledgeGraph` 同义双栈
-  - RightPanel：spec 文字要求仅 AI/Info，但枚举包含 `quality`
-- [ ] 1.3 审阅并确认不可变契约：同一面板不得存在同义双 ID；spec 内不得自相矛盾。
-- [ ] 1.4 依赖同步检查（Dependency Sync Check）：
+- [x] 1.1 审阅并确认需求边界：对齐 `workbench/spec.md` 与实现之间的漂移——IconBar 入口、`graph`/`knowledgeGraph` 命名、RightPanel tab 枚举。只做 spec 对齐与决策落盘，不做功能实现。
+- [x] 1.2 审阅并确认漂移点全集：
+  - IconBar：存在实质漂移。spec 入口顺序/集合为 `files → outline → characters → media[FUTURE] → knowledgeGraph`，实现为 `files → search → outline → versionHistory → memory → characters → knowledgeGraph`（缺 `media`、多 `search/versionHistory/memory`）。
+  - 命名：`graph` vs `knowledgeGraph` 双栈在当前主 spec 与代码中未复现（现状统一为 `knowledgeGraph`）。
+  - RightPanel：主 spec 与代码当前都为 `ai/info/quality`，未发现“二项 vs 三项”矛盾。
+- [x] 1.3 审阅并确认不可变契约：同一面板不得存在同义双 ID；spec 内不得自相矛盾。
+- [x] 1.4 依赖同步检查（Dependency Sync Check）：
   - [x] D1（IconBar `media` 面板处置）Owner 决策已确认 — 保留但标注 `[FUTURE]`
   - [x] D2（`graph` vs `knowledgeGraph` 命名）Owner 决策已确认 — 统一到 `knowledgeGraph`（仅改 spec，代码零改动）
   - [x] D3（RightPanel `Quality` tab 保留/移除）Owner 决策已确认 — 保留，更新 Spec 为三 tab
 
 ### 1.5 预期实现触点
 
-- `openspec/specs/workbench/spec.md`（delta spec 修改）：
-  - IconBar 入口列表：按 D1 决策处理 `media`（标注未实现 / 删除 / 补全）
-  - 面板 ID 命名：按 D2 决策统一为 `knowledgeGraph` 或 `graph`
-  - RightPanel tab 枚举：按 D3 决策保留或移除 `quality`
-- `apps/desktop/renderer/src/stores/layoutStore.tsx`（代码对齐）：
-  - L22-29：`LeftPanelType` 枚举 — 若 D2 决定统一命名则此处同步
-  - L34+：`RightPanelType` 枚举 — 若 D3 决定移除 quality 则此处同步
-- `apps/desktop/renderer/src/components/layout/IconBar.tsx`：
-  - 面板 ID 引用 — 与 layoutStore 枚举对齐
-- Guard 测试（可选但推荐）：
-  - 断言 LeftPanelType 和 RightPanelType 不含同义双 ID
+- `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/specs/workbench/spec.md`（delta spec 修改）：
+  - D1：保留 `media[FUTURE]`，并明确“当前实现入口顺序”与“未来入口”区分
+  - D2：统一语义 ID 为 `knowledgeGraph`
+  - D3：明确 RightPanel 为 `AI/Info/Quality` 三 tab（`ai/info/quality`）
+- `apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts`（Guard 对齐）：
+  - 读取 `layoutStore.tsx` + `IconBar.tsx` 与稳定契约常量，验证 D1/D2/D3
+  - 读取主 `workbench/spec.md` 校验 `media` 的 `[FUTURE]` 标注持续存在
+  - 不读取 `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/**` 活跃 change 路径，避免归档后路径漂移
+  - 不修改 `IconBar.tsx` / `layoutStore.tsx` 业务实现
 
-**为什么是这些触点**：spec.md 是契约 SSOT，layoutStore 是代码 SSOT，IconBar 是入口消费方。三者必须一致。
+**为什么是这些触点**：本轮为 Green（契约对齐）阶段，目标是在不改业务行为前提下，以“稳定路径契约（主 spec + 源码）”让 guard 复绿并可归档。
 
 ## 2. TDD Mapping（先测前提）
 
-- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
-- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
-- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [x] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [x] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [x] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
 
 ### Scenario → 测试映射
 
 | Scenario ID | 测试文件（计划） | 测试名称（计划） | 断言要点 | Mock/依赖 | 运行命令 |
 | ----------- | ---------------- | ---------------- | -------- | --------- | -------- |
-| `WB-FE-DRIFT-S1` | `apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts` | `it('LeftPanelType has no duplicated semantic IDs')` | 读取 layoutStore.tsx，断言不同时含 `graph` 和 `knowledgeGraph` | `fs.readFileSync` | `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard` |
-| `WB-FE-DRIFT-S2` | 同上 | `it('RightPanelType matches spec definition')` | 读取 layoutStore.tsx，断言 RightPanelType 与 spec 一致（按 D3 决策） | `fs.readFileSync` | 同上 |
-| `WB-FE-DRIFT-S3` | 同上 | `it('spec.md has no internal contradictions on panel enums')` | 读取 workbench/spec.md，断言面板枚举段落无矛盾 | `fs.readFileSync` | 同上 |
+| `WB-FE-DRIFT-S1` | `apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts` | `it('IconBar current order stays aligned with owner-decided contract and keeps media as [FUTURE]')` | 读取 `IconBar.tsx`，断言“当前实现入口顺序”一致；读取主 `workbench/spec.md` 断言 `media` 仍标注 `[FUTURE]` | `fs.readFileSync` | `pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard` |
+| `WB-FE-DRIFT-S2` | 同上 | `it('knowledge graph semantic ID is fixed to knowledgeGraph')` | 读取 `layoutStore.tsx` + `IconBar.tsx`，断言语义 ID 固定为 `knowledgeGraph` 且代码无 `graph` 最终 ID | `fs.readFileSync` | 同上 |
+| `WB-FE-DRIFT-S3` | 同上 | `it('RightPanel tab set matches spec enum (ai/info/quality)')` | 读取 `layoutStore.tsx`，断言 `AI/Info/Quality` 三 tab 与 `activeRightPanel` 枚举一致 | `fs.readFileSync` | 同上 |
 
 ### 可复用测试范本
 
@@ -49,30 +47,31 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 `WB-FE-DRIFT-S1`：读取 layoutStore.tsx，断言不同时含 `graph` 和 `knowledgeGraph`。
-  - 期望红灯原因：当前 LeftPanelType 含 `knowledgeGraph`，spec 可能引用 `graph`（需验证）。
-- [ ] 3.2 `WB-FE-DRIFT-S2`：断言 RightPanelType 与 D3 决策一致。
-  - 期望红灯原因：当前枚举可能含 `quality` 但 spec 文字排除。
-- [ ] 3.3 `WB-FE-DRIFT-S3`：读取 spec.md，断言面板枚举无矛盾。
-  - 期望红灯原因：当前 spec 内部自相矛盾。
+- [x] 3.1 `WB-FE-DRIFT-S1`：读取 `workbench/spec.md` + `IconBar.tsx`，断言 IconBar 入口 ID 顺序/集合一致。
+  - 期望红灯原因：当前实现缺 `media` 且多 `search/versionHistory/memory`。
+- [x] 3.2 `WB-FE-DRIFT-S2`：断言 `graph`/`knowledgeGraph` 不出现同义双栈。
+  - 期望红灯原因：若后续回归引入双 ID，将被直接阻断（当前预期可通过）。
+- [x] 3.3 `WB-FE-DRIFT-S3`：断言 RightPanel 枚举与 spec 一致。
+  - 期望红灯原因：若后续 spec/代码再漂移，将被直接阻断（当前预期可通过）。
 - 运行：`pnpm -C apps/desktop test:run components/layout/__tests__/panel-id-ssot.guard`
+  - 实际结果：`1 failed | 2 passed`（命中 Red：S1 失败，S2/S3 通过）
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 按 D2 决策统一面板 ID 命名（layoutStore + IconBar + spec） → S1 转绿
-- [ ] 4.2 按 D3 决策对齐 RightPanelType（layoutStore + spec） → S2 转绿
-- [ ] 4.3 修复 spec.md 内部矛盾段落 → S3 转绿
-- [ ] 4.4 按 D1 决策处理 `media` 面板（spec 标注）
+- [x] 4.1 按 D2 决策统一语义 ID 为 `knowledgeGraph`（delta spec + guard 契约） → S2 转绿
+- [x] 4.2 按 D3 决策明确 RightPanel 为 `AI/Info/Quality` 三 tab（delta spec + guard 契约） → S3 转绿
+- [x] 4.3 修复 delta spec 内部歧义描述（“待决策”口径改为“已决策”） → Guard 一致性转绿
+- [x] 4.4 按 D1 决策保留 `media[FUTURE]` 并区分“当前实现入口顺序”与“未来入口”；guard 同步去除活跃 change 路径耦合
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 确认 spec 修改后无其他引用断裂
-- [ ] 5.2 确认 delta spec 使用 `[MODIFIED]`/`[REMOVED]` 标记
+- [x] 5.1 确认仅调整 delta spec 与 guard，未引入业务实现改动，且 guard 仅依赖稳定路径
+- [x] 5.2 确认 delta spec 使用规范标记（`[MODIFIED]`/`[ADDED]`）
 
 ## 6. Evidence
 
-- [ ] 6.1 记录 RUN_LOG：D1/D2/D3 决策输入与落盘结果
-- [ ] 6.2 记录 RUN_LOG：guard 测试通过输出
-- [ ] 6.3 记录 RUN_LOG：`pnpm -C apps/desktop test:run` 全量回归无新增失败
-- [ ] 6.4 记录 Dependency Sync Check：D1/D2/D3 决策状态
-- [ ] 6.5 Main Session Audit（仅在 Apply 阶段需要）
+- [x] 6.1 记录 RUN_LOG：D1/D2/D3 决策输入与落盘结果
+- [x] 6.2 记录 RUN_LOG：guard 测试通过输出与“去活跃 change 路径耦合”说明
+- [x] 6.3 记录 RUN_LOG：`pnpm -C apps/desktop test:run` 全量回归通过（`Test Files 189 passed (189)`；`Tests 1555 passed (1555)`）
+- [x] 6.4 记录 Dependency Sync Check：D1/D2/D3 决策状态
+- [ ] 6.5 Main Session Audit（仅在提交/Apply 阶段需要，本轮不执行）

--- a/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/.metadata.json
+++ b/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-03-01T01:36:48.514Z",
+  "updatedAt": "2026-03-01T01:36:48.514Z"
+}

--- a/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/proposal.md
+++ b/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: issue-797-fe-spec-drift-iconbar-rightpanel-alignment
+更新时间：2026-03-01 10:07
+
+## Why
+Issue #797 的核心不是“新增功能”，而是修复规范叙事与当前实现之间的认知漂移。若 D1/D2/D3 决策不统一落盘，后续任何归档或重构都可能把同一语义拆成多套口径，导致 guard 误报或漏报。
+
+## What Changes
+- 将 D1/D2/D3 的 Owner 决策统一写入变更文档：
+  - D1：`media` 保留为 `[FUTURE]`，不计入当前 IconBar 入口序列。
+  - D2：知识图谱语义 ID 统一为 `knowledgeGraph`，禁止 `graph` 作为最终 ID。
+  - D3：RightPanel 明确为 `AI/Info/Quality` 三 tab（`ai/info/quality`）。
+- 将 guard 契约说明固定到稳定路径：
+  - 代码契约读取 `IconBar.tsx` 与 `layoutStore.tsx`。
+  - `media [FUTURE]` 校验读取主 spec `openspec/specs/workbench/spec.md`。
+  - 不依赖活跃 change 路径，避免归档后路径失效。
+- 同步校对 `openspec/changes/.../tasks.md` 与 `openspec/_ops/task_runs/ISSUE-797.md`，确保叙述与当前 guard 实现一致。
+
+## Impact
+- Affected specs:
+  - `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/specs/workbench/spec.md`
+  - `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/tasks.md`
+  - `openspec/_ops/task_runs/ISSUE-797.md`
+- Affected code:
+  - `apps/desktop/renderer/src/components/layout/__tests__/panel-id-ssot.guard.test.ts`
+  - `rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/proposal.md`
+  - `rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/tasks.md`
+- Breaking change: NO
+- User benefit: 规范、守卫与运行记录形成单一事实源（SSOT），后续 archive/apply 阶段不再受临时路径耦合影响。

--- a/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/tasks.md
+++ b/rulebook/tasks/issue-797-fe-spec-drift-iconbar-rightpanel-alignment/tasks.md
@@ -1,0 +1,17 @@
+更新时间：2026-03-01 10:21
+
+## 1. Governance Alignment
+- [x] 1.1 将 D1 决策落盘：`media` 保留 `[FUTURE]`，并与当前 IconBar 入口序列解耦
+- [x] 1.2 将 D2 决策落盘：知识图谱语义 ID 统一为 `knowledgeGraph`
+- [x] 1.3 将 D3 决策落盘：RightPanel 固定 `ai/info/quality` 三 tab
+- [x] 1.4 将 guard 口径改为稳定路径校验，移除对活跃 change 路径的依赖
+
+## 2. Evidence & Consistency
+- [x] 2.1 校对 `openspec/changes/fe-spec-drift-iconbar-rightpanel-alignment/tasks.md` 与 guard 实现一致
+- [x] 2.2 校对 `openspec/_ops/task_runs/ISSUE-797.md`，补齐 guard 去耦合证据描述
+- [x] 2.3 将 Rulebook `proposal.md` 与 `tasks.md` 从模板占位替换为真实治理内容
+
+## 3. Pending (Out of Scope)
+- [ ] 3.1 提交/PR/auto-merge（本次按要求不提交）
+- [x] 3.2 全量长测试回归证据已补齐（`pnpm -C apps/desktop test:run`：`189 files` / `1555 tests` 全通过）
+- [ ] 3.3 Main Session Audit（仅提交/Apply 阶段需要，本次不执行）


### PR DESCRIPTION
Closes #797

## Summary
- 在 `openspec/changes/EXECUTION_ORDER.md` 新增“## 依赖说明”章节，补全依赖语义、并行/互斥规则、Owner 决策门、以及第一批双 lane 的依赖边界。
- 同步更新 `EXECUTION_ORDER.md` 更新时间，消除 preflight 对治理文档一致性的阻断。
- 执行 main-session resign，刷新 ISSUE-797 的审计签名链。

## Test plan
- `scripts/main_audit_resign.sh --issue 797 --no-push --skip-preflight`
- `scripts/agent_pr_preflight.sh --mode fast`

## Evidence
- Preflight 输出：`OK: fast preflight checks passed`
- RUN_LOG：`openspec/_ops/task_runs/ISSUE-797.md`
- 关键提交：`1f859e396b62c23e4c042b4378bc040edf083c2b`、`fa07d238`
