### PR TITLE
improve(main): 统一缺失 API Key 错误语义

### DIFF
--- a/apps/desktop/main/src/services/ai/__tests__/aiService-provider-unavailable.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-provider-unavailable.test.ts
@@ -11,7 +11,7 @@ function createLogger(): Logger {
   };
 }
 
-// --- runSkill maps missing provider credentials to AI_PROVIDER_UNAVAILABLE ---
+// --- runSkill keeps missing provider credentials as AI_NOT_CONFIGURED ---
 {
   const originalFetch = globalThis.fetch;
 
@@ -54,7 +54,7 @@ function createLogger(): Logger {
       );
     }
 
-    assert.equal(result.error.code, "AI_PROVIDER_UNAVAILABLE");
+    assert.equal(result.error.code, "AI_NOT_CONFIGURED");
     assert.equal(fetchCalled, false, "must fail before provider network call");
   } finally {
     globalThis.fetch = originalFetch;

--- a/apps/desktop/main/src/services/ai/__tests__/provider-resolver-no-fallback.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/provider-resolver-no-fallback.test.ts
@@ -132,3 +132,30 @@ function createLogger(): Logger {
   assert.equal(resolved.data.backup?.baseUrl, "https://proxy.example");
   assert.equal(resolved.data.backup?.apiKey, "sk-proxy");
 }
+
+// proxy disabled + explicit baseUrl + missing API key should fail as AI_NOT_CONFIGURED
+{
+  const resolver = createProviderResolver({
+    logger: createLogger(),
+    now: () => 1_000,
+  });
+
+  const resolved = await resolver.resolveProviderConfig({
+    env: {
+      CREONOW_E2E: "1",
+      CREONOW_AI_PROVIDER: "anthropic",
+      CREONOW_AI_BASE_URL: "http://127.0.0.1:9",
+    },
+    runtimeAiTimeoutMs: 30_000,
+    getFakeServer: async () => {
+      throw new Error("should not be called");
+    },
+  });
+
+  assert.equal(resolved.ok, false);
+  if (resolved.ok) {
+    throw new Error("missing api key should fail when baseUrl is explicit");
+  }
+  assert.equal(resolved.error.code, "AI_NOT_CONFIGURED");
+  assert.match(resolved.error.message, /api key/i);
+}

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -1199,13 +1199,6 @@ export function createAiService(deps: {
       getProxySettings: deps.getProxySettings,
     });
     if (!cfgRes.ok) {
-      if (cfgRes.error.code === "AI_NOT_CONFIGURED") {
-        return ipcError(
-          "AI_PROVIDER_UNAVAILABLE",
-          "请先在设置中配置 AI 服务",
-          cfgRes.error.details,
-        );
-      }
       return cfgRes;
     }
     const primaryCfg = cfgRes.data.primary;

--- a/apps/desktop/main/src/services/ai/providerResolver.ts
+++ b/apps/desktop/main/src/services/ai/providerResolver.ts
@@ -383,10 +383,15 @@ export function createProviderResolver(deps: {
         ? args.env.CREONOW_AI_API_KEY
         : undefined;
 
-    if (!isE2E(args.env) && provider !== "proxy" && !apiKey) {
+    const hasExplicitBaseUrl =
+      typeof envBaseUrl === "string" && envBaseUrl.trim().length > 0;
+    const requiresApiKey =
+      provider !== "proxy" && (!isE2E(args.env) || hasExplicitBaseUrl);
+
+    if (requiresApiKey && !apiKey) {
       return ipcError(
         "AI_NOT_CONFIGURED",
-        "AI service is not configured. Configure it in Settings first.",
+        "AI service is not configured: API key is required. Configure API key in Settings first.",
       );
     }
 

--- a/apps/desktop/renderer/src/lib/errorMessages.test.ts
+++ b/apps/desktop/renderer/src/lib/errorMessages.test.ts
@@ -19,7 +19,7 @@ describe("errorMessages", () => {
         code: "AI_NOT_CONFIGURED",
         message: "AI service is not configured",
       }),
-    ).toBe("请先在设置中配置 AI 服务");
+    ).toBe("请先在设置中配置 AI API Key");
   });
 
   it("preserves timeout detail when mapping IPC_TIMEOUT", () => {

--- a/apps/desktop/renderer/src/lib/errorMessages.ts
+++ b/apps/desktop/renderer/src/lib/errorMessages.ts
@@ -11,7 +11,7 @@ const USER_FACING_MESSAGE_BY_CODE: Partial<
   VALIDATION_ERROR: () => "请求参数不符合契约",
   FORBIDDEN: () => "调用方未授权",
   INTERNAL_ERROR: () => "内部错误",
-  AI_NOT_CONFIGURED: () => "请先在设置中配置 AI 服务",
+  AI_NOT_CONFIGURED: () => "请先在设置中配置 AI API Key",
   IPC_TIMEOUT: (backendMessage) => {
     const detail = TIMEOUT_DETAIL_PATTERN.exec(backendMessage)?.[1];
     return detail ? `请求超时（${detail}）` : "请求超时";

--- a/apps/desktop/renderer/src/lib/ipcClient.test.ts
+++ b/apps/desktop/renderer/src/lib/ipcClient.test.ts
@@ -77,7 +77,7 @@ describe("ipcClient.invoke", () => {
       return;
     }
     expect(result.error.code).toBe("AI_NOT_CONFIGURED");
-    expect(result.error.message).toBe("请先在设置中配置 AI 服务");
+    expect(result.error.message).toBe("请先在设置中配置 AI API Key");
   });
 
   it("handles non-Error throwables", async () => {

--- a/apps/desktop/tests/e2e/proxy-error-semantics.spec.ts
+++ b/apps/desktop/tests/e2e/proxy-error-semantics.spec.ts
@@ -45,10 +45,7 @@ async function ipcInvoke<C extends IpcChannel>(
   )) as IpcInvokeResult<C>;
 }
 
-// Skip: This test requires CREONOW_E2E=0 to test real API key validation,
-// but E2E mode is needed to skip onboarding. The test passes with E2E=0 when
-// onboarding is already completed (e.g., via localStorage).
-test.skip("proxy disabled + missing api key => INVALID_ARGUMENT", async () => {
+test("proxy disabled + missing api key => AI_NOT_CONFIGURED", async () => {
   const userDataDir = await createIsolatedUserDataDir();
   const appRoot = getAppRoot();
 
@@ -79,7 +76,7 @@ test.skip("proxy disabled + missing api key => INVALID_ARGUMENT", async () => {
 
   expect(run.ok).toBe(false);
   if (!run.ok) {
-    expect(run.error.code).toBe("INVALID_ARGUMENT");
+    expect(run.error.code).toBe("AI_NOT_CONFIGURED");
     expect(run.error.message.toLowerCase()).toContain("api key");
   }
 

--- a/apps/desktop/tests/integration/ai-provider-unavailable-degrade.test.ts
+++ b/apps/desktop/tests/integration/ai-provider-unavailable-degrade.test.ts
@@ -35,7 +35,11 @@ try {
 
   const service = createAiService({
     logger: createLogger(),
-    env: {},
+    env: {
+      CREONOW_AI_API_KEY: "sk-env",
+      CREONOW_AI_PROVIDER: "openai",
+      CREONOW_AI_BASE_URL: primaryBaseUrl,
+    },
     sleep: async () => {},
     rateLimitPerMinute: 1_000,
     getProxySettings: () => ({
@@ -47,8 +51,16 @@ try {
       openAiCompatibleApiKey: null,
       openAiByokBaseUrl: primaryBaseUrl,
       openAiByokApiKey: "sk-primary",
+      openAiByok: {
+        baseUrl: primaryBaseUrl,
+        apiKey: "sk-primary",
+      },
       anthropicByokBaseUrl: backupBaseUrl,
       anthropicByokApiKey: "sk-backup",
+      anthropicByok: {
+        baseUrl: backupBaseUrl,
+        apiKey: "sk-backup",
+      },
     }),
   });
 

--- a/apps/desktop/tests/integration/ai-skill-context-integration.test.ts
+++ b/apps/desktop/tests/integration/ai-skill-context-integration.test.ts
@@ -297,7 +297,7 @@ function createKnowledgeEntity(args: {
 }
 
 // AIS-ERR-S1
-// should map missing API key on run path to AI_PROVIDER_UNAVAILABLE
+// should return AI_NOT_CONFIGURED on run path when API key is missing
 {
   const service = createAiService({
     logger: createNoopLogger(),
@@ -323,7 +323,8 @@ function createKnowledgeEntity(args: {
   if (result.ok) {
     assert.fail("expected missing key to be rejected");
   }
-  assert.equal(result.error.code, "AI_PROVIDER_UNAVAILABLE");
+  assert.equal(result.error.code, "AI_NOT_CONFIGURED");
+  assert.match(result.error.message, /api key/i);
 }
 
 // AIS-HISTORY-S1 / AIS-HISTORY-S2


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (non-task branch)

## 主题
修复 proxy disabled 且缺失 API Key 时错误语义不一致的问题，并补齐对应回归覆盖。

## 改动列表
- fix(ai): runSkill 不再把 `AI_NOT_CONFIGURED` 重写成 `AI_PROVIDER_UNAVAILABLE`，保持配置缺失语义直出。
- fix(ai): provider resolver 在显式配置 baseUrl 时强制要求 API Key，缺失时返回 `AI_NOT_CONFIGURED` 且消息包含 API key。
- test(ai): 取消 `proxy-error-semantics` 里“缺失 api key”场景的 skip，并将断言更新为 `AI_NOT_CONFIGURED`。
- test(renderer): 同步更新 `errorMessages`/`ipcClient`/integration 断言，新增 resolver 边界测试覆盖显式 baseUrl + 缺失 key。

## 为什么改
当前链路里同一类“配置缺失”在不同层被映射成不同错误码，导致前端提示和自动化断言语义漂移。统一为 `AI_NOT_CONFIGURED` 后，用户提示可预测，回归测试也能稳定约束真实行为。

## 问题与风险
1. 具体问题（文件+场景）：`apps/desktop/main/src/services/ai/aiService.ts` 在 `runSkill` 中把 resolver 返回的 `AI_NOT_CONFIGURED` 改写成 `AI_PROVIDER_UNAVAILABLE`；`apps/desktop/tests/e2e/proxy-error-semantics.spec.ts` 对应场景被 skip，未形成持续回归保护。
2. 不改的最坏后果：用户缺失 API Key 时会收到错误语义不一致的提示，前端可能展示错误引导；后续改动继续放大语义漂移，导致线上定位和支持成本上升。
3. 有效性验证方式：
   - `pnpm desktop:ensure-native-node-abi` 通过
   - `pnpm exec tsx apps/desktop/main/src/services/ai/__tests__/provider-resolver-no-fallback.test.ts` 通过
   - `pnpm exec tsx apps/desktop/main/src/services/ai/__tests__/aiService-provider-unavailable.test.ts` 通过
   - `pnpm exec tsx apps/desktop/tests/integration/ai-skill-context-integration.test.ts` 通过
   - `pnpm typecheck` 通过
   - `pnpm lint` 通过（仅存量 warning，无新增 error）
   - `pnpm -C apps/desktop test:e2e -- tests/e2e/proxy-error-semantics.spec.ts` 在当前环境失败，原因为缺少 X server/`$DISPLAY`，非本改动逻辑失败

## 用户影响
- 缺失 API Key 时，用户会稳定收到“请先在设置中配置 AI API Key”的可操作提示。
- 对于 proxy disabled + 显式 baseUrl 的配置，错误码稳定为 `AI_NOT_CONFIGURED`，与前端文案和测试断言一致。

## 回滚点
- 单提交回滚：`git revert 9756a53c`

## Open PR 排重检查
- 扫描时间：2026-03-01 10:47:39 CST
- 当前 open PR 概览：#799、#755
- 文件重叠检查：与 #799、#755 无文件重叠
- 处理决策：本次为独立 AI 错误语义修复，单独建 PR

## Skill 执行记录
- [ ] amano-pr-deep-review 已执行（含深度审计结论）
- [ ] receiving-code-review 已执行（含反馈处理结论）
- [ ] verification-before-completion 已执行（含最新命令证据）

## 验证
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（无新增 error）
- [x] 关键回归测试通过（unit/integration）
- [ ] e2e 在本机无图形环境下可执行（受 X server 缺失限制）

## 注意
- 不涉及业务行为新增，仅统一既有配置缺失语义
- 不涉及 IPC 契约变更

Fixes #798

---
🤖 by 天野 (automated iteration)
