### PR TITLE
infra: add independent review infrastructure (#804)

### DIFF
--- a/.github/workflows/openspec-log-guard.yml
+++ b/.github/workflows/openspec-log-guard.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 3
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate completed active changes are archived (tasks.md all checked)
@@ -101,11 +101,12 @@ jobs:
             echo "✅ RUN_LOG format validated"
 
             python3 scripts/validate_main_session_audit_ci.py "$RUN_LOG"
+            python3 scripts/validate_independent_review_ci.py "$RUN_LOG"
           else
             if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*Skip-Reason[[:space:]]*:'; then
               echo "✅ Non-task branch with required Skip-Reason"
             else
-              FIX_LINE="Skip-Reason: automated quality iteration by 天野 (non-task branch)"
+              FIX_LINE="Skip-Reason: governance closeout on non-task branch"
               echo "skip_reason_missing=true" >> "$GITHUB_OUTPUT"
 
               echo "❌ Missing Skip-Reason in PR body"
@@ -143,7 +144,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const marker = '<!-- openspec-skip-reason-guidance -->';
-            const fixLine = 'Skip-Reason: automated quality iteration by 天野 (non-task branch)';
+            const fixLine = 'Skip-Reason: governance closeout on non-task branch';
             const body = [
               marker,
               'OpenSpec Log Guard 检测到当前分支不是 `task/*`，但 PR 描述缺少 `Skip-Reason:`。',

--- a/docs/delivery-rule-mapping.md
+++ b/docs/delivery-rule-mapping.md
@@ -1,5 +1,7 @@
 # Delivery Rule Mapping Matrix (CN Skill v2)
 
+更新时间：2026-03-01 14:10
+
 本表用于审计“规则声明 -> 仓库门禁 -> 脚本校验”是否一致。
 
 | 规则项                              | 外部 Skill                                       | 仓库规则主源                         | 宪法入口             | Workflow / Script                                                                                 |
@@ -12,6 +14,7 @@
 | 门禁全绿 + auto-merge               | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 5  | `AGENTS.md` P4       | `ci.yml`, `merge-serial.yml`, `openspec-log-guard.yml`                                            |
 | 控制面收口（必须回到 `main`）       | 外部 Skill §二 规则 6                            | `docs/delivery-skill.md` §二 规则 6  | `AGENTS.md` P4 + §五 | `agent_pr_preflight.py`（分支与任务收口校验）                                                     |
 | 主会话审计强制（子代理完成≠可合并） | 外部 Skill §二 规则 3/5                          | `docs/delivery-skill.md` §二 规则 16 | `AGENTS.md` P3 + P4  | `agent_pr_preflight.py` + `openspec-log-guard.yml`（`Reviewed-HEAD-SHA == HEAD^` + 签字提交隔离） |
+| 独立审计前置强制（作者/审计分离）   | 外部 Skill §二 规则 5                            | `docs/delivery-skill.md` §二 规则 17 | `AGENTS.md` P4 + P7  | `openspec-log-guard.yml` + `validate_independent_review_ci.py`（`Author-Agent != Reviewer-Agent` + `Decision=PASS` + `Reviewed-HEAD-SHA == HEAD^^`） |
 | 非 task 分支必须 Skip-Reason        | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | `openspec-log-guard.yml`                                                                          |
 | gh 超时 3 次 + 升级                 | 外部 Skill §四                                   | `docs/delivery-skill.md` §四         | `AGENTS.md` §七      | 执行规范（RUN_LOG 记录）                                                                          |
 

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -1,6 +1,6 @@
 # OpenSpec + Rulebook + GitHub 交付规则
 
-更新时间：2026-02-21 11:57
+更新时间：2026-03-01 14:10
 
 本文件是 CreoNow 的交付规则主源（Source of Truth）。
 本文件只定义约束条件和验收标准，不定义具体命令和脚本参数。
@@ -43,8 +43,9 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 14. **环境基线强制**：创建 `task/*` 分支和 worktree 前，必须先同步控制面到最新 `origin/main`。
 15. **RUN_LOG PR 真实链接强制**：`openspec/_ops/task_runs/ISSUE-<N>.md` 的 `PR` 字段不得为占位符（如 `待回填/TBD/TODO`）。
 16. **主会话审计强制**：RUN_LOG 必须包含 `## Main Session Audit`，且同时满足 `Audit-Owner=main-session`、`Reviewed-HEAD-SHA==签字提交的 HEAD^`、`Spec-Compliance/Code-Quality/Fresh-Verification` 全部 `PASS`、`Blocking-Issues=0`、`Decision=ACCEPT`；并且签字提交 `HEAD^..HEAD` 仅允许变更当前任务 RUN_LOG。任一不满足必须被 preflight 与 `openspec-log-guard` 阻断，子代理完成不得替代主会话签字。
-17. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
-18. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
+17. **独立审计前置强制**：`task/<N>-<slug>` 分支进入合并前，必须存在 `openspec/_ops/reviews/ISSUE-<N>.md` 并通过独立审计校验：`Author-Agent != Reviewer-Agent`、`Decision=PASS`、`Reviewed-HEAD-SHA==签字提交的 HEAD^^（代码审计基线）`；由 `openspec-log-guard` 阻断未满足场景。
+18. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
+19. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
 
 ---
 
@@ -56,7 +57,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | 2. 规格制定   | OpenSpec spec 已编写或更新；Rulebook task 已创建并通过 validate；若有上游依赖则 Dependency Sync Check 已完成并落盘 |
 | 3. 环境隔离   | 控制面 `origin/main` 已同步，Worktree 已创建，工作目录已切换                                                       |
 | 4. 实现与测试 | 按 TDD 循环实现；所有测试通过；RUN_LOG 已记录                                                                      |
-| 5. 提交与合并 | PR 已创建；auto-merge 已开启；三个 checks 全绿；PR 已确认合并                                                      |
+| 5. 提交与合并 | PR 已创建；独立审计记录已通过；auto-merge 已开启；三个 checks 全绿；PR 已确认合并                                  |
 | 6. 收口与归档 | 控制面 `main` 已包含任务提交；worktree 已清理；Rulebook task 已归档（可同 PR 自归档，无需递归 closeout issue）     |
 
 ---
@@ -67,6 +68,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | ------------------------------------ | ------------------------------------------------------------------------------------------- | -------------------------- |
 | `gh` 命令超时                        | 最多重试 3 次（间隔 10s），仍失败必须记录 RUN_LOG 并升级                                    |
 | PR 需要 review                       | 记录 blocker，通知 reviewer，等待处理，禁止 silent abandonment                              |
+| 独立审计缺失或未通过                 | 阻断交付；先补齐 `openspec/_ops/reviews/ISSUE-<N>.md` 并满足 Author/Reviewer 分离 + PASS + SHA 对齐，再继续        |
 | checks 失败                          | 修复后重新 push，重跑并记录失败原因和修复证据                                               |
 | Spec 不存在或不完整                  | 必须先补 spec 并确认，禁止猜测实现                                                          |
 | 上游依赖产出与当前 change 假设不一致 | 先做 Dependency Sync Check 并记录，再更新 proposal/spec/tasks（必要时更新 EXECUTION_ORDER） | 跳过更新直接进入 Red/Green |

--- a/docs/references/exception-handling.md
+++ b/docs/references/exception-handling.md
@@ -1,5 +1,7 @@
 # 异常处理
 
+更新时间：2026-03-01 14:10
+
 | 遇到的情况                           | 必须做                                                                                                   | 禁止做                     |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------- |
 | Spec 不存在或不完整                  | 通知 Owner，请求补充 spec                                                                                | 根据猜测直接写代码         |
@@ -7,6 +9,7 @@
 | 上游依赖产出与当前 change 假设不一致 | 先做 Dependency Sync Check 并记录 → 更新 proposal/spec/tasks（必要时更新 EXECUTION_ORDER）→ 经确认后继续 | 跳过更新直接进入 Red/Green |
 | `gh` 命令超时                        | 重试 3 次（间隔 10s），仍失败 → 记录 RUN_LOG → 升级                                                      | 静默忽略                   |
 | PR 需要 review                       | 记录 blocker → 通知 reviewer → 等待                                                                      | 静默放弃                   |
+| 独立审计缺失或失败                   | 补齐 `openspec/_ops/reviews/ISSUE-<N>.md`，并确保 `Author-Agent != Reviewer-Agent`、`Decision=PASS`、`Reviewed-HEAD-SHA == HEAD^^`（代码审计基线） | 跳过独立审计直接合并       |
 | CI 失败                              | 修复 → push → 再次 watch → 写入 RUN_LOG                                                                  | 先合并再修                 |
 | Rulebook task 缺失或不合规           | 阻断交付，先修复 Rulebook 再继续（active 必须 validate；archive 必须结构完整）                           | 跳过 Rulebook 直接实现     |
 | 非 `task/*` 分支提交 PR              | PR body 必须包含 `Skip-Reason:`                                                                          | 不说明原因直接跳过 RUN_LOG |

--- a/openspec/_ops/reviews/ISSUE-804.md
+++ b/openspec/_ops/reviews/ISSUE-804.md
@@ -1,0 +1,43 @@
+# ISSUE-804 Independent Review
+
+更新时间：2026-03-01 15:20
+
+- Issue: #804
+- PR: https://github.com/Leeky1017/CreoNow/pull/805
+- Author-Agent: codex
+- Reviewer-Agent: claude
+- Reviewed-HEAD-SHA: 78b26cfd07ea63688f3f8b412663ed4b27427044
+- Decision: PASS
+
+## Scope
+
+- `scripts/independent_review_record.sh`：审计记录模板生成脚本
+- `scripts/validate_independent_review_ci.py`：CI 校验逻辑（字段完整性、Author≠Reviewer、Decision=PASS、SHA 对齐）
+- `openspec/_ops/reviews/TEMPLATE.md`：审计记录模板
+- `.github/workflows/openspec-log-guard.yml`：集成独立审计校验步骤
+- `scripts/agent_pr_automerge_and_sync.sh`：去掉 admin bypass（REVIEW_REQUIRED → exit 1）
+- `scripts/agent_worktree_setup.sh`：默认 bootstrap 依赖（--no-bootstrap 可关闭）
+- `docs/delivery-skill.md`：新增规则17（独立审计前置强制），规则编号重排（17→18→19）
+- `docs/delivery-rule-mapping.md`：映射规则17到 CI 校验
+- `docs/references/exception-handling.md`：新增独立审计异常处理行
+- `scripts/README.md`：新增脚本文档
+
+## Findings
+
+- 严重问题：无
+- 中等级问题：`validate_independent_review_ci.py` 的 `HEAD^^` 假设在 rebase 后会导致 SHA 失效，需要重新生成 review record。已在 plan 中列为后续迭代点，当前阶段可接受。
+- 低风险问题：
+  - `independent_review_record.sh` 生成模板的 Findings/Verification 含 TODO 占位符，CI 不校验是否已替换。已列为后续迭代点。
+  - TEMPLATE.md 用中文（"严重问题/中等级问题"），脚本生成的用英文 TODO，语言不一致。不影响功能。
+  - `validate_independent_review_ci.py` 依赖 `agent_pr_preflight` 模块的 `run()`/`git_root()`/`require_file()`，已验证三个函数均存在且签名匹配。
+  - `agent_worktree_setup.sh` 参数解析正确，`shift 2` 后进入 flag 循环，`BOOTSTRAP` 默认 `true`，逻辑无误。
+  - `agent_pr_automerge_and_sync.sh` 第 309 行改为调用 `main_audit_resign.sh --issue --preflight-mode fast`，已验证该脚本存在且接受这两个参数。
+
+## Verification
+
+- `scripts/validate_independent_review_ci.py`：逐行审查 import 链，确认 `agent_pr_preflight.run()`、`git_root()`、`require_file()` 三个函数存在且签名匹配
+- `scripts/agent_pr_automerge_and_sync.sh`：确认 `main_audit_resign.sh` 存在，接受 `--issue` 和 `--preflight-mode` 参数
+- `scripts/agent_worktree_setup.sh`：确认参数解析逻辑正确，bootstrap 默认开启，pnpm 路径引用安全
+- `scripts/independent_review_record.sh`：确认参数校验、SHA 格式校验、模板生成逻辑完整
+- `.github/workflows/openspec-log-guard.yml`：确认 `validate_independent_review_ci.py` 在 main session audit 之后串行执行
+- `docs/delivery-skill.md`：确认规则17定义清晰，规则编号重排连续（原17→18，原18→19）

--- a/openspec/_ops/reviews/TEMPLATE.md
+++ b/openspec/_ops/reviews/TEMPLATE.md
@@ -1,0 +1,24 @@
+# ISSUE-<N> Independent Review
+
+更新时间：2026-03-01 14:10
+
+- Issue: #<N>
+- PR: <https://github.com/<owner>/<repo>/pull/<N>>
+- Author-Agent: <codex|claude|other>
+- Reviewer-Agent: <codex|claude|other>
+- Reviewed-HEAD-SHA: <40-hex; must equal final signing sequence HEAD^^ (reviewed code baseline)>
+- Decision: <PASS|FAIL>
+
+## Scope
+
+- 审计范围（文件/模块/场景）
+
+## Findings
+
+- 严重问题（若无，写“无”）
+- 中等级问题（若无，写“无”）
+- 低风险问题（若无，写“无”）
+
+## Verification
+
+- 关键验证命令与结果

--- a/openspec/_ops/task_runs/ISSUE-804.md
+++ b/openspec/_ops/task_runs/ISSUE-804.md
@@ -1,0 +1,56 @@
+# ISSUE-804
+
+更新时间：2026-03-01 15:25
+
+- Issue: #804
+- Branch: task/804-independent-review-infrastructure
+- PR: https://github.com/Leeky1017/CreoNow/pull/805
+
+## Plan
+
+- 收口 Codex 设计的独立审计基础设施改动，按标准交付流程合并到 main
+- 本次收口本身即独立审计流程的首次实战验证（dogfooding）
+
+## Runs
+
+### 2026-03-01 15:15 Code Review — 全量审查 Codex 改动
+
+- Scope: 10 个文件（3 新增 + 7 修改），+332 行 -19 行
+- 审查要点：
+  - `validate_independent_review_ci.py`：import 链校验（`agent_pr_preflight.run/git_root/require_file` 三个函数均存在且签名匹配）；`HEAD^^` 语义正确（三层提交序列假设成立）
+  - `agent_pr_automerge_and_sync.sh`：第 309 行改为 `main_audit_resign.sh --issue --preflight-mode fast`，已确认脚本存在且接受该参数；第 384-388 行 REVIEW_REQUIRED 改为 exit 1，逻辑正确
+  - `agent_worktree_setup.sh`：参数解析正确，`shift 2` 后进入 flag 循环，`BOOTSTRAP` 默认 `true`，pnpm 路径引用安全
+  - `independent_review_record.sh`：参数校验、SHA 格式校验、模板生成逻辑完整
+  - `delivery-skill.md`：规则17定义清晰，规则编号重排连续（原17→18，原18→19）
+  - `openspec-log-guard.yml`：`validate_independent_review_ci.py` 在 main session audit 之后串行执行
+- Result: PASS（无阻断级问题）
+
+### 2026-03-01 15:18 Independent Review — Claude 审计 Codex 改动
+
+- Author-Agent: codex
+- Reviewer-Agent: claude
+- Reviewed-HEAD-SHA: 78b26cfd07ea63688f3f8b412663ed4b27427044
+- Decision: PASS
+- Findings:
+  - 中等：HEAD^^ 假设在 rebase 后失效（已列为后续迭代点）
+  - 低：TODO 占位符未 CI 校验、TEMPLATE.md 中英文不一致（已列为后续迭代点）
+- Review record: `openspec/_ops/reviews/ISSUE-804.md`
+
+### 2026-03-01 15:22 CI Failure — openspec-log-guard fetch-depth insufficient
+
+- Check: `openspec-log-guard`
+- Exit code: `1`
+- Error: `RuntimeError: [INDEPENDENT_REVIEW] failed to resolve HEAD^^; independent review expects canonical sequence`
+- Root cause: `.github/workflows/openspec-log-guard.yml` 使用 `fetch-depth: 2`，只够解析 `HEAD^`（main session audit），不够解析 `HEAD^^`（independent review）
+- Fix: 将 `fetch-depth` 从 `2` 改为 `3`
+- Action: soft reset 三层提交，将修复合入代码 commit，重新提交三层序列
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 96ce9403b6bef67d5a17f7ef4a0fe5abeaed293e
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,8 @@
 | `agent_pr_preflight.sh`            | 提交前 / PR 前的预检查                          | 阶段 5：提交前     |
 | `agent_pr_automerge_and_sync.sh`   | 创建 PR + auto-merge + 等待                     | 阶段 5：提交与合并 |
 | `main_audit_resign.sh`             | RUN_LOG 主会话审计重签（`Reviewed-HEAD-SHA`）   | BEHIND/sync 后修复 |
+| `independent_review_record.sh`     | 生成 `openspec/_ops/reviews/ISSUE-<N>.md` 初稿  | 独立审计执行前     |
+| `validate_independent_review_ci.py`| 校验独立审计记录（CI）                          | `openspec-log-guard` 内 |
 | `agent_worktree_cleanup.sh`        | 清理 worktree                                   | 阶段 6：收口       |
 | `team_delivery_status.py`          | 聚合 Team/GitHub/Governance 状态并给出可合并判定 | 盯盘/收口阶段      |
 | `ipc-acceptance-gate.ts`           | IPC acceptance SLO 门禁                         | 阶段 4：实现与测试 |
@@ -42,4 +44,9 @@
 - Main Session Audit 回填标准操作：
   - 回填时机：功能改动提交完成后、推送分支前执行一次重签；若后续又有代码提交，必须再次重签
   - 回填命令：`scripts/main_audit_resign.sh --issue <N> --preflight-mode fast`（会刷新 `Reviewed-HEAD-SHA` 并立即做本地快检）
+- 独立审计记录标准操作：
+  - 生成初稿：`scripts/independent_review_record.sh --issue <N> --author <agent> --reviewer <agent> --pr-url <url>`
+  - 审计签字：填写 Findings/Verification，并确保 `Decision=PASS`、`Reviewed-HEAD-SHA` 对齐代码审计基线（最终签字序列 `HEAD^^`）
+- `agent_worktree_setup.sh` 默认会在新 worktree 内执行 `pnpm install --frozen-lockfile`（可用 `--no-bootstrap` 关闭）。
+- `agent_pr_automerge_and_sync.sh` 在回填 RUN_LOG PR 链接后会自动执行 `main_audit_resign.sh`；并且遇到 `REVIEW_REQUIRED` 时会阻断合并，不再走 admin bypass。
 - `agent_pr_automerge_and_sync.sh` 在 GitHub TLS 抖动时会标记 `transient` 并自动重试，必要时回退到 `gh run list` 快照通道。

--- a/scripts/agent_pr_automerge_and_sync.sh
+++ b/scripts/agent_pr_automerge_and_sync.sh
@@ -306,7 +306,7 @@ fi
 backfill_runlog_pr_link "$PR_NUMBER"
 if [[ "$RUNLOG_BACKFILLED" == "true" && "$SKIP_PREFLIGHT" != "true" ]]; then
   set +e
-  scripts/agent_pr_preflight.sh
+  scripts/main_audit_resign.sh --issue "$ISSUE_NUMBER" --preflight-mode fast
   PREFLIGHT_RC=$?
   set -e
 fi
@@ -382,17 +382,9 @@ while true; do
   fi
 
   if [[ "$REVIEW_DECISION" == "REVIEW_REQUIRED" ]]; then
-    echo "WARN: PR #${PR_NUMBER} is blocked by review requirement; attempting admin merge to keep delivery autonomous." >&2
-    set +e
-    run_gh_with_retry gh pr merge "$PR_NUMBER" --admin --squash -d >/dev/null
-    MERGE_RC=$?
-    set -e
-    if [[ $MERGE_RC -ne 0 ]]; then
-      echo "ERROR: admin merge failed for PR #${PR_NUMBER} (review required still blocking)." >&2
-      comment_pr "$PR_NUMBER" "Auto-merge is enabled and checks are green, but GitHub reports \`reviewDecision=REVIEW_REQUIRED\` and admin merge failed. Repo must allow admin bypass for autonomous delivery. PR: ${PR_URL}"
-      exit 1
-    fi
-    continue
+    echo "ERROR: PR #${PR_NUMBER} is blocked by review requirement; independent review must be completed before merge." >&2
+    comment_pr "$PR_NUMBER" "PR is blocked by \`reviewDecision=REVIEW_REQUIRED\`. Complete independent review before merge. PR: ${PR_URL}"
+    exit 1
   fi
 
   if [[ "$REVIEW_DECISION" == "CHANGES_REQUESTED" ]]; then

--- a/scripts/agent_worktree_setup.sh
+++ b/scripts/agent_worktree_setup.sh
@@ -1,11 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/agent_worktree_setup.sh <issue-number> <slug> [--no-bootstrap]
+
+Options:
+  --no-bootstrap   Skip dependency bootstrap in the new worktree
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
 N="${1:-}"
 SLUG="${2:-}"
+BOOTSTRAP="true"
+shift 2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-bootstrap)
+      BOOTSTRAP="false"
+      shift 1
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
 
 if [[ -z "$N" || -z "$SLUG" ]]; then
-  echo "Usage: scripts/agent_worktree_setup.sh <issue-number> <slug>" >&2
+  usage >&2
   exit 2
 fi
 
@@ -35,3 +69,13 @@ git fetch origin main
 git worktree add -b "$BRANCH" "$DIR" origin/main
 echo "Worktree created: $DIR"
 echo "Branch: $BRANCH"
+
+if [[ "$BOOTSTRAP" == "true" ]]; then
+  if command -v pnpm >/dev/null 2>&1 && [[ -f "${DIR}/package.json" ]]; then
+    echo "Bootstrapping dependencies in ${DIR} ..."
+    pnpm -C "$DIR" install --frozen-lockfile
+    echo "Bootstrap completed: pnpm install --frozen-lockfile"
+  else
+    echo "[SKIP] bootstrap: pnpm or package.json not found in ${DIR}"
+  fi
+fi

--- a/scripts/independent_review_record.sh
+++ b/scripts/independent_review_record.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/independent_review_record.sh --issue <N> --author <agent> --reviewer <agent> [options]
+
+Options:
+  --issue <N>           Issue number (required)
+  --author <agent>      Author agent identity, e.g. codex (required)
+  --reviewer <agent>    Reviewer agent identity, e.g. claude (required)
+  --decision <value>    PASS or FAIL (default: PASS)
+  --pr-url <url>        Optional PR URL
+  --reviewed-sha <sha>  Reviewed code commit SHA (default: current HEAD before review-record commit)
+EOF
+}
+
+ISSUE_NUMBER=""
+AUTHOR_AGENT=""
+REVIEWER_AGENT=""
+DECISION="PASS"
+PR_URL=""
+REVIEWED_SHA=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      ISSUE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --author)
+      AUTHOR_AGENT="${2:-}"
+      shift 2
+      ;;
+    --reviewer)
+      REVIEWER_AGENT="${2:-}"
+      shift 2
+      ;;
+    --decision)
+      DECISION="${2:-}"
+      shift 2
+      ;;
+    --pr-url)
+      PR_URL="${2:-}"
+      shift 2
+      ;;
+    --reviewed-sha)
+      REVIEWED_SHA="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$ISSUE_NUMBER" || -z "$AUTHOR_AGENT" || -z "$REVIEWER_AGENT" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --issue must be numeric, got: ${ISSUE_NUMBER}" >&2
+  exit 2
+fi
+
+DECISION="$(echo "$DECISION" | tr '[:lower:]' '[:upper:]')"
+if [[ "$DECISION" != "PASS" && "$DECISION" != "FAIL" ]]; then
+  echo "ERROR: --decision must be PASS or FAIL, got: ${DECISION}" >&2
+  exit 2
+fi
+
+if [[ -z "$REVIEWED_SHA" ]]; then
+  REVIEWED_SHA="$(git rev-parse HEAD)"
+fi
+
+if [[ ! "$REVIEWED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "ERROR: --reviewed-sha must be a 40-hex commit sha, got: ${REVIEWED_SHA}" >&2
+  exit 2
+fi
+
+UPDATED_AT="$(date '+%Y-%m-%d %H:%M')"
+OUT_PATH="openspec/_ops/reviews/ISSUE-${ISSUE_NUMBER}.md"
+
+mkdir -p "openspec/_ops/reviews"
+
+cat > "$OUT_PATH" <<EOF
+# ISSUE-${ISSUE_NUMBER} Independent Review
+
+更新时间：${UPDATED_AT}
+
+- Issue: #${ISSUE_NUMBER}
+- PR: ${PR_URL}
+- Author-Agent: ${AUTHOR_AGENT}
+- Reviewer-Agent: ${REVIEWER_AGENT}
+- Reviewed-HEAD-SHA: ${REVIEWED_SHA}
+- Decision: ${DECISION}
+
+## Scope
+
+- TODO: describe reviewed scope
+
+## Findings
+
+- TODO: add findings with severity and file references
+
+## Verification
+
+- TODO: list verification commands and outcomes
+EOF
+
+echo "OK: wrote ${OUT_PATH}"

--- a/scripts/validate_independent_review_ci.py
+++ b/scripts/validate_independent_review_ci.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import agent_pr_preflight as preflight
+
+
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "Issue",
+    "Author-Agent",
+    "Reviewer-Agent",
+    "Reviewed-HEAD-SHA",
+    "Decision",
+)
+
+
+def extract_field(content: str, field: str, path: str) -> str:
+    match = re.search(rf"^- {re.escape(field)}:\s*(.+)$", content, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"[INDEPENDENT_REVIEW] missing field '{field}' in {path}")
+    value = match.group(1).strip()
+    if not value:
+        raise RuntimeError(f"[INDEPENDENT_REVIEW] empty field '{field}' in {path}")
+    return value
+
+
+def derive_issue_number(run_log_rel: str) -> str:
+    match = re.search(r"ISSUE-(\d+)\.md$", run_log_rel)
+    if not match:
+        raise RuntimeError(
+            "[INDEPENDENT_REVIEW] cannot derive issue number from run log path: "
+            f"{run_log_rel}"
+        )
+    return match.group(1)
+
+
+def normalize_issue_value(value: str) -> str:
+    cleaned = value.strip()
+    if cleaned.startswith("#"):
+        cleaned = cleaned[1:]
+    return cleaned
+
+
+def current_head_grandparent_sha(repo_root: str) -> str:
+    res = preflight.run(["git", "rev-parse", "HEAD^^"], cwd=repo_root)
+    if res.code != 0:
+        raise RuntimeError(
+            "[INDEPENDENT_REVIEW] failed to resolve HEAD^^; independent review expects canonical sequence "
+            "(reviewed code commit -> review record commit -> main-session signing commit)"
+        )
+    return res.out.strip()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(
+            "Usage: python3 scripts/validate_independent_review_ci.py <run-log-path>",
+            file=sys.stderr,
+        )
+        return 2
+
+    run_log_rel = sys.argv[1]
+    issue_number = derive_issue_number(run_log_rel)
+    review_rel = f"openspec/_ops/reviews/ISSUE-{issue_number}.md"
+
+    repo = preflight.git_root()
+    run_log_abs = os.path.join(repo, run_log_rel)
+    review_abs = os.path.join(repo, review_rel)
+
+    preflight.require_file(run_log_abs)
+    preflight.require_file(review_abs)
+
+    with open(review_abs, "r", encoding="utf-8") as fp:
+        content = fp.read()
+
+    fields = {field: extract_field(content, field, review_rel) for field in REQUIRED_FIELDS}
+
+    issue_value = normalize_issue_value(fields["Issue"])
+    if issue_value != issue_number:
+        raise RuntimeError(
+            f"[INDEPENDENT_REVIEW] Issue mismatch in {review_rel}: expected #{issue_number}, got {fields['Issue']}"
+        )
+
+    author_agent = fields["Author-Agent"].strip().lower()
+    reviewer_agent = fields["Reviewer-Agent"].strip().lower()
+    if author_agent == reviewer_agent:
+        raise RuntimeError(
+            f"[INDEPENDENT_REVIEW] Author-Agent and Reviewer-Agent must differ in {review_rel}"
+        )
+
+    decision = fields["Decision"].strip().upper()
+    if decision != "PASS":
+        raise RuntimeError(
+            f"[INDEPENDENT_REVIEW] Decision must be PASS in {review_rel}, got {fields['Decision']}"
+        )
+
+    reviewed_sha = fields["Reviewed-HEAD-SHA"].strip()
+    if not re.match(r"^[0-9a-fA-F]{40}$", reviewed_sha):
+        raise RuntimeError(
+            f"[INDEPENDENT_REVIEW] Reviewed-HEAD-SHA must be 40-hex in {review_rel}, got {reviewed_sha}"
+        )
+
+    expected_reviewed_sha = current_head_grandparent_sha(repo)
+    if reviewed_sha.lower() != expected_reviewed_sha.lower():
+        raise RuntimeError(
+            "[INDEPENDENT_REVIEW] Reviewed-HEAD-SHA mismatch: "
+            f"review={reviewed_sha}, expected={expected_reviewed_sha} (HEAD^^)"
+        )
+
+    print(f"✅ Independent review validated: {review_rel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #804

独立审计基础设施落地，用 git commit 顺序做密码学证明，确保"先审后并"。

### 核心改动

- **Agent 分离强制**：`Author-Agent != Reviewer-Agent`，CI 校验，不靠人工
- **SHA 基线对齐**：review 覆盖的是实际代码（`HEAD^^`），不是审计元数据
- **去 admin bypass**：`agent_pr_automerge_and_sync.sh` 遇到 `REVIEW_REQUIRED` 直接失败
- **Worktree 默认 bootstrap**：`agent_worktree_setup.sh` 默认执行 `pnpm install --frozen-lockfile`
- **交付规则17**：独立审计前置强制，由 `openspec-log-guard` 阻断未满足场景

### 文件清单

**新增**：
- `scripts/independent_review_record.sh`
- `scripts/validate_independent_review_ci.py`
- `openspec/_ops/reviews/TEMPLATE.md`

**修改**：
- `.github/workflows/openspec-log-guard.yml`
- `scripts/agent_worktree_setup.sh`
- `scripts/agent_pr_automerge_and_sync.sh`
- `docs/delivery-skill.md`
- `docs/delivery-rule-mapping.md`
- `docs/references/exception-handling.md`
- `scripts/README.md`