### PR TITLE
docs: sync EO after merged lane updates (#811)

### DIFF
--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-01 16:12
+更新时间：2026-03-01 17:56
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
@@ -23,10 +23,10 @@
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
 | 1 | 1-1 | `fe-rightpanel-ai-tabbar-layout` | AiPanel 簇 | — | 已完成并归档（PR #801） |
-| 1 | 1-2 | `fe-rightpanel-ai-guidance-and-style` | AiPanel 簇 | `fe-rightpanel-ai-tabbar-layout` | 执行中（PR #809，待独立审计） |
+| 1 | 1-2 | `fe-rightpanel-ai-guidance-and-style` | AiPanel 簇 | `fe-rightpanel-ai-tabbar-layout` | 已完成（PR #809，待归档） |
 | 1 | 1-3 | `fe-cleanup-proxysection-and-mocks` | AiPanel 簇 | — | 待执行 |
 | 2 | 2-1 | `fe-spec-drift-iconbar-rightpanel-alignment` | Layout 簇 | D1/D2/D3 已决策 | 已完成并归档（PR #799） |
-| 2 | 2-2 | `fe-leftpanel-dialog-migration` | Layout 簇 | `fe-spec-drift-iconbar-rightpanel-alignment`, D1/D2 已决策 | 执行中（ISSUE-807，PR #808） |
+| 2 | 2-2 | `fe-leftpanel-dialog-migration` | Layout 簇 | `fe-spec-drift-iconbar-rightpanel-alignment`, D1/D2 已决策 | 已完成（PR #808，待归档） |
 | 2 | 2-3 | `fe-ai-panel-toggle-button` | Layout 簇 | — | 待执行 |
 | — | 收尾 | `fe-dashboard-welcome-merge-and-ghost-actions` | AppShell 簇 | `fe-cleanup-proxysection-and-mocks`, `fe-ui-open-folder-entrypoints`(第二批), 且与 leftpanel/toggle 共享 AppShell.tsx 需等其完成 | 待执行 |
 
@@ -221,9 +221,9 @@
 
 ## 依赖说明
 
-- 当前子任务：`ISSUE-807`（`fe-leftpanel-dialog-migration`，PR #808）。
-- 依赖关系：`fe-rightpanel-ai-guidance-and-style` 与 `fe-leftpanel-dialog-migration` 继续分别依赖已归档的 lane 起点 change。
-- 同步结论：归档后依赖关系保持成立，无新增漂移。
+- 当前子任务：无（第一批剩余收尾项待推进）。
+- 依赖关系：`fe-rightpanel-ai-guidance-and-style` 与 `fe-leftpanel-dialog-migration` 已分别在 PR #809 / #808 合并；两者仍需执行变更归档。
+- 同步结论：依赖关系无漂移，当前收口焦点为完成归档与后续 lane 推进。
 
 ## Owner 决策阻塞项
 


### PR DESCRIPTION
Closes #811

Skip-Reason: governance closeout on non-task branch

## Summary
- synchronize `openspec/changes/EXECUTION_ORDER.md` with actual post-merge status
- mark `fe-rightpanel-ai-guidance-and-style` (PR #809) and `fe-leftpanel-dialog-migration` (PR #808) as completed pending archive
- refresh dependency note wording to reflect merged state

## Verification
- `python3 scripts/check_doc_timestamps.py --files openspec/changes/EXECUTION_ORDER.md`

## Notes
- local controlplane accidental deletion of `openspec/changes/archive/.gitkeep` has been restored (workspace cleanliness fix, not part of this PR diff)
