### PR TITLE
ci: enforce progressive governance evidence timeline (#825)

### DIFF
--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -46,6 +46,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 17. **独立审计前置强制**：`task/<N>-<slug>` 分支进入合并前，必须存在 `openspec/_ops/reviews/ISSUE-<N>.md` 并通过独立审计校验：`Author-Agent != Reviewer-Agent`、`Decision=PASS`、`Reviewed-HEAD-SHA==签字提交的 HEAD^^（代码审计基线）`；由 `openspec-log-guard` 阻断未满足场景。
 18. **完成变更归档强制**：当 `openspec/changes/<change>/tasks.md` 全部勾选完成时，必须归档到 `openspec/changes/archive/`，不得继续停留在活跃目录。
 19. **Rulebook 自归档无递归**：允许当前任务在同一 PR 中将自身 Rulebook task 从 `active` 归档到 `archive`；不得仅为“归档当前任务”再创建递归 closeout issue。
+20. **过程记录时序强制**：`Rulebook/RUN_LOG/OpenSpec tasks` 必须在执行过程中持续更新，不得只在最终审计签字尾段集中回填；若分支存在前序交付提交但治理证据仅出现在最后签字尾段提交，preflight 必须阻断。
 
 ---
 
@@ -81,6 +82,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | RUN_LOG 主会话审计缺失/未通过        | 阻断交付；先补齐 `## Main Session Audit` 并满足全部通过条件，确保签字提交仅变更 RUN_LOG     |
 | 活跃 change 已完成但未归档           | 阻断交付，先归档到 `openspec/changes/archive/` 再继续                                       |
 | 当前任务已在同 PR 归档               | 允许 preflight 通过 archive 路径校验，不要求再次创建 closeout issue                         |
+| Rulebook/RUN_LOG 仅在末尾集中补录    | 阻断交付；在执行期补充过程记录提交后重新签字，再重新 preflight                               |
 
 ---
 

--- a/openspec/_ops/reviews/ISSUE-825.md
+++ b/openspec/_ops/reviews/ISSUE-825.md
@@ -1,0 +1,27 @@
+# ISSUE-825 Independent Review
+
+更新时间：2026-03-01 20:51
+
+- Issue: #825
+- PR: https://github.com/Leeky1017/CreoNow/pull/826
+- Author-Agent: leeky1017
+- Reviewer-Agent: codex
+- Reviewed-HEAD-SHA: 49fabdaa6d710a461b3fbaa83416258e341a7297
+- Decision: PASS
+
+## Scope
+
+- 审计 `agent_pr_preflight.py` 新增“过程记录时序”门禁逻辑是否能识别末尾集中补录。
+- 审计 `docs/delivery-skill.md` 与 `scripts/README.md` 是否与新门禁一致。
+
+## Findings
+
+- 严重问题：无
+- 中等级问题：无
+- 低风险问题：无
+
+## Verification
+
+- `python3 -m py_compile scripts/agent_pr_preflight.py`：通过。
+- `rulebook task validate issue-825-enforce-progressive-governance-updates`：通过（warning: no spec files）。
+- `git diff --name-only origin/main...49fabdaa6d710a461b3fbaa83416258e341a7297`：包含脚本 + 治理文档 + RUN_LOG/Rulebook 证据链。

--- a/openspec/_ops/task_runs/ISSUE-825.md
+++ b/openspec/_ops/task_runs/ISSUE-825.md
@@ -43,7 +43,7 @@
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: PENDING
+- Reviewed-HEAD-SHA: b9559290bb8240a8390dc42a11e287fac305bd86
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-825.md
+++ b/openspec/_ops/task_runs/ISSUE-825.md
@@ -1,0 +1,47 @@
+# ISSUE-825
+- Issue: #825
+- Branch: task/825-enforce-progressive-governance-updates
+- PR: 待创建（创建后回填真实链接）
+
+## Plan
+- 在 preflight 增加“过程记录时序”门禁，阻断末尾一次性回填
+- 同步 `docs/delivery-skill.md` 与 `scripts/README.md`，把规则写成明确可执行条款
+
+## Runs
+
+### 2026-03-01 20:45 Intake
+- Command: `rulebook task create issue-825-enforce-progressive-governance-updates`
+- Command: `rulebook task validate issue-825-enforce-progressive-governance-updates`
+- Key output: task 已创建且 validate 通过（warning: no spec files）
+
+### 2026-03-01 20:46 Gate implementation
+- File: `scripts/agent_pr_preflight.py`
+- Changes made:
+  - 新增 `validate_progress_evidence_timeline` 校验分支提交历史中的治理证据时序。
+  - 新增 commit 级文件采集函数，识别 `RUN_LOG/review/rulebook task/openspec change task` 过程证据。
+  - 在 Rulebook 校验后接入该时序门禁；命中“仅末尾补录”时阻断 preflight。
+
+### 2026-03-01 20:47 Governance docs sync
+- File: `docs/delivery-skill.md`
+- Changes made:
+  - 新增硬约束：过程记录时序强制（禁止最后签字尾段集中回填）。
+  - 在异常处理表新增对应阻断与修复路径。
+- File: `scripts/README.md`
+- Changes made:
+  - 在 preflight 校验清单新增“末尾集中补录阻断”说明。
+
+### 2026-03-01 20:48 Local verification
+- Command: `python3 -m py_compile scripts/agent_pr_preflight.py`
+- Key output: 通过（exit 0）
+- Command: `rulebook task validate issue-825-enforce-progressive-governance-updates`
+- Key output: 通过（warning: no spec files）
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: PENDING
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-825.md
+++ b/openspec/_ops/task_runs/ISSUE-825.md
@@ -1,7 +1,7 @@
 # ISSUE-825
 - Issue: #825
 - Branch: task/825-enforce-progressive-governance-updates
-- PR: 待创建（创建后回填真实链接）
+- PR: https://github.com/Leeky1017/CreoNow/pull/826
 
 ## Plan
 - 在 preflight 增加“过程记录时序”门禁，阻断末尾一次性回填
@@ -35,6 +35,10 @@
 - Key output: 通过（exit 0）
 - Command: `rulebook task validate issue-825-enforce-progressive-governance-updates`
 - Key output: 通过（warning: no spec files）
+
+### 2026-03-01 20:49 PR created
+- Command: `gh pr create --base main --head task/825-enforce-progressive-governance-updates --title "ci: enforce progressive governance evidence timeline (#825)" --body-file ...`
+- Key output: PR created `https://github.com/Leeky1017/CreoNow/pull/826`
 
 ## Main Session Audit
 

--- a/rulebook/tasks/issue-825-enforce-progressive-governance-updates/.metadata.json
+++ b/rulebook/tasks/issue-825-enforce-progressive-governance-updates/.metadata.json
@@ -1,0 +1,5 @@
+{
+  "status": "pending",
+  "createdAt": "2026-03-01T12:46:01.004Z",
+  "updatedAt": "2026-03-01T12:46:01.004Z"
+}

--- a/rulebook/tasks/issue-825-enforce-progressive-governance-updates/proposal.md
+++ b/rulebook/tasks/issue-825-enforce-progressive-governance-updates/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: issue-825-enforce-progressive-governance-updates
+
+更新时间：2026-03-01 20:45
+
+## Why
+
+现有流程虽要求 Spec/Rulebook 前置，但缺少“过程记录时序”硬门禁，导致部分任务在末尾集中回填 `rulebook + run_log + audit`。
+这会放大遗漏风险，并在合并前集中触发修补式返工。
+
+## What Changes
+
+- 在 `scripts/agent_pr_preflight.py` 增加“过程记录时序校验”：若分支存在早期交付提交，但 Rulebook/RUN_LOG 仅在最后签字阶段出现，直接阻断。
+- 在 `docs/delivery-skill.md` 明确“边做边记”硬约束与失败示例。
+- 在 `scripts/README.md` 同步新门禁说明与触发条件。
+
+## Impact
+
+- Affected specs:
+  - `docs/delivery-skill.md`
+- Affected code:
+  - `scripts/agent_pr_preflight.py`
+  - `scripts/README.md`
+- Breaking change: NO
+- User benefit: 过程证据前置，减少末尾补录返工与遗漏。

--- a/rulebook/tasks/issue-825-enforce-progressive-governance-updates/tasks.md
+++ b/rulebook/tasks/issue-825-enforce-progressive-governance-updates/tasks.md
@@ -1,0 +1,20 @@
+更新时间：2026-03-01 20:45
+
+## 1. Governance
+
+- [x] 1.1 绑定 OPEN Issue `#825` 与任务分支 `task/825-enforce-progressive-governance-updates`
+- [x] 1.2 明确目标：禁止末尾一次性回填，改为过程化记录硬门禁
+- [x] 1.3 Rulebook task 创建并 validate 通过
+
+## 2. Implementation
+
+- [x] 2.1 preflight 增加“过程记录时序”校验函数
+- [x] 2.2 将新校验接入 fast/full preflight 主流程
+- [x] 2.3 docs/delivery-skill.md 新增边做边记强约束与异常规则
+- [x] 2.4 scripts/README.md 更新 preflight 校验说明
+
+## 3. Evidence & Delivery
+
+- [x] 3.1 RUN_LOG 已落盘：`openspec/_ops/task_runs/ISSUE-825.md`
+- [ ] 3.2 独立审计记录已落盘：`openspec/_ops/reviews/ISSUE-825.md`
+- [ ] 3.3 preflight + required checks 全绿并合并到 `main`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,7 @@
   - `task/<N>-<slug>` 对应 GitHub Issue `#N` 必须为 `OPEN`（阻断复用已关闭/历史 Issue）
   - `openspec/_ops/task_runs/ISSUE-<N>.md` 的 `PR` 字段不得为占位符（必须为真实链接）
   - `## Main Session Audit` 的 `Reviewed-HEAD-SHA` 不得保留占位值（如 `PENDING_SHA` / `TBD`）；命中后会本地阻断并提示执行 `scripts/main_audit_resign.sh --issue <N> --preflight-mode fast`
+  - 分支提交历史中的过程证据时序：若存在前序交付提交但 `Rulebook/RUN_LOG/OpenSpec tasks` 仅在最后签字尾段提交出现，视为“末尾集中补录”并阻断
 - `agent_pr_preflight.sh` 支持 `--mode commit|fast|full`：
   - `commit`：task 分支提交前本地快检（仅校验 staged 文件），拦截文档时间戳格式与 `openspec/_ops/task_runs/ISSUE-*.md` 缺少 `## Main Session Audit` 段落
   - `fast`：治理与签字链路快检（Issue/Rulebook/RUN_LOG/Main Audit/doc 时间戳/OpenSpec 结构）

--- a/scripts/agent_pr_preflight.py
+++ b/scripts/agent_pr_preflight.py
@@ -519,6 +519,89 @@ def collect_changed_files(repo: str) -> set[str]:
     return changed_files
 
 
+def collect_branch_commits(repo: str) -> list[str]:
+    res = run(["git", "rev-list", "--reverse", "origin/main..HEAD"], cwd=repo)
+    if res.code != 0:
+        raise RuntimeError("[GOV_EVIDENCE] failed to list branch commits (origin/main..HEAD)")
+    return [line.strip() for line in res.out.splitlines() if line.strip()]
+
+
+def collect_commit_changed_files(repo: str, sha: str) -> set[str]:
+    res = run(["git", "show", "--name-only", "--pretty=format:", sha], cwd=repo)
+    if res.code != 0:
+        raise RuntimeError(f"[GOV_EVIDENCE] failed to inspect commit files: {sha}")
+    return {line.strip() for line in res.out.splitlines() if line.strip()}
+
+
+def _is_progress_artifact_path(path: str, *, issue_number: str, task_id: str, slug: str) -> bool:
+    run_log_rel = f"openspec/_ops/task_runs/ISSUE-{issue_number}.md"
+    review_rel = f"openspec/_ops/reviews/ISSUE-{issue_number}.md"
+    if path in {run_log_rel, review_rel}:
+        return True
+
+    if path.startswith(f"rulebook/tasks/{task_id}/"):
+        return True
+    if re.match(rf"^rulebook/tasks/archive/[^/]+-{re.escape(task_id)}/", path):
+        return True
+
+    if slug:
+        if path.startswith(f"openspec/changes/{slug}/"):
+            return True
+        if path.startswith(f"openspec/changes/archive/{slug}/"):
+            return True
+
+    return False
+
+
+def validate_progress_evidence_timeline(repo: str, *, issue_number: str, task_id: str, slug: str) -> None:
+    commits = collect_branch_commits(repo)
+    if len(commits) <= 1:
+        print("(skip) progressive evidence check: <= 1 commit in branch range")
+        return
+
+    progress_indexes: list[int] = []
+    has_non_progress_before_head = False
+
+    for idx, sha in enumerate(commits):
+        changed = collect_commit_changed_files(repo, sha)
+        if not changed:
+            continue
+
+        has_progress = any(
+            _is_progress_artifact_path(path, issue_number=issue_number, task_id=task_id, slug=slug)
+            for path in changed
+        )
+        has_non_progress = any(
+            not _is_progress_artifact_path(path, issue_number=issue_number, task_id=task_id, slug=slug)
+            for path in changed
+        )
+
+        if has_progress:
+            progress_indexes.append(idx)
+        if idx < len(commits) - 1 and has_non_progress:
+            has_non_progress_before_head = True
+
+    if not progress_indexes:
+        raise RuntimeError(
+            "[GOV_EVIDENCE] branch has no progress artifacts for current issue "
+            f"(RUN_LOG/review/rulebook/change-task): issue #{issue_number}"
+        )
+
+    if has_non_progress_before_head:
+        has_progress_before_signing_tail = any(idx < len(commits) - 2 for idx in progress_indexes)
+        if not has_progress_before_signing_tail:
+            raise RuntimeError(
+                "[GOV_EVIDENCE] progress artifacts were only introduced in the final signing tail commits "
+                "(typically review/signoff). This indicates end-backfill. Update Rulebook/RUN_LOG/OpenSpec task "
+                "during execution, then re-sign main-session audit."
+            )
+
+    print(
+        "OK: progressive evidence timeline check passed "
+        f"(commits={len(commits)}, progress_commits={len(progress_indexes)})"
+    )
+
+
 def collect_staged_files(repo: str) -> set[str]:
     res = run(
         ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
@@ -622,6 +705,13 @@ def main(argv: list[str]) -> int:
             must_run(["rulebook", "task", "validate", task_id], cwd=repo)
         else:
             print(f"(skip) rulebook task validate: current task is archived at {task_location.path}")
+
+        validate_progress_evidence_timeline(
+            repo,
+            issue_number=issue_number,
+            task_id=task_id,
+            slug=slug,
+        )
 
         print("\n== Workspace checks ==")
         # Keep preflight OS-agnostic; Windows-only build/E2E are enforced in CI.


### PR DESCRIPTION
## Summary
- add preflight hard-gate to block end-backfill of governance evidence (`rulebook/run_log/openspec task` only appearing in final signing tail commits)
- update delivery contract docs to require progressive updates during execution
- sync scripts guide with new preflight behavior

## Validation
- python3 -m py_compile scripts/agent_pr_preflight.py
- rulebook task validate issue-825-enforce-progressive-governance-updates
- bash scripts/agent_pr_preflight.sh --mode commit

Closes #825
