### PR TITLE
improve(main): harden backend guardrails for #845 #847 #850

### DIFF
--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -415,6 +415,7 @@ function registerIpcHandlers(deps: {
     db: deps.db,
     logger: deps.logger,
     semanticIndex,
+    projectSessionBinding,
   });
 
   registerRagIpcHandlers({

--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -384,6 +384,7 @@ function registerIpcHandlers(deps: {
     stateExtractor,
     semanticIndex,
     computeRunner: utilityProcessFoundation.compute,
+    projectSessionBinding,
   });
 
   registerExportIpcHandlers({

--- a/apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts
@@ -4,6 +4,7 @@ import type { IpcMain } from "electron";
 
 import type { Logger } from "../../logging/logger";
 import { registerContextFsHandlers } from "../contextFs";
+import { registerFileIpcHandlers } from "../file";
 import { registerKnowledgeGraphIpcHandlers } from "../knowledgeGraph";
 import { registerMemoryIpcHandlers } from "../memory";
 import { createProjectSessionBindingRegistry } from "../projectSessionBinding";
@@ -109,6 +110,49 @@ function createEvent(webContentsId: number): { sender: { id: number } } {
   assert.equal(knowledgeDenied.error?.code, "FORBIDDEN");
 }
 
+// Scenario: file:document:* handlers reject mismatched bound projectId [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  binding.bind({ webContentsId: 88, projectId: "project-bound" });
+
+  const fileHarness = createIpcHarness();
+  registerFileIpcHandlers({
+    ipcMain: fileHarness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const fileCreate = fileHarness.handlers.get("file:document:create");
+  assert.ok(fileCreate, "expected file:document:create handler");
+
+  const createDenied = (await fileCreate!(createEvent(88), {
+    projectId: "project-other",
+    title: "Title",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+  assert.equal(createDenied.ok, false);
+  assert.equal(createDenied.error?.code, "FORBIDDEN");
+
+  const fileSave = fileHarness.handlers.get("file:document:save");
+  assert.ok(fileSave, "expected file:document:save handler");
+
+  const saveDenied = (await fileSave!(createEvent(88), {
+    projectId: "project-other",
+    documentId: "doc-1",
+    contentJson: "{\"type\":\"doc\",\"content\":[]}",
+    actor: "user",
+    reason: "manual-save",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+  assert.equal(saveDenied.ok, false);
+  assert.equal(saveDenied.error?.code, "FORBIDDEN");
+}
+
 // Scenario: unbound renderer session must fail closed for project-scoped IPC [ADDED]
 {
   const binding = createProjectSessionBindingRegistry();
@@ -134,6 +178,33 @@ function createEvent(webContentsId: number): { sender: { id: number } } {
 
   const deniedWhenUnbound = (await contextRulesList!(createEvent(999), {
     projectId: "project-guess",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(deniedWhenUnbound.ok, false);
+  assert.equal(deniedWhenUnbound.error?.code, "FORBIDDEN");
+}
+
+// Scenario: file:document:* handlers fail closed when renderer session is unbound [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  const fileHarness = createIpcHarness();
+
+  registerFileIpcHandlers({
+    ipcMain: fileHarness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const fileSetCurrent = fileHarness.handlers.get("file:document:setcurrent");
+  assert.ok(fileSetCurrent, "expected file:document:setcurrent handler");
+
+  const deniedWhenUnbound = (await fileSetCurrent!(createEvent(999), {
+    projectId: "project-guess",
+    documentId: "doc-1",
   })) as {
     ok: boolean;
     error?: { code?: string };

--- a/apps/desktop/main/src/ipc/__tests__/search-project-access-guard.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/search-project-access-guard.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+
+import type { Logger } from "../../logging/logger";
+import { registerSearchIpcHandlers } from "../search";
+import { createProjectSessionBindingRegistry } from "../projectSessionBinding";
+import type { HybridRankingService } from "../../services/search/hybridRankingService";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createIpcHarness(): {
+  handlers: Map<string, Handler>;
+  ipcMain: IpcMain;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+  return { handlers, ipcMain };
+}
+
+function createEvent(webContentsId: number): { sender: { id: number } } {
+  return { sender: { id: webContentsId } };
+}
+
+// Scenario: all project-scoped search channels reject mismatched bound projectId [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  binding.bind({ webContentsId: 77, projectId: "project-bound" });
+
+  const harness = createIpcHarness();
+  registerSearchIpcHandlers({
+    ipcMain: harness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const channels: Array<{ name: string; payload: unknown }> = [
+    {
+      name: "search:fts:query",
+      payload: { projectId: "project-other", query: "needle" },
+    },
+    {
+      name: "search:fts:reindex",
+      payload: { projectId: "project-other" },
+    },
+    {
+      name: "search:query:strategy",
+      payload: {
+        projectId: "project-other",
+        query: "needle",
+        strategy: "fts",
+      },
+    },
+    {
+      name: "search:rank:explain",
+      payload: {
+        projectId: "project-other",
+        query: "needle",
+        strategy: "fts",
+      },
+    },
+    {
+      name: "search:replace:preview",
+      payload: {
+        projectId: "project-other",
+        scope: "wholeProject",
+        query: "a",
+        replaceWith: "b",
+      },
+    },
+    {
+      name: "search:replace:execute",
+      payload: {
+        projectId: "project-other",
+        scope: "wholeProject",
+        query: "a",
+        replaceWith: "b",
+      },
+    },
+  ];
+
+  for (const channel of channels) {
+    const handler = harness.handlers.get(channel.name);
+    assert.ok(handler, `expected handler ${channel.name}`);
+    const denied = (await handler!(createEvent(77), channel.payload)) as {
+      ok: boolean;
+      error?: { code?: string };
+    };
+    assert.equal(denied.ok, false, `${channel.name} should be denied`);
+    assert.equal(
+      denied.error?.code,
+      "FORBIDDEN",
+      `${channel.name} should return FORBIDDEN`,
+    );
+  }
+}
+
+// Scenario: unbound renderer session fails closed for project-scoped search channels [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  const harness = createIpcHarness();
+  registerSearchIpcHandlers({
+    ipcMain: harness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const ftsQuery = harness.handlers.get("search:fts:query");
+  assert.ok(ftsQuery, "expected search:fts:query handler");
+
+  const deniedWhenUnbound = (await ftsQuery!(createEvent(999), {
+    projectId: "project-guess",
+    query: "needle",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(deniedWhenUnbound.ok, false);
+  assert.equal(deniedWhenUnbound.error?.code, "FORBIDDEN");
+}
+
+// Scenario: blank projectId is normalized to bound project id before strategy query [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  binding.bind({ webContentsId: 101, projectId: "project-bound" });
+
+  let observedProjectId: string | null = null;
+  const ranking: HybridRankingService = {
+    queryByStrategy: (payload) => {
+      observedProjectId = payload.projectId;
+      if (payload.projectId !== "project-bound") {
+        return {
+          ok: false as const,
+          error: {
+            code: "INVALID_ARGUMENT",
+            message: "projectId was not normalized",
+          },
+        };
+      }
+      return {
+        ok: true as const,
+        data: {
+          traceId: "trace-search",
+          costMs: 1,
+          strategy: payload.strategy,
+          fallback: "none",
+          results: [],
+          total: 0,
+          hasMore: false,
+          backpressure: {
+            candidateLimit: 10_000,
+            candidateCount: 0,
+            truncated: false,
+          },
+        },
+      };
+    },
+    rankExplain: () => ({
+      ok: true,
+      data: {
+        strategy: "fts",
+        explanations: [],
+        total: 0,
+        backpressure: {
+          candidateLimit: 10_000,
+          candidateCount: 0,
+          truncated: false,
+        },
+      },
+    }),
+  };
+
+  const harness = createIpcHarness();
+  registerSearchIpcHandlers({
+    ipcMain: harness.ipcMain,
+    db: {} as never,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+    hybridRankingService: ranking,
+  });
+
+  const queryByStrategy = harness.handlers.get("search:query:strategy");
+  assert.ok(queryByStrategy, "expected search:query:strategy handler");
+
+  const response = (await queryByStrategy!(createEvent(101), {
+    projectId: "   ",
+    query: "needle",
+    strategy: "fts",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(response.ok, true);
+  assert.equal(observedProjectId, "project-bound");
+}

--- a/apps/desktop/main/src/ipc/file.ts
+++ b/apps/desktop/main/src/ipc/file.ts
@@ -23,6 +23,8 @@ import {
   type StateExtractor,
 } from "../services/kg/stateExtractor";
 import { createStatsService } from "../services/stats/statsService";
+import { guardAndNormalizeProjectAccess } from "./projectAccessGuard";
+import type { ProjectSessionBindingRegistry } from "./projectSessionBinding";
 
 type Actor = "user" | "auto" | "ai";
 type SaveReason = "manual-save" | "autosave" | "ai-accept" | "status-change";
@@ -183,6 +185,7 @@ export function registerFileIpcHandlers(deps: {
   stateExtractor?: StateExtractor | null;
   semanticIndex?: SemanticChunkIndexService;
   computeRunner?: EmbeddingComputeRunner | null;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
   const semanticAutosaveEmbeddingRuntime =
     createSemanticAutosaveEmbeddingRuntime({
@@ -191,7 +194,27 @@ export function registerFileIpcHandlers(deps: {
       computeRunner: deps.computeRunner,
     });
 
-  deps.ipcMain.handle(
+  function handleWithProjectAccess<TPayload, TResponse>(
+    channel: string,
+    listener: (
+      event: unknown,
+      payload: TPayload,
+    ) => Promise<IpcResponse<TResponse>>,
+  ): void {
+    deps.ipcMain.handle(channel, async (event, payload) => {
+      const guarded = guardAndNormalizeProjectAccess({
+        event,
+        payload,
+        projectSessionBinding: deps.projectSessionBinding,
+      });
+      if (!guarded.ok) {
+        return guarded.response as IpcResponse<TResponse>;
+      }
+      return listener(event, payload as TPayload);
+    });
+  }
+
+  handleWithProjectAccess(
     "file:document:create",
     async (
       _e,
@@ -237,7 +260,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:list",
     async (
       _e,
@@ -276,7 +299,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:read",
     async (
       _e,
@@ -328,7 +351,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:update",
     async (
       _e,
@@ -377,7 +400,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:save",
     async (
       _e,
@@ -530,7 +553,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:getcurrent",
     async (
       _e,
@@ -557,7 +580,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:setcurrent",
     async (
       _e,
@@ -593,7 +616,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:reorder",
     async (
       _e,
@@ -623,7 +646,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:updatestatus",
     async (
       _e,
@@ -679,7 +702,7 @@ export function registerFileIpcHandlers(deps: {
     },
   );
 
-  deps.ipcMain.handle(
+  handleWithProjectAccess(
     "file:document:delete",
     async (
       _e,

--- a/apps/desktop/main/src/ipc/search.ts
+++ b/apps/desktop/main/src/ipc/search.ts
@@ -12,6 +12,8 @@ import {
   type SemanticRetriever,
 } from "../services/search/hybridRankingService";
 import { createSearchReplaceService } from "../services/search/searchReplaceService";
+import { guardAndNormalizeProjectAccess } from "./projectAccessGuard";
+import type { ProjectSessionBindingRegistry } from "./projectSessionBinding";
 
 type SearchReplaceService = ReturnType<typeof createSearchReplaceService>;
 type FtsService = ReturnType<typeof createFtsService>;
@@ -119,42 +121,104 @@ function hasProjectId(payload: unknown): payload is { projectId: string } {
   return typeof projectId === "string" && projectId.trim().length > 0;
 }
 
-function registerSearchReplaceHandlers(
-  ipcMain: IpcMain,
-  db: Database.Database | null,
-  logger: Logger,
-  replaceService: SearchReplaceService | null,
-): void {
-  ipcMain.handle("search:replace:preview", async (_e, payload: Parameters<SearchReplaceService["preview"]>[0]) => {
-    if (!db || !replaceService) {
-      return { ok: false, error: { code: "DB_ERROR", message: "Database not ready" } };
+function handleWithProjectAccess<TPayload, TResponse>(args: {
+  ipcMain: IpcMain;
+  channel: string;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
+  listener: (
+    event: unknown,
+    payload: TPayload,
+  ) => Promise<IpcResponse<TResponse>>;
+}): void {
+  args.ipcMain.handle(args.channel, async (event, payload) => {
+    const guarded = guardAndNormalizeProjectAccess({
+      event,
+      payload,
+      projectSessionBinding: args.projectSessionBinding,
+    });
+    if (!guarded.ok) {
+      return guarded.response as IpcResponse<TResponse>;
     }
-    try {
-      const res = replaceService.preview(payload);
-      if (!res.ok) {
-        logger.error("search_replace_preview_failed", { code: res.error.code, message: res.error.message });
-        return { ok: false, error: res.error };
+
+    return args.listener(event, payload as TPayload);
+  });
+}
+
+function registerSearchReplaceHandlers(args: {
+  ipcMain: IpcMain;
+  db: Database.Database | null;
+  logger: Logger;
+  replaceService: SearchReplaceService | null;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
+}): void {
+  const { ipcMain, db, logger, replaceService, projectSessionBinding } = args;
+
+  handleWithProjectAccess<
+    Parameters<SearchReplaceService["preview"]>[0],
+    unknown
+  >({
+    ipcMain,
+    channel: "search:replace:preview",
+    projectSessionBinding,
+    listener: async (_e, payload) => {
+      if (!db || !replaceService) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
       }
-      return { ok: true, data: res.data };
-    } catch (error) {
-      return toInternalSearchError(logger, "search_replace_preview_exception", error);
-    }
+      try {
+        const res = replaceService.preview(payload);
+        if (!res.ok) {
+          logger.error("search_replace_preview_failed", {
+            code: res.error.code,
+            message: res.error.message,
+          });
+          return { ok: false, error: res.error };
+        }
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          logger,
+          "search_replace_preview_exception",
+          error,
+        );
+      }
+    },
   });
 
-  ipcMain.handle("search:replace:execute", async (_e, payload: Parameters<SearchReplaceService["execute"]>[0]) => {
-    if (!db || !replaceService) {
-      return { ok: false, error: { code: "DB_ERROR", message: "Database not ready" } };
-    }
-    try {
-      const res = replaceService.execute(payload);
-      if (!res.ok) {
-        logger.error("search_replace_execute_failed", { code: res.error.code, message: res.error.message });
-        return { ok: false, error: res.error };
+  handleWithProjectAccess<
+    Parameters<SearchReplaceService["execute"]>[0],
+    unknown
+  >({
+    ipcMain,
+    channel: "search:replace:execute",
+    projectSessionBinding,
+    listener: async (_e, payload) => {
+      if (!db || !replaceService) {
+        return {
+          ok: false,
+          error: { code: "DB_ERROR", message: "Database not ready" },
+        };
       }
-      return { ok: true, data: res.data };
-    } catch (error) {
-      return toInternalSearchError(logger, "search_replace_execute_exception", error);
-    }
+      try {
+        const res = replaceService.execute(payload);
+        if (!res.ok) {
+          logger.error("search_replace_execute_failed", {
+            code: res.error.code,
+            message: res.error.message,
+          });
+          return { ok: false, error: res.error };
+        }
+        return { ok: true, data: res.data };
+      } catch (error) {
+        return toInternalSearchError(
+          logger,
+          "search_replace_execute_exception",
+          error,
+        );
+      }
+    },
   });
 }
 
@@ -163,13 +227,34 @@ function registerFtsHandlers(args: {
   db: Database.Database | null;
   logger: Logger;
   ftsService: FtsService | null;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
-  const { ipcMain, db, logger, ftsService } = args;
-  ipcMain.handle(
-    "search:fts:query",
-    async (
+  const { ipcMain, db, logger, ftsService, projectSessionBinding } = args;
+  handleWithProjectAccess<
+    unknown,
+    {
+      results: Array<{
+        projectId: string;
+        documentId: string;
+        documentTitle: string;
+        documentType: string;
+        snippet: string;
+        highlights: Array<{ start: number; end: number }>;
+        anchor: { start: number; end: number };
+        score: number;
+        updatedAt: number;
+      }>;
+      total: number;
+      hasMore: boolean;
+      indexState: "ready" | "rebuilding";
+    }
+  >({
+    ipcMain,
+    channel: "search:fts:query",
+    projectSessionBinding,
+    listener: async (
       _e,
-      payload: unknown,
+      payload,
     ): Promise<
       IpcResponse<{
         results: Array<{
@@ -247,16 +332,28 @@ function registerFtsHandlers(args: {
         });
         return { ok: true, data: res.data };
       } catch (error) {
-        return toInternalSearchError(logger, "search_fts_query_exception", error);
+        return toInternalSearchError(
+          logger,
+          "search_fts_query_exception",
+          error,
+        );
       }
     },
-  );
+  });
 
-  ipcMain.handle(
-    "search:fts:reindex",
-    async (
+  handleWithProjectAccess<
+    unknown,
+    {
+      indexState: "ready";
+      reindexed: number;
+    }
+  >({
+    ipcMain,
+    channel: "search:fts:reindex",
+    projectSessionBinding,
+    listener: async (
       _e,
-      payload: unknown,
+      payload,
     ): Promise<
       IpcResponse<{
         indexState: "ready";
@@ -307,7 +404,7 @@ function registerFtsHandlers(args: {
         );
       }
     },
-  );
+  });
 }
 
 function registerRankingHandlers(args: {
@@ -315,19 +412,52 @@ function registerRankingHandlers(args: {
   db: Database.Database | null;
   logger: Logger;
   hybridRankingService: HybridRankingService | null;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
-  const { ipcMain, db, logger, hybridRankingService } = args;
-  ipcMain.handle(
-    "search:query:strategy",
-    async (
+  const { ipcMain, db, logger, hybridRankingService, projectSessionBinding } =
+    args;
+
+  handleWithProjectAccess<
+    {
+      projectId: string;
+      query: string;
+      strategy: "fts" | "semantic" | "hybrid";
+      limit?: number;
+      offset?: number;
+    },
+    {
+      traceId: string;
+      costMs: number;
+      strategy: "fts" | "semantic" | "hybrid";
+      fallback: "fts" | "none";
+      notice?: string;
+      results: Array<{
+        documentId: string;
+        chunkId: string;
+        snippet: string;
+        finalScore: number;
+        scoreBreakdown: {
+          bm25: number;
+          semantic: number;
+          recency: number;
+        };
+        updatedAt: number;
+      }>;
+      total: number;
+      hasMore: boolean;
+      backpressure: {
+        candidateLimit: number;
+        candidateCount: number;
+        truncated: boolean;
+      };
+    }
+  >({
+    ipcMain,
+    channel: "search:query:strategy",
+    projectSessionBinding,
+    listener: async (
       _e,
-      payload: {
-        projectId: string;
-        query: string;
-        strategy: "fts" | "semantic" | "hybrid";
-        limit?: number;
-        offset?: number;
-      },
+      payload,
     ): Promise<
       IpcResponse<{
         traceId: string;
@@ -387,21 +517,46 @@ function registerRankingHandlers(args: {
         );
       }
     },
-  );
+  });
 
-  ipcMain.handle(
-    "search:rank:explain",
-    async (
+  handleWithProjectAccess<
+    {
+      projectId: string;
+      query: string;
+      strategy: "fts" | "semantic" | "hybrid";
+      documentId?: string;
+      chunkId?: string;
+      limit?: number;
+      offset?: number;
+    },
+    {
+      strategy: "fts" | "semantic" | "hybrid";
+      explanations: Array<{
+        documentId: string;
+        chunkId: string;
+        snippet: string;
+        finalScore: number;
+        scoreBreakdown: {
+          bm25: number;
+          semantic: number;
+          recency: number;
+        };
+        updatedAt: number;
+      }>;
+      total: number;
+      backpressure: {
+        candidateLimit: number;
+        candidateCount: number;
+        truncated: boolean;
+      };
+    }
+  >({
+    ipcMain,
+    channel: "search:rank:explain",
+    projectSessionBinding,
+    listener: async (
       _e,
-      payload: {
-        projectId: string;
-        query: string;
-        strategy: "fts" | "semantic" | "hybrid";
-        documentId?: string;
-        chunkId?: string;
-        limit?: number;
-        offset?: number;
-      },
+      payload,
     ): Promise<
       IpcResponse<{
         strategy: "fts" | "semantic" | "hybrid";
@@ -455,7 +610,7 @@ function registerRankingHandlers(args: {
         );
       }
     },
-  );
+  });
 }
 
 /**
@@ -470,6 +625,7 @@ export function registerSearchIpcHandlers(deps: {
   semanticIndex?: SemanticChunkIndexService;
   semanticRetriever?: SemanticRetriever;
   hybridRankingService?: HybridRankingService;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
   const ftsService = deps.db
     ? createFtsService({ db: deps.db, logger: deps.logger })
@@ -499,17 +655,20 @@ export function registerSearchIpcHandlers(deps: {
     db: deps.db,
     logger: deps.logger,
     ftsService,
+    projectSessionBinding: deps.projectSessionBinding,
   });
   registerRankingHandlers({
     ipcMain: deps.ipcMain,
     db: deps.db,
     logger: deps.logger,
     hybridRankingService,
+    projectSessionBinding: deps.projectSessionBinding,
   });
-  registerSearchReplaceHandlers(
-    deps.ipcMain,
-    deps.db,
-    deps.logger,
+  registerSearchReplaceHandlers({
+    ipcMain: deps.ipcMain,
+    db: deps.db,
+    logger: deps.logger,
     replaceService,
-  );
+    projectSessionBinding: deps.projectSessionBinding,
+  });
 }

--- a/apps/desktop/preload/src/ipcGateway.ts
+++ b/apps/desktop/preload/src/ipcGateway.ts
@@ -186,6 +186,16 @@ function isIpcResponse<TData>(value: unknown): value is IpcResponse<TData> {
   );
 }
 
+function estimateBinaryByteLength(value: unknown): number | null {
+  if (value instanceof ArrayBuffer) {
+    return value.byteLength;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return value.byteLength;
+  }
+  return null;
+}
+
 /**
  * Estimate payload byte-size for preload boundary guarding.
  *
@@ -243,6 +253,11 @@ function estimatePayloadSize(
     }
     if (valueType !== "object" || value === null) {
       return null;
+    }
+
+    const binaryByteLength = estimateBinaryByteLength(value);
+    if (binaryByteLength !== null) {
+      return binaryByteLength;
     }
 
     const objectValue = value as object;

--- a/apps/desktop/preload/src/ipcGateway.ts
+++ b/apps/desktop/preload/src/ipcGateway.ts
@@ -195,12 +195,11 @@ function estimatePayloadSize(
   payload: unknown,
   maxBytes?: number,
 ): number | null {
-  if (
-    payload === undefined ||
-    typeof payload === "function" ||
-    typeof payload === "symbol"
-  ) {
+  if (payload === undefined) {
     return 0;
+  }
+  if (typeof payload === "function" || typeof payload === "symbol") {
+    return null;
   }
 
   const encoder = new TextEncoder();
@@ -236,12 +235,11 @@ function estimatePayloadSize(
     if (valueType === "bigint") {
       return null;
     }
-    if (
-      valueType === "undefined" ||
-      valueType === "function" ||
-      valueType === "symbol"
-    ) {
+    if (valueType === "undefined") {
       return inArray ? 4 : 0;
+    }
+    if (valueType === "function" || valueType === "symbol") {
+      return null;
     }
     if (valueType !== "object" || value === null) {
       return null;
@@ -290,11 +288,7 @@ function estimatePayloadSize(
       const recordValue = value as Record<string, unknown>;
       for (const key of Object.keys(recordValue)) {
         const propertyValue = recordValue[key];
-        if (
-          propertyValue === undefined ||
-          typeof propertyValue === "function" ||
-          typeof propertyValue === "symbol"
-        ) {
+        if (propertyValue === undefined) {
           continue;
         }
 

--- a/apps/desktop/tests/unit/context-engineering.test.ts
+++ b/apps/desktop/tests/unit/context-engineering.test.ts
@@ -64,3 +64,32 @@ assert(
     (e) => e.patternId === "openai_api_key_sk" && e.matchCount >= 1,
   ),
 );
+
+const githubTokenRedaction = redactText({
+  text: [
+    "ownerToken=gho_ABCDEF1234567890",
+    "classicToken=ghp_ABCDEF1234567890",
+    "fineGrained=github_pat_ABCDEF1234567890_ABCDEFGH",
+  ].join(" "),
+  sourceRef: ".creonow/settings/world.md",
+});
+assert(
+  !githubTokenRedaction.redactedText.includes("gho_ABCDEF1234567890"),
+  "gho_ token should be redacted",
+);
+assert(
+  !githubTokenRedaction.redactedText.includes("ghp_ABCDEF1234567890"),
+  "ghp_ token should be redacted",
+);
+assert(
+  !githubTokenRedaction.redactedText.includes(
+    "github_pat_ABCDEF1234567890_ABCDEFGH",
+  ),
+  "github_pat_ token should be redacted",
+);
+assert(
+  githubTokenRedaction.evidence.some(
+    (e) => e.patternId === "github_token" && e.matchCount === 3,
+  ),
+  "github token evidence should include all three token families",
+);

--- a/apps/desktop/tests/unit/ipc-preload-security.spec.ts
+++ b/apps/desktop/tests/unit/ipc-preload-security.spec.ts
@@ -210,3 +210,54 @@ type AuditEvent = {
   assert.equal(details?.serializationIssue?.path, "$.input.dangerousBigInt");
   assert.equal(details?.serializationIssue?.reason, "BIGINT_NOT_SERIALIZABLE");
 }
+
+// S6: structured-clone 不可克隆字段（function/symbol）必须在预检返回 INVALID_ARGUMENT [ADDED]
+{
+  const cases = [
+    {
+      name: "function",
+      payload: { input: { callback: () => "unsafe" } },
+      expectedPath: "$.input.callback",
+      expectedReason: "FUNCTION_NOT_SERIALIZABLE",
+    },
+    {
+      name: "symbol",
+      payload: { input: { token: Symbol("unsafe") } },
+      expectedPath: "$.input.token",
+      expectedReason: "SYMBOL_NOT_SERIALIZABLE",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    let invoked = false;
+    const gateway = createPreloadIpcGateway({
+      allowedChannels: ["app:system:ping"],
+      rendererId: "renderer-6",
+      now: () => 1_717_171_000_600,
+      requestIdFactory: () => `req-invalid-structured-clone-${testCase.name}`,
+      invoke: async () => {
+        invoked = true;
+        throw new Error("DataCloneError");
+      },
+    });
+
+    const res = await gateway.invoke("app:system:ping", testCase.payload);
+    assert.equal(invoked, false);
+    assert.equal(res.ok, false);
+    if (res.ok) {
+      assert.fail("expected INVALID_ARGUMENT response");
+    }
+
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+    const details = res.error.details as
+      | {
+          serializationIssue?: { path?: string; reason?: string };
+        }
+      | undefined;
+    assert.equal(details?.serializationIssue?.path, testCase.expectedPath);
+    assert.equal(
+      details?.serializationIssue?.reason,
+      testCase.expectedReason,
+    );
+  }
+}

--- a/apps/desktop/tests/unit/ipc-preload-security.spec.ts
+++ b/apps/desktop/tests/unit/ipc-preload-security.spec.ts
@@ -261,3 +261,41 @@ type AuditEvent = {
     );
   }
 }
+
+// S7: ArrayBuffer 超限必须在预检返回 IPC_PAYLOAD_TOO_LARGE 并阻断 invoke [ADDED]
+{
+  let invoked = false;
+  const limitBytes = 10 * 1024 * 1024;
+  const gateway = createPreloadIpcGateway({
+    allowedChannels: ["app:system:ping"],
+    rendererId: "renderer-7",
+    maxPayloadBytes: limitBytes,
+    now: () => 1_717_171_000_700,
+    requestIdFactory: () => "req-arraybuffer-too-large",
+    invoke: async () => {
+      invoked = true;
+      return { ok: true, data: { accepted: true } };
+    },
+  });
+
+  const payload = {
+    blob: new ArrayBuffer(20 * 1024 * 1024),
+  };
+
+  const res = await gateway.invoke("app:system:ping", payload);
+  assert.equal(invoked, false);
+  assert.equal(res.ok, false);
+  if (res.ok) {
+    assert.fail("expected IPC_PAYLOAD_TOO_LARGE response");
+  }
+  assert.equal(res.error.code, "IPC_PAYLOAD_TOO_LARGE");
+  const details = res.error.details as
+    | {
+        payloadBytes?: number;
+        limitBytes?: number;
+      }
+    | undefined;
+  assert.equal(details?.limitBytes, limitBytes);
+  assert.equal(typeof details?.payloadBytes, "number");
+  assert((details?.payloadBytes ?? 0) > limitBytes);
+}

--- a/packages/shared/redaction/redact.github-token.test.ts
+++ b/packages/shared/redaction/redact.github-token.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+
+import { redactText } from "./redact";
+
+const githubTokens = [
+  "gho_ABCDEF1234567890",
+  "ghp_QWERTY0987654321",
+  "github_pat_11AA22BB33CC44DD55EE66FF77GG88HH99II",
+];
+
+const redaction = redactText({
+  text: githubTokens.join(" "),
+  sourceRef: "packages/shared/redaction/redact.github-token.test.ts",
+});
+
+for (const token of githubTokens) {
+  assert(
+    !redaction.redactedText.includes(token),
+    `${token.slice(0, 16)}... should be redacted`,
+  );
+}
+
+const githubTokenEvidence = redaction.evidence.find(
+  (item) => item.patternId === "github_token",
+);
+assert(githubTokenEvidence, "github token evidence should exist");
+assert.equal(githubTokenEvidence.matchCount, 3);

--- a/packages/shared/redaction/redact.github-token.test.ts
+++ b/packages/shared/redaction/redact.github-token.test.ts
@@ -5,6 +5,9 @@ import { redactText } from "./redact";
 const githubTokens = [
   "gho_ABCDEF1234567890",
   "ghp_QWERTY0987654321",
+  "ghs_ZYXWVUTSRQPONMLK",
+  "ghu_A1B2C3D4E5F6G7H8",
+  "ghr_1234ABCD5678EFGH",
   "github_pat_11AA22BB33CC44DD55EE66FF77GG88HH99II",
 ];
 
@@ -24,4 +27,4 @@ const githubTokenEvidence = redaction.evidence.find(
   (item) => item.patternId === "github_token",
 );
 assert(githubTokenEvidence, "github token evidence should exist");
-assert.equal(githubTokenEvidence.matchCount, 3);
+assert.equal(githubTokenEvidence.matchCount, 6);

--- a/packages/shared/redaction/redact.ts
+++ b/packages/shared/redaction/redact.ts
@@ -27,7 +27,7 @@ const PATTERNS: Pattern[] = [
   },
   {
     id: "github_token",
-    re: /\b(?:gho|ghp|github_pat)_[A-Za-z0-9_]{10,}\b/g,
+    re: /\b(?:gho|ghp|ghs|ghu|ghr|github_pat)_[A-Za-z0-9_]{10,}\b/g,
   },
   {
     id: "windows_abs_path",

--- a/packages/shared/redaction/redact.ts
+++ b/packages/shared/redaction/redact.ts
@@ -26,8 +26,8 @@ const PATTERNS: Pattern[] = [
     re: /AKIA[0-9A-Z]{16}/g,
   },
   {
-    id: "github_token_gho",
-    re: /gho_[A-Za-z0-9]{10,}/g,
+    id: "github_token",
+    re: /\b(?:gho|ghp|github_pat)_[A-Za-z0-9_]{10,}\b/g,
   },
   {
     id: "windows_abs_path",


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (bot:asuka + status:ready backend guardrails)

## 主题
- 修复 preload 参数序列化误分类、补齐 GitHub token 脱敏规则、并为 file:document:* IPC 接入 project-session 访问守卫。

## 关联 Issue
- Fixes #845
- Fixes #847
- Fixes #850

## 背景与问题定义
- 问题场景（文件 + 触发路径）：
  - `apps/desktop/preload/src/ipcGateway.ts`：当 payload 含 `function/symbol` 时，预检尺寸估算未将其识别为不可序列化，后续落入内部错误分支。
  - `packages/shared/redaction/redact.ts`：仅匹配 `gho_`，未覆盖 `ghp_` 与 `github_pat_`，日志与上下文文本存在漏脱敏风险。
  - `apps/desktop/main/src/ipc/file.ts`：`file:document:*` handler 未统一绑定 `projectSessionBinding`，可被跨会话 `projectId` 探测并触发非预期访问。
- 根因分析（为什么会发生）：
  - structured clone 与 JSON 可序列化语义边界未统一；`function/symbol` 在估算阶段被当作可跳过字段处理。
  - GitHub token 正则策略历史上只覆盖单一前缀，缺少三类官方前缀统一建模。
  - `file` IPC 注册路径未复用 project 访问守卫，导致通道级访问控制不一致。
- 不修最坏后果（必须具体）：
  - 用户输入不可克隆对象时前端收到 `INTERNAL`，误导为系统故障且无法给出可修复反馈。
  - `ghp_/github_pat_` 可能以明文进入审计日志/上下文拼装，形成凭证泄露面。
  - 恶意或异常 renderer 会话可携带他项目 `projectId` 请求 `file:document:*`，造成跨项目读写尝试与数据隔离风险。

## 改动说明（按文件）
- `apps/desktop/preload/src/ipcGateway.ts`: 将 `function/symbol` 在 `estimatePayloadSize` 直接判为不可序列化（返回 `null`），避免误入内部错误链路。
- `apps/desktop/tests/unit/ipc-preload-security.spec.ts`: 新增 S6 场景，覆盖 `function`/`symbol` payload 必须返回 `INVALID_ARGUMENT` 与精确 `serializationIssue`。
- `packages/shared/redaction/redact.ts`: 将 GitHub token 规则统一为 `github_token`，正则覆盖 `gho_/ghp_/github_pat_`。
- `packages/shared/redaction/redact.github-token.test.ts`: 新增 shared 级回归测试，验证三类 token 全部被脱敏并保留 evidence。
- `apps/desktop/tests/unit/context-engineering.test.ts`: 增补上下文脱敏回归，验证三类 GitHub token 在上游消费路径均被遮蔽。
- `apps/desktop/main/src/ipc/file.ts`: 引入 `guardAndNormalizeProjectAccess`，为全部 `file:document:*` handler 统一套用 `handleWithProjectAccess`。
- `apps/desktop/main/src/index.ts`: 注册 file IPC 时注入 `projectSessionBinding` 依赖。
- `apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts`: 增加 file 文档通道在“绑定不匹配/未绑定”下均返回 `FORBIDDEN` 的回归断言。

## 风险评估与防护
- 可能回归点：
  - `file:document:*` 全量接入守卫后，历史未绑定 renderer 可能提前失败为 `FORBIDDEN`。
  - GitHub token 新正则对边界字符串可能出现误匹配/漏匹配。
- 防护措施（测试/断言/日志）：
  - preload 安全单测新增 structured-clone 非法类型断言。
  - redaction 新增 shared 测试 + context-engineering 集成场景双层覆盖。
  - project access guard 测试新增 file 通道错绑与未绑定双场景。
- 兼容性影响：
  - 无 IPC 契约字段变更；仅将越权/不可序列化输入更早、更明确地拒绝。

## 验证证据（必须含命令、退出码、关键输出）
- `pnpm typecheck`
  - exit_code: 0
  - key_output: `tsc --noEmit` 无错误退出。
- `pnpm lint`
  - exit_code: 0
  - key_output: 62 条既有 warning（max-lines/complexity/react-hooks），0 error，未引入新增 lint error。
- `pnpm test:unit`
  - exit_code: 0
  - key_output: discovered unit suites 全通过；Vitest 汇总 `Test Files 10 passed, Tests 36 passed`。
- 其他定向验证：
  - `node --import tsx apps/desktop/tests/unit/ipc-preload-security.spec.ts` exit_code=0
  - `node --import tsx apps/desktop/tests/unit/context-engineering.test.ts` exit_code=0
  - `node --import tsx packages/shared/redaction/redact.github-token.test.ts` exit_code=0
  - `node --import tsx apps/desktop/main/src/ipc/__tests__/project-access-guard.test.ts` exit_code=0

## Open PR 排重检查
- 扫描时间：2026-03-02 01:51:57 CST
- 扫描命令：
  - `gh pr list --state open --limit 200 --json number,title,headRefName,url --template '{{range .}}#{{.number}}\t{{.headRefName}}\t{{.title}}\t{{.url}}{{"\\n"}}{{end}}'`
  - `for pr in 843 842 841 840; do gh pr view "$pr" --json files --template '{{range .files}}{{.path}}{{"\\n"}}{{end}}'; done`
- 重叠文件/主题：无重叠（现有 open PR 全为 renderer 前端专题）。
- 处理决策（新开/并入/换题）：新开 backend guardrails PR。

## Reviewer 引导（Checa 重点审计）
- 高风险文件：
  - `apps/desktop/main/src/ipc/file.ts`
  - `apps/desktop/preload/src/ipcGateway.ts`
  - `packages/shared/redaction/redact.ts`
- 建议优先检查路径：
  - `file:document:*` handler 是否全部经过 `handleWithProjectAccess`。
  - `estimatePayloadSize` 对 `function/symbol/bigint/undefined` 的分支语义是否与错误映射一致。
  - `github_token` 正则是否覆盖 3 类前缀且不会吞掉非 token 文本。
- 已知边界与限制：
  - 本 PR 未修改 renderer 侧 EO 活跃前端整改范围；只覆盖 main/preload/shared 及后端测试。

## 回滚方案
- 回滚 commit/分支：
  - `git revert 74071bd`
  - `git revert a3bf9d9`
  - `git revert b7ca1e9`
- 回滚后需恢复的数据/配置：无需额外数据迁移或配置恢复。


---

## 追加修复（并入同 PR，避免与 open PR 文件重叠）
- Fixes #852
- 追加主题：为 `search:*` IPC 全链路接入会话级 `projectId` 绑定守卫，阻断跨项目检索/替换越权。

### 追加改动（按文件）
- `apps/desktop/main/src/ipc/search.ts`: 引入 `guardAndNormalizeProjectAccess`，统一包装 `search:fts:*`、`search:query:*`、`search:rank:*`、`search:replace:*` 通道。
- `apps/desktop/main/src/index.ts`: 注册 search IPC 时注入 `projectSessionBinding`。
- `apps/desktop/main/src/ipc/__tests__/search-project-access-guard.test.ts`: 新增错绑/未绑定/空 projectId 归一化三类回归断言。

### 追加验证证据
- `pnpm typecheck` exit_code=0
- `pnpm lint` exit_code=0（62 条既有 warning，0 error）
- `pnpm test:unit` exit_code=0（Vitest 汇总 `Test Files 10 passed, Tests 36 passed`）
- `node --import tsx apps/desktop/main/src/ipc/__tests__/search-project-access-guard.test.ts` exit_code=0

### 并入决策说明（Open PR 排重）
- 复核发现 issue #852 需要改 `apps/desktop/main/src/index.ts`，与 open PR #851 已改文件重叠。
- 按“重叠不得重复开 PR”门禁，已将 #852 修复并入当前 PR #851，而非新开重复 PR。
