### PR TITLE
fix: short-circuit pre-aborted background task execution (#856)

### DIFF
--- a/apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts
+++ b/apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts
@@ -82,6 +82,27 @@ async function main(): Promise<void> {
     }
   });
 
+  await runScenario(
+    "BE-TG-S1 pre-aborted: does not invoke execute callback",
+    async () => {
+      const runner = createBackgroundTaskRunner();
+      const controller = new AbortController();
+      controller.abort(new Error("already aborted"));
+
+      let invoked = 0;
+      const result = await runner.run({
+        execute: async () => {
+          invoked += 1;
+          return "unexpected";
+        },
+        signal: controller.signal,
+        timeoutMs: 5000,
+      });
+      assert.equal(result.status, "aborted");
+      assert.equal(invoked, 0);
+    },
+  );
+
   await runScenario("BE-TG-S1 crashed: crashAll returns crashed status", async () => {
     const runner = createBackgroundTaskRunner();
     const resultPromise = runner.run({

--- a/apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts
+++ b/apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts
@@ -84,6 +84,29 @@ import { createBackgroundTaskRunner } from "../backgroundTaskRunner";
 
 /**
  * Scenario: BE-UPF-S1
+ * should short-circuit pre-aborted signal without invoking execute callback.
+ */
+{
+  const runner = createBackgroundTaskRunner();
+  const controller = new AbortController();
+  controller.abort(new Error("already_aborted"));
+
+  let invoked = 0;
+  const result = await runner.run({
+    timeoutMs: 100,
+    signal: controller.signal,
+    execute: async () => {
+      invoked += 1;
+      return "unexpected";
+    },
+  });
+
+  assert.equal(result.status, "aborted");
+  assert.equal(invoked, 0);
+}
+
+/**
+ * Scenario: BE-UPF-S1
  * should return crashed status when utility process crash signal is raised.
  */
 {

--- a/apps/desktop/main/src/services/utilityprocess/backgroundTaskRunner.ts
+++ b/apps/desktop/main/src/services/utilityprocess/backgroundTaskRunner.ts
@@ -128,6 +128,12 @@ export function createBackgroundTaskRunner(): BackgroundTaskRunner {
       });
 
       const executionResult = (async (): Promise<BackgroundTaskResult<T>> => {
+        if (controller.signal.aborted) {
+          return timeoutTriggered
+            ? { status: "timeout", error: createTimeoutError() }
+            : { status: "aborted", error: createAbortError() };
+        }
+
         const execute = args.execute ?? args.run;
         if (!execute) {
           return {


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (bot:asuka issue fix)

## 主题
- 修复 `backgroundTaskRunner` 在 `signal` 调用前已 aborted 时仍执行任务回调的问题，确保取消语义前置生效。

## 关联 Issue
- Fixes #856

## 背景与问题定义
- 问题场景（文件 + 触发路径）：`apps/desktop/main/src/services/utilityprocess/backgroundTaskRunner.ts` 的 `run()` 在接入外部 `signal` 时，若信号已是 aborted，仍会进入 `executionResult` 并触发 `execute(controller.signal)`。
- 根因分析（为什么会发生）：`executionResult` 缺少 pre-aborted 短路分支，外部 abort 只通过 `Promise.race` 让返回值变为 `aborted`，但未阻止回调实际执行。
- 不修最坏后果（必须具体）：上层已判定“取消成功”，底层回调仍可能继续写盘/发起计算，形成“状态已取消但副作用仍发生”的幽灵执行。

## 改动说明（按文件）
- `apps/desktop/main/src/services/utilityprocess/backgroundTaskRunner.ts`: 在 `executionResult` 顶部新增 `controller.signal.aborted` 短路，pre-aborted 时直接返回 `aborted/timeout`，不再调用 `execute`。
- `apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts`: 新增 pre-aborted 合同场景，断言 `status=aborted` 且 `invoked=0`。
- `apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts`: 新增同等回归场景，覆盖另一条契约测试入口，确保不会回归。

## 风险评估与防护
- 可能回归点：`run()` pre-aborted 直接返回后，若调用方依赖“回调被触发一次”的旧行为会变化（该旧行为为 bug）。
- 防护措施（测试/断言/日志）：双合同测试新增 `invoked=0` 断言，明确拦截“状态 aborted 但回调仍执行”。
- 兼容性影响：未改 IPC 契约、未改 renderer，行为仅收敛为 spec 要求的“无幽灵执行”。

## 验证证据（必须含命令、退出码、关键输出）
- `pnpm typecheck`
  - exit_code: 0
  - key_output: `tsc --noEmit` 正常退出。
- `pnpm lint`
  - exit_code: 0
  - key_output: `✖ 62 problems (0 errors, 62 warnings)`（既有 warning 基线，无新增 error）。
- `pnpm test:unit`
  - exit_code: 1
  - key_output: sandbox 环境 `tsx` 启动命名管道失败：`listen EPERM /tmp/tsx-1000/*.pipe`。
- 其他定向验证：
  - `node --import tsx apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts`（Red）exit_code=1，关键输出 `AssertionError: 1 !== 0`。
  - `node --import tsx apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts`（Green）exit_code=0。
  - `node --import tsx apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts`（Red）exit_code=1，关键输出 `[BE-TG-S1 pre-aborted: does not invoke execute callback] 1 !== 0`。
  - `node --import tsx apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts`（Green）exit_code=0，关键输出 `[BE-TG-S1] all scenarios passed`。

## Open PR 排重检查
- 扫描时间：2026-03-02 02:41:43 CST
- 扫描命令：
  - `mcp__github__search_pull_requests query="repo:Leeky1017/CreoNow is:open is:pr"`
  - `mcp__github__pull_request_read method="get_files" pullNumber=851`
  - `mcp__github__search_pull_requests query="repo:Leeky1017/CreoNow is:open is:pr 856"`
- 重叠文件/主题：
  - open PR #840/#841/#842/#843 均为 renderer 前端专题；
  - open PR #851 虽为 backend，但改动集中在 `ipc/file.ts`、`preload/ipcGateway.ts`、`packages/shared/redaction/*`，与本 PR 的 `utilityprocess/backgroundTaskRunner*` 无文件重叠；
  - issue/PR 关键词 `856` 无现存 open PR。
- 处理决策（新开/并入/换题）：新开独立修复 PR，避免与现有 lane 交叉。

## Reviewer 引导（Checa 重点审计）
- 高风险文件：
  - `apps/desktop/main/src/services/utilityprocess/backgroundTaskRunner.ts`
  - `apps/desktop/main/src/services/utilityprocess/__tests__/background-task-runner.contract.test.ts`
  - `apps/desktop/main/src/__tests__/contract/background-task-runner.contract.test.ts`
- 建议优先检查路径：
  - `executionResult` pre-aborted 短路是否位于 `execute` 调用之前；
  - pre-aborted 场景是否确实断言 `invoked===0`（避免“状态对了但副作用还在”）；
  - timeout/crash 既有分支是否未被回归破坏。
- 已知边界与限制：
  - 本 PR 未触碰 EO 活跃前端整改文件，也未新增 compat/shim/legacy/re-export；
  - 完整 `pnpm test:unit` 受当前 sandbox `EPERM` 限制，已用两条契约入口完成定向 Red/Green 验证。

## 回滚方案
- 回滚 commit/分支：`git revert 8b8b8c3dcb0df4b172a748cea836e7462bf8dea3`
- 回滚后需恢复的数据/配置：无需数据迁移或配置恢复。