### PR TITLE
improve(main): 修复 lifecyclePurge 沙箱根路径误删风险 (#846)

### DIFF
--- a/apps/desktop/main/src/services/projects/projectService.ts
+++ b/apps/desktop/main/src/services/projects/projectService.ts
@@ -1198,13 +1198,22 @@ export function createProjectService(args: {
       }
 
       const sandboxRootPath = path.join(args.userDataDir, PROJECT_SANDBOX_DIR_NAME);
-      if (!isPathInsideDirectory(project.data.rootPath, sandboxRootPath)) {
+      const normalizedProjectRootPath = path.resolve(project.data.rootPath);
+      const normalizedSandboxRootPath = path.resolve(sandboxRootPath);
+      const isSandboxRootPath =
+        normalizedProjectRootPath === normalizedSandboxRootPath;
+      const isInsideSandbox = isPathInsideDirectory(
+        normalizedProjectRootPath,
+        normalizedSandboxRootPath,
+      );
+      if (isSandboxRootPath || !isInsideSandbox) {
         args.logger.error("project_lifecycle_purge_sandbox_violation", {
           code: "PROJECT_PURGE_PERMISSION_DENIED",
           trace_id: traceId,
           project_id: projectId,
           root_path: project.data.rootPath,
           sandbox_root: sandboxRootPath,
+          is_sandbox_root: isSandboxRootPath,
         });
         return ipcError(
           "PROJECT_PURGE_PERMISSION_DENIED",

--- a/apps/desktop/main/src/services/projects/projectService.ts
+++ b/apps/desktop/main/src/services/projects/projectService.ts
@@ -205,6 +205,18 @@ function isPathInsideDirectory(targetPath: string, directoryPath: string): boole
   );
 }
 
+function normalizePathForEquality(inputPath: string): string {
+  const resolvedPath = path.resolve(inputPath);
+  const rootPath = path.parse(resolvedPath).root;
+  const trimmedPath = resolvedPath.replace(/[\\/]+$/, "");
+  const normalizedPath =
+    trimmedPath.length === 0 ? rootPath : trimmedPath;
+  if (process.platform === "win32") {
+    return normalizedPath.toLowerCase();
+  }
+  return normalizedPath;
+}
+
 /**
  * Normalize and validate a project name.
  *
@@ -1198,13 +1210,17 @@ export function createProjectService(args: {
       }
 
       const sandboxRootPath = path.join(args.userDataDir, PROJECT_SANDBOX_DIR_NAME);
-      const normalizedProjectRootPath = path.resolve(project.data.rootPath);
-      const normalizedSandboxRootPath = path.resolve(sandboxRootPath);
+      const normalizedProjectRootPath = normalizePathForEquality(
+        project.data.rootPath,
+      );
+      const normalizedSandboxRootPath = normalizePathForEquality(
+        sandboxRootPath,
+      );
       const isSandboxRootPath =
         normalizedProjectRootPath === normalizedSandboxRootPath;
       const isInsideSandbox = isPathInsideDirectory(
-        normalizedProjectRootPath,
-        normalizedSandboxRootPath,
+        project.data.rootPath,
+        sandboxRootPath,
       );
       if (isSandboxRootPath || !isInsideSandbox) {
         args.logger.error("project_lifecycle_purge_sandbox_violation", {

--- a/apps/desktop/tests/integration/project-purge.regression-guards.test.ts
+++ b/apps/desktop/tests/integration/project-purge.regression-guards.test.ts
@@ -33,6 +33,52 @@ async function assertArchivedState(args: {
   assert.equal(typeof row?.archivedAt, "number");
 }
 
+function toMixedCasePath(inputPath: string): string {
+  return Array.from(inputPath)
+    .map((char, index) => {
+      if (!/[a-zA-Z]/.test(char)) {
+        return char;
+      }
+      return index % 2 === 0 ? char.toUpperCase() : char.toLowerCase();
+    })
+    .join("");
+}
+
+async function withWindowsPathSemantics<T>(
+  run: () => Promise<T>,
+): Promise<T> {
+  const mutablePath = path as unknown as {
+    resolve: typeof path.resolve;
+    relative: typeof path.relative;
+    isAbsolute: typeof path.isAbsolute;
+  };
+
+  const originalResolve = mutablePath.resolve;
+  const originalRelative = mutablePath.relative;
+  const originalIsAbsolute = mutablePath.isAbsolute;
+  const originalPlatform = process.platform;
+
+  Object.defineProperty(process, "platform", {
+    value: "win32",
+    configurable: true,
+  });
+  mutablePath.resolve = path.win32.resolve.bind(path.win32);
+  mutablePath.relative = path.win32.relative.bind(path.win32);
+  mutablePath.isAbsolute = path.win32.isAbsolute.bind(path.win32);
+
+  try {
+    return await run();
+  } finally {
+    mutablePath.resolve = originalResolve;
+    mutablePath.relative = originalRelative;
+    mutablePath.isAbsolute = originalIsAbsolute;
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+  }
+}
+
 /**
  * issue #831
  * should reject out-of-bound root_path and keep project archived
@@ -209,6 +255,75 @@ async function shouldRejectSandboxRootPathPollution(): Promise<void> {
   }
 }
 
+/**
+ * issue #862
+ * should reject mixed-case sandbox root pollution on windows-like semantics
+ */
+async function shouldRejectMixedCaseSandboxRootPathPollution(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-purge-sandbox-root-mixed-case-"),
+  );
+  const db = createProjectTestDb();
+  const service = createProjectService({
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  try {
+    const projectA = service.create({
+      name: "Mixed-case sandbox root polluted project",
+    });
+    assert.equal(projectA.ok, true);
+    if (!projectA.ok) {
+      throw new Error("failed to create project A");
+    }
+
+    const projectB = service.create({
+      name: "Sibling project survives mixed-case pollution",
+    });
+    assert.equal(projectB.ok, true);
+    if (!projectB.ok) {
+      throw new Error("failed to create project B");
+    }
+
+    const markerPath = path.join(projectB.data.rootPath, "must-survive.txt");
+    await fs.writeFile(markerPath, "marker");
+
+    const archived = service.lifecycleArchive({
+      projectId: projectA.data.projectId,
+      traceId: "trace-sandbox-root-mixed-case-archive",
+    });
+    assert.equal(archived.ok, true);
+
+    const sandboxRootPath = path.join(userDataDir, "projects");
+    const mixedCaseSandboxRootPath = toMixedCasePath(sandboxRootPath);
+    db.prepare("UPDATE projects SET root_path = ? WHERE project_id = ?").run(
+      mixedCaseSandboxRootPath,
+      projectA.data.projectId,
+    );
+
+    const purged = await withWindowsPathSemantics(async () =>
+      service.lifecyclePurge({
+        projectId: projectA.data.projectId,
+        traceId: "trace-sandbox-root-mixed-case-purge",
+      }),
+    );
+    assert.equal(purged.ok, false);
+    if (purged.ok || !purged.error) {
+      throw new Error("expected PROJECT_PURGE_PERMISSION_DENIED");
+    }
+    assert.equal(purged.error.code, "PROJECT_PURGE_PERMISSION_DENIED");
+
+    await assertArchivedState({ db, projectId: projectA.data.projectId });
+    assert.equal(await pathExists(projectB.data.rootPath), true);
+    assert.equal(await pathExists(markerPath), true);
+  } finally {
+    db.close();
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  }
+}
+
 async function main(): Promise<void> {
   const failures: Error[] = [];
 
@@ -231,6 +346,13 @@ async function main(): Promise<void> {
   } catch (error) {
     failures.push(error as Error);
     console.error("[issue-846]", error);
+  }
+
+  try {
+    await shouldRejectMixedCaseSandboxRootPathPollution();
+  } catch (error) {
+    failures.push(error as Error);
+    console.error("[issue-862]", error);
   }
 
   if (failures.length > 0) {

--- a/apps/desktop/tests/integration/project-purge.regression-guards.test.ts
+++ b/apps/desktop/tests/integration/project-purge.regression-guards.test.ts
@@ -146,6 +146,69 @@ async function shouldKeepDirectoryWhenDbDeleteFails(): Promise<void> {
   }
 }
 
+/**
+ * issue #846
+ * should reject sandbox root path pollution and keep sibling project directories
+ */
+async function shouldRejectSandboxRootPathPollution(): Promise<void> {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "creonow-purge-sandbox-root-"),
+  );
+  const db = createProjectTestDb();
+  const service = createProjectService({
+    db,
+    userDataDir,
+    logger: createNoopLogger(),
+  });
+
+  try {
+    const projectA = service.create({ name: "Sandbox root polluted project" });
+    assert.equal(projectA.ok, true);
+    if (!projectA.ok) {
+      throw new Error("failed to create project A");
+    }
+
+    const projectB = service.create({ name: "Sibling project must survive" });
+    assert.equal(projectB.ok, true);
+    if (!projectB.ok) {
+      throw new Error("failed to create project B");
+    }
+
+    const markerPath = path.join(projectB.data.rootPath, "must-survive.txt");
+    await fs.writeFile(markerPath, "marker");
+
+    const archived = service.lifecycleArchive({
+      projectId: projectA.data.projectId,
+      traceId: "trace-sandbox-root-archive",
+    });
+    assert.equal(archived.ok, true);
+
+    const sandboxRootPath = path.join(userDataDir, "projects");
+    db.prepare("UPDATE projects SET root_path = ? WHERE project_id = ?").run(
+      sandboxRootPath,
+      projectA.data.projectId,
+    );
+
+    const purged = service.lifecyclePurge({
+      projectId: projectA.data.projectId,
+      traceId: "trace-sandbox-root-purge",
+    });
+    assert.equal(purged.ok, false);
+    if (purged.ok || !purged.error) {
+      throw new Error("expected PROJECT_PURGE_PERMISSION_DENIED");
+    }
+    assert.equal(purged.error.code, "PROJECT_PURGE_PERMISSION_DENIED");
+
+    await assertArchivedState({ db, projectId: projectA.data.projectId });
+    assert.equal(await pathExists(sandboxRootPath), true);
+    assert.equal(await pathExists(projectB.data.rootPath), true);
+    assert.equal(await pathExists(markerPath), true);
+  } finally {
+    db.close();
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  }
+}
+
 async function main(): Promise<void> {
   const failures: Error[] = [];
 
@@ -161,6 +224,13 @@ async function main(): Promise<void> {
   } catch (error) {
     failures.push(error as Error);
     console.error("[issue-832]", error);
+  }
+
+  try {
+    await shouldRejectSandboxRootPathPollution();
+  } catch (error) {
+    failures.push(error as Error);
+    console.error("[issue-846]", error);
   }
 
   if (failures.length > 0) {


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (bot:asuka issue #846 backend guardrail)

## 主题
- 修复 `lifecyclePurge` 在项目根路径被污染为沙箱根目录时的误删风险，阻断整目录删除。

## 关联 Issue
- Fixes #846

## 背景与问题定义
- 问题场景（文件 + 触发路径）：`apps/desktop/main/src/services/projects/projectService.ts` 的 `lifecyclePurge` 仅校验“是否在沙箱目录内”，当 `root_path` 被污染为 `<userData>/projects` 时仍会通过校验并执行 `rmSync`。
- 根因分析（为什么会发生）：路径门禁缺少“禁止等于沙箱根路径”分支，仅做了 `isPathInsideDirectory` 包含关系判断。
- 不修最坏后果（必须具体）：删除单个项目会误删整个 `projects` 沙箱目录，导致同机其它项目目录与文档被一并清空，形成不可逆数据丢失。

## 改动说明（按文件）
- `apps/desktop/main/src/services/projects/projectService.ts`: 增加 `isSandboxRootPath` 判定并与 existing sandbox-inside 校验组合，命中时返回 `PROJECT_PURGE_PERMISSION_DENIED`，且日志附带 `is_sandbox_root`。
- `apps/desktop/tests/integration/project-purge.regression-guards.test.ts`: 新增 issue #846 回归用例，构造 root_path=沙箱根目录污染场景，断言 purge 被拒绝且同沙箱 sibling 项目与标记文件仍存在。

## 风险评估与防护
- 可能回归点：历史异常数据若 root_path 非法，purge 行为从“继续执行”变为“拒绝执行”。
- 防护措施（测试/断言/日志）：新增集成回归测试覆盖污染场景；错误日志保留 traceId/projectId/rootPath 便于排查。
- 兼容性影响：未改 IPC 契约与前端行为，仅收敛后端安全门禁。

## 验证证据（必须含命令、退出码、关键输出）
- `pnpm typecheck`
  - exit_code: 0
  - key_output: `tsc --noEmit` 正常退出。
- `pnpm lint`
  - exit_code: 0
  - key_output: `✖ 62 problems (0 errors, 62 warnings)`（仓库既有 warning 基线，无新增 error）。
- `pnpm test:unit`
  - exit_code: 0
  - key_output: `Test Files 10 passed, Tests 36 passed`（终段 vitest 汇总全绿）。
- 其他定向验证：
  - `node --import tsx apps/desktop/tests/integration/project-purge.regression-guards.test.ts`
    - exit_code: 0
    - key_output: 进程正常退出（无断言失败）。

## Open PR 排重检查
- 扫描时间：2026-03-02 03:00:11 CST
- 扫描命令：
  - `gh pr list --state open --limit 200 --json number,title,headRefName,url --template '{{range .}}#{{.number}}\t{{.headRefName}}\t{{.title}}\t{{.url}}{{"\n"}}{{end}}'`
  - `gh pr view 851 --json files --template '{{range .files}}{{.path}}{{"\n"}}{{end}}'`
  - `gh pr view 859 --json files --template '{{range .files}}{{.path}}{{"\n"}}{{end}}'`
- 重叠文件/主题：open PR #851（ipc/file/preload/redaction）与 #859（backgroundTaskRunner）均与 `projectService`/`project-purge.regression-guards` 无文件重叠。
- 处理决策（新开/并入/换题）：新开独立修复 PR。

## Reviewer 引导（Checa 重点审计）
- 高风险文件：
  - `apps/desktop/main/src/services/projects/projectService.ts`
  - `apps/desktop/tests/integration/project-purge.regression-guards.test.ts`
- 建议优先检查路径：
  - `lifecyclePurge` 中 `isSandboxRootPath || !isInsideSandbox` 的拒绝条件是否位于删除前；
  - 新增回归用例是否覆盖“污染项目被拒绝 + sibling 目录存活”。
- 已知边界与限制：仅修正后端 purge 安全门禁；不涉及 EO 活跃前端范围。

## 回滚方案
- 回滚 commit/分支：`git revert <commit_sha>`（或回滚分支 `amano/issue-846-lifecycle-purge-guard`）
- 回滚后需恢复的数据/配置：无额外数据迁移；仅恢复代码到旧逻辑。
