### PR TITLE
improve(main): 收紧 version/export IPC 会话项目绑定防线 (#867)

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts
@@ -5,12 +5,18 @@ import type { IpcMain } from "electron";
 
 import type { Logger } from "../../logging/logger";
 import { registerExportIpcHandlers } from "../export";
+import { createProjectSessionBindingRegistry } from "../projectSessionBinding";
 
 type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
 
 function createMockIpcMain(): {
   ipcMain: IpcMain;
   invoke: (channel: string, payload: unknown) => Promise<unknown>;
+  invokeFrom: (
+    webContentsId: number,
+    channel: string,
+    payload: unknown,
+  ) => Promise<unknown>;
 } {
   const handlers = new Map<string, Handler>();
   return {
@@ -23,6 +29,15 @@ function createMockIpcMain(): {
       const handler = handlers.get(channel);
       assert.ok(handler, `expected handler ${channel}`);
       return handler({}, payload);
+    },
+    invokeFrom: async (
+      webContentsId: number,
+      channel: string,
+      payload: unknown,
+    ) => {
+      const handler = handlers.get(channel);
+      assert.ok(handler, `expected handler ${channel}`);
+      return handler({ sender: { id: webContentsId } }, payload);
     },
   };
 }
@@ -104,6 +119,44 @@ async function main(): Promise<void> {
 
   assert.equal(dbMissing.ok, false);
   assert.equal(dbMissing.error?.code, "DB_ERROR");
+
+  const binding = createProjectSessionBindingRegistry();
+  binding.bind({ webContentsId: 77, projectId: "project-bound" });
+
+  const guardHarness = createMockIpcMain();
+  const guardLogger = createLogger();
+
+  registerExportIpcHandlers({
+    ipcMain: guardHarness.ipcMain,
+    db: {} as never,
+    logger: guardLogger.logger,
+    userDataDir: process.cwd(),
+    projectSessionBinding: binding,
+  });
+
+  const exportDenied = (await guardHarness.invokeFrom(
+    77,
+    "export:document:markdown",
+    { projectId: "project-other", documentId: "doc-1" },
+  )) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(exportDenied.ok, false);
+  assert.equal(exportDenied.error?.code, "FORBIDDEN");
+
+  const bundleDeniedWhenUnbound = (await guardHarness.invokeFrom(
+    999,
+    "export:project:bundle",
+    { projectId: "project-guess" },
+  )) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(bundleDeniedWhenUnbound.ok, false);
+  assert.equal(bundleDeniedWhenUnbound.error?.code, "FORBIDDEN");
 }
 
 void main().catch((error) => {

--- a/apps/desktop/main/src/ipc/__tests__/version-project-access-guard.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/version-project-access-guard.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+
+import type { IpcMain } from "electron";
+
+import type { Logger } from "../../logging/logger";
+import { registerVersionIpcHandlers } from "../version";
+import { createProjectSessionBindingRegistry } from "../projectSessionBinding";
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createIpcHarness(): {
+  handlers: Map<string, Handler>;
+  ipcMain: IpcMain;
+} {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+  return { handlers, ipcMain };
+}
+
+function createEvent(webContentsId: number): { sender: { id: number } } {
+  return { sender: { id: webContentsId } };
+}
+
+// Scenario: version:snapshot:create rejects mismatched bound projectId [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+  binding.bind({ webContentsId: 71, projectId: "project-bound" });
+
+  const harness = createIpcHarness();
+  registerVersionIpcHandlers({
+    ipcMain: harness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const snapshotCreate = harness.handlers.get("version:snapshot:create");
+  assert.ok(snapshotCreate, "expected version:snapshot:create handler");
+
+  const denied = (await snapshotCreate!(createEvent(71), {
+    projectId: "project-other",
+    documentId: "doc-1",
+    contentJson: "{\"type\":\"doc\",\"content\":[]}",
+    actor: "user",
+    reason: "manual-save",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(denied.ok, false);
+  assert.equal(denied.error?.code, "FORBIDDEN");
+}
+
+// Scenario: version:snapshot:create fails closed when renderer session is unbound [ADDED]
+{
+  const binding = createProjectSessionBindingRegistry();
+
+  const harness = createIpcHarness();
+  registerVersionIpcHandlers({
+    ipcMain: harness.ipcMain,
+    db: null,
+    logger: createLogger(),
+    projectSessionBinding: binding,
+  });
+
+  const snapshotCreate = harness.handlers.get("version:snapshot:create");
+  assert.ok(snapshotCreate, "expected version:snapshot:create handler");
+
+  const denied = (await snapshotCreate!(createEvent(999), {
+    projectId: "project-guess",
+    documentId: "doc-1",
+    contentJson: "{\"type\":\"doc\",\"content\":[]}",
+    actor: "user",
+    reason: "manual-save",
+  })) as {
+    ok: boolean;
+    error?: { code?: string };
+  };
+
+  assert.equal(denied.ok, false);
+  assert.equal(denied.error?.code, "FORBIDDEN");
+}

--- a/apps/desktop/main/src/ipc/export.ts
+++ b/apps/desktop/main/src/ipc/export.ts
@@ -4,6 +4,11 @@ import type Database from "better-sqlite3";
 import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
 import { createExportService } from "../services/export/exportService";
+import { guardAndNormalizeProjectAccess } from "./projectAccessGuard";
+import {
+  getProjectSessionBindingRegistry,
+  type ProjectSessionBindingRegistry,
+} from "./projectSessionBinding";
 
 type ExportPayloadError = IpcError;
 
@@ -80,8 +85,13 @@ export function registerExportIpcHandlers(deps: {
   db: Database.Database | null;
   logger: Logger;
   userDataDir: string;
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
+  const projectSessionBinding =
+    deps.projectSessionBinding ?? getProjectSessionBindingRegistry() ?? undefined;
+
   const invokeDocumentExport = async (
+    event: unknown,
     channel: string,
     payload: unknown,
     run: (args: DocumentExportPayload) => Promise<
@@ -89,6 +99,15 @@ export function registerExportIpcHandlers(deps: {
       | { ok: false; error: ExportPayloadError }
     >,
   ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
+    const guarded = guardAndNormalizeProjectAccess({
+      event,
+      payload,
+      projectSessionBinding,
+    });
+    if (!guarded.ok) {
+      return guarded.response;
+    }
+
     const parsed = parseDocumentExportPayload(payload);
     if (!parsed.ok) {
       return { ok: false, error: parsed.error };
@@ -125,6 +144,7 @@ export function registerExportIpcHandlers(deps: {
         userDataDir: deps.userDataDir,
       });
       return invokeDocumentExport(
+        _e,
         "export:document:markdown",
         payload,
         async (args) => svc.exportMarkdown(args),
@@ -150,6 +170,7 @@ export function registerExportIpcHandlers(deps: {
         userDataDir: deps.userDataDir,
       });
       return invokeDocumentExport(
+        _e,
         "export:document:pdf",
         payload,
         async (args) => svc.exportPdf(args),
@@ -175,6 +196,7 @@ export function registerExportIpcHandlers(deps: {
         userDataDir: deps.userDataDir,
       });
       return invokeDocumentExport(
+        _e,
         "export:document:docx",
         payload,
         async (args) => svc.exportDocx(args),
@@ -201,6 +223,7 @@ export function registerExportIpcHandlers(deps: {
         userDataDir: deps.userDataDir,
       });
       return invokeDocumentExport(
+        _e,
         "export:document:txt",
         payload,
         async (args) => svc.exportTxt(args),
@@ -211,9 +234,18 @@ export function registerExportIpcHandlers(deps: {
   deps.ipcMain.handle(
     "export:project:bundle",
     async (
-      _e,
+      event,
       payload: unknown,
     ): Promise<IpcResponse<{ relativePath: string; bytesWritten: number }>> => {
+      const guarded = guardAndNormalizeProjectAccess({
+        event,
+        payload,
+        projectSessionBinding,
+      });
+      if (!guarded.ok) {
+        return guarded.response;
+      }
+
       if (!deps.db) {
         return {
           ok: false,

--- a/apps/desktop/main/src/ipc/projectSessionBinding.ts
+++ b/apps/desktop/main/src/ipc/projectSessionBinding.ts
@@ -4,6 +4,15 @@ export type ProjectSessionBindingRegistry = {
   clear: (args: { webContentsId: number }) => void;
 };
 
+let activeProjectSessionBindingRegistry: ProjectSessionBindingRegistry | null =
+  null;
+
+export function getProjectSessionBindingRegistry():
+  | ProjectSessionBindingRegistry
+  | null {
+  return activeProjectSessionBindingRegistry;
+}
+
 /**
  * Build a renderer-session project binding registry.
  *
@@ -13,7 +22,7 @@ export type ProjectSessionBindingRegistry = {
 export function createProjectSessionBindingRegistry(): ProjectSessionBindingRegistry {
   const activeProjectByWebContents = new Map<number, string>();
 
-  return {
+  const registry: ProjectSessionBindingRegistry = {
     bind: ({ webContentsId, projectId }) => {
       if (!Number.isInteger(webContentsId) || webContentsId <= 0) {
         return;
@@ -44,4 +53,7 @@ export function createProjectSessionBindingRegistry(): ProjectSessionBindingRegi
       activeProjectByWebContents.delete(webContentsId);
     },
   };
+
+  activeProjectSessionBindingRegistry = registry;
+  return registry;
 }

--- a/apps/desktop/main/src/ipc/version.ts
+++ b/apps/desktop/main/src/ipc/version.ts
@@ -11,6 +11,11 @@ import {
   type VersionSnapshotActor,
   type VersionSnapshotReason,
 } from "../services/documents/documentService";
+import { guardAndNormalizeProjectAccess } from "./projectAccessGuard";
+import {
+  getProjectSessionBindingRegistry,
+  type ProjectSessionBindingRegistry,
+} from "./projectSessionBinding";
 
 const DEFAULT_IO_RETRY_MAX_ATTEMPTS = 3;
 const DEFAULT_IO_TIMEOUT_MS = 5_000;
@@ -177,6 +182,7 @@ export function registerVersionIpcHandlers(deps: {
     rollback?: number;
     merge?: number;
   };
+  projectSessionBinding?: ProjectSessionBindingRegistry;
 }): void {
   const serviceFactory = deps.serviceFactory ?? createDocumentService;
   const ioRetryMaxAttempts = normalizeRetryMaxAttempts(deps.ioRetryMaxAttempts);
@@ -193,6 +199,8 @@ export function registerVersionIpcHandlers(deps: {
       maxDiffPayloadBytes:
         deps.maxDiffPayloadBytes ?? DEFAULT_MAX_DIFF_PAYLOAD_BYTES,
     });
+  const projectSessionBinding =
+    deps.projectSessionBinding ?? getProjectSessionBindingRegistry() ?? undefined;
 
   const rollbackConflict = (documentId: string): IpcResponse<never> => ({
     ok: false,
@@ -271,7 +279,7 @@ export function registerVersionIpcHandlers(deps: {
 
   deps.ipcMain.handle(
     "version:snapshot:create",
-    async (_e, payload: unknown): Promise<
+    async (event, payload: unknown): Promise<
       IpcResponse<{
         versionId: string;
         contentHash: string;
@@ -280,6 +288,15 @@ export function registerVersionIpcHandlers(deps: {
         compaction?: SnapshotCompactionEvent;
       }>
     > => {
+      const guarded = guardAndNormalizeProjectAccess({
+        event,
+        payload,
+        projectSessionBinding,
+      });
+      if (!guarded.ok) {
+        return guarded.response;
+      }
+
       if (!deps.db) {
         return {
           ok: false,


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (bot:asuka issue fix)

## 主题
- 为 `version:*` 与 `export:*` IPC 入口统一接入 `projectSessionBinding` 防线，阻断跨项目 payload 越权。

## 关联 Issue
- Fixes #867

## 背景与问题定义
- 问题场景（文件 + 触发路径）：`apps/desktop/main/src/ipc/version.ts` 与 `apps/desktop/main/src/ipc/export.ts` 的 handler 主要依赖 `payload.projectId`，未在入口做 sender 会话绑定校验。
- 根因分析（为什么会发生）：既有 `guardAndNormalizeProjectAccess` 已存在，但 version/export 通道未接入统一守卫，导致通道级访问控制不一致。
- 不修最坏后果（必须具体）：恶意或异常 renderer 可伪造 `projectId` 对非当前项目触发快照写入/文档导出请求，造成跨项目数据泄露与误操作风险。

## 改动说明（按文件）
- `apps/desktop/main/src/ipc/version.ts`: 为 `version:snapshot:create` 增加 `guardAndNormalizeProjectAccess` 入口校验，并支持注入/回退读取 `projectSessionBinding`。
- `apps/desktop/main/src/ipc/export.ts`: 为 `export:document:*` 与 `export:project:bundle` 增加 sender-session 绑定校验，拒绝错绑或未绑定请求。
- `apps/desktop/main/src/ipc/projectSessionBinding.ts`: 暴露活动 registry 读取能力，供 handler 在未显式注入时安全回退获取绑定。
- `apps/desktop/main/src/ipc/__tests__/version-project-access-guard.test.ts`: 新增 version IPC 越权/未绑定拒绝回归用例。
- `apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts`: 新增 export IPC 错绑/未绑定返回 `FORBIDDEN` 的回归断言。

## 风险评估与防护
- 可能回归点：历史未建立 project session 绑定的调用会从“继续执行”收敛为 `FORBIDDEN`。
- 防护措施（测试/断言/日志）：新增 version/export 两组越权拒绝测试，并保留原有 payload 结构校验路径。
- 兼容性影响：未改 IPC 契约字段，仅收紧后端鉴权前置逻辑（fail-closed）。

## 验证证据（必须含命令、退出码、关键输出）
- `pnpm typecheck`
  - exit_code: 0
  - key_output: `tsc --noEmit` 正常退出
- `pnpm lint`
  - exit_code: 0
  - key_output: `✖ 62 problems (0 errors, 62 warnings)`（既有 warning 基线）
- `pnpm test:unit`
  - exit_code: 0
  - key_output: `Test Files 10 passed (10), Tests 36 passed (36)`
- 其他定向验证：
  - `node --import tsx apps/desktop/main/src/ipc/__tests__/version-project-access-guard.test.ts` -> exit_code: 0
  - `node --import tsx apps/desktop/main/src/ipc/__tests__/export-ipc.test.ts` -> exit_code: 0

## Open PR 排重检查
- 扫描时间：2026-03-02 05:10:33 CST
- 扫描命令：
  - `gh pr list --state open --limit 200 --json number,title,headRefName,url --template '{{range .}}#{{.number}}\t{{.headRefName}}\t{{.title}}\t{{.url}}{{"\\n"}}{{end}}'`
  - `for pr in 851 859 860 863; do gh pr view $pr --json files --template '{{range .files}}{{.path}}{{"\\n"}}{{end}}' | grep -E 'apps/desktop/main/src/ipc/(export|version|projectSessionBinding|__tests__/export-ipc|__tests__/version-project-access-guard)' || true; done`
- 重叠文件/主题：与 open backend PR #851/#859/#860/#863 无文件重叠。
- 处理决策（新开/并入/换题）：新开独立 PR，避免并行 lane 交叉污染。

## Reviewer 引导（Checa 重点审计）
- 高风险文件：
  - `apps/desktop/main/src/ipc/version.ts`
  - `apps/desktop/main/src/ipc/export.ts`
  - `apps/desktop/main/src/ipc/projectSessionBinding.ts`
- 建议优先检查路径：
  - `guardAndNormalizeProjectAccess` 是否在 DB/业务逻辑前执行；
  - version/export handler 是否统一 fail-closed；
  - 新增测试是否覆盖“错绑 + 未绑定”两个拒绝分支。
- 已知边界与限制：本 PR 不触及 EO 活跃前端范围，仅改 main IPC 与对应后端测试。

## 回滚方案
- 回滚 commit/分支：`git revert b196643` 或回滚分支 `amano/issue-867-version-export-binding`
- 回滚后需恢复的数据/配置：无需数据迁移或配置恢复。