### PR TITLE
improve(shared): clamp IPC payload runtime governance upper bound (#872)

### DIFF
--- a/apps/desktop/tests/integration/runtime-governance-consistency.test.ts
+++ b/apps/desktop/tests/integration/runtime-governance-consistency.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { RUNTIME_GOVERNANCE_DEFAULTS } from "@shared/runtimeGovernance";
 import { resolveRuntimeGovernanceFromEnv as resolveMain } from "../../main/src/config/runtimeGovernance";
+import { createPreloadIpcGateway } from "../../preload/src/ipcGateway";
 import { resolveRuntimeGovernanceFromEnv as resolvePreload } from "../../preload/src/runtimeGovernance";
 
 // S1-RC-S1
@@ -13,6 +14,56 @@ import { resolveRuntimeGovernanceFromEnv as resolvePreload } from "../../preload
   assert.deepEqual(mainCfg, RUNTIME_GOVERNANCE_DEFAULTS);
   assert.deepEqual(preloadCfg, RUNTIME_GOVERNANCE_DEFAULTS);
   assert.deepEqual(preloadCfg, mainCfg);
+}
+
+// S1-RC-S4
+// clamps oversized IPC payload env and keeps preload payload guard effective
+{
+  const oversizedEnv = {
+    CN_IPC_MAX_PAYLOAD_BYTES: "2147483647",
+  };
+
+  const mainCfg = resolveMain(oversizedEnv);
+  const preloadCfg = resolvePreload(oversizedEnv);
+
+  assert.equal(
+    mainCfg.ipc.maxPayloadBytes,
+    RUNTIME_GOVERNANCE_DEFAULTS.ipc.maxPayloadBytes,
+  );
+  assert.deepEqual(preloadCfg, mainCfg);
+
+  let invoked = false;
+  const gateway = createPreloadIpcGateway({
+    allowedChannels: ["app:system:ping"],
+    rendererId: "runtime-governance-consistency",
+    maxPayloadBytes: preloadCfg.ipc.maxPayloadBytes,
+    requestIdFactory: () => "req-runtime-governance-clamp",
+    now: () => 1_717_171_001_000,
+    invoke: async () => {
+      invoked = true;
+      return { ok: true, data: { accepted: true } };
+    },
+    auditLog: () => {},
+  });
+
+  const response = await gateway.invoke("app:system:ping", {
+    blob: "x".repeat(20 * 1024 * 1024),
+  });
+  assert.equal(invoked, false);
+  assert.equal(response.ok, false);
+  if (response.ok) {
+    assert.fail("expected IPC_PAYLOAD_TOO_LARGE");
+  }
+  assert.equal(response.error.code, "IPC_PAYLOAD_TOO_LARGE");
+  const details = response.error.details as
+    | {
+        limitBytes?: number;
+      }
+    | undefined;
+  assert.equal(
+    details?.limitBytes,
+    RUNTIME_GOVERNANCE_DEFAULTS.ipc.maxPayloadBytes,
+  );
 }
 
 // S1-RC-S2

--- a/packages/shared/runtimeGovernance.ts
+++ b/packages/shared/runtimeGovernance.ts
@@ -38,6 +38,9 @@ export const RUNTIME_GOVERNANCE_DEFAULTS: RuntimeGovernance = {
   },
 };
 
+const IPC_MAX_PAYLOAD_BYTES_HARD_CAP =
+  RUNTIME_GOVERNANCE_DEFAULTS.ipc.maxPayloadBytes;
+
 function pickRaw(args: {
   env: RuntimeGovernanceEnv;
   primaryKey: string;
@@ -59,7 +62,11 @@ function pickRaw(args: {
   return undefined;
 }
 
-function parsePositiveInt(raw: string | undefined, fallback: number): number {
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  maxValue?: number,
+): number {
   if (typeof raw !== "string") {
     return fallback;
   }
@@ -74,6 +81,14 @@ function parsePositiveInt(raw: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(trimmed, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return fallback;
+  }
+
+  if (
+    typeof maxValue === "number" &&
+    Number.isFinite(maxValue) &&
+    maxValue > 0
+  ) {
+    return Math.min(parsed, maxValue);
   }
 
   return parsed;
@@ -127,6 +142,7 @@ export function resolveRuntimeGovernanceFromEnv(
       legacyKey: "CREONOW_IPC_MAX_PAYLOAD_BYTES",
     }),
     RUNTIME_GOVERNANCE_DEFAULTS.ipc.maxPayloadBytes,
+    IPC_MAX_PAYLOAD_BYTES_HARD_CAP,
   );
 
   const aiTimeoutMs = parsePositiveInt(


### PR DESCRIPTION
Skip-Reason: automated quality iteration by 天野 (bot:asuka issue fix)

## 主题
- 为 `CN_IPC_MAX_PAYLOAD_BYTES` 增加安全硬上限，防止极大 env 值把 preload payload guard 抬升到 GiB 级。

## 关联 Issue
- Fixes #872

## 背景与问题定义
- 问题场景（文件 + 触发路径）：`packages/shared/runtimeGovernance.ts` 仅做正整数解析，`CN_IPC_MAX_PAYLOAD_BYTES=2147483647` 时会原样透传到 `apps/desktop/preload/src/ipc.ts -> createPreloadIpcGateway(maxPayloadBytes)`。
- 根因分析（为什么会发生）：运行时治理解析缺少 per-key 上限策略，导致“合法但极大”的环境值绕过默认 10MB 安全预算。
- 不修最坏后果（必须具体）：单条异常配置即可使 IPC 入口接受超大请求体，放大 preload/main 端内存与 CPU 压力，触发卡顿或进程不稳定，并且问题来源难以从业务日志直接定位。

## 改动说明（按文件）
- `packages/shared/runtimeGovernance.ts`: 新增 `IPC_MAX_PAYLOAD_BYTES_HARD_CAP`，并为 `parsePositiveInt` 增加可选 `maxValue`；`CN_IPC_MAX_PAYLOAD_BYTES` 解析结果改为 `min(parsed, hard_cap)`。
- `apps/desktop/tests/integration/runtime-governance-consistency.test.ts`: 增加超大 env 回归（`2147483647`），断言 main/preload 都被 clamp 到默认上限，并验证 20MB payload 仍被 preload gateway 拒绝（`IPC_PAYLOAD_TOO_LARGE`）。

## 风险评估与防护
- 可能回归点：历史上依赖 `CN_IPC_MAX_PAYLOAD_BYTES` 提升到 10MB 以上的场景将被收敛为硬上限。
- 防护措施（测试/断言/日志）：新增一致性 + 网关联动回归，直接覆盖“超大 env -> clamp -> 超限 payload 拒绝”主路径。
- 兼容性影响：未引入 compat/shim/legacy/re-export；仅收紧共享运行时配置解析。

## 验证证据（必须含命令、退出码、关键输出）
- `pnpm typecheck`
  - exit_code: 1
  - key_output: `sh: 1: tsc: not found`（当前工作树无本地 node_modules）
- `pnpm lint`
  - exit_code: 1
  - key_output: `ESLint couldn't find a configuration file`（当前工作树无本地 node_modules）
- `pnpm test:unit`
  - exit_code: 1
  - key_output: `sh: 1: tsx: not found`（当前工作树无本地 node_modules）
- 其他定向验证：
  - `node --import tsx apps/desktop/tests/integration/runtime-governance-consistency.test.ts`（Red）
    - exit_code: 1
    - key_output: `actual 2147483647 !== expected 10485760`
  - `node --import tsx apps/desktop/tests/integration/runtime-governance-consistency.test.ts`（Green）
    - exit_code: 0
    - key_output: 无断言失败
  - `node --import tsx apps/desktop/tests/unit/ipc-preload-security.spec.ts`
    - exit_code: 0
    - key_output: 无断言失败

## Open PR 排重检查
- 扫描时间：2026-03-02 07:27:55 CST
- 扫描命令：
  - `mcp__github__search_pull_requests query="repo:Leeky1017/CreoNow is:open"`
  - `mcp__github__pull_request_read method="get_files" pullNumber=870`
  - `mcp__github__pull_request_read method="get_files" pullNumber=869`
  - `mcp__github__pull_request_read method="get_files" pullNumber=863`
  - `mcp__github__pull_request_read method="get_files" pullNumber=860`
  - `mcp__github__pull_request_read method="get_files" pullNumber=859`
  - `mcp__github__pull_request_read method="get_files" pullNumber=851`
- 重叠文件/主题：与 open backend PR #870/#869/#863/#860/#859/#851 均无文件重叠；其余 open PR #840/#841/#842/#843 为前端主题。
- 处理决策（新开/并入/换题）：新开独立 PR，保持 issue #872 的 shared+preload 安全收敛最小改动面。

## Reviewer 引导（Checa 重点审计）
- 高风险文件：
  - `packages/shared/runtimeGovernance.ts`
  - `apps/desktop/tests/integration/runtime-governance-consistency.test.ts`
- 建议优先检查路径：
  - `parsePositiveInt(..., maxValue)` 对 `CN_IPC_MAX_PAYLOAD_BYTES` 的 clamp 是否仅影响该键；
  - 新增回归是否同时验证 main/preload 一致性与 preload payload guard 的拒绝行为。
- 已知边界与限制：本 PR 不修改 `apps/desktop/tests/unit/ipc-preload-security.spec.ts`（并行任务保留文件），通过新增 integration 回归覆盖联动行为。

## 回滚方案
- 回滚 commit/分支：`git revert 6f840b1f317f5fa58ad907f14eaf31bb88610f5e` 或回滚分支 `amano/issue-872-runtime-governance-cap-v2`。
- 回滚后需恢复的数据/配置：无需数据迁移；仅恢复 runtime governance IPC 上限策略。