### PR TITLE
SearchPanel tokenized rewrite (#895)

### DIFF
--- a/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
@@ -90,11 +90,13 @@ describe("SearchPanel", () => {
     it("点击分类按钮应切换分类", () => {
       render(<SearchPanel projectId="test-project" open={true} />);
 
-      const allButton = screen.getByText("All");
-      expect(allButton).toBeInTheDocument();
+      const allButtonText = screen.getByText("All");
+      expect(allButtonText).toBeInTheDocument();
 
-      // All 按钮默认选中
-      expect(allButton.className).toContain("bg-[var(--color-info)]");
+      // All 按钮默认选中 — Button primitive wraps children in <span>,
+      // so we check the closest <button> ancestor for the active className
+      const allButton = allButtonText.closest("button");
+      expect(allButton?.className).toContain("bg-[var(--color-info)]");
     });
   });
 

--- a/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.test.tsx
@@ -94,7 +94,7 @@ describe("SearchPanel", () => {
       expect(allButton).toBeInTheDocument();
 
       // All 按钮默认选中
-      expect(allButton.className).toContain("bg-[#3b82f6]");
+      expect(allButton.className).toContain("bg-[var(--color-info)]");
     });
   });
 

--- a/apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts
@@ -62,4 +62,40 @@ describe("SearchPanel token guard", () => {
     });
     expect(violations, `Found transition-all:\n${violations.join("\n")}`).toHaveLength(0);
   });
+
+  it("does not contain native <button or <input elements (WB-FE-SRCH-S2)", () => {
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      // Skip comments, import lines, and type annotations
+      const trimmed = line.trim();
+      if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("import")) return;
+      // Check for native <button or <input (lowercase JSX tags)
+      // Use \b to handle tags split across lines (e.g. "<button\n  type=...")
+      if (/<button\b/.test(line) || /<input\b/.test(line)) {
+        violations.push(`L${i + 1}: ${trimmed}`);
+      }
+    });
+    expect(violations, `Found native elements (should use Primitives):\n${violations.join("\n")}`).toHaveLength(0);
+  });
+
+  it("gates animations with motion-safe modifier (WB-FE-SRCH-S3b)", () => {
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
+      // Skip @keyframes definitions — they are CSS, not Tailwind classes
+      if (trimmed.startsWith("@keyframes")) return;
+      // Check for animate-* classes not gate by motion-safe:
+      if (/\banimate-/.test(line)) {
+        // Remove motion-safe:animate- occurrences, then check if ungated animate- remains
+        const cleaned = line.replace(/motion-safe:animate-/g, "");
+        if (/\banimate-/.test(cleaned)) {
+          violations.push(`L${i + 1}: ${trimmed}`);
+        }
+      }
+    });
+    expect(violations, `Found ungated animations (use motion-safe: prefix):\n${violations.join("\n")}`).toHaveLength(0);
+  });
 });

--- a/apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect } from "vitest";
+
+const src = readFileSync(
+  resolve(__dirname, "SearchPanel.tsx"),
+  "utf-8",
+);
+
+describe("SearchPanel token guard", () => {
+  it("does not contain raw hex color values (WB-FE-SRCH-S1)", () => {
+    // Match #xxx, #xxxx, #xxxxxx, #xxxxxxxx but not CSS var() references or comments
+    const hexPattern = /(?<!=\s*['"])#(?:[0-9a-fA-F]{3,8})\b/g;
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      // Skip comments and import lines
+      if (line.trim().startsWith("//") || line.trim().startsWith("*") || line.trim().startsWith("import")) return;
+      const matches = line.match(hexPattern);
+      if (matches) {
+        violations.push(`L${i + 1}: ${matches.join(", ")}`);
+      }
+    });
+    expect(violations, `Found raw hex values:\n${violations.join("\n")}`).toHaveLength(0);
+  });
+
+  it("does not contain raw rgba values (WB-FE-SRCH-S1)", () => {
+    const rgbaPattern = /rgba\s*\(/g;
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      if (line.trim().startsWith("//") || line.trim().startsWith("*")) return;
+      if (rgbaPattern.test(line)) {
+        violations.push(`L${i + 1}: ${line.trim()}`);
+        rgbaPattern.lastIndex = 0;
+      }
+    });
+    expect(violations, `Found raw rgba:\n${violations.join("\n")}`).toHaveLength(0);
+  });
+
+  it("does not contain inline style attributes (WB-FE-SRCH-S1b)", () => {
+    const stylePattern = /style\s*=\s*\{\{/g;
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      if (line.trim().startsWith("//") || line.trim().startsWith("*")) return;
+      if (stylePattern.test(line)) {
+        violations.push(`L${i + 1}: ${line.trim()}`);
+        stylePattern.lastIndex = 0;
+      }
+    });
+    expect(violations, `Found inline styles:\n${violations.join("\n")}`).toHaveLength(0);
+  });
+
+  it("does not use transition-all (WB-FE-SRCH-S3)", () => {
+    const lines = src.split("\n");
+    const violations: string[] = [];
+    lines.forEach((line, i) => {
+      if (line.includes("transition-all")) {
+        violations.push(`L${i + 1}: ${line.trim()}`);
+      }
+    });
+    expect(violations, `Found transition-all:\n${violations.join("\n")}`).toHaveLength(0);
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
+import { Button } from "../../components/primitives/Button";
+import { Input } from "../../components/primitives/Input";
+import { ListItem } from "../../components/primitives/ListItem";
 import { Spinner } from "../../components/primitives/Spinner";
+import { Toggle } from "../../components/primitives/Toggle";
 import { useFileStore } from "../../stores/fileStore";
 import { useSearchStore, type SearchStatus } from "../../stores/searchStore";
 
@@ -105,48 +109,18 @@ function CategoryButton(props: {
   onClick: () => void;
 }): JSX.Element {
   return (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      size="sm"
       onClick={props.onClick}
-      className={`px-3 py-1 text-xs font-medium rounded-full transition-colors whitespace-nowrap ${
+      className={`!px-3 !py-1 !h-auto !text-xs !font-medium !rounded-full whitespace-nowrap ${
         props.active
-          ? "bg-[var(--color-info)] text-white shadow-lg shadow-[var(--color-info-subtle)]"
-          : "bg-[var(--color-separator)] text-[var(--color-fg-muted)] border border-transparent hover:border-white/10 hover:text-white hover:bg-white/10"
+          ? "!bg-[var(--color-info)] !text-white shadow-lg shadow-[var(--color-info-subtle)]"
+          : "!bg-[var(--color-separator)] !text-[var(--color-fg-muted)] !border !border-transparent hover:!border-white/10 hover:!text-white hover:!bg-white/10"
       }`}
     >
       {props.label}
-    </button>
-  );
-}
-
-/**
- * Toggle switch component matching design spec.
- */
-function ToggleSwitch(props: {
-  id: string;
-  label: string;
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-}): JSX.Element {
-  return (
-    <label
-      htmlFor={props.id}
-      className="flex items-center gap-2 cursor-pointer group"
-    >
-      <div className="relative inline-block w-7 h-4 align-middle select-none">
-        <input
-          id={props.id}
-          type="checkbox"
-          checked={props.checked}
-          onChange={(e) => props.onChange(e.target.checked)}
-          className="peer absolute block w-3 h-3 rounded-full bg-white appearance-none cursor-pointer top-0.5 left-0.5 checked:translate-x-3 transition-transform duration-200"
-        />
-        <div className="block overflow-hidden h-4 rounded-full bg-white/10 peer-checked:bg-[var(--color-info)] transition-colors duration-200" />
-      </div>
-      <span className="text-xs text-[var(--color-fg-muted)] group-hover:text-white transition-colors">
-        {props.label}
-      </span>
-    </label>
+    </Button>
   );
 }
 
@@ -163,15 +137,15 @@ function DocumentResultItem(props: {
   const { item, query, isActive, isFlashing, onClick } = props;
 
   return (
-    <button
-      type="button"
+    <ListItem
+      interactive
       onClick={onClick}
       data-testid={`search-result-item-${item.documentId ?? item.id}`}
-      className={`group w-full text-left mx-2 p-2 rounded-lg flex items-start gap-3 transition-colors relative overflow-hidden ${
+      className={`group w-full text-left mx-2 !p-2 !h-auto !rounded-lg !items-start !gap-3 relative ${
         isActive
-          ? "bg-[var(--color-separator)] border border-[var(--color-separator)]"
-          : "border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)]"
-      } ${isFlashing ? "ring-1 ring-[var(--color-info)] animate-pulse" : ""}`}
+          ? "!bg-[var(--color-separator)] border border-[var(--color-separator)]"
+          : "border border-transparent hover:!bg-[var(--color-separator)] hover:border-[var(--color-separator)]"
+      } ${isFlashing ? "ring-1 ring-[var(--color-info)] motion-safe:animate-pulse" : ""}`}
     >
       {/* Active indicator bar */}
       {isActive && (
@@ -270,7 +244,7 @@ function DocumentResultItem(props: {
           />
         </svg>
       </div>
-    </button>
+    </ListItem>
   );
 }
 
@@ -285,10 +259,10 @@ function MemoryResultItem(props: {
   const { item, query, onClick } = props;
 
   return (
-    <button
-      type="button"
+    <ListItem
+      interactive
       onClick={onClick}
-      className="group w-full text-left mx-2 mt-1 p-2 rounded-lg border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)] flex items-start gap-3 transition-colors"
+      className="group w-full text-left mx-2 mt-1 !p-2 !h-auto !rounded-lg border border-transparent hover:!bg-[var(--color-separator)] hover:border-[var(--color-separator)] !items-start !gap-3"
     >
       {/* Icon */}
       <div className="mt-1 w-8 h-8 rounded flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
@@ -339,7 +313,7 @@ function MemoryResultItem(props: {
           </div>
         )}
       </div>
-    </button>
+    </ListItem>
   );
 }
 
@@ -354,10 +328,10 @@ function KnowledgeResultItem(props: {
   const { item, query, onClick } = props;
 
   return (
-    <button
-      type="button"
+    <ListItem
+      interactive
       onClick={onClick}
-      className="group w-full text-left mx-2 p-2 rounded-lg border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)] flex items-start gap-3 transition-colors"
+      className="group w-full text-left mx-2 !p-2 !h-auto !rounded-lg border border-transparent hover:!bg-[var(--color-separator)] hover:border-[var(--color-separator)] !items-start !gap-3"
     >
       {/* Icon */}
       <div className="mt-1 w-8 h-8 rounded bg-[var(--color-separator)] flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
@@ -390,7 +364,7 @@ function KnowledgeResultItem(props: {
           </div>
         )}
       </div>
-    </button>
+    </ListItem>
   );
 }
 
@@ -592,7 +566,7 @@ export function SearchPanel(props: {
 
       {/* Glass Panel Modal */}
       <div
-        className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-50 bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] animate-[slideDown_0.3s_ease-out]"
+        className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-50 bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] motion-safe:animate-[slideDown_0.3s_ease-out]"
       >
         {/* Header */}
         <div
@@ -613,7 +587,7 @@ export function SearchPanel(props: {
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
               />
             </svg>
-            <input
+            <Input
               ref={inputRef}
               data-testid="search-input"
               type="text"
@@ -621,14 +595,15 @@ export function SearchPanel(props: {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleInputKeyDown}
               placeholder="Search documents, memories, knowledge..."
-              className="flex-1 bg-transparent border-none outline-none text-lg text-white placeholder-[var(--color-fg-placeholder)] font-[var(--font-family-ui)] font-light h-8"
+              className="flex-1 !bg-transparent !border-none !outline-none !text-lg !text-white !placeholder-[var(--color-fg-placeholder)] !font-[var(--font-family-ui)] !font-light !h-8 !px-0 !rounded-none"
             />
             {effectiveStatus === "loading" && <Spinner size="sm" />}
             {onClose && (
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={onClose}
-                className="p-1 rounded-md text-[var(--color-fg-placeholder)] hover:text-white hover:bg-[var(--color-separator)] transition-colors"
+                className="!p-1 !h-auto !rounded-md !text-[var(--color-fg-placeholder)] hover:!text-white hover:!bg-[var(--color-separator)]"
               >
                 <svg
                   className="w-5 h-5"
@@ -643,7 +618,7 @@ export function SearchPanel(props: {
                     d="M6 18L18 6M6 6l12 12"
                   />
                 </svg>
-              </button>
+              </Button>
             )}
           </div>
 
@@ -681,17 +656,17 @@ export function SearchPanel(props: {
             className="px-4 py-3 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-raised)]"
           >
             <div className="flex items-center gap-6">
-              <ToggleSwitch
+              <Toggle
                 id="semantic-toggle"
                 label="Semantic Search"
                 checked={semanticSearch}
-                onChange={setSemanticSearch}
+                onCheckedChange={setSemanticSearch}
               />
-              <ToggleSwitch
+              <Toggle
                 id="archived-toggle"
                 label="Include Archived"
                 checked={includeArchived}
-                onChange={setIncludeArchived}
+                onCheckedChange={setIncludeArchived}
               />
             </div>
 
@@ -699,9 +674,10 @@ export function SearchPanel(props: {
               <span className="text-[10px] text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
                 Scope
               </span>
-              <button
-                type="button"
-                className="flex items-center gap-1.5 px-2 py-1 rounded bg-[var(--color-separator)] border border-[var(--color-separator)] text-xs text-[var(--color-fg-muted)] hover:text-white hover:border-white/10 transition-colors"
+              <Button
+                variant="ghost"
+                size="sm"
+                className="!flex !items-center !gap-1.5 !px-2 !py-1 !h-auto !rounded !bg-[var(--color-separator)] !border !border-[var(--color-separator)] !text-xs !text-[var(--color-fg-muted)] hover:!text-white hover:!border-white/10"
               >
                 <span>Current Project</span>
                 <svg
@@ -717,7 +693,7 @@ export function SearchPanel(props: {
                     d="M19 9l-7 7-7-7"
                   />
                 </svg>
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -750,7 +726,7 @@ export function SearchPanel(props: {
             /* Reindex rebuilding state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <svg
-                className="w-16 h-16 text-[var(--color-info)] mb-4 animate-pulse"
+                className="w-16 h-16 text-[var(--color-info)] mb-4 motion-safe:animate-pulse"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -791,13 +767,13 @@ export function SearchPanel(props: {
               <p className="text-xs text-[var(--color-fg-muted)] text-center">
                 {lastError.message}
               </p>
-              <button
-                type="button"
+              <Button
+                variant="primary"
                 onClick={handleRetrySearch}
-                className="mt-6 px-4 py-2 bg-[var(--color-info)] text-white text-sm font-medium rounded-lg hover:bg-[var(--color-info)] hover:brightness-110 transition-colors"
+                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-white !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
               >
                 重试搜索
-              </button>
+              </Button>
             </div>
           ) : hasQuery && !hasResults && effectiveStatus !== "loading" ? (
             /* No results state */
@@ -829,9 +805,9 @@ export function SearchPanel(props: {
                   建议检查拼写或使用不同关键词
                 </p>
               </div>
-              <button
-                type="button"
-                className="mt-6 px-4 py-2 bg-[var(--color-info)] text-white text-sm font-medium rounded-lg hover:bg-[var(--color-info)] hover:brightness-110 transition-colors flex items-center gap-2"
+              <Button
+                variant="primary"
+                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-white !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
               >
                 <svg
                   className="w-4 h-4"
@@ -847,14 +823,14 @@ export function SearchPanel(props: {
                   />
                 </svg>
                 Search in all projects
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="ghost"
                 onClick={() => setQuery("")}
-                className="mt-3 text-xs text-[var(--color-fg-muted)] hover:text-white transition-colors"
+                className="mt-3 !h-auto !text-xs !text-[var(--color-fg-muted)] hover:!text-white"
               >
                 Clear search
-              </button>
+              </Button>
             </div>
           ) : (
             /* Results */
@@ -923,12 +899,12 @@ export function SearchPanel(props: {
               {/* View more */}
               {totalResults > 5 && (
                 <div className="p-2 text-center border-t border-[var(--color-separator)] mt-2">
-                  <button
-                    type="button"
-                    className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-info)] transition-colors py-2 w-full"
+                  <Button
+                    variant="ghost"
+                    className="!text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-info)] !py-2 w-full !h-auto"
                   >
                     View {totalResults - 5} more results
-                  </button>
+                  </Button>
                 </div>
               )}
             </>

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -84,7 +84,7 @@ function HighlightText(props: { text: string; query: string }): JSX.Element {
         regex.test(part) ? (
           <span
             key={index}
-            className="bg-[rgba(59,130,246,0.2)] text-[#60a5fa] rounded-sm px-0.5"
+            className="bg-[var(--color-info-subtle)] text-[var(--color-info)] rounded-sm px-0.5"
           >
             {part}
           </span>
@@ -108,10 +108,10 @@ function CategoryButton(props: {
     <button
       type="button"
       onClick={props.onClick}
-      className={`px-3 py-1 text-xs font-medium rounded-full transition-all whitespace-nowrap ${
+      className={`px-3 py-1 text-xs font-medium rounded-full transition-colors whitespace-nowrap ${
         props.active
-          ? "bg-[#3b82f6] text-white shadow-lg shadow-[rgba(59,130,246,0.2)]"
-          : "bg-[rgba(255,255,255,0.05)] text-[#888888] border border-transparent hover:border-[rgba(255,255,255,0.1)] hover:text-white hover:bg-[rgba(255,255,255,0.1)]"
+          ? "bg-[var(--color-info)] text-white shadow-lg shadow-[var(--color-info-subtle)]"
+          : "bg-[var(--color-separator)] text-[var(--color-fg-muted)] border border-transparent hover:border-white/10 hover:text-white hover:bg-white/10"
       }`}
     >
       {props.label}
@@ -141,9 +141,9 @@ function ToggleSwitch(props: {
           onChange={(e) => props.onChange(e.target.checked)}
           className="peer absolute block w-3 h-3 rounded-full bg-white appearance-none cursor-pointer top-0.5 left-0.5 checked:translate-x-3 transition-transform duration-200"
         />
-        <div className="block overflow-hidden h-4 rounded-full bg-[rgba(255,255,255,0.1)] peer-checked:bg-[#3b82f6] transition-colors duration-200" />
+        <div className="block overflow-hidden h-4 rounded-full bg-white/10 peer-checked:bg-[var(--color-info)] transition-colors duration-200" />
       </div>
-      <span className="text-xs text-[#888888] group-hover:text-white transition-colors">
+      <span className="text-xs text-[var(--color-fg-muted)] group-hover:text-white transition-colors">
         {props.label}
       </span>
     </label>
@@ -167,23 +167,23 @@ function DocumentResultItem(props: {
       type="button"
       onClick={onClick}
       data-testid={`search-result-item-${item.documentId ?? item.id}`}
-      className={`group w-full text-left mx-2 p-2 rounded-lg flex items-start gap-3 transition-all relative overflow-hidden ${
+      className={`group w-full text-left mx-2 p-2 rounded-lg flex items-start gap-3 transition-colors relative overflow-hidden ${
         isActive
-          ? "bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.05)]"
-          : "border border-transparent hover:bg-[rgba(255,255,255,0.05)] hover:border-[rgba(255,255,255,0.05)]"
-      } ${isFlashing ? "ring-1 ring-[#3b82f6] animate-pulse" : ""}`}
+          ? "bg-[var(--color-separator)] border border-[var(--color-separator)]"
+          : "border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)]"
+      } ${isFlashing ? "ring-1 ring-[var(--color-info)] animate-pulse" : ""}`}
     >
       {/* Active indicator bar */}
       {isActive && (
-        <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-[#3b82f6]" />
+        <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-[var(--color-info)]" />
       )}
 
       {/* Icon */}
       <div
-        className={`mt-1 w-8 h-8 rounded flex items-center justify-center border border-[rgba(255,255,255,0.05)] shrink-0 transition-colors ${
+        className={`mt-1 w-8 h-8 rounded flex items-center justify-center border border-[var(--color-separator)] shrink-0 transition-colors ${
           isActive
-            ? "bg-[rgba(255,255,255,0.05)] text-white"
-            : "bg-[rgba(255,255,255,0.05)] text-[#888888] group-hover:text-white"
+            ? "bg-[var(--color-separator)] text-white"
+            : "bg-[var(--color-separator)] text-[var(--color-fg-muted)] group-hover:text-white"
         }`}
       >
         <svg
@@ -206,13 +206,13 @@ function DocumentResultItem(props: {
         <div className="flex items-center justify-between gap-2 mb-0.5">
           <h4
             className={`text-sm font-medium truncate transition-colors ${
-              isActive ? "text-white" : "text-[#888888] group-hover:text-white"
+              isActive ? "text-white" : "text-[var(--color-fg-muted)] group-hover:text-white"
             }`}
           >
             <HighlightText text={item.title} query={query} />
           </h4>
           {item.matchScore && (
-            <span className="text-[10px] font-mono text-[#3b82f6] bg-[rgba(59,130,246,0.1)] px-1.5 py-0.5 rounded border border-[rgba(59,130,246,0.2)] shrink-0">
+            <span className="text-[10px] font-mono text-[var(--color-info)] bg-[var(--color-info-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-info-subtle)] shrink-0">
               {item.matchScore}% match
             </span>
           )}
@@ -220,8 +220,8 @@ function DocumentResultItem(props: {
         <p
           className={`text-xs leading-relaxed transition-colors ${
             isActive
-              ? "text-[#888888] line-clamp-2"
-              : "text-[#444444] group-hover:text-[#888888] line-clamp-1"
+              ? "text-[var(--color-fg-muted)] line-clamp-2"
+              : "text-[var(--color-fg-placeholder)] group-hover:text-[var(--color-fg-muted)] line-clamp-1"
           }`}
         >
           <HighlightText text={item.snippet || ""} query={query} />
@@ -229,7 +229,7 @@ function DocumentResultItem(props: {
         {item.path && (
           <div className="flex items-center gap-2 mt-2">
             <svg
-              className="w-3 h-3 text-[#444444]"
+              className="w-3 h-3 text-[var(--color-fg-placeholder)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -241,11 +241,11 @@ function DocumentResultItem(props: {
                 d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"
               />
             </svg>
-            <span className="text-[10px] text-[#444444]">{item.path}</span>
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.path}</span>
             {item.editedTime && (
               <>
-                <span className="text-[10px] text-[#444444] mx-1">•</span>
-                <span className="text-[10px] text-[#444444]">
+                <span className="text-[10px] text-[var(--color-fg-placeholder)] mx-1">•</span>
+                <span className="text-[10px] text-[var(--color-fg-placeholder)]">
                   {item.editedTime}
                 </span>
               </>
@@ -257,7 +257,7 @@ function DocumentResultItem(props: {
       {/* Hover arrow */}
       <div className="hidden group-hover:flex items-center self-center pr-2">
         <svg
-          className="w-4 h-4 text-[#888888]"
+          className="w-4 h-4 text-[var(--color-fg-muted)]"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -288,10 +288,10 @@ function MemoryResultItem(props: {
     <button
       type="button"
       onClick={onClick}
-      className="group w-full text-left mx-2 mt-1 p-2 rounded-lg border border-transparent hover:bg-[rgba(255,255,255,0.05)] hover:border-[rgba(255,255,255,0.05)] flex items-start gap-3 transition-all"
+      className="group w-full text-left mx-2 mt-1 p-2 rounded-lg border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)] flex items-start gap-3 transition-colors"
     >
       {/* Icon */}
-      <div className="mt-1 w-8 h-8 rounded flex items-center justify-center text-[#888888] group-hover:text-white border border-[rgba(255,255,255,0.05)] shrink-0 transition-colors">
+      <div className="mt-1 w-8 h-8 rounded flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
         <svg
           className="w-4 h-4"
           fill="none"
@@ -310,20 +310,20 @@ function MemoryResultItem(props: {
       {/* Content */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-2 mb-0.5">
-          <h4 className="text-sm font-medium text-[#888888] group-hover:text-white transition-colors truncate">
+          <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-white transition-colors truncate">
             <HighlightText text={item.title} query={query} />
           </h4>
-          <span className="text-[10px] font-mono text-[rgba(16,185,129,0.7)] bg-[rgba(16,185,129,0.1)] px-1.5 py-0.5 rounded border border-[rgba(16,185,129,0.1)] opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          <span className="text-[10px] font-mono text-[var(--color-success)] bg-[var(--color-success-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-success-subtle)] opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
             High Relevance
           </span>
         </div>
-        <p className="text-xs text-[#444444] group-hover:text-[#888888] transition-colors leading-relaxed line-clamp-1">
+        <p className="text-xs text-[var(--color-fg-placeholder)] group-hover:text-[var(--color-fg-muted)] transition-colors leading-relaxed line-clamp-1">
           <HighlightText text={item.snippet || ""} query={query} />
         </p>
         {item.meta && (
           <div className="flex items-center gap-2 mt-2">
             <svg
-              className="w-3 h-3 text-[#444444]"
+              className="w-3 h-3 text-[var(--color-fg-placeholder)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -335,7 +335,7 @@ function MemoryResultItem(props: {
                 d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z"
               />
             </svg>
-            <span className="text-[10px] text-[#444444]">{item.meta}</span>
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.meta}</span>
           </div>
         )}
       </div>
@@ -357,10 +357,10 @@ function KnowledgeResultItem(props: {
     <button
       type="button"
       onClick={onClick}
-      className="group w-full text-left mx-2 p-2 rounded-lg border border-transparent hover:bg-[rgba(255,255,255,0.05)] hover:border-[rgba(255,255,255,0.05)] flex items-start gap-3 transition-all"
+      className="group w-full text-left mx-2 p-2 rounded-lg border border-transparent hover:bg-[var(--color-separator)] hover:border-[var(--color-separator)] flex items-start gap-3 transition-colors"
     >
       {/* Icon */}
-      <div className="mt-1 w-8 h-8 rounded bg-[rgba(255,255,255,0.05)] flex items-center justify-center text-[#888888] group-hover:text-white border border-[rgba(255,255,255,0.05)] shrink-0 transition-colors">
+      <div className="mt-1 w-8 h-8 rounded bg-[var(--color-separator)] flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
         <svg
           className="w-4 h-4"
           fill="none"
@@ -378,15 +378,15 @@ function KnowledgeResultItem(props: {
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <h4 className="text-sm font-medium text-[#888888] group-hover:text-white transition-colors truncate mb-1">
+        <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-white transition-colors truncate mb-1">
           <HighlightText text={item.title} query={query} />
         </h4>
         {item.meta && (
           <div className="flex items-center gap-2">
-            <span className="text-[10px] text-[#444444] border border-[rgba(255,255,255,0.05)] px-1.5 py-0.5 rounded">
+            <span className="text-[10px] text-[var(--color-fg-placeholder)] border border-[var(--color-separator)] px-1.5 py-0.5 rounded">
               Entity
             </span>
-            <span className="text-[10px] text-[#444444]">{item.meta}</span>
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.meta}</span>
           </div>
         )}
       </div>
@@ -405,13 +405,13 @@ function ResultGroup(props: {
 }): JSX.Element {
   return (
     <div
-      className={`py-2 ${props.hasBorderTop ? "border-t border-[rgba(255,255,255,0.04)]" : ""}`}
+      className={`py-2 ${props.hasBorderTop ? "border-t border-[var(--color-separator)]" : ""}`}
     >
       <div className="px-4 py-1.5 flex items-center justify-between">
-        <span className="text-[10px] font-semibold text-[#444444] uppercase tracking-widest">
+        <span className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-widest">
           {props.title}
         </span>
-        <span className="text-[10px] font-mono text-[#444444]">
+        <span className="text-[10px] font-mono text-[var(--color-fg-placeholder)]">
           {props.count} {props.count === 1 ? "match" : "matches"}
         </span>
       </div>
@@ -430,10 +430,10 @@ function KeyHint(props: {
 }): JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-[rgba(255,255,255,0.1)] border border-[rgba(255,255,255,0.05)] text-[10px] text-[#888888] font-mono">
+      <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-white/10 border border-[var(--color-separator)] text-[10px] text-[var(--color-fg-muted)] font-mono">
         {props.icon || props.text}
       </span>
-      <span className="text-[10px] text-[#444444] ml-1">{props.label}</span>
+      <span className="text-[10px] text-[var(--color-fg-placeholder)] ml-1">{props.label}</span>
     </div>
   );
 }
@@ -592,24 +592,16 @@ export function SearchPanel(props: {
 
       {/* Glass Panel Modal */}
       <div
-        className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-50"
-        style={{
-          background: "#0f0f0f",
-          border: "1px solid rgba(255, 255, 255, 0.06)",
-          boxShadow:
-            "0 24px 48px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.02) inset",
-          animation: "slideDown 0.3s ease-out",
-        }}
+        className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-50 bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] animate-[slideDown_0.3s_ease-out]"
       >
         {/* Header */}
         <div
-          className="flex flex-col border-b border-[rgba(255,255,255,0.06)]"
-          style={{ background: "#0f0f0f" }}
+          className="flex flex-col border-b border-[var(--color-separator)] bg-[var(--color-bg-surface)]"
         >
           {/* Search input row */}
           <div className="flex items-center px-4 py-4 gap-3">
             <svg
-              className="w-5 h-5 text-[#888888]"
+              className="w-5 h-5 text-[var(--color-fg-muted)]"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -629,15 +621,14 @@ export function SearchPanel(props: {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleInputKeyDown}
               placeholder="Search documents, memories, knowledge..."
-              className="flex-1 bg-transparent border-none outline-none text-lg text-white placeholder-[#444444] font-light h-8"
-              style={{ fontFamily: "var(--font-family-ui)" }}
+              className="flex-1 bg-transparent border-none outline-none text-lg text-white placeholder-[var(--color-fg-placeholder)] font-[var(--font-family-ui)] font-light h-8"
             />
             {effectiveStatus === "loading" && <Spinner size="sm" />}
             {onClose && (
               <button
                 type="button"
                 onClick={onClose}
-                className="p-1 rounded-md text-[#444444] hover:text-white hover:bg-[rgba(255,255,255,0.05)] transition-colors"
+                className="p-1 rounded-md text-[var(--color-fg-placeholder)] hover:text-white hover:bg-[var(--color-separator)] transition-colors"
               >
                 <svg
                   className="w-5 h-5"
@@ -687,8 +678,7 @@ export function SearchPanel(props: {
 
           {/* Filter options bar */}
           <div
-            className="px-4 py-3 border-t border-[rgba(255,255,255,0.06)] flex items-center justify-between"
-            style={{ background: "#121212" }}
+            className="px-4 py-3 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-raised)]"
           >
             <div className="flex items-center gap-6">
               <ToggleSwitch
@@ -706,12 +696,12 @@ export function SearchPanel(props: {
             </div>
 
             <div className="flex items-center gap-2">
-              <span className="text-[10px] text-[#444444] uppercase tracking-wider font-medium">
+              <span className="text-[10px] text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
                 Scope
               </span>
               <button
                 type="button"
-                className="flex items-center gap-1.5 px-2 py-1 rounded bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.05)] text-xs text-[#888888] hover:text-white hover:border-[rgba(255,255,255,0.1)] transition-all"
+                className="flex items-center gap-1.5 px-2 py-1 rounded bg-[var(--color-separator)] border border-[var(--color-separator)] text-xs text-[var(--color-fg-muted)] hover:text-white hover:border-white/10 transition-colors"
               >
                 <span>Current Project</span>
                 <svg
@@ -734,14 +724,13 @@ export function SearchPanel(props: {
 
         {/* Results container */}
         <div
-          className="flex-1 overflow-y-auto"
-          style={{ background: "#0f0f0f" }}
+          className="flex-1 overflow-y-auto bg-[var(--color-bg-surface)]"
         >
           {!hasQuery && !hasResults ? (
             /* Empty state - no query */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <svg
-                className="w-16 h-16 text-[#444444] mb-4"
+                className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -753,7 +742,7 @@ export function SearchPanel(props: {
                   d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
                 />
               </svg>
-              <p className="text-sm text-[#888888] text-center">
+              <p className="text-sm text-[var(--color-fg-muted)] text-center">
                 Enter a search term to find documents
               </p>
             </div>
@@ -761,7 +750,7 @@ export function SearchPanel(props: {
             /* Reindex rebuilding state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <svg
-                className="w-16 h-16 text-[#3b82f6] mb-4 animate-pulse"
+                className="w-16 h-16 text-[var(--color-info)] mb-4 animate-pulse"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -776,7 +765,7 @@ export function SearchPanel(props: {
               <p className="text-sm font-medium text-white text-center mb-2">
                 正在重建索引，请稍后重试
               </p>
-              <p className="text-xs text-[#888888] text-center">
+              <p className="text-xs text-[var(--color-fg-muted)] text-center">
                 查询词：&ldquo;{effectiveQuery}&rdquo;
               </p>
             </div>
@@ -784,7 +773,7 @@ export function SearchPanel(props: {
             /* Search error state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <svg
-                className="w-16 h-16 text-[#ef4444] mb-4"
+                className="w-16 h-16 text-[var(--color-error)] mb-4"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -799,13 +788,13 @@ export function SearchPanel(props: {
               <p className="text-sm font-medium text-white text-center mb-2">
                 搜索失败，请重试
               </p>
-              <p className="text-xs text-[#888888] text-center">
+              <p className="text-xs text-[var(--color-fg-muted)] text-center">
                 {lastError.message}
               </p>
               <button
                 type="button"
                 onClick={handleRetrySearch}
-                className="mt-6 px-4 py-2 bg-[#3b82f6] text-white text-sm font-medium rounded-lg hover:bg-[#2563eb] transition-colors"
+                className="mt-6 px-4 py-2 bg-[var(--color-info)] text-white text-sm font-medium rounded-lg hover:bg-[var(--color-info)] hover:brightness-110 transition-colors"
               >
                 重试搜索
               </button>
@@ -814,7 +803,7 @@ export function SearchPanel(props: {
             /* No results state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <svg
-                className="w-16 h-16 text-[#444444] mb-4"
+                className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -829,20 +818,20 @@ export function SearchPanel(props: {
               <p className="text-sm font-medium text-white text-center mb-2">
                 未找到匹配结果
               </p>
-              <p className="text-xs text-[#888888] text-center">
+              <p className="text-xs text-[var(--color-fg-muted)] text-center">
                 查询词：&ldquo;{effectiveQuery}&rdquo;
               </p>
-              <div className="mt-6 p-4 bg-[rgba(255,255,255,0.03)] rounded-lg border border-[rgba(255,255,255,0.06)]">
-                <p className="text-[10px] text-[#444444] font-medium uppercase tracking-wider mb-2">
+              <div className="mt-6 p-4 bg-[var(--color-separator)] rounded-lg border border-[var(--color-separator)]">
+                <p className="text-[10px] text-[var(--color-fg-placeholder)] font-medium uppercase tracking-wider mb-2">
                   建议
                 </p>
-                <p className="text-xs text-[#888888]">
+                <p className="text-xs text-[var(--color-fg-muted)]">
                   建议检查拼写或使用不同关键词
                 </p>
               </div>
               <button
                 type="button"
-                className="mt-6 px-4 py-2 bg-[#3b82f6] text-white text-sm font-medium rounded-lg hover:bg-[#2563eb] transition-colors flex items-center gap-2"
+                className="mt-6 px-4 py-2 bg-[var(--color-info)] text-white text-sm font-medium rounded-lg hover:bg-[var(--color-info)] hover:brightness-110 transition-colors flex items-center gap-2"
               >
                 <svg
                   className="w-4 h-4"
@@ -862,7 +851,7 @@ export function SearchPanel(props: {
               <button
                 type="button"
                 onClick={() => setQuery("")}
-                className="mt-3 text-xs text-[#888888] hover:text-white transition-colors"
+                className="mt-3 text-xs text-[var(--color-fg-muted)] hover:text-white transition-colors"
               >
                 Clear search
               </button>
@@ -933,10 +922,10 @@ export function SearchPanel(props: {
 
               {/* View more */}
               {totalResults > 5 && (
-                <div className="p-2 text-center border-t border-[rgba(255,255,255,0.04)] mt-2">
+                <div className="p-2 text-center border-t border-[var(--color-separator)] mt-2">
                   <button
                     type="button"
-                    className="text-xs text-[#888888] hover:text-[#3b82f6] transition-colors py-2 w-full"
+                    className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-info)] transition-colors py-2 w-full"
                   >
                     View {totalResults - 5} more results
                   </button>
@@ -948,17 +937,16 @@ export function SearchPanel(props: {
 
         {/* Footer */}
         <div
-          className="border-t border-[rgba(255,255,255,0.06)] px-4 py-3 flex items-center justify-between shrink-0"
-          style={{ background: "#121212" }}
+          className="border-t border-[var(--color-separator)] px-4 py-3 flex items-center justify-between shrink-0 bg-[var(--color-bg-raised)]"
         >
           <div className="flex items-center gap-4">
             {hasResults && (
               <>
-                <span className="text-xs text-[#888888] font-medium">
+                <span className="text-xs text-[var(--color-fg-muted)] font-medium">
                   {totalResults} {totalResults === 1 ? "result" : "results"}
                 </span>
-                <div className="h-3 w-px bg-[rgba(255,255,255,0.1)]" />
-                <span className="text-[10px] text-[#444444]">
+                <div className="h-3 w-px bg-white/10" />
+                <span className="text-[10px] text-[var(--color-fg-placeholder)]">
                   Search took 0.04s
                 </span>
               </>

--- a/openspec/_ops/reviews/ISSUE-895.md
+++ b/openspec/_ops/reviews/ISSUE-895.md
@@ -1,0 +1,31 @@
+# ISSUE-895 Independent Review
+
+更新时间：2026-03-02 12:47
+
+- Issue: #895
+- PR: https://github.com/Leeky1017/CreoNow/pull/898
+- Author-Agent: codex
+- Reviewer-Agent: claude
+- Reviewed-HEAD-SHA: 4a4f8dc15ef1ef0d4dcc192228c93374285dc623
+- Decision: PASS
+
+## Scope
+
+- `apps/desktop/renderer/src/features/search/SearchPanel.tsx`：确认原生 `<button>/<input>` 已替换为 Design System Primitives，动画均加 `motion-safe:` 前缀。
+- `apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts`：确认 S2/S3b guard 覆盖审计阻断项并保持稳定。
+- `apps/desktop/renderer/src/features/search/SearchPanel.test.tsx`：确认交互测试与 Button primitive 渲染结构一致。
+- `openspec/_ops/task_runs/ISSUE-895.md`：核对 RUN_LOG 必填字段与 Main Session Audit 结构。
+
+## Findings
+
+- 严重问题：无。
+- 中等级问题：无。
+- 低风险问题：无。
+- 结论：此前阻断项（S2/S3b）修复完成且回放通过，当前审计结论为 PASS。
+
+## Verification
+
+- `pnpm -C apps/desktop typecheck`：通过。
+- `pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard`：通过（`1 file / 6 tests`）。
+- `pnpm -C apps/desktop test:run`：通过（`214 files / 1633 tests`）。
+- `gh pr view 898 --json headRefOid,statusCheckRollup`：确认代码检查已通过，剩余门禁聚焦治理收口。

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -9,7 +9,7 @@
 | Issue | #895 |
 | Branch | `task/895-searchpanel-tokenized-rewrite` |
 | Change | `fe-searchpanel-tokenized-rewrite` |
-| PR | 待回填 |
+| PR | https://github.com/Leeky1017/CreoNow/pull/898 |
 
 ## Dependency Sync Check
 

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -1,6 +1,6 @@
 # RUN_LOG: ISSUE-895 — SearchPanel tokenized rewrite
 
-更新时间：2026-03-02 11:20
+更新时间：2026-03-02 12:15
 
 ## Meta
 
@@ -19,7 +19,7 @@
 
 ## Runs
 
-### Red 阶段
+### Red 阶段（S1/S1b/S3）
 
 ```
 pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
@@ -31,7 +31,7 @@ pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
    × does not use transition-all (WB-FE-SRCH-S3)              — 5 处 transition-all
 ```
 
-### Green 阶段
+### Green 阶段（S1/S1b/S3）
 
 ```
 pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
@@ -43,13 +43,43 @@ pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
    ✓ does not use transition-all (WB-FE-SRCH-S3)
 ```
 
+### Red 阶段（S2/S3b）— 审计后补充
+
+```
+pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
+
+ FAIL  SearchPanel.token-guard.test.ts (6 tests | 2 failed)
+   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
+   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
+   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
+   ✓ does not use transition-all (WB-FE-SRCH-S3)
+   × does not contain native <button or <input elements (WB-FE-SRCH-S2)
+     — 11 处 native <button>/<input>
+   × gates animations with motion-safe modifier (WB-FE-SRCH-S3b)
+     — 3 处未加 motion-safe: 前缀的 animate-*
+```
+
+### Green 阶段（S2/S3b）— 审计后补充
+
+```
+pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
+
+ ✓ SearchPanel.token-guard.test.ts (6 tests) 5ms
+   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
+   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
+   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
+   ✓ does not use transition-all (WB-FE-SRCH-S3)
+   ✓ does not contain native <button or <input elements (WB-FE-SRCH-S2)
+   ✓ gates animations with motion-safe modifier (WB-FE-SRCH-S3b)
+```
+
 ### 全量回归
 
 ```
 pnpm -C apps/desktop test:run
 
  Test Files  214 passed (214)
-      Tests  1631 passed (1631)
+      Tests  1633 passed (1633)
 ```
 
 ### Typecheck
@@ -64,10 +94,18 @@ pnpm -C apps/desktop typecheck
 
 | 文件 | 操作 |
 |------|------|
-| `apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts` | 新建 — 4 个 guard 测试 |
-| `apps/desktop/renderer/src/features/search/SearchPanel.tsx` | 修改 — 70 处 token 替换 |
-| `apps/desktop/renderer/src/features/search/SearchPanel.test.tsx` | 修改 — 1 处断言更新 |
+| `apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts` | 修改 — 6 个 guard 测试（+2 S2/S3b） |
+| `apps/desktop/renderer/src/features/search/SearchPanel.tsx` | 修改 — token 替换 + 原生元素 → Primitives + motion-safe |
+| `apps/desktop/renderer/src/features/search/SearchPanel.test.tsx` | 修改 — 适配 Button primitive 内 span 包装 |
 
 ## Main Session Audit
 
-待独立审计完成后补充。
+| 字段 | 值 |
+|------|-----|
+| Audit-Owner | 待独立审计员指派 |
+| Reviewed-HEAD-SHA | 待 push 后更新 |
+| Spec-Compliance | S1 ✅ S1b ✅ S2 ✅ S3 ✅ S3b ✅ |
+| Code-Quality | Typecheck ✅ · 全量回归 214/214 ✅ |
+| Fresh-Verification | 审计后补充 S2/S3b 完成，全量回归已通过 |
+| Blocking-Issues | 无 |
+| Decision | 待审计员决定 |

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -1,0 +1,73 @@
+# RUN_LOG: ISSUE-895 — SearchPanel tokenized rewrite
+
+更新时间：2026-03-02 11:20
+
+## Meta
+
+| 字段 | 值 |
+|------|-----|
+| Issue | #895 |
+| Branch | `task/895-searchpanel-tokenized-rewrite` |
+| Change | `fe-searchpanel-tokenized-rewrite` |
+| PR | 待回填 |
+
+## Dependency Sync Check
+
+- `fe-hotfix-searchpanel-backdrop-close`：已归档（PR #798），关闭语义稳定 ✅
+- `fe-composites-p0-panel-and-command-items`：已归档，PanelContainer/CommandItem 可用 ✅
+- 结论：无漂移
+
+## Runs
+
+### Red 阶段
+
+```
+pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
+
+ FAIL  SearchPanel.token-guard.test.ts (4 tests | 4 failed)
+   × does not contain raw hex color values (WB-FE-SRCH-S1)    — 56 violations
+   × does not contain raw rgba values (WB-FE-SRCH-S1)         — 多处 rgba()
+   × does not contain inline style attributes (WB-FE-SRCH-S1b) — 6 个 style={{}}
+   × does not use transition-all (WB-FE-SRCH-S3)              — 5 处 transition-all
+```
+
+### Green 阶段
+
+```
+pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
+
+ ✓ SearchPanel.token-guard.test.ts (4 tests) 4ms
+   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
+   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
+   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
+   ✓ does not use transition-all (WB-FE-SRCH-S3)
+```
+
+### 全量回归
+
+```
+pnpm -C apps/desktop test:run
+
+ Test Files  214 passed (214)
+      Tests  1631 passed (1631)
+```
+
+### Typecheck
+
+```
+pnpm -C apps/desktop typecheck
+> tsc -p tsconfig.json --noEmit
+(exit 0)
+```
+
+## 变更文件
+
+| 文件 | 操作 |
+|------|------|
+| `apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts` | 新建 — 4 个 guard 测试 |
+| `apps/desktop/renderer/src/features/search/SearchPanel.tsx` | 修改 — 70 处 token 替换 |
+| `apps/desktop/renderer/src/features/search/SearchPanel.test.tsx` | 修改 — 1 处断言更新 |
+
+## Main Session Audit
+
+待独立审计完成后补充。

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -103,7 +103,7 @@ pnpm -C apps/desktop typecheck
 | 字段 | 值 |
 |------|-----|
 | Audit-Owner | 待独立审计员指派 |
-| Reviewed-HEAD-SHA | 待 push 后更新 |
+| Reviewed-HEAD-SHA | `a7c84453` |
 | Spec-Compliance | S1 ✅ S1b ✅ S2 ✅ S3 ✅ S3b ✅ |
 | Code-Quality | Typecheck ✅ · 全量回归 214/214 ✅ |
 | Fresh-Verification | 审计后补充 S2/S3b 完成，全量回归已通过 |

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -34,7 +34,7 @@
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: <to-be-filled by signing commit head^>
+- Reviewed-HEAD-SHA: 5ae373b93e82e7e4760eccd1ea57fd2b70a3b1c8
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-895.md
+++ b/openspec/_ops/task_runs/ISSUE-895.md
@@ -1,111 +1,42 @@
-# RUN_LOG: ISSUE-895 — SearchPanel tokenized rewrite
+# ISSUE-895
+- Issue: #895
+- Branch: task/895-searchpanel-tokenized-rewrite
+- PR: https://github.com/Leeky1017/CreoNow/pull/898
 
-更新时间：2026-03-02 12:15
-
-## Meta
-
-| 字段 | 值 |
-|------|-----|
-| Issue | #895 |
-| Branch | `task/895-searchpanel-tokenized-rewrite` |
-| Change | `fe-searchpanel-tokenized-rewrite` |
-| PR | https://github.com/Leeky1017/CreoNow/pull/898 |
-
-## Dependency Sync Check
-
-- `fe-hotfix-searchpanel-backdrop-close`：已归档（PR #798），关闭语义稳定 ✅
-- `fe-composites-p0-panel-and-command-items`：已归档，PanelContainer/CommandItem 可用 ✅
-- 结论：无漂移
+## Plan
+- 收口独立审计阻塞项：补齐 S2/S3b 测试与实现证据，并完成治理签字链。
+- 保持功能改动不回退，聚焦门禁通过（openspec-log-guard / ci / merge-serial）。
+- 通过后进入 auto-merge，串行合并回 main。
 
 ## Runs
 
-### Red 阶段（S1/S1b/S3）
+### 2026-03-02 12:10 功能阻塞修复（S2/S3b）
+- Command: `pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard`
+- Key output: `6 passed (6)`，新增并通过 `WB-FE-SRCH-S2` 与 `WB-FE-SRCH-S3b` guard。
+- Command: `pnpm -C apps/desktop typecheck`
+- Key output: `exit 0`。
+- Command: `pnpm -C apps/desktop test:run`
+- Key output: `Test Files 214 passed (214)`，`Tests 1633 passed (1633)`。
 
-```
-pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
+### 2026-03-02 12:42 独立复核回放
+- Command: `pnpm -C apps/desktop typecheck`
+- Key output: `exit 0`。
+- Command: `pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard`
+- Key output: `Test Files 1 passed (1)`，`Tests 6 passed (6)`。
+- Command: `pnpm -C apps/desktop test:run`
+- Key output: `Test Files 214 passed (214)`，`Tests 1633 passed (1633)`。
 
- FAIL  SearchPanel.token-guard.test.ts (4 tests | 4 failed)
-   × does not contain raw hex color values (WB-FE-SRCH-S1)    — 56 violations
-   × does not contain raw rgba values (WB-FE-SRCH-S1)         — 多处 rgba()
-   × does not contain inline style attributes (WB-FE-SRCH-S1b) — 6 个 style={{}}
-   × does not use transition-all (WB-FE-SRCH-S3)              — 5 处 transition-all
-```
-
-### Green 阶段（S1/S1b/S3）
-
-```
-pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
-
- ✓ SearchPanel.token-guard.test.ts (4 tests) 4ms
-   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
-   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
-   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
-   ✓ does not use transition-all (WB-FE-SRCH-S3)
-```
-
-### Red 阶段（S2/S3b）— 审计后补充
-
-```
-pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
-
- FAIL  SearchPanel.token-guard.test.ts (6 tests | 2 failed)
-   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
-   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
-   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
-   ✓ does not use transition-all (WB-FE-SRCH-S3)
-   × does not contain native <button or <input elements (WB-FE-SRCH-S2)
-     — 11 处 native <button>/<input>
-   × gates animations with motion-safe modifier (WB-FE-SRCH-S3b)
-     — 3 处未加 motion-safe: 前缀的 animate-*
-```
-
-### Green 阶段（S2/S3b）— 审计后补充
-
-```
-pnpm -C apps/desktop test:run features/search/SearchPanel.token-guard
-
- ✓ SearchPanel.token-guard.test.ts (6 tests) 5ms
-   ✓ does not contain raw hex color values (WB-FE-SRCH-S1)
-   ✓ does not contain raw rgba values (WB-FE-SRCH-S1)
-   ✓ does not contain inline style attributes (WB-FE-SRCH-S1b)
-   ✓ does not use transition-all (WB-FE-SRCH-S3)
-   ✓ does not contain native <button or <input elements (WB-FE-SRCH-S2)
-   ✓ gates animations with motion-safe modifier (WB-FE-SRCH-S3b)
-```
-
-### 全量回归
-
-```
-pnpm -C apps/desktop test:run
-
- Test Files  214 passed (214)
-      Tests  1633 passed (1633)
-```
-
-### Typecheck
-
-```
-pnpm -C apps/desktop typecheck
-> tsc -p tsconfig.json --noEmit
-(exit 0)
-```
-
-## 变更文件
-
-| 文件 | 操作 |
-|------|------|
-| `apps/desktop/renderer/src/features/search/SearchPanel.token-guard.test.ts` | 修改 — 6 个 guard 测试（+2 S2/S3b） |
-| `apps/desktop/renderer/src/features/search/SearchPanel.tsx` | 修改 — token 替换 + 原生元素 → Primitives + motion-safe |
-| `apps/desktop/renderer/src/features/search/SearchPanel.test.tsx` | 修改 — 适配 Button primitive 内 span 包装 |
+### 2026-03-02 12:45 治理签字链准备
+- Command: `scripts/independent_review_record.sh --issue 895 --author codex --reviewer claude --pr-url https://github.com/Leeky1017/CreoNow/pull/898`
+- Key output: 生成 `openspec/_ops/reviews/ISSUE-895.md`。
+- Command: `scripts/main_audit_resign.sh --issue 895 --preflight-mode fast`
+- Key output: 生成 RUN_LOG-only 签字提交并执行 fast preflight。
 
 ## Main Session Audit
-
-| 字段 | 值 |
-|------|-----|
-| Audit-Owner | 待独立审计员指派 |
-| Reviewed-HEAD-SHA | `a7c84453` |
-| Spec-Compliance | S1 ✅ S1b ✅ S2 ✅ S3 ✅ S3b ✅ |
-| Code-Quality | Typecheck ✅ · 全量回归 214/214 ✅ |
-| Fresh-Verification | 审计后补充 S2/S3b 完成，全量回归已通过 |
-| Blocking-Issues | 无 |
-| Decision | 待审计员决定 |
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: <to-be-filled by signing commit head^>
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-02 10:47
+更新时间：2026-03-02 11:25
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
@@ -78,9 +78,9 @@
 
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
-| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | 待执行 |
-| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | 待执行 |
-| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | 待执行 |
+| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | PR #898 待审计 |
+| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | PR #899 待审计 |
+| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | PR #900 待审计 |
 | A | 3b-1 | `fe-lucide-icon-unification` | icon import 广撒网簇 | Wave 3a 完成后（分别与 searchpanel/zenmode/herocard 共享文件） | 待执行 |
 | B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 待执行 |
 | A | 3c-1 | `fe-feature-focus-visible-coverage` | AiPanel/SearchPanel/Dashboard + `main.css` + `tokens.css` 簇 | Wave 3b 完成后 | 待执行 |


### PR DESCRIPTION
## Summary

SearchPanel 全面回归设计系统 Token 体系：
- 移除 ~70 处 hex/rgba 硬编码 → CSS variables
- 移除 6 处 inline style → Tailwind + Token class
- 替换 5 处 transition-all → transition-colors
- 新增 4 条 guard 测试防止 token 逃逸回归

## Change
`openspec/changes/fe-searchpanel-tokenized-rewrite/`

## Verification
- typecheck: PASS
- 214 test files / 1631 tests: ALL PASS
- guard tests: 4/4 RED → GREEN

## Status
等待独立审计。不启用 auto-merge。

Closes #895