### PR TITLE
docs: fix EO wave3a closeout note drift (#903)

### DIFF
--- a/openspec/_ops/reviews/ISSUE-903.md
+++ b/openspec/_ops/reviews/ISSUE-903.md
@@ -1,0 +1,27 @@
+# ISSUE-903 Independent Review
+
+更新时间：2026-03-02 13:36
+
+- Issue: #903
+- PR: https://github.com/Leeky1017/CreoNow/pull/904
+- Author-Agent: codex
+- Reviewer-Agent: claude
+- Reviewed-HEAD-SHA: ef24238f533e9f28d3c6ef19d689a0475d438ba7
+- Decision: PASS
+
+## Scope
+
+- `openspec/changes/EXECUTION_ORDER.md`：确认第三批 Wave 3a 收口说明与已合并事实一致。
+- `openspec/_ops/task_runs/ISSUE-903.md`：确认 RUN_LOG 字段、Plan/Runs、Main Session Audit 结构完整。
+
+## Findings
+
+- 严重问题：无。
+- 中等级问题：无。
+- 低风险问题：无。
+- 结论：EO 说明漂移已修复，审计结论 PASS。
+
+## Verification
+
+- `rg -n "ISSUE-901|PR #902|ISSUE-833" openspec/changes/EXECUTION_ORDER.md`：通过（旧说明已替换）。
+- `gh pr view 904 --repo Leeky1017/CreoNow --json headRefOid,statusCheckRollup`：确认门禁重跑后可验证。

--- a/openspec/_ops/task_runs/ISSUE-903.md
+++ b/openspec/_ops/task_runs/ISSUE-903.md
@@ -1,0 +1,27 @@
+# ISSUE-903
+- Issue: #903
+- Branch: task/903-eo-wave3a-closeout-note-fix
+- PR: https://github.com/Leeky1017/CreoNow/pull/904
+
+## Plan
+- 修复 `openspec/changes/EXECUTION_ORDER.md` 的说明漂移，确保 Wave 3a 收口信息与已合并事实一致。
+- 通过审计链（RUN_LOG + independent review + main-session sign）满足 `openspec-log-guard`。
+
+## Runs
+
+### 2026-03-02 13:27 EO 文档修复
+- Command: `edit openspec/changes/EXECUTION_ORDER.md`
+- Key output: 更新时间刷新；将旧的 `ISSUE-833` 说明替换为 `ISSUE-901 / PR #902` 的真实收口记录。
+
+### 2026-03-02 13:27 核验
+- Command: `rg -n "ISSUE-901|PR #902|ISSUE-833" openspec/changes/EXECUTION_ORDER.md`
+- Key output: 已包含 `ISSUE-901` 与 `PR #902`，不再保留旧 `ISSUE-833` 说明。
+
+## Main Session Audit
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: <to-be-filled by signing commit head^>
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-903.md
+++ b/openspec/_ops/task_runs/ISSUE-903.md
@@ -19,7 +19,7 @@
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: <to-be-filled by signing commit head^>
+- Reviewed-HEAD-SHA: 67e2d4f381db70086a7ffd74393b6f8ec975dfff
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-02 13:12
+更新时间：2026-03-02 13:27
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
@@ -226,11 +226,11 @@
 - `fe-ui-open-folder-entrypoints`：已归档到 `openspec/changes/archive/fe-ui-open-folder-entrypoints`（merge commit `91e56f28`，PR #830）。
 - `fe-dashboard-welcome-merge-and-ghost-actions`：已归档到 `openspec/changes/archive/fe-dashboard-welcome-merge-and-ghost-actions`（merge commit `91e56f28`，PR #830）。
 
-## 依赖说明
+## 本次同步说明（ISSUE-901）
 
-- 当前子任务：`ISSUE-833`（归档 PR #830 对应 change 与治理同步）。
-- 依赖关系：`dashboard` 收尾依赖的 open-folder 链路已在 PR #830 合并，并完成三项 change 归档迁移。
-- 同步结论：第一批收尾与第二批 open-folder 链路均已“合并 + 归档”，执行顺序文档已与实际状态对齐。
+- 当前子任务：`ISSUE-901`（Wave 3a 三项归档与 EO 同步）。
+- 依赖关系：`PR #898`、`PR #899`、`PR #900` 已按串行顺序合并；closeout 由 `PR #902` 完成。
+- 同步结论：Wave 3a 三项已“合并 + 归档”，执行顺序文档已与实际状态对齐，后续可进入 Wave 3b。
 
 ## Owner 决策阻塞项
 


### PR DESCRIPTION
## Summary
- refresh EO timestamp
- replace stale closeout note (`ISSUE-833`) with actual Wave 3a closeout (`ISSUE-901`, `PR #902`)
- keep Wave 3a merged+archived status wording consistent

## Verification
- `rg -n "ISSUE-901|PR #902|ISSUE-833" openspec/changes/EXECUTION_ORDER.md`

Closes #903
