### PR TITLE
feat: add P2 composites EmptyState/ConfirmDialog/InfoBar (#926)

### DIFF
--- a/apps/desktop/renderer/src/components/composites/ConfirmDialog.test.tsx
+++ b/apps/desktop/renderer/src/components/composites/ConfirmDialog.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  const defaultProps = {
+    title: "Delete project?",
+    description: "This action cannot be undone.",
+    confirmLabel: "Delete",
+    cancelLabel: "Cancel",
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    open: true,
+  };
+
+  it("renders title and description when open", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText("Delete project?")).toBeInTheDocument();
+    expect(
+      screen.getByText("This action cannot be undone."),
+    ).toBeInTheDocument();
+  });
+
+  it("applies destructive style to confirm button", () => {
+    render(<ConfirmDialog {...defaultProps} destructive />);
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    expect(confirmBtn.className).toMatch(/destructive/i);
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("renders confirm button without destructive style by default", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    expect(confirmBtn.className).not.toMatch(/destructive/i);
+  });
+});

--- a/apps/desktop/renderer/src/components/composites/ConfirmDialog.tsx
+++ b/apps/desktop/renderer/src/components/composites/ConfirmDialog.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { Dialog } from "../primitives/Dialog";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ConfirmDialogProps {
+  /** Dialog title */
+  title: string;
+  /** Description text explaining the action */
+  description: string;
+  /** Label for the confirm button */
+  confirmLabel: string;
+  /** Label for the cancel button */
+  cancelLabel: string;
+  /** Whether the action is destructive (applies danger styling to confirm) */
+  destructive?: boolean;
+  /** Callback when the user confirms */
+  onConfirm: () => void;
+  /** Callback when the user cancels */
+  onCancel: () => void;
+  /** Controlled open state */
+  open: boolean;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const confirmBaseStyles = [
+  "px-4",
+  "py-2",
+  "text-sm",
+  "font-medium",
+  "rounded-[var(--radius-md)]",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+const confirmDefaultStyles = [
+  "bg-[var(--color-fg-default)]",
+  "text-[var(--color-fg-inverse)]",
+  "hover:bg-[var(--color-fg-muted)]",
+].join(" ");
+
+const confirmDestructiveStyles = [
+  "destructive",
+  "bg-[var(--color-error)]",
+  "text-[var(--color-fg-inverse)]",
+  "hover:bg-[var(--color-error)]/90",
+].join(" ");
+
+const cancelStyles = [
+  "px-4",
+  "py-2",
+  "text-sm",
+  "font-medium",
+  "rounded-[var(--radius-md)]",
+  "bg-transparent",
+  "text-[var(--color-fg-muted)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "hover:text-[var(--color-fg-default)]",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * ConfirmDialog — a reusable confirmation dialog composite.
+ *
+ * Built on top of the Dialog primitive, providing a standard
+ * confirmation pattern with:
+ * - Title and description
+ * - Confirm and Cancel buttons
+ * - Optional destructive styling (red confirm button)
+ *
+ * Used for delete confirmations, irreversible actions, etc.
+ *
+ * @example
+ * ```tsx
+ * <ConfirmDialog
+ *   open={showConfirm}
+ *   title="Delete project?"
+ *   description="This action cannot be undone."
+ *   confirmLabel="Delete"
+ *   cancelLabel="Cancel"
+ *   destructive
+ *   onConfirm={handleDelete}
+ *   onCancel={() => setShowConfirm(false)}
+ * />
+ * ```
+ */
+export function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  destructive = false,
+  onConfirm,
+  onCancel,
+  open,
+}: ConfirmDialogProps): JSX.Element {
+  const confirmClassName = destructive
+    ? `${confirmBaseStyles} ${confirmDestructiveStyles}`
+    : `${confirmBaseStyles} ${confirmDefaultStyles}`;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onCancel();
+        }
+      }}
+      title={title}
+      description={description}
+      closeOnEscape
+      closeOnOverlayClick
+      footer={
+        <>
+          <button
+            type="button"
+            className={cancelStyles}
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={confirmClassName}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    >
+      {/* Dialog body is empty — title + description cover the content */}
+      <span />
+    </Dialog>
+  );
+}

--- a/apps/desktop/renderer/src/components/composites/ConfirmDialog.tsx
+++ b/apps/desktop/renderer/src/components/composites/ConfirmDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Dialog } from "../primitives/Dialog";
 
 // =============================================================================

--- a/apps/desktop/renderer/src/components/composites/EmptyState.test.tsx
+++ b/apps/desktop/renderer/src/components/composites/EmptyState.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EmptyState } from "./EmptyState";
+
+describe("EmptyState", () => {
+  it("renders icon, title, and description", () => {
+    render(
+      <EmptyState
+        icon={<span data-testid="empty-icon">📁</span>}
+        title="No files"
+        description="Create a new file to get started"
+      />,
+    );
+    expect(screen.getByTestId("empty-icon")).toBeInTheDocument();
+    expect(screen.getByText("No files")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create a new file to get started"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders action button when provided", () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        title="No files"
+        action={<button onClick={onClick}>Create File</button>}
+      />,
+    );
+    const btn = screen.getByText("Create File");
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders without icon and description", () => {
+    render(<EmptyState title="Empty" />);
+    expect(screen.getByText("Empty")).toBeInTheDocument();
+  });
+
+  it("applies custom data-testid", () => {
+    render(<EmptyState title="Test" data-testid="custom-empty" />);
+    expect(screen.getByTestId("custom-empty")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/components/composites/EmptyState.tsx
+++ b/apps/desktop/renderer/src/components/composites/EmptyState.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface EmptyStateProps {
+  /** Optional icon displayed above the title */
+  icon?: React.ReactNode;
+  /** Main title text describing the empty state */
+  title: string;
+  /** Optional description providing additional context */
+  description?: string;
+  /** Optional action slot (typically a button) */
+  action?: React.ReactNode;
+  /** Additional CSS class for the outer container */
+  className?: string;
+  /** data-testid for testing */
+  "data-testid"?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const containerStyles = [
+  "flex",
+  "flex-col",
+  "items-center",
+  "justify-center",
+  "gap-3",
+  "p-6",
+  "text-center",
+].join(" ");
+
+const iconStyles = [
+  "text-[color:var(--color-fg-muted)]",
+  "[&>svg]:w-12",
+  "[&>svg]:h-12",
+].join(" ");
+
+const titleStyles = [
+  "text-sm",
+  "font-semibold",
+  "text-[color:var(--color-fg-default)]",
+].join(" ");
+
+const descriptionStyles = [
+  "text-xs",
+  "text-[color:var(--color-fg-muted)]",
+  "max-w-[240px]",
+  "leading-relaxed",
+].join(" ");
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * EmptyState — a reusable composite for displaying empty content states.
+ *
+ * Provides a consistent empty state layout with:
+ * - Icon (optional): muted color, 48px size
+ * - Title: semibold text
+ * - Description (optional): muted helper text
+ * - Action (optional): slot for a CTA button
+ *
+ * Used by FileTreePanel, CharacterCardList, and other panels to
+ * display a consistent "no content" message with optional actions.
+ *
+ * @example
+ * ```tsx
+ * <EmptyState
+ *   icon={<FolderOpen />}
+ *   title="暂无文件"
+ *   description="开始创建你的第一个文件"
+ *   action={<Button onClick={onCreate}>新建文件</Button>}
+ * />
+ * ```
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className = "",
+  "data-testid": testId,
+}: EmptyStateProps): JSX.Element {
+  return (
+    <div
+      data-testid={testId}
+      className={`${containerStyles} ${className}`}
+      role="status"
+    >
+      {icon && <div className={iconStyles}>{icon}</div>}
+      <h3 className={titleStyles}>{title}</h3>
+      {description && <p className={descriptionStyles}>{description}</p>}
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/components/composites/InfoBar.test.tsx
+++ b/apps/desktop/renderer/src/components/composites/InfoBar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InfoBar } from "./InfoBar";
+
+describe("InfoBar", () => {
+  it("renders message with correct variant style", () => {
+    render(
+      <InfoBar variant="warning" message="Disk space low" data-testid="infobar" />,
+    );
+    expect(screen.getByText("Disk space low")).toBeInTheDocument();
+    const bar = screen.getByTestId("infobar");
+    expect(bar.className).toMatch(/warning/i);
+  });
+
+  it("renders action slot when provided", () => {
+    const onClick = vi.fn();
+    render(
+      <InfoBar
+        variant="info"
+        message="Update available"
+        action={<button onClick={onClick}>Update</button>}
+        data-testid="infobar"
+      />,
+    );
+    const btn = screen.getByText("Update");
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders dismiss button when dismissible", () => {
+    const onDismiss = vi.fn();
+    render(
+      <InfoBar
+        variant="error"
+        message="Something went wrong"
+        dismissible
+        onDismiss={onDismiss}
+        data-testid="infobar"
+      />,
+    );
+    const dismissBtn = screen.getByRole("button", { name: /dismiss|close/i });
+    fireEvent.click(dismissBtn);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("renders all variant types", () => {
+    const variants = ["info", "warning", "error", "success"] as const;
+    for (const variant of variants) {
+      const { unmount } = render(
+        <InfoBar
+          variant={variant}
+          message={`${variant} message`}
+          data-testid={`infobar-${variant}`}
+        />,
+      );
+      const bar = screen.getByTestId(`infobar-${variant}`);
+      expect(bar.className).toMatch(new RegExp(variant, "i"));
+      unmount();
+    }
+  });
+});

--- a/apps/desktop/renderer/src/components/composites/InfoBar.tsx
+++ b/apps/desktop/renderer/src/components/composites/InfoBar.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Visual variant for the InfoBar */
+export type InfoBarVariant = "info" | "warning" | "error" | "success";
+
+export interface InfoBarProps {
+  /** Visual variant that drives the color scheme */
+  variant: InfoBarVariant;
+  /** Message text to display */
+  message: string;
+  /** Optional action slot (typically a button or link) */
+  action?: React.ReactNode;
+  /** Whether the bar can be dismissed */
+  dismissible?: boolean;
+  /** Callback when the dismiss button is clicked */
+  onDismiss?: () => void;
+  /** Additional CSS class for the outer container */
+  className?: string;
+  /** data-testid for testing */
+  "data-testid"?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const baseStyles = [
+  "flex",
+  "items-center",
+  "gap-3",
+  "px-3",
+  "py-2",
+  "text-xs",
+  "rounded-[var(--radius-md)]",
+  "border",
+].join(" ");
+
+/**
+ * Variant styles using design tokens.
+ *
+ * Each variant uses semantic CSS variables for border, background,
+ * and text colors to respect dark/light theme switching.
+ */
+const variantStyles: Record<InfoBarVariant, string> = {
+  info: [
+    "infobar-info",
+    "border-[var(--color-info)]",
+    "bg-[var(--color-info)]/10",
+    "text-[var(--color-fg-default)]",
+  ].join(" "),
+  warning: [
+    "infobar-warning",
+    "border-[var(--color-warning)]",
+    "bg-[var(--color-warning)]/10",
+    "text-[var(--color-fg-default)]",
+  ].join(" "),
+  error: [
+    "infobar-error",
+    "border-[var(--color-error)]",
+    "bg-[var(--color-error)]/10",
+    "text-[var(--color-fg-default)]",
+  ].join(" "),
+  success: [
+    "infobar-success",
+    "border-[var(--color-success)]",
+    "bg-[var(--color-success)]/10",
+    "text-[var(--color-fg-default)]",
+  ].join(" "),
+};
+
+const dismissButtonStyles = [
+  "ml-auto",
+  "shrink-0",
+  "p-1",
+  "rounded-[var(--radius-sm)]",
+  "text-[var(--color-fg-muted)]",
+  "hover:text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)]",
+  "transition-colors",
+  "duration-[var(--duration-fast)]",
+  "focus-visible:outline",
+  "focus-visible:outline-[length:var(--ring-focus-width)]",
+  "focus-visible:outline-offset-[var(--ring-focus-offset)]",
+  "focus-visible:outline-[var(--color-ring-focus)]",
+].join(" ");
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * InfoBar — a panel-level notification bar composite.
+ *
+ * Displays contextual messages within panels with variant-driven styling:
+ * - info: blue accent
+ * - warning: yellow/amber accent
+ * - error: red accent
+ * - success: green accent
+ *
+ * Supports optional action slots and dismissibility.
+ * Not a Toast — InfoBar is persistent inline content within a panel.
+ *
+ * @example
+ * ```tsx
+ * <InfoBar
+ *   variant="warning"
+ *   message="Disk space running low"
+ *   action={<Button size="sm" variant="ghost">Manage</Button>}
+ *   dismissible
+ *   onDismiss={() => setShowWarning(false)}
+ * />
+ * ```
+ */
+export function InfoBar({
+  variant,
+  message,
+  action,
+  dismissible = false,
+  onDismiss,
+  className = "",
+  "data-testid": testId,
+}: InfoBarProps): JSX.Element {
+  return (
+    <div
+      data-testid={testId}
+      role="status"
+      className={`${baseStyles} ${variantStyles[variant]} ${className}`}
+    >
+      <span className="flex-1">{message}</span>
+      {action && <div className="shrink-0">{action}</div>}
+      {dismissible && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          className={dismissButtonStyles}
+          onClick={onDismiss}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <path d="M4 4L12 12M12 4L4 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/character/CharacterCardEmptyState.test.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardEmptyState.test.tsx
@@ -14,7 +14,10 @@ describe("CharacterCardList.empty-state", () => {
     );
 
     expect(
-      screen.getByText("暂无角色，开始创建你的第一个角色"),
+      screen.getByText("暂无角色"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("开始创建你的第一个角色"),
     ).toBeInTheDocument();
 
     const cta = screen.getByRole("button", { name: "创建角色" });

--- a/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
@@ -1,3 +1,5 @@
+import { EmptyState } from "../../components/composites/EmptyState";
+
 export interface CharacterCardSummary {
   id: string;
   name: string;
@@ -39,18 +41,19 @@ export function CharacterCardList({
         data-testid="character-card-list-empty"
         className={`h-full flex items-center justify-center p-4 bg-[var(--color-bg-base)] ${className}`}
       >
-        <div className="text-center space-y-3">
-          <p className="text-sm text-[var(--color-fg-muted)]">
-            暂无角色，开始创建你的第一个角色
-          </p>
-          <button
-            type="button"
-            onClick={onCreateCharacter}
-            className="px-4 py-2 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] transition-colors"
-          >
-            创建角色
-          </button>
-        </div>
+        <EmptyState
+          title="暂无角色"
+          description="开始创建你的第一个角色"
+          action={
+            <button
+              type="button"
+              onClick={onCreateCharacter}
+              className="px-4 py-2 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] transition-colors"
+            >
+              创建角色
+            </button>
+          }
+        />
       </section>
     );
   }

--- a/apps/desktop/renderer/src/features/character/DeleteConfirmDialog.tsx
+++ b/apps/desktop/renderer/src/features/character/DeleteConfirmDialog.tsx
@@ -3,10 +3,10 @@
  *
  * A confirmation dialog for deleting a character.
  * Shows a warning message and requires explicit confirmation.
+ * Refactored to use ConfirmDialog composite.
  */
-import { Dialog, Button } from "../../components/primitives";
+import { ConfirmDialog } from "../../components/composites/ConfirmDialog";
 
-import { TriangleAlert } from "lucide-react";
 export interface DeleteConfirmDialogProps {
   /** Controlled open state */
   open: boolean;
@@ -19,20 +19,10 @@ export interface DeleteConfirmDialogProps {
 }
 
 /**
- * Warning icon
- */
-function WarningIcon() {
-  return <TriangleAlert size={24} strokeWidth={1.5} className="text-[var(--color-warning)]" />;
-}
-
-/**
  * DeleteConfirmDialog - Confirmation dialog for character deletion
  *
- * Features:
- * - Warning icon and message
- * - Displays character name in message
- * - Cancel and Delete buttons
- * - Delete button uses danger variant
+ * Built on ConfirmDialog composite with destructive styling.
+ * Maintains the same external API for backward compatibility.
  *
  * @example
  * ```tsx
@@ -56,33 +46,16 @@ export function DeleteConfirmDialog({
   };
 
   return (
-    <Dialog
+    <ConfirmDialog
       open={open}
-      onOpenChange={onOpenChange}
       title="Delete Character"
-      description={`Are you sure you want to delete "${characterName}"? This action cannot be undone.`}
-      footer={
-        <div className="flex justify-end gap-3">
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button variant="danger" size="sm" onClick={handleConfirm}>
-            Delete
-          </Button>
-        </div>
-      }
-    >
-      <div className="flex items-start gap-4 py-2">
-        <div className="shrink-0 p-2 rounded-full bg-[var(--color-warning)]/10">
-          <WarningIcon />
-        </div>
-        <div className="flex-1">
-          <p className="text-sm text-[var(--color-fg-muted)] leading-relaxed">
-            Deleting <strong className="text-[var(--color-fg-default)]">{characterName}</strong> will
-            remove all their data, including relationships and chapter appearances.
-          </p>
-        </div>
-      </div>
-    </Dialog>
+      description={`Are you sure you want to delete "${characterName}"? This action cannot be undone. All their data, including relationships and chapter appearances, will be removed.`}
+      confirmLabel="Delete"
+      cancelLabel="Cancel"
+      destructive
+      onConfirm={handleConfirm}
+      onCancel={() => onOpenChange(false)}
+    />
   );
 }
+

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.empty-state.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.empty-state.test.tsx
@@ -78,7 +78,10 @@ describe("FileTreePanel empty state", () => {
     await renderFileTreePanel("proj-empty");
 
     expect(
-      screen.getByText("暂无文件，开始创建你的第一个文件"),
+      screen.getByText("暂无文件"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("开始创建你的第一个文件"),
     ).toBeInTheDocument();
 
     const createButton = screen.getByRole("button", { name: "新建文件" });

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
@@ -74,7 +74,10 @@ describe("FileTreePanel", () => {
       render(<FileTreePanel projectId="test-project" />);
 
       expect(
-        screen.getByText("暂无文件，开始创建你的第一个文件"),
+        screen.getByText("暂无文件"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("开始创建你的第一个文件"),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "新建文件" }),

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -11,6 +11,7 @@ import {
   type ContextMenuItem,
 } from "../../components/primitives";
 import { PanelContainer } from "../../components/composites/PanelContainer";
+import { EmptyState } from "../../components/composites/EmptyState";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { useEditorStore } from "../../stores/editorStore";
 import {
@@ -781,19 +782,20 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             Loading files…
           </Text>
         ) : items.length === 0 ? (
-          <div className="p-3 flex flex-col gap-2">
-            <Text size="small" color="muted" className="block">
-              暂无文件，开始创建你的第一个文件
-            </Text>
-            <Button
-              data-testid="file-create-empty"
-              variant="secondary"
-              size="sm"
-              onClick={() => void onCreate("chapter")}
-            >
-              新建文件
-            </Button>
-          </div>
+          <EmptyState
+            title="暂无文件"
+            description="开始创建你的第一个文件"
+            action={
+              <Button
+                data-testid="file-create-empty"
+                variant="secondary"
+                size="sm"
+                onClick={() => void onCreate("chapter")}
+              >
+                新建文件
+              </Button>
+            }
+          />
         ) : (
           <div className="flex flex-col gap-1 p-2">
             {visibleNodes.map((entry) => {

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -135,19 +135,29 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
     data-testid="character-card-list-empty"
   >
     <div
-      class="text-center space-y-3"
+      class="flex flex-col items-center justify-center gap-3 p-6 text-center "
+      role="status"
     >
+      <h3
+        class="text-sm font-semibold text-[color:var(--color-fg-default)]"
+      >
+        暂无角色
+      </h3>
       <p
-        class="text-sm text-[var(--color-fg-muted)]"
+        class="text-xs text-[color:var(--color-fg-muted)] max-w-[240px] leading-relaxed"
       >
-        暂无角色，开始创建你的第一个角色
+        开始创建你的第一个角色
       </p>
-      <button
-        class="px-4 py-2 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] transition-colors"
-        type="button"
+      <div
+        class="mt-1"
       >
-        创建角色
-      </button>
+        <button
+          class="px-4 py-2 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] transition-colors"
+          type="button"
+        >
+          创建角色
+        </button>
+      </div>
     </div>
   </section>
 </div>

--- a/openspec/_ops/reviews/ISSUE-926.md
+++ b/openspec/_ops/reviews/ISSUE-926.md
@@ -1,0 +1,33 @@
+# ISSUE-926 Independent Review
+
+更新时间：2026-03-03 10:40
+
+- Issue: #926
+- PR: https://github.com/Leeky1017/CreoNow/pull/930
+- Author-Agent: claude
+- Reviewer-Agent: codex
+- Reviewed-HEAD-SHA: 87fd79e9c43d35fb4444730fc021b17117eead24
+- Decision: PASS
+
+## Scope
+
+- `apps/desktop/renderer/src/components/composites/EmptyState.tsx`：新增空状态 Composite
+- `apps/desktop/renderer/src/components/composites/ConfirmDialog.tsx`：新增确认对话框 Composite
+- `apps/desktop/renderer/src/components/composites/InfoBar.tsx`：新增信息栏 Composite
+- Feature 迁移：FileTreePanel、CharacterCardList、DeleteConfirmDialog
+- `openspec/changes/EXECUTION_ORDER.md`：回退修复（从 main 还原）
+
+## Findings
+
+- 严重问题：
+  - `EXECUTION_ORDER.md` 事实性回退——把已合并 PR 状态写回"待执行/待审计"（已修复：从 origin/main 恢复）
+- 中等级问题：无
+- 低风险问题：
+  - `ConfirmDialog.tsx` 未使用 `import React`（已由主会话清理）
+
+## Verification
+
+- `pnpm typecheck` → PASS
+- 定向测试 25 tests → PASS
+- `EXECUTION_ORDER.md` 已与 origin/main 一致（diff 已确认）
+- 全回归 228 files / 1687 tests → PASS（主会话验证）

--- a/openspec/_ops/reviews/ISSUE-926.md
+++ b/openspec/_ops/reviews/ISSUE-926.md
@@ -1,12 +1,12 @@
 # ISSUE-926 Independent Review
 
-更新时间：2026-03-03 10:40
+更新时间：2026-03-03 11:07
 
 - Issue: #926
 - PR: https://github.com/Leeky1017/CreoNow/pull/930
 - Author-Agent: claude
 - Reviewer-Agent: codex
-- Reviewed-HEAD-SHA: 87fd79e9c43d35fb4444730fc021b17117eead24
+- Reviewed-HEAD-SHA: f074d30f725551bbbc25177ec02dae18f616c3f9
 - Decision: PASS
 
 ## Scope

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -58,7 +58,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 84d6c5a56d9d5eaff983342453f19aaf83d7ca1e
+- Reviewed-HEAD-SHA: 0f554c0352fbccfa5d3a9d70651697fe1e9e254e
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -5,7 +5,7 @@
 | Issue       | #926                                         |
 | Branch      | task/926-fe-composites-p2                     |
 | Change      | fe-composites-p2-empties-and-confirms         |
-| PR          | 待回填                                       |
+| PR          | https://github.com/Leeky1017/CreoNow/pull/930 |
 
 ## Dependency Sync Check
 - 上游 `fe-composites-p0`: PR #919 已合并 main ✓，无漂移

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -55,7 +55,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: PENDING_SHA
+- Reviewed-HEAD-SHA: 973095b3629b9d46148defabe619440244273263
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -58,7 +58,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 0f554c0352fbccfa5d3a9d70651697fe1e9e254e
+- Reviewed-HEAD-SHA: a38bc31430e72858d9bde8473f441ec45ff609f9
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -58,7 +58,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 68d288c0f8640e3ecc92e93c5dce9ec74ed7ed05
+- Reviewed-HEAD-SHA: 84d6c5a56d9d5eaff983342453f19aaf83d7ca1e
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -55,7 +55,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 973095b3629b9d46148defabe619440244273263
+- Reviewed-HEAD-SHA: 4fea02c4e0f50eb13d9157671f57bec59a8b498d
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -58,7 +58,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 4fea02c4e0f50eb13d9157671f57bec59a8b498d
+- Reviewed-HEAD-SHA: d631eed451fb5307268bf4e02919c6b4f69a72f1
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -5,7 +5,10 @@
 - Change: fe-composites-p2-empties-and-confirms
 - PR: https://github.com/Leeky1017/CreoNow/pull/930
 
-## Dependency Sync Check
+## Plan
+- 新增 P2 级 Composite 组件（EmptyState / ConfirmDialog / InfoBar），迁移 Feature 层散装空状态和确认弹窗。
+
+
 - 上游 `fe-composites-p0`: PR #919 已合并 main ✓，无漂移
 - 上游 `fe-composites-p1`: 已合并 main ✓，无漂移
 

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -58,7 +58,7 @@ Test Files  228 passed (228)
 
 ## Main Session Audit
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: d631eed451fb5307268bf4e02919c6b4f69a72f1
+- Reviewed-HEAD-SHA: 68d288c0f8640e3ecc92e93c5dce9ec74ed7ed05
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -1,0 +1,23 @@
+# ISSUE-926: fe-composites-p2-empties-and-confirms
+
+| 字段        | 值                                           |
+| ----------- | -------------------------------------------- |
+| Issue       | #926                                         |
+| Branch      | task/926-fe-composites-p2                     |
+| Change      | fe-composites-p2-empties-and-confirms         |
+| PR          | 待回填                                       |
+
+## Dependency Sync Check
+- 上游 `fe-composites-p0`: PR #919 已合并 main ✓，无漂移
+- 上游 `fe-composites-p1`: 已合并 main ✓，无漂移
+
+## Runs
+
+### Red
+（待记录）
+
+### Green
+（待记录）
+
+### Full Regression
+（待记录）

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -1,11 +1,9 @@
 # ISSUE-926: fe-composites-p2-empties-and-confirms
 
-| 字段        | 值                                           |
-| ----------- | -------------------------------------------- |
-| Issue       | #926                                         |
-| Branch      | task/926-fe-composites-p2                     |
-| Change      | fe-composites-p2-empties-and-confirms         |
-| PR          | https://github.com/Leeky1017/CreoNow/pull/930 |
+- Issue: #926
+- Branch: task/926-fe-composites-p2
+- Change: fe-composites-p2-empties-and-confirms
+- PR: https://github.com/Leeky1017/CreoNow/pull/930
 
 ## Dependency Sync Check
 - 上游 `fe-composites-p0`: PR #919 已合并 main ✓，无漂移
@@ -53,3 +51,13 @@ Test Files  228 passed (228)
    Duration  45.65s
 ```
 全量回归零失败 ✓
+
+
+## Main Session Audit
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: PENDING_SHA
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT

--- a/openspec/_ops/task_runs/ISSUE-926.md
+++ b/openspec/_ops/task_runs/ISSUE-926.md
@@ -14,10 +14,42 @@
 ## Runs
 
 ### Red
-（待记录）
+```
+Test Files  3 failed (3)
+      Tests  no tests
+
+FAIL  EmptyState.test.tsx — Failed to resolve import "./EmptyState"
+FAIL  ConfirmDialog.test.tsx — Failed to resolve import "./ConfirmDialog"
+FAIL  InfoBar.test.tsx — Failed to resolve import "./InfoBar"
+```
+所有测试如期失败：源模块不存在。Red 确认 ✓
 
 ### Green
-（待记录）
+```
+pnpm -C apps/desktop test:run -- --reporter=verbose components/composites/EmptyState
+ ✓ renderer/src/components/composites/EmptyState.test.tsx (4 tests) 55ms
+
+pnpm -C apps/desktop test:run -- --reporter=verbose components/composites/ConfirmDialog
+ ✓ renderer/src/components/composites/ConfirmDialog.test.tsx (5 tests) 580ms
+
+pnpm -C apps/desktop test:run -- --reporter=verbose components/composites/InfoBar
+ ✓ renderer/src/components/composites/InfoBar.test.tsx (4 tests) 268ms
+
+Composite tests: 13/13 passed ✓
+```
+
+### Feature Regression
+```
+pnpm -C apps/desktop test:run -- --reporter=verbose features/files/FileTreePanel
+ — FileTreePanel empty-state migration OK ✓
+pnpm -C apps/desktop test:run -- --reporter=verbose features/character/
+ — CharacterCardList + DeleteConfirmDialog migration OK ✓
+```
 
 ### Full Regression
-（待记录）
+```
+Test Files  228 passed (228)
+      Tests  1687 passed (1687)
+   Duration  45.65s
+```
+全量回归零失败 ✓

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,12 +1,12 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-02 23:24
+更新时间：2026-03-02 11:25
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 **13**（前端整改拆分，基于 `docs/frontend-overhaul-plan.md` §七，`fe-rightpanel-ai-tabbar-layout`、`fe-rightpanel-ai-guidance-and-style`、`fe-spec-drift-iconbar-rightpanel-alignment`、`fe-hotfix-searchpanel-backdrop-close`、`fe-leftpanel-dialog-migration`、`fe-cleanup-proxysection-and-mocks`、`fe-ai-panel-toggle-button`、`fe-ipc-open-folder-contract`、`fe-ui-open-folder-entrypoints`、`fe-dashboard-welcome-merge-and-ghost-actions`、`fe-project-image-cropper`、`fe-error-boundary-partitioning`、`fe-skeleton-loading-states`、`fe-i18n-language-switcher-foundation`、`fe-onboarding-flow-refresh`、`fe-searchpanel-tokenized-rewrite`、`fe-zenmode-token-escape-cleanup`、`fe-dashboard-herocard-responsive-layout`、`fe-lucide-icon-unification`、`fe-theme-switch-smoothing`、`fe-desktop-native-binding-packaging`、`fe-desktop-window-lifecycle-uplift`、`fe-composites-p0-panel-and-command-items`、`fe-editor-tokenization-selection-and-spacing`、`fe-editor-advanced-interactions` 已归档）。
+- 当前活跃 change 数量为 **23**（前端整改拆分，基于 `docs/frontend-overhaul-plan.md` §七，`fe-rightpanel-ai-tabbar-layout`、`fe-rightpanel-ai-guidance-and-style`、`fe-spec-drift-iconbar-rightpanel-alignment`、`fe-hotfix-searchpanel-backdrop-close`、`fe-leftpanel-dialog-migration`、`fe-cleanup-proxysection-and-mocks`、`fe-ai-panel-toggle-button`、`fe-ipc-open-folder-contract`、`fe-ui-open-folder-entrypoints`、`fe-dashboard-welcome-merge-and-ghost-actions`、`fe-project-image-cropper`、`fe-error-boundary-partitioning`、`fe-skeleton-loading-states`、`fe-i18n-language-switcher-foundation`、`fe-onboarding-flow-refresh` 已归档）。
 - 执行模式：**4 批次渐进推进**（第一批核心体验 → 第二批功能补全 → 第三批设计系统回归 → 第四批独立 Issue 收口）。
 - 规则：
   - 任一 change 开始 Red 前，必须完成该 change 的依赖同步检查（Dependency Sync Check）。
@@ -78,11 +78,11 @@
 
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
-| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | 已完成并归档（PR #898） |
-| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | 已完成并归档（PR #899） |
-| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | 已完成并归档（PR #900） |
-| A | 3b-1 | `fe-lucide-icon-unification` | icon import 广撒网簇 | Wave 3a 完成后（分别与 searchpanel/zenmode/herocard 共享文件） | 已完成并归档（PR #909） |
-| B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 已完成并归档（PR #910） |
+| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | PR #898 待审计 |
+| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | PR #899 待审计 |
+| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | PR #900 待审计 |
+| A | 3b-1 | `fe-lucide-icon-unification` | icon import 广撒网簇 | Wave 3a 完成后（分别与 searchpanel/zenmode/herocard 共享文件） | 待执行 |
+| B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 待执行 |
 | A | 3c-1 | `fe-feature-focus-visible-coverage` | AiPanel/SearchPanel/Dashboard + `main.css` + `tokens.css` 簇 | Wave 3b 完成后 | 待执行 |
 | A | 3c-2 | `fe-visual-noise-reduction` | AiPanel/Dashboard + `tokens.css` 簇 | `fe-feature-focus-visible-coverage`；且需 `fe-rightpanel-ai-tabbar-layout`, `fe-rightpanel-ai-guidance-and-style`, `fe-leftpanel-dialog-migration` | 待执行 |
 | A | 3c-3 | `fe-reduced-motion-respect` | AiPanel/SearchPanel + `main.css` + `tokens.css` 簇 | `fe-visual-noise-reduction` | 待执行 |
@@ -108,12 +108,12 @@
 
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
-| N1 | 4-0 | `fe-desktop-native-binding-packaging` | 主进程独立簇 | — | 已完成并归档（PR #911） |
-| N2 | 4-0 | `fe-desktop-window-lifecycle-uplift` | 主进程独立簇 | — | 已完成并归档（PR #912） |
+| N1 | 4-0 | `fe-desktop-native-binding-packaging` | 主进程独立簇 | — | 待执行 |
+| N2 | 4-0 | `fe-desktop-window-lifecycle-uplift` | 主进程独立簇 | — | 待执行 |
 | A | 4a-1 | `fe-i18n-language-switcher-foundation` | i18n/Onboarding/SettingsGeneral 簇 | — | 已完成并归档（PR #843） |
-| B | 4a-1 | `fe-composites-p0-panel-and-command-items` | SearchPanel/AiPanel/CommandPalette/FileTree 簇 | — | 已完成并归档（PR #919） |
-| C | 4a-1 | `fe-editor-tokenization-selection-and-spacing` | `tokens.css` + `main.css` + typography 簇 | — | 已完成并归档（PR #917） |
-| D | 4a-1 | `fe-editor-advanced-interactions` | EditorPane 簇 | — | 已完成并归档（PR #918） |
+| B | 4a-1 | `fe-composites-p0-panel-and-command-items` | SearchPanel/AiPanel/CommandPalette/FileTree 簇 | — | 待执行 |
+| C | 4a-1 | `fe-editor-tokenization-selection-and-spacing` | `tokens.css` + `main.css` + typography 簇 | — | 待执行 |
+| D | 4a-1 | `fe-editor-advanced-interactions` | EditorPane 簇 | — | 待执行 |
 | A | 4b-1 | `fe-i18n-core-pages-keying` | SearchPanel/AiPanel/CommandPalette/Dashboard/Onboarding 簇 | `fe-i18n-language-switcher-foundation` | 待执行 |
 | B | 4b-1 | `fe-composites-p1-search-and-forms` | SettingsGeneral + Forms 簇 | `fe-composites-p0-panel-and-command-items` | 待执行 |
 | C | 4b-1 | `fe-composites-p2-empties-and-confirms` | FileTreePanel + Empty/Confirm 簇 | `fe-composites-p0-panel-and-command-items` | 待执行 |
@@ -182,12 +182,12 @@
   fe-i18n-language-switcher-foundation (第四批) ──→ fe-onboarding-flow-refresh
 
 第三批（3 波推进）
-  Wave 3a: fe-searchpanel-tokenized-rewrite ∥ fe-zenmode-token-escape-cleanup ∥ fe-dashboard-herocard-responsive-layout（已完成并归档，PR #898/#899/#900）
-  Wave 3b: fe-lucide-icon-unification ∥ fe-theme-switch-smoothing（已完成并归档，PR #909/#910）
+  Wave 3a: fe-searchpanel-tokenized-rewrite ∥ fe-zenmode-token-escape-cleanup ∥ fe-dashboard-herocard-responsive-layout
+  Wave 3b: fe-lucide-icon-unification ∥ fe-theme-switch-smoothing
   Wave 3c: fe-feature-focus-visible-coverage ──→ fe-visual-noise-reduction ──→ fe-reduced-motion-respect
 
 第四批（独立 lane + 冲突簇波次）
-  独立 lane: fe-desktop-native-binding-packaging ∥ fe-desktop-window-lifecycle-uplift（已完成并归档，PR #911/#912）
+  独立 lane: fe-desktop-native-binding-packaging ∥ fe-desktop-window-lifecycle-uplift
 
   Wave 4a:
     fe-i18n-language-switcher-foundation
@@ -225,15 +225,12 @@
 - `fe-ipc-open-folder-contract`：已归档到 `openspec/changes/archive/fe-ipc-open-folder-contract`（merge commit `91e56f28`，PR #830）。
 - `fe-ui-open-folder-entrypoints`：已归档到 `openspec/changes/archive/fe-ui-open-folder-entrypoints`（merge commit `91e56f28`，PR #830）。
 - `fe-dashboard-welcome-merge-and-ghost-actions`：已归档到 `openspec/changes/archive/fe-dashboard-welcome-merge-and-ghost-actions`（merge commit `91e56f28`，PR #830）。
-- `fe-composites-p0-panel-and-command-items`：已归档到 `openspec/changes/archive/fe-composites-p0-panel-and-command-items`（merge commit `f798c553`，PR #919）。
-- `fe-editor-tokenization-selection-and-spacing`：已归档到 `openspec/changes/archive/fe-editor-tokenization-selection-and-spacing`（merge commit `704f0bce`，PR #917）。
-- `fe-editor-advanced-interactions`：已归档到 `openspec/changes/archive/fe-editor-advanced-interactions`（merge commit `70bdeee8`，PR #918）。
 
-## 本次同步说明（ISSUE-922）
+## 依赖说明
 
-- 当前子任务：`ISSUE-922`（Wave 4a 三项归档与 EO 同步）。
-- 依赖关系：`PR #919`、`PR #917`、`PR #918` 已按串行顺序合并；本次 closeout 负责归档与执行顺序文档收口。
-- 同步结论：Wave 4a 三项已“合并 + 归档”，后续可按依赖推进 Wave 4b（`fe-composites-p1/p2`、`fe-hotkeys-shortcuts-unification`、`fe-editor-inline-diff-decoration-integration`、`fe-i18n-core-pages-keying`）。
+- 当前子任务：`ISSUE-833`（归档 PR #830 对应 change 与治理同步）。
+- 依赖关系：`dashboard` 收尾依赖的 open-folder 链路已在 PR #830 合并，并完成三项 change 归档迁移。
+- 同步结论：第一批收尾与第二批 open-folder 链路均已“合并 + 归档”，执行顺序文档已与实际状态对齐。
 
 ## Owner 决策阻塞项
 

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,12 +1,12 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-02 11:25
+更新时间：2026-03-02 23:24
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 **23**（前端整改拆分，基于 `docs/frontend-overhaul-plan.md` §七，`fe-rightpanel-ai-tabbar-layout`、`fe-rightpanel-ai-guidance-and-style`、`fe-spec-drift-iconbar-rightpanel-alignment`、`fe-hotfix-searchpanel-backdrop-close`、`fe-leftpanel-dialog-migration`、`fe-cleanup-proxysection-and-mocks`、`fe-ai-panel-toggle-button`、`fe-ipc-open-folder-contract`、`fe-ui-open-folder-entrypoints`、`fe-dashboard-welcome-merge-and-ghost-actions`、`fe-project-image-cropper`、`fe-error-boundary-partitioning`、`fe-skeleton-loading-states`、`fe-i18n-language-switcher-foundation`、`fe-onboarding-flow-refresh` 已归档）。
+- 当前活跃 change 数量为 **13**（前端整改拆分，基于 `docs/frontend-overhaul-plan.md` §七，`fe-rightpanel-ai-tabbar-layout`、`fe-rightpanel-ai-guidance-and-style`、`fe-spec-drift-iconbar-rightpanel-alignment`、`fe-hotfix-searchpanel-backdrop-close`、`fe-leftpanel-dialog-migration`、`fe-cleanup-proxysection-and-mocks`、`fe-ai-panel-toggle-button`、`fe-ipc-open-folder-contract`、`fe-ui-open-folder-entrypoints`、`fe-dashboard-welcome-merge-and-ghost-actions`、`fe-project-image-cropper`、`fe-error-boundary-partitioning`、`fe-skeleton-loading-states`、`fe-i18n-language-switcher-foundation`、`fe-onboarding-flow-refresh`、`fe-searchpanel-tokenized-rewrite`、`fe-zenmode-token-escape-cleanup`、`fe-dashboard-herocard-responsive-layout`、`fe-lucide-icon-unification`、`fe-theme-switch-smoothing`、`fe-desktop-native-binding-packaging`、`fe-desktop-window-lifecycle-uplift`、`fe-composites-p0-panel-and-command-items`、`fe-editor-tokenization-selection-and-spacing`、`fe-editor-advanced-interactions` 已归档）。
 - 执行模式：**4 批次渐进推进**（第一批核心体验 → 第二批功能补全 → 第三批设计系统回归 → 第四批独立 Issue 收口）。
 - 规则：
   - 任一 change 开始 Red 前，必须完成该 change 的依赖同步检查（Dependency Sync Check）。
@@ -78,11 +78,11 @@
 
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
-| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | PR #898 待审计 |
-| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | PR #899 待审计 |
-| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | PR #900 待审计 |
-| A | 3b-1 | `fe-lucide-icon-unification` | icon import 广撒网簇 | Wave 3a 完成后（分别与 searchpanel/zenmode/herocard 共享文件） | 待执行 |
-| B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 待执行 |
+| A | 3a-1 | `fe-searchpanel-tokenized-rewrite` | SearchPanel + `main.css` 簇 | 前置 hotfix 已归档 | 已完成并归档（PR #898） |
+| B | 3a-1 | `fe-zenmode-token-escape-cleanup` | ZenMode + `tokens.css` 簇 | — | 已完成并归档（PR #899） |
+| C | 3a-1 | `fe-dashboard-herocard-responsive-layout` | DashboardPage 簇 | — | 已完成并归档（PR #900） |
+| A | 3b-1 | `fe-lucide-icon-unification` | icon import 广撒网簇 | Wave 3a 完成后（分别与 searchpanel/zenmode/herocard 共享文件） | 已完成并归档（PR #909） |
+| B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 已完成并归档（PR #910） |
 | A | 3c-1 | `fe-feature-focus-visible-coverage` | AiPanel/SearchPanel/Dashboard + `main.css` + `tokens.css` 簇 | Wave 3b 完成后 | 待执行 |
 | A | 3c-2 | `fe-visual-noise-reduction` | AiPanel/Dashboard + `tokens.css` 簇 | `fe-feature-focus-visible-coverage`；且需 `fe-rightpanel-ai-tabbar-layout`, `fe-rightpanel-ai-guidance-and-style`, `fe-leftpanel-dialog-migration` | 待执行 |
 | A | 3c-3 | `fe-reduced-motion-respect` | AiPanel/SearchPanel + `main.css` + `tokens.css` 簇 | `fe-visual-noise-reduction` | 待执行 |
@@ -108,12 +108,12 @@
 
 | Lane | 顺序 | Change | 文件冲突簇 | 依赖 | 状态 |
 |------|------|--------|-----------|------|------|
-| N1 | 4-0 | `fe-desktop-native-binding-packaging` | 主进程独立簇 | — | 待执行 |
-| N2 | 4-0 | `fe-desktop-window-lifecycle-uplift` | 主进程独立簇 | — | 待执行 |
+| N1 | 4-0 | `fe-desktop-native-binding-packaging` | 主进程独立簇 | — | 已完成并归档（PR #911） |
+| N2 | 4-0 | `fe-desktop-window-lifecycle-uplift` | 主进程独立簇 | — | 已完成并归档（PR #912） |
 | A | 4a-1 | `fe-i18n-language-switcher-foundation` | i18n/Onboarding/SettingsGeneral 簇 | — | 已完成并归档（PR #843） |
-| B | 4a-1 | `fe-composites-p0-panel-and-command-items` | SearchPanel/AiPanel/CommandPalette/FileTree 簇 | — | 待执行 |
-| C | 4a-1 | `fe-editor-tokenization-selection-and-spacing` | `tokens.css` + `main.css` + typography 簇 | — | 待执行 |
-| D | 4a-1 | `fe-editor-advanced-interactions` | EditorPane 簇 | — | 待执行 |
+| B | 4a-1 | `fe-composites-p0-panel-and-command-items` | SearchPanel/AiPanel/CommandPalette/FileTree 簇 | — | 已完成并归档（PR #919） |
+| C | 4a-1 | `fe-editor-tokenization-selection-and-spacing` | `tokens.css` + `main.css` + typography 簇 | — | 已完成并归档（PR #917） |
+| D | 4a-1 | `fe-editor-advanced-interactions` | EditorPane 簇 | — | 已完成并归档（PR #918） |
 | A | 4b-1 | `fe-i18n-core-pages-keying` | SearchPanel/AiPanel/CommandPalette/Dashboard/Onboarding 簇 | `fe-i18n-language-switcher-foundation` | 待执行 |
 | B | 4b-1 | `fe-composites-p1-search-and-forms` | SettingsGeneral + Forms 簇 | `fe-composites-p0-panel-and-command-items` | 待执行 |
 | C | 4b-1 | `fe-composites-p2-empties-and-confirms` | FileTreePanel + Empty/Confirm 簇 | `fe-composites-p0-panel-and-command-items` | 待执行 |
@@ -182,12 +182,12 @@
   fe-i18n-language-switcher-foundation (第四批) ──→ fe-onboarding-flow-refresh
 
 第三批（3 波推进）
-  Wave 3a: fe-searchpanel-tokenized-rewrite ∥ fe-zenmode-token-escape-cleanup ∥ fe-dashboard-herocard-responsive-layout
-  Wave 3b: fe-lucide-icon-unification ∥ fe-theme-switch-smoothing
+  Wave 3a: fe-searchpanel-tokenized-rewrite ∥ fe-zenmode-token-escape-cleanup ∥ fe-dashboard-herocard-responsive-layout（已完成并归档，PR #898/#899/#900）
+  Wave 3b: fe-lucide-icon-unification ∥ fe-theme-switch-smoothing（已完成并归档，PR #909/#910）
   Wave 3c: fe-feature-focus-visible-coverage ──→ fe-visual-noise-reduction ──→ fe-reduced-motion-respect
 
 第四批（独立 lane + 冲突簇波次）
-  独立 lane: fe-desktop-native-binding-packaging ∥ fe-desktop-window-lifecycle-uplift
+  独立 lane: fe-desktop-native-binding-packaging ∥ fe-desktop-window-lifecycle-uplift（已完成并归档，PR #911/#912）
 
   Wave 4a:
     fe-i18n-language-switcher-foundation
@@ -225,12 +225,15 @@
 - `fe-ipc-open-folder-contract`：已归档到 `openspec/changes/archive/fe-ipc-open-folder-contract`（merge commit `91e56f28`，PR #830）。
 - `fe-ui-open-folder-entrypoints`：已归档到 `openspec/changes/archive/fe-ui-open-folder-entrypoints`（merge commit `91e56f28`，PR #830）。
 - `fe-dashboard-welcome-merge-and-ghost-actions`：已归档到 `openspec/changes/archive/fe-dashboard-welcome-merge-and-ghost-actions`（merge commit `91e56f28`，PR #830）。
+- `fe-composites-p0-panel-and-command-items`：已归档到 `openspec/changes/archive/fe-composites-p0-panel-and-command-items`（merge commit `f798c553`，PR #919）。
+- `fe-editor-tokenization-selection-and-spacing`：已归档到 `openspec/changes/archive/fe-editor-tokenization-selection-and-spacing`（merge commit `704f0bce`，PR #917）。
+- `fe-editor-advanced-interactions`：已归档到 `openspec/changes/archive/fe-editor-advanced-interactions`（merge commit `70bdeee8`，PR #918）。
 
-## 依赖说明
+## 本次同步说明（ISSUE-922）
 
-- 当前子任务：`ISSUE-833`（归档 PR #830 对应 change 与治理同步）。
-- 依赖关系：`dashboard` 收尾依赖的 open-folder 链路已在 PR #830 合并，并完成三项 change 归档迁移。
-- 同步结论：第一批收尾与第二批 open-folder 链路均已“合并 + 归档”，执行顺序文档已与实际状态对齐。
+- 当前子任务：`ISSUE-922`（Wave 4a 三项归档与 EO 同步）。
+- 依赖关系：`PR #919`、`PR #917`、`PR #918` 已按串行顺序合并；本次 closeout 负责归档与执行顺序文档收口。
+- 同步结论：Wave 4a 三项已“合并 + 归档”，后续可按依赖推进 Wave 4b（`fe-composites-p1/p2`、`fe-hotkeys-shortcuts-unification`、`fe-editor-inline-diff-decoration-integration`、`fe-i18n-core-pages-keying`）。
 
 ## Owner 决策阻塞项
 

--- a/rulebook/tasks/issue-926-fe-composites-p2/.metadata.json
+++ b/rulebook/tasks/issue-926-fe-composites-p2/.metadata.json
@@ -1,0 +1,7 @@
+{
+  "id": "issue-926-fe-composites-p2",
+  "issue": 926,
+  "status": "active",
+  "change": "fe-composites-p2-empties-and-confirms",
+  "created": "2026-03-03"
+}

--- a/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
+++ b/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: fe-composites-p2-empties-and-confirms
+
+引用自 `openspec/changes/fe-composites-p2-empties-and-confirms/proposal.md`。
+
+## 概要
+
+新增三个 P2 Composite 组件：
+
+1. **EmptyState** — 统一空状态展示（icon + title + description + action）
+2. **ConfirmDialog** — 基于 Dialog Primitive 的确认弹窗（支持 destructive 语义）
+3. **InfoBar** — 面板内提示条（variant 驱动样式 + action + dismiss）
+
+同时迁移 Feature 层散装空状态和确认弹窗至对应 Composite。

--- a/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
+++ b/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
@@ -2,6 +2,10 @@
 
 引用自 `openspec/changes/fe-composites-p2-empties-and-confirms/proposal.md`。
 
+## Why
+
+Feature 层空状态和确认弹窗各自内联实现，样式与交互不一致。新增 P2 级 Composite 组件统一空状态、确认对话框、信息条的视觉语义和可访问性。
+
 ## 概要
 
 新增三个 P2 Composite 组件：

--- a/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
+++ b/rulebook/tasks/issue-926-fe-composites-p2/proposal.md
@@ -1,4 +1,5 @@
 # Proposal: fe-composites-p2-empties-and-confirms
+更新时间：2026-03-03 09:37
 
 引用自 `openspec/changes/fe-composites-p2-empties-and-confirms/proposal.md`。
 

--- a/rulebook/tasks/issue-926-fe-composites-p2/tasks.md
+++ b/rulebook/tasks/issue-926-fe-composites-p2/tasks.md
@@ -1,4 +1,5 @@
 # Tasks: issue-926-fe-composites-p2
+更新时间：2026-03-03 09:37
 
 ## Checklist
 

--- a/rulebook/tasks/issue-926-fe-composites-p2/tasks.md
+++ b/rulebook/tasks/issue-926-fe-composites-p2/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: issue-926-fe-composites-p2
+
+## Checklist
+
+- [x] Rulebook task 创建（.metadata.json / proposal.md / tasks.md）
+- [ ] Red：创建 EmptyState / ConfirmDialog / InfoBar 测试
+- [ ] Green：实现三个 Composite 组件
+- [ ] Green：迁移 Feature 层散装空状态和确认弹窗
+- [ ] Refactor：a11y 检查、代码清理
+- [ ] 全量回归通过
+- [ ] RUN_LOG 完整
+- [ ] PR 创建


### PR DESCRIPTION
## Summary
Add P2 Composite components for empty states, confirm dialogs, and info bars.

### New Composites
- **EmptyState**: Unified empty state with icon, title, description, and optional action
- **ConfirmDialog**: Standardized confirm dialog with destructive mode support
- **InfoBar**: Variant-driven info/warning/error/success notification bar

### Feature Migrations
- FileTreePanel: empty state migrated to EmptyState composite
- CharacterCardList: empty state migrated to EmptyState composite
- DeleteConfirmDialog: migrated to ConfirmDialog composite

### Testing
- 13 unit tests for 3 composites (all pass)
- Feature regression tests pass (FileTreePanel, CharacterCardList, DeleteConfirmDialog)
- Full regression: 228 test files, 1687 tests — all pass

Closes #926