### PR TITLE
feat: inject deterministic now parameter to eliminate Date.now() non-determinism (#948)

### DIFF
--- a/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
+++ b/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
@@ -24,6 +24,21 @@ function utcDateKey(ts: number): string {
   return new Date(ts).toISOString().slice(0, 10);
 }
 
+/**
+ * Compute the 7-day date range (from/to) for the analytics view.
+ *
+ * Accepts an optional `now` timestamp for deterministic testing.
+ */
+export function computeDateRange(now: number = Date.now()): {
+  from: string;
+  to: string;
+} {
+  return {
+    to: utcDateKey(now),
+    from: utcDateKey(now - 6 * 24 * 60 * 60 * 1000),
+  };
+}
+
 function formatSeconds(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
   const m = Math.floor(s / 60);
@@ -98,8 +113,7 @@ export function AnalyticsPageContent(): JSX.Element {
     }
     setToday(todayRes.data);
 
-    const to = utcDateKey(Date.now());
-    const from = utcDateKey(Date.now() - 6 * 24 * 60 * 60 * 1000);
+    const { from, to } = computeDateRange();
     const rangeRes = await invoke("stats:range:get", { from, to });
     if (!rangeRes.ok) {
       setError(rangeRes.error);

--- a/apps/desktop/renderer/src/features/analytics/__tests__/analytics.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/analytics/__tests__/analytics.determinism.test.ts
@@ -1,0 +1,32 @@
+/**
+ * S5: AnalyticsPage date-range determinism test
+ *
+ * Verifies that the date-range computation (utcDateKey) can be driven
+ * by an injected `now` value, yielding stable from/to keys.
+ *
+ * Red: computeDateRange is not exported (doesn't exist yet) →
+ *      import resolves to undefined → TypeError when invoked.
+ */
+import { describe, it, expect } from "vitest";
+
+import { computeDateRange } from "../AnalyticsPage";
+
+describe("computeDateRange (Analytics) — deterministic now injection", () => {
+  it("computes stable 7-day range with injected now", () => {
+    // 2026-03-01T12:00:00Z
+    const fixedNow = new Date("2026-03-01T12:00:00Z").getTime();
+    const { from, to } = computeDateRange(fixedNow);
+
+    expect(to).toBe("2026-03-01");
+    expect(from).toBe("2026-02-23");
+  });
+
+  it("handles epoch boundary correctly", () => {
+    // 1970-01-08T00:00:00Z — exactly 7 days after epoch
+    const fixedNow = 7 * 24 * 60 * 60 * 1000;
+    const { from, to } = computeDateRange(fixedNow);
+
+    expect(to).toBe("1970-01-08");
+    expect(from).toBe("1970-01-02");
+  });
+});

--- a/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
@@ -315,8 +315,11 @@ type TFunction = (key: string, options?: Record<string, unknown>) => string;
  *
  * Why: Relative time strings ("just now", "5 minutes ago") vary by locale.
  */
-function formatRelativeTime(timestamp: number, t: TFunction): string {
-  const now = Date.now();
+export function formatRelativeTime(
+  timestamp: number,
+  t: TFunction,
+  now: number = Date.now(),
+): string {
   const diff = now - timestamp;
 
   const minutes = Math.floor(diff / 60000);

--- a/apps/desktop/renderer/src/features/dashboard/__tests__/formatRelativeTime.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/dashboard/__tests__/formatRelativeTime.determinism.test.ts
@@ -1,0 +1,51 @@
+/**
+ * S1: Dashboard formatRelativeTime determinism test
+ *
+ * Verifies that formatRelativeTime accepts an injected `now` parameter
+ * so that test output is deterministic and independent of the real clock.
+ *
+ * Red: formatRelativeTime is not exported from DashboardPage.tsx →
+ *      import resolves to undefined → TypeError when invoked.
+ */
+import { describe, it, expect } from "vitest";
+
+import { formatRelativeTime } from "../DashboardPage";
+
+type TFunction = (key: string, options?: Record<string, unknown>) => string;
+
+const mockT: TFunction = (key, options) => {
+  if (key === "dashboard.time.justNow") return "Just now";
+  if (key === "dashboard.time.minutesAgo")
+    return `${options?.count} minutes ago`;
+  if (key === "dashboard.time.hoursAgo") return `${options?.count} hours ago`;
+  if (key === "dashboard.time.daysAgo") return `${options?.count} days ago`;
+  return key;
+};
+
+describe("formatRelativeTime (Dashboard) — deterministic now injection", () => {
+  const fixedNow = 1_700_000_060_000;
+
+  it('returns "Just now" for timestamps within 60s of injected now', () => {
+    const timestamp = fixedNow - 30_000; // 30 s before fixedNow
+    const result = formatRelativeTime(timestamp, mockT, fixedNow);
+    expect(result).toBe("Just now");
+  });
+
+  it("returns minutes-ago for timestamps within 1 h of injected now", () => {
+    const timestamp = fixedNow - 5 * 60_000; // 5 min before
+    const result = formatRelativeTime(timestamp, mockT, fixedNow);
+    expect(result).toBe("5 minutes ago");
+  });
+
+  it("returns hours-ago for timestamps within 24 h of injected now", () => {
+    const timestamp = fixedNow - 3 * 3_600_000; // 3 h before
+    const result = formatRelativeTime(timestamp, mockT, fixedNow);
+    expect(result).toBe("3 hours ago");
+  });
+
+  it("returns days-ago for timestamps within 7 d of injected now", () => {
+    const timestamp = fixedNow - 2 * 86_400_000; // 2 d before
+    const result = formatRelativeTime(timestamp, mockT, fixedNow);
+    expect(result).toBe("2 days ago");
+  });
+});

--- a/apps/desktop/renderer/src/features/editor/__tests__/aiStreamUndo.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/editor/__tests__/aiStreamUndo.determinism.test.ts
@@ -1,0 +1,42 @@
+/**
+ * S6: aiStreamUndo checkpoint timestamp determinism test
+ *
+ * Verifies that buildAiStreamUndoCheckpoint accepts an optional `now`
+ * parameter so that the checkpoint timestamp is deterministic in tests.
+ *
+ * Red: The `now` field is not in the args type and is ignored by the
+ *      function → checkpoint.timestamp !== fixedNow → assertion fails.
+ */
+import { describe, it, expect } from "vitest";
+
+import { buildAiStreamUndoCheckpoint } from "../aiStreamUndo";
+
+describe("buildAiStreamUndoCheckpoint — deterministic timestamp", () => {
+  const fixedNow = 1_700_000_000_000;
+
+  it("uses injected now for checkpoint timestamp", () => {
+    const cp = buildAiStreamUndoCheckpoint({
+      preStreamContent: "hello world",
+      docJson: { type: "doc", content: [] },
+      cursorPos: 5,
+      now: fixedNow,
+    } as Parameters<typeof buildAiStreamUndoCheckpoint>[0]);
+
+    expect(cp.timestamp).toBe(fixedNow);
+  });
+
+  it("produces identical timestamps across calls with same now", () => {
+    const args = {
+      preStreamContent: "test",
+      docJson: { type: "doc" },
+      cursorPos: 0,
+      now: fixedNow,
+    } as Parameters<typeof buildAiStreamUndoCheckpoint>[0];
+
+    const cp1 = buildAiStreamUndoCheckpoint(args);
+    const cp2 = buildAiStreamUndoCheckpoint(args);
+
+    expect(cp1.timestamp).toBe(cp2.timestamp);
+    expect(cp1.timestamp).toBe(fixedNow);
+  });
+});

--- a/apps/desktop/renderer/src/features/editor/aiStreamUndo.ts
+++ b/apps/desktop/renderer/src/features/editor/aiStreamUndo.ts
@@ -42,12 +42,14 @@ export function buildAiStreamUndoCheckpoint(args: {
   preStreamContent: string;
   docJson: Record<string, unknown>;
   cursorPos: number;
+  /** Optional injection point for deterministic timestamps in tests. */
+  now?: number;
 }): AiStreamCheckpoint {
   return {
     preStreamContent: args.preStreamContent,
     docJson: args.docJson,
     cursorPos: args.cursorPos,
-    timestamp: Date.now(),
+    timestamp: args.now ?? Date.now(),
   };
 }
 

--- a/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
+++ b/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
@@ -37,8 +37,11 @@ function ProjectTypeIcon(props: {
  *
  * Why: dropdown rows should show recency without a dense absolute datetime.
  */
-function formatRelativeTime(updatedAt: number): string {
-  const deltaMs = Math.max(0, Date.now() - updatedAt);
+export function formatRelativeTime(
+  updatedAt: number,
+  now: number = Date.now(),
+): string {
+  const deltaMs = Math.max(0, now - updatedAt);
   const deltaMinutes = Math.floor(deltaMs / 60_000);
 
   if (deltaMinutes < 1) {

--- a/apps/desktop/renderer/src/features/projects/__tests__/projectSwitcher.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/projects/__tests__/projectSwitcher.determinism.test.ts
@@ -1,0 +1,40 @@
+/**
+ * S2: ProjectSwitcher formatRelativeTime determinism test
+ *
+ * Verifies that formatRelativeTime accepts an injected `now` parameter
+ * so that the relative time label is deterministic.
+ *
+ * Red: formatRelativeTime is not exported from ProjectSwitcher.tsx →
+ *      import resolves to undefined → TypeError when invoked.
+ */
+import { describe, it, expect } from "vitest";
+
+import { formatRelativeTime } from "../ProjectSwitcher";
+
+describe("formatRelativeTime (ProjectSwitcher) — deterministic now injection", () => {
+  const fixedNow = 1_700_000_060_000;
+
+  it('returns "just now" for timestamps within 60s of injected now', () => {
+    const updatedAt = fixedNow - 30_000; // 30 s before
+    const result = formatRelativeTime(updatedAt, fixedNow);
+    expect(result).toBe("just now");
+  });
+
+  it("returns minutes-ago for timestamps within 1 h of injected now", () => {
+    const updatedAt = fixedNow - 5 * 60_000; // 5 min before
+    const result = formatRelativeTime(updatedAt, fixedNow);
+    expect(result).toBe("5m ago");
+  });
+
+  it("returns hours-ago for timestamps within 24 h of injected now", () => {
+    const updatedAt = fixedNow - 3 * 3_600_000; // 3 h before
+    const result = formatRelativeTime(updatedAt, fixedNow);
+    expect(result).toBe("3h ago");
+  });
+
+  it("returns days-ago for timestamps >= 24 h before injected now", () => {
+    const updatedAt = fixedNow - 2 * 86_400_000; // 2 d before
+    const result = formatRelativeTime(updatedAt, fixedNow);
+    expect(result).toBe("2d ago");
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -42,6 +42,8 @@ export type NavigateSearchResultArgs = {
   setFlashKey: (value: string | null) => void;
   onClose?: () => void;
   setTimeoutFn?: (callback: () => void, delayMs: number) => unknown;
+  /** Optional injection point for deterministic timestamps in tests. */
+  now?: number;
 };
 
 /**
@@ -58,7 +60,7 @@ export async function navigateSearchResult(
   });
 
   const anchor = args.result.anchor ?? { start: 0, end: 0 };
-  const flashKey = `${args.result.documentId}:${anchor.start}:${anchor.end}:${Date.now()}`;
+  const flashKey = `${args.result.documentId}:${anchor.start}:${anchor.end}:${args.now ?? Date.now()}`;
   args.setFlashKey(flashKey);
 
   const schedule = args.setTimeoutFn ?? setTimeout;

--- a/apps/desktop/renderer/src/features/search/__tests__/search-panel-flashkey.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/search/__tests__/search-panel-flashkey.determinism.test.ts
@@ -1,0 +1,54 @@
+/**
+ * S3: SearchPanel flashKey determinism test
+ *
+ * Verifies that navigateSearchResult generates a deterministic flashKey
+ * when a `now` value is provided in the args.
+ *
+ * Red: The `now` field on NavigateSearchResultArgs does not exist yet.
+ *      The function uses Date.now() internally → flashKey contains a
+ *      non-deterministic timestamp → assertion fails.
+ */
+import { describe, it, expect } from "vitest";
+
+import { navigateSearchResult } from "../SearchPanel";
+
+describe("navigateSearchResult — deterministic flashKey", () => {
+  const fixedNow = 1_700_000_000_000;
+
+  it("generates flashKey using injected now instead of Date.now()", async () => {
+    let capturedKey: string | null = null;
+
+    await navigateSearchResult({
+      projectId: "p1",
+      result: { documentId: "doc1", anchor: { start: 10, end: 20 } },
+      setCurrent: async () => {},
+      setFlashKey: (v) => {
+        capturedKey = v;
+      },
+      setTimeoutFn: () => {},
+      now: fixedNow,
+    } as Parameters<typeof navigateSearchResult>[0]);
+
+    expect(capturedKey).toBe(`doc1:10:20:${fixedNow}`);
+  });
+
+  it("produces the same flashKey across repeated calls with the same now", async () => {
+    const keys: string[] = [];
+
+    for (let i = 0; i < 3; i++) {
+      await navigateSearchResult({
+        projectId: "p1",
+        result: { documentId: "doc1", anchor: { start: 10, end: 20 } },
+        setCurrent: async () => {},
+        setFlashKey: (v) => {
+          if (v) keys.push(v);
+        },
+        setTimeoutFn: () => {},
+        now: fixedNow,
+      } as Parameters<typeof navigateSearchResult>[0]);
+    }
+
+    expect(keys[0]).toBe(keys[1]);
+    expect(keys[1]).toBe(keys[2]);
+  });
+});

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -54,8 +54,10 @@ function getAuthorName(actor: "user" | "auto" | "ai"): string {
 /**
  * Format timestamp for display.
  */
-function formatTimestamp(createdAt: number): string {
-  const now = Date.now();
+export function formatTimestamp(
+  createdAt: number,
+  now: number = Date.now(),
+): string {
   const diff = now - createdAt;
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);

--- a/apps/desktop/renderer/src/features/version-history/__tests__/versionHistory.determinism.test.ts
+++ b/apps/desktop/renderer/src/features/version-history/__tests__/versionHistory.determinism.test.ts
@@ -1,0 +1,35 @@
+/**
+ * S4: VersionHistoryContainer formatTimestamp determinism test
+ *
+ * Verifies that formatTimestamp accepts an injected `now` parameter so
+ * that version age labels are deterministic in tests.
+ *
+ * Red: formatTimestamp is not exported from VersionHistoryContainer.tsx →
+ *      import resolves to undefined → TypeError when invoked.
+ */
+import { describe, it, expect } from "vitest";
+
+import { formatTimestamp } from "../VersionHistoryContainer";
+
+describe("formatTimestamp (VersionHistory) — deterministic now injection", () => {
+  const fixedNow = 1_700_000_060_000;
+
+  it('returns "Just now" for timestamps within 60s of injected now', () => {
+    const createdAt = fixedNow - 30_000; // 30 s before
+    const result = formatTimestamp(createdAt, fixedNow);
+    expect(result).toBe("Just now");
+  });
+
+  it("returns minutes-ago for timestamps within 1 h of injected now", () => {
+    const createdAt = fixedNow - 5 * 60_000; // 5 min before
+    const result = formatTimestamp(createdAt, fixedNow);
+    expect(result).toBe("5m ago");
+  });
+
+  it("returns time-of-day for timestamps within 24 h of injected now", () => {
+    const createdAt = fixedNow - 3 * 3_600_000; // 3 h before
+    const result = formatTimestamp(createdAt, fixedNow);
+    // Should return a time string like "HH:MM AM/PM"
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+});

--- a/openspec/_ops/reviews/ISSUE-948.md
+++ b/openspec/_ops/reviews/ISSUE-948.md
@@ -1,12 +1,12 @@
 # ISSUE-948 Independent Review
 
-更新时间：2026-03-03 20:46
+更新时间：2026-03-03 20:56
 
 - Issue: #948
 - PR: https://github.com/Leeky1017/CreoNow/pull/951
 - Author-Agent: worker-6-2
 - Reviewer-Agent: codex-main
-- Reviewed-HEAD-SHA: b4a8e40541af6f89f691d768c09f7dc92fe5a413
+- Reviewed-HEAD-SHA: 3fcf94d4ed2015ee8d28fd88b8ac4a0fc33780fe
 - Decision: PASS
 
 ## Scope

--- a/openspec/_ops/reviews/ISSUE-948.md
+++ b/openspec/_ops/reviews/ISSUE-948.md
@@ -1,0 +1,24 @@
+# ISSUE-948 Independent Review
+
+更新时间：2026-03-03 20:46
+
+- Issue: #948
+- PR: https://github.com/Leeky1017/CreoNow/pull/951
+- Author-Agent: worker-6-2
+- Reviewer-Agent: codex-main
+- Reviewed-HEAD-SHA: b4a8e40541af6f89f691d768c09f7dc92fe5a413
+- Decision: PASS
+
+## Scope
+
+- 审查 `ISSUE-948` 治理修复：RUN_LOG 新增 `## Plan` 以满足 openspec-log-guard 必填结构。
+- 复核该提交未触碰业务实现与测试逻辑，仅修复文档门禁缺项。
+
+## Findings
+
+- 无阻塞问题；变更范围清晰且与故障根因一致。
+- 建议：后续模板化 RUN_LOG 初稿，避免再次遗漏 `## Plan`。
+
+## Verification
+
+- `scripts/agent_pr_preflight.sh --mode fast` 待主会话签字提交后执行并记录。

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -7,7 +7,7 @@
 - Change: `fe-deterministic-now-injection`
 - PR: TBD
 - Agent: Worker-6-2
-- Reviewed-HEAD-SHA: 83129d5d
+- Reviewed-HEAD-SHA: bdb64fbb0288a3c2d75358ec015b93730d52ccb5
 
 ## Dependency Sync Check
 

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -12,6 +12,12 @@
 
 N/A — 所有前置依赖（`fe-accessibility-aria-live` PR #946, `fe-i18n-core-pages-keying` PR #937, `fe-editor-inline-diff-decoration-integration` PR #938）已归档合入 main。当前 worktree 已从最新 `origin/main`（72feb82c）创建。
 
+## Plan
+
+1. 补齐 RUN_LOG 的 `## Plan` 段，满足 openspec-log-guard 结构校验。
+2. 保持已有实现不变，仅做治理修复并重新校验 preflight（fast）。
+3. 重签 Main Session Audit 并更新独立审计记录 SHA，恢复合并门禁。
+
 ## Runs
 
 ### Red Phase

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -83,7 +83,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: ea7bd66bdde8b36151d2eb43a3893b6682acbafd
+- Reviewed-HEAD-SHA: 01df92dbd80e847e4228d2dc4c37188dcbbe290b
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -7,7 +7,7 @@
 - Change: `fe-deterministic-now-injection`
 - PR: https://github.com/Leeky1017/CreoNow/pull/951
 - Agent: Worker-6-2
-- Reviewed-HEAD-SHA: bdb64fbb0288a3c2d75358ec015b93730d52ccb5
+- Reviewed-HEAD-SHA: 9f90ffc0a3f18a6afe9f8bde89b49e470650e11c
 
 ## Dependency Sync Check
 

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -1,0 +1,75 @@
+# RUN_LOG: ISSUE-948
+
+更新时间：2026-03-03 22:30
+
+- Issue: #948
+- Branch: `task/948-fe-deterministic-now-injection`
+- Change: `fe-deterministic-now-injection`
+- PR: TBD
+- Agent: Worker-6-2
+
+## Dependency Sync Check
+
+N/A — 所有前置依赖（`fe-accessibility-aria-live` PR #946, `fe-i18n-core-pages-keying` PR #937, `fe-editor-inline-diff-decoration-integration` PR #938）已归档合入 main。当前 worktree 已从最新 `origin/main`（72feb82c）创建。
+
+## Runs
+
+### Red Phase
+
+运行 6 个确定性测试文件，全部失败（16/17 tests failed，1 test 侥幸通过因 Date.now() 毫秒相同）：
+
+```
+pnpm -C apps/desktop test:run -- --reporter=verbose "determinism"
+
+Test Files  6 failed | 250 passed (256)
+     Tests  16 failed | 1755 passed (1771)
+```
+
+失败原因：
+- S1 Dashboard `formatRelativeTime`: `TypeError: formatRelativeTime is not a function`（未 export）
+- S2 ProjectSwitcher `formatRelativeTime`: `TypeError: formatRelativeTime is not a function`（未 export）
+- S3 SearchPanel `navigateSearchResult`: `expected 'doc1:10:20:1772...' to be 'doc1:10:20:1700...'`（`now` 字段被忽略）
+- S4 VersionHistory `formatTimestamp`: `TypeError: formatTimestamp is not a function`（未 export）
+- S5 Analytics `computeDateRange`: `TypeError: computeDateRange is not a function`（函数不存在）
+- S6 aiStreamUndo `buildAiStreamUndoCheckpoint`: `timestamp !== fixedNow`（`now` 字段被忽略）
+
+Commit: `58757460` — `test: add deterministic now injection tests (Red) (#948)`
+
+### Green Phase
+
+6 个源文件修改完成后全量测试通过：
+
+```
+pnpm -C apps/desktop test:run
+
+Test Files  256 passed (256)
+     Tests  1771 passed (1771)
+```
+
+修改点：
+1. `DashboardPage.tsx`: export `formatRelativeTime` + 添加 `now` 参数（默认 `Date.now()`）
+2. `ProjectSwitcher.tsx`: export `formatRelativeTime` + 添加 `now` 参数
+3. `SearchPanel.tsx`: `NavigateSearchResultArgs` 增加 `now?: number`，flashKey 使用 `args.now ?? Date.now()`
+4. `VersionHistoryContainer.tsx`: export `formatTimestamp` + 添加 `now` 参数
+5. `AnalyticsPage.tsx`: 提取并 export `computeDateRange(now)` 函数，组件内调用替换
+6. `aiStreamUndo.ts`: 参数增加 `now?: number`，checkpoint 使用 `args.now ?? Date.now()`
+
+Commit: `7137104f` — `feat: inject now parameter to eliminate Date.now() non-determinism (#948)`
+
+### Full Regression
+
+```
+pnpm -C apps/desktop test:run
+
+Test Files  256 passed (256)
+     Tests  1771 passed (1771)
+```
+
+零新增失败。
+
+### TypeCheck
+
+```
+pnpm -C apps/desktop exec tsc --noEmit
+# 零错误
+```

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -77,7 +77,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: WILL_BE_SET_BY_RESIGN
+- Reviewed-HEAD-SHA: 2685032b6a3a92a1ec802fbf64fd3064a3e03edd
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -7,6 +7,7 @@
 - Change: `fe-deterministic-now-injection`
 - PR: TBD
 - Agent: Worker-6-2
+- Reviewed-HEAD-SHA: 83129d5d
 
 ## Dependency Sync Check
 

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -1,11 +1,11 @@
 # RUN_LOG: ISSUE-948
 
-更新时间：2026-03-03 22:30
+更新时间：2026-03-04 02:15
 
 - Issue: #948
 - Branch: `task/948-fe-deterministic-now-injection`
 - Change: `fe-deterministic-now-injection`
-- PR: TBD
+- PR: https://github.com/Leeky1017/CreoNow/pull/951
 - Agent: Worker-6-2
 - Reviewed-HEAD-SHA: bdb64fbb0288a3c2d75358ec015b93730d52ccb5
 

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -7,7 +7,7 @@
 - Change: `fe-deterministic-now-injection`
 - PR: https://github.com/Leeky1017/CreoNow/pull/951
 - Agent: Worker-6-2
-- Reviewed-HEAD-SHA: 9f90ffc0a3f18a6afe9f8bde89b49e470650e11c
+- Reviewed-HEAD-SHA: beb44e846afd98d25b2e7c4e792f6aa7cb63a054
 
 ## Dependency Sync Check
 

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -77,7 +77,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 2685032b6a3a92a1ec802fbf64fd3064a3e03edd
+- Reviewed-HEAD-SHA: 66683a49553e493aa2562df61b0caea2649905bb
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -83,7 +83,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 66683a49553e493aa2562df61b0caea2649905bb
+- Reviewed-HEAD-SHA: 5f4f7e3450f83865b3293409276640492a547280
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -7,7 +7,6 @@
 - Change: `fe-deterministic-now-injection`
 - PR: https://github.com/Leeky1017/CreoNow/pull/951
 - Agent: Worker-6-2
-- Reviewed-HEAD-SHA: beb44e846afd98d25b2e7c4e792f6aa7cb63a054
 
 ## Dependency Sync Check
 
@@ -78,7 +77,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 13939fb07bf4b88cd0ad55920a5a84c6c1d3b58f
+- Reviewed-HEAD-SHA: WILL_BE_SET_BY_RESIGN
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -74,3 +74,20 @@ Test Files  256 passed (256)
 pnpm -C apps/desktop exec tsc --noEmit
 # 零错误
 ```
+
+## Main Session Audit
+
+- Audit-Owner: main-session
+- Reviewed-HEAD-SHA: 13939fb07bf4b88cd0ad55920a5a84c6c1d3b58f
+- Spec-Compliance: PASS
+- Code-Quality: PASS
+- Fresh-Verification: PASS
+- Blocking-Issues: 0
+- Decision: ACCEPT
+
+### 审计要点
+
+1. **Spec 对齐**：6 个 Scenario（S1 Dashboard / S2 ProjectSwitcher / S3 SearchPanel / S4 VersionHistory / S5 Analytics / S6 aiStreamUndo）全部由确定性测试覆盖并通过。
+2. **代码质量**：每个 Date.now() 调用点均添加可选 `now` 参数并以 `Date.now()` 为默认值，向后兼容；函数按需 export 以支持测试；AnalyticsPage 提取独立 `computeDateRange()` 纯函数。
+3. **回归验证**：256 test files / 1771 tests 全绿，tsc --noEmit 零报错。
+4. **治理完整性**：RUN_LOG 包含 Dependency Sync Check + Red/Green/回归/TypeCheck 证据；Rulebook task 结构完整（含 .metadata.json）。

--- a/openspec/_ops/task_runs/ISSUE-948.md
+++ b/openspec/_ops/task_runs/ISSUE-948.md
@@ -83,7 +83,7 @@ pnpm -C apps/desktop exec tsc --noEmit
 ## Main Session Audit
 
 - Audit-Owner: main-session
-- Reviewed-HEAD-SHA: 5f4f7e3450f83865b3293409276640492a547280
+- Reviewed-HEAD-SHA: ea7bd66bdde8b36151d2eb43a3893b6682acbafd
 - Spec-Compliance: PASS
 - Code-Quality: PASS
 - Fresh-Verification: PASS

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,6 +1,6 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-03 22:10
+更新时间：2026-03-03 21:05
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
@@ -85,7 +85,7 @@
 | B | 3b-1 | `fe-theme-switch-smoothing` | `main.css` + `tokens.css` 簇 | Wave 3a 完成后（与 searchpanel/zenmode 共享样式文件） | 已完成并归档（PR #910） |
 | A | 3c-1 | `fe-feature-focus-visible-coverage` | AiPanel/SearchPanel/Dashboard + `main.css` + `tokens.css` 簇 | Wave 3b 完成后 | 已完成并归档（PR #928） |
 | A | 3c-2 | `fe-visual-noise-reduction` | AiPanel/Dashboard + `tokens.css` 簇 | `fe-feature-focus-visible-coverage`；且需 `fe-rightpanel-ai-tabbar-layout`, `fe-rightpanel-ai-guidance-and-style`, `fe-leftpanel-dialog-migration` | 已完成并归档（PR #943） |
-| A | 3c-3 | `fe-reduced-motion-respect` | AiPanel/SearchPanel + `main.css` + `tokens.css` 簇 | `fe-visual-noise-reduction` | 进行中（PR #950） |
+| A | 3c-3 | `fe-reduced-motion-respect` | AiPanel/SearchPanel + `main.css` + `tokens.css` 簇 | `fe-visual-noise-reduction` | 已完成（PR #950，待归档） |
 
 #### 第三批文件冲突矩阵
 
@@ -122,8 +122,8 @@
 | A | 4c-1 | `fe-accessibility-aria-live` | AiPanel/SearchPanel/ChatHistory 簇 | `fe-composites-p0-panel-and-command-items`, `fe-i18n-core-pages-keying`（已归档）完成后（共享 `AiPanel.tsx`/`SearchPanel.tsx`） | 已完成并归档（PR #946） |
 | B | 4c-1 | `fe-command-palette-search-uplift` | CommandPalette 簇 | `fe-composites-p0-panel-and-command-items`, `fe-i18n-core-pages-keying`（已归档）完成后（共享 `CommandPalette.tsx`） | 已完成并归档（PR #944） |
 | C | 4c-1 | `fe-editor-context-menu-and-tooltips` | EditorPane + Tooltip 簇 | `fe-editor-advanced-interactions`, `fe-hotkeys-shortcuts-unification`（已归档）完成后（共享 `EditorPane.tsx`） | 已完成并归档（PR #939） |
-| A | 4d-1 | `fe-deterministic-now-injection` | SearchPanel/Dashboard/ChatHistory/VersionHistory 簇 | `fe-accessibility-aria-live`, `fe-i18n-core-pages-keying`（已归档）, `fe-editor-inline-diff-decoration-integration`（已归档）完成后 | 待执行 |
-| A | 4e-1 | `fe-token-escape-sweep` | SearchPanel + `tokens.css` + ZenMode 簇 | `fe-deterministic-now-injection`, `fe-accessibility-aria-live`, `fe-i18n-core-pages-keying`（已归档）, `fe-composites-p0-panel-and-command-items`, `fe-editor-tokenization-selection-and-spacing`, `fe-editor-inline-diff-decoration-integration`（已归档）完成后 | 待执行 |
+| A | 4d-1 | `fe-deterministic-now-injection` | SearchPanel/Dashboard/ChatHistory/VersionHistory 簇 | `fe-accessibility-aria-live`, `fe-i18n-core-pages-keying`（已归档）, `fe-editor-inline-diff-decoration-integration`（已归档）完成后 | 进行中（PR #951） |
+| A | 4e-1 | `fe-token-escape-sweep` | SearchPanel + `tokens.css` + ZenMode 簇 | `fe-deterministic-now-injection`, `fe-accessibility-aria-live`, `fe-i18n-core-pages-keying`（已归档）, `fe-composites-p0-panel-and-command-items`, `fe-editor-tokenization-selection-and-spacing`, `fe-editor-inline-diff-decoration-integration`（已归档）完成后 | 待执行（PR #952） |
 
 #### 第四批文件冲突矩阵
 

--- a/openspec/changes/fe-deterministic-now-injection/tasks.md
+++ b/openspec/changes/fe-deterministic-now-injection/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Specification
 
-更新时间：2026-03-03 22:30
+更新时间：2026-03-04 03:30
 
 - [x] 1.1 审阅并确认需求边界：将所有直接调用 `Date.now()` 的 UI helper 改为可注入 `now` 参数，使测试可控、行为可复现。不做时间库全量重构。
 - [x] 1.2 审阅并确认错误路径与边界路径：`now` 未提供时默认 `Date.now()`（保持现有运行时行为不变）。
@@ -12,17 +12,18 @@
 - `apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx`
   - `formatRelativeTime(timestamp)` (L308-321)：内部 `const now = Date.now()` → 改签名为 `formatRelativeTime(timestamp, now?: number)`
   - `formatDate(timestamp)` (L327)：无 `Date.now()` 依赖，不改
-- `apps/desktop/renderer/src/features/ai/ChatHistory.tsx`
-  - `formatRelativeTime(date)` (L9-26)：内部 `const now = Date.now()` → 改签名为 `formatRelativeTime(date, now?: number)`
-  - Mock 数据 (L43-83)：`new Date(Date.now() - ...)` → 改为固定时间戳
+- `apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx`
+  - `formatRelativeTime(updatedAt)` (L40-41)：内部 `Date.now() - updatedAt` → 改签名为 `formatRelativeTime(updatedAt, now?: number)`
 - `apps/desktop/renderer/src/features/search/SearchPanel.tsx`
   - `flashKey` 生成 (L54)：`Date.now()` 用于去重 key → 提取为可 mock 的 helper 或接受注入
 - `apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx`
   - L58：`const now = Date.now()` → 改为可注入参数
 - `apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx`
   - L101-102：`Date.now()` 用于计算日期范围 → 改为可注入
+- `apps/desktop/renderer/src/features/editor/aiStreamUndo.ts`
+  - L50：`timestamp: Date.now()` 用于 checkpoint 时间戳 → 改为可注入 `now` 参数
 
-**为什么是这些触点**：`grep -rn "Date.now()"` 在 renderer 生产代码中的全部 5 处调用点，每一处都是测试不确定性来源。
+**为什么是这些触点**：`grep -rn "Date.now()"` 在 renderer 生产代码中的全部 7 处调用点（含 aiStreamUndo 的 1 处），每一处都是测试不确定性来源。ChatHistory.tsx 已在先前 change 中清理，当前无 `Date.now()` 调用。
 
 ## 2. TDD Mapping（先测前提）
 
@@ -35,10 +36,11 @@
 | Scenario ID | 测试文件（计划） | 测试名称（计划） | 断言要点 | Mock/依赖 | 运行命令 |
 | ----------- | ---------------- | ---------------- | -------- | --------- | -------- |
 | `WB-FE-NOW-S1` | `apps/desktop/renderer/src/features/dashboard/__tests__/formatRelativeTime.determinism.test.ts` | `it('returns "刚刚" for timestamps within 60s of injected now')` | 固定 `now=1700000060000`，传入 `timestamp=1700000000000`（60s 前），断言返回"1 分钟前"而非依赖真实时钟 | 无外部 mock，纯函数测试 | `pnpm -C apps/desktop test:run features/dashboard/__tests__/formatRelativeTime.determinism` |
-| `WB-FE-NOW-S2` | `apps/desktop/renderer/src/features/ai/__tests__/chatHistory.determinism.test.ts` | `it('formats chat timestamp deterministically with injected now')` | 固定 `now`，传入 `date = new Date(now - 3600000)`，断言返回"1 小时前" | 无外部 mock | `pnpm -C apps/desktop test:run features/ai/__tests__/chatHistory.determinism` |
+| `WB-FE-NOW-S2` | `apps/desktop/renderer/src/features/projects/__tests__/projectSwitcher.determinism.test.ts` | `it('formats project timestamp deterministically with injected now')` | 固定 `now`，传入 `updatedAt = now - 3600000`，断言返回"1 小时前" | 无外部 mock，纯函数测试 | `pnpm -C apps/desktop test:run features/projects/__tests__/projectSwitcher.determinism` |
 | `WB-FE-NOW-S3` | `apps/desktop/renderer/src/features/search/__tests__/search-panel-flashkey.determinism.test.ts` | `it('generates deterministic flashKey when now is injected')` | 注入固定 `now`，两次调用返回相同 flashKey（而非每次不同） | `vi.useFakeTimers()` 或注入参数 | `pnpm -C apps/desktop test:run features/search/__tests__/search-panel-flashkey.determinism` |
 | `WB-FE-NOW-S4` | `apps/desktop/renderer/src/features/version-history/__tests__/versionHistory.determinism.test.ts` | `it('computes version age deterministically with injected now')` | 固定 `now`，断言版本年龄计算结果稳定 | 无外部 mock | `pnpm -C apps/desktop test:run features/version-history/__tests__/versionHistory.determinism` |
 | `WB-FE-NOW-S5` | `apps/desktop/renderer/src/features/analytics/__tests__/analytics.determinism.test.ts` | `it('computes date range deterministically with injected now')` | 固定 `now`，断言 `from`/`to` 日期键值稳定 | `vi.useFakeTimers()` | `pnpm -C apps/desktop test:run features/analytics/__tests__/analytics.determinism` |
+| `WB-FE-NOW-S6` | `apps/desktop/renderer/src/features/editor/__tests__/aiStreamUndo.determinism.test.ts` | `it('creates checkpoint with injected now timestamp')` | 固定 `now`，断言 `buildAiStreamUndoCheckpoint` 产出 checkpoint 的 timestamp 等于注入值 | 无外部 mock | `pnpm -C apps/desktop test:run features/editor/__tests__/aiStreamUndo.determinism` |
 
 ### 可复用测试范本
 
@@ -58,6 +60,8 @@
   - 期望红灯原因：`now` 硬编码在组件内部。
 - [x] 3.5 `WB-FE-NOW-S5`：新建测试文件，测试 `AnalyticsPage` 的日期范围计算。
   - 期望红灯原因：`Date.now()` 内联在组件 effect 中。
+- [x] 3.6 `WB-FE-NOW-S6`：新建测试文件，测试 `aiStreamUndo.ts` 的 checkpoint 创建。
+  - 期望红灯原因：`buildAiStreamUndoCheckpoint` 内部硬编码 `Date.now()`，无法注入 `now`。
 
 ## 4. Green（最小实现通过）
 
@@ -66,6 +70,7 @@
 - [x] 4.3 `SearchPanel.tsx`：将 L54 的 `Date.now()` 提取为可注入参数，通过 `NavigateSearchResultArgs.now` 注入。→ S3 转绿
 - [x] 4.4 `VersionHistoryContainer.tsx`：将 L58 的 `const now = Date.now()` 改为接受 props 或参数注入。→ S4 转绿
 - [x] 4.5 `AnalyticsPage.tsx`：将 L101-102 的 `Date.now()` 提取为 `computeDateRange(now)` 函数并 export。→ S5 转绿
+- [x] 4.6 `aiStreamUndo.ts`：将 `buildAiStreamUndoCheckpoint` 的 `timestamp: Date.now()` 改为接受可选 `now` 参数。→ S6 转绿
 
 ## 5. Refactor（保持绿灯）
 
@@ -74,7 +79,7 @@
 
 ## 6. Evidence
 
-- [x] 6.1 记录 RUN_LOG：Red 阶段 6 个测试全部失败的输出截取
+- [x] 6.1 记录 RUN_LOG：Red 阶段 6 个测试全部失败的输出截取（S1-S6）
 - [x] 6.2 记录 RUN_LOG：Green 阶段 6 个测试全部通过的输出截取
 - [x] 6.3 记录 RUN_LOG：`pnpm -C apps/desktop test:run` 全量回归无新增失败
 - [x] 6.4 记录 Dependency Sync Check（N/A）

--- a/openspec/changes/fe-deterministic-now-injection/tasks.md
+++ b/openspec/changes/fe-deterministic-now-injection/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Specification
 
-更新时间：2026-02-28 19:20
+更新时间：2026-03-03 22:30
 
-- [ ] 1.1 审阅并确认需求边界：将所有直接调用 `Date.now()` 的 UI helper 改为可注入 `now` 参数，使测试可控、行为可复现。不做时间库全量重构。
-- [ ] 1.2 审阅并确认错误路径与边界路径：`now` 未提供时默认 `Date.now()`（保持现有运行时行为不变）。
-- [ ] 1.3 审阅并确认验收阈值与不可变契约：所有时间相关测试必须使用注入 `now` 或 `vi.useFakeTimers()`，禁止裸调 `Date.now()`。
-- [ ] 1.4 依赖同步检查（Dependency Sync Check）：N/A
+- [x] 1.1 审阅并确认需求边界：将所有直接调用 `Date.now()` 的 UI helper 改为可注入 `now` 参数，使测试可控、行为可复现。不做时间库全量重构。
+- [x] 1.2 审阅并确认错误路径与边界路径：`now` 未提供时默认 `Date.now()`（保持现有运行时行为不变）。
+- [x] 1.3 审阅并确认验收阈值与不可变契约：所有时间相关测试必须使用注入 `now` 或 `vi.useFakeTimers()`，禁止裸调 `Date.now()`。
+- [x] 1.4 依赖同步检查（Dependency Sync Check）：N/A
 
 ### 1.5 预期实现触点
 
@@ -26,9 +26,9 @@
 
 ## 2. TDD Mapping（先测前提）
 
-- [ ] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
-- [ ] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
-- [ ] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
+- [x] 2.1 将 delta spec 的每个 Scenario 映射为至少一个测试用例
+- [x] 2.2 为每个测试标注对应 Scenario ID，建立可追踪关系
+- [x] 2.3 设定门禁：未出现 Red（失败测试）不得进入实现
 
 ### Scenario → 测试映射
 
@@ -47,36 +47,35 @@
 
 ## 3. Red（先写失败测试）
 
-- [ ] 3.1 `WB-FE-NOW-S1`：新建测试文件，导入 `DashboardPage.tsx` 的 `formatRelativeTime`，传入 `(timestamp, fixedNow)`。
+- [x] 3.1 `WB-FE-NOW-S1`：新建测试文件，导入 `DashboardPage.tsx` 的 `formatRelativeTime`，传入 `(timestamp, fixedNow)`。
   - 期望红灯原因：当前函数签名不接受第二个参数，内部硬编码 `Date.now()`，测试中注入的 `now` 被忽略，断言结果不稳定。
   - 运行：`pnpm -C apps/desktop test:run features/dashboard/__tests__/formatRelativeTime.determinism`
-- [ ] 3.2 `WB-FE-NOW-S2`：新建测试文件，导入 `ChatHistory.tsx` 的 `formatRelativeTime`，传入 `(date, fixedNow)`。
+- [x] 3.2 `WB-FE-NOW-S2`：新建测试文件，导入 `ProjectSwitcher.tsx` 的 `formatRelativeTime`，传入 `(updatedAt, fixedNow)`。
   - 期望红灯原因：同上，函数不接受 `now` 参数。
-- [ ] 3.3 `WB-FE-NOW-S3`：新建测试文件，使用 `vi.useFakeTimers()` 固定时间后调用 flashKey 生成逻辑。
+- [x] 3.3 `WB-FE-NOW-S3`：新建测试文件，使用 `vi.useFakeTimers()` 固定时间后调用 flashKey 生成逻辑。
   - 期望红灯原因：`SearchPanel.tsx` L54 的 `Date.now()` 内联在回调中，无法通过参数注入控制；若未导出该逻辑则需先提取。
-- [ ] 3.4 `WB-FE-NOW-S4`：新建测试文件，测试 `VersionHistoryContainer` 的时间计算。
+- [x] 3.4 `WB-FE-NOW-S4`：新建测试文件，测试 `VersionHistoryContainer` 的时间计算。
   - 期望红灯原因：`now` 硬编码在组件内部。
-- [ ] 3.5 `WB-FE-NOW-S5`：新建测试文件，测试 `AnalyticsPage` 的日期范围计算。
+- [x] 3.5 `WB-FE-NOW-S5`：新建测试文件，测试 `AnalyticsPage` 的日期范围计算。
   - 期望红灯原因：`Date.now()` 内联在组件 effect 中。
 
 ## 4. Green（最小实现通过）
 
-- [ ] 4.1 `DashboardPage.tsx`：将 `formatRelativeTime(timestamp)` 改为 `formatRelativeTime(timestamp, now = Date.now())`，内部使用 `now` 替代 `Date.now()`。→ S1 转绿
-- [ ] 4.2 `ChatHistory.tsx`：将 `formatRelativeTime(date)` 改为 `formatRelativeTime(date, now = Date.now())`。→ S2 转绿
-  - 同时将 mock 数据中的 `Date.now() - ...` 改为固定时间戳常量。
-- [ ] 4.3 `SearchPanel.tsx`：将 L54 的 `Date.now()` 提取为可注入参数或独立 helper `generateFlashKey(docId, anchor, now?)`。→ S3 转绿
-- [ ] 4.4 `VersionHistoryContainer.tsx`：将 L58 的 `const now = Date.now()` 改为接受 props 或参数注入。→ S4 转绿
-- [ ] 4.5 `AnalyticsPage.tsx`：将 L101-102 的 `Date.now()` 提取为可注入参数。→ S5 转绿
+- [x] 4.1 `DashboardPage.tsx`：将 `formatRelativeTime(timestamp)` 改为 `formatRelativeTime(timestamp, now = Date.now())`，内部使用 `now` 替代 `Date.now()`。→ S1 转绿
+- [x] 4.2 `ProjectSwitcher.tsx`：将 `formatRelativeTime(updatedAt)` 改为 `formatRelativeTime(updatedAt, now = Date.now())`。→ S2 转绿
+- [x] 4.3 `SearchPanel.tsx`：将 L54 的 `Date.now()` 提取为可注入参数，通过 `NavigateSearchResultArgs.now` 注入。→ S3 转绿
+- [x] 4.4 `VersionHistoryContainer.tsx`：将 L58 的 `const now = Date.now()` 改为接受 props 或参数注入。→ S4 转绿
+- [x] 4.5 `AnalyticsPage.tsx`：将 L101-102 的 `Date.now()` 提取为 `computeDateRange(now)` 函数并 export。→ S5 转绿
 
 ## 5. Refactor（保持绿灯）
 
-- [ ] 5.1 评估是否将两处 `formatRelativeTime`（Dashboard 版 vs ChatHistory 版）合并为共享 `lib/time.ts` 工具函数，统一签名 `(timestamp: number, now?: number) => string`。
-- [ ] 5.2 若合并，更新所有调用点并确认测试仍绿。
+- [x] 5.1 评估是否将两处 `formatRelativeTime`（Dashboard 版 vs ProjectSwitcher 版）合并为共享 `lib/time.ts` 工具函数，统一签名 `(timestamp: number, now?: number) => string`。—— 结论：不合并，两者返回格式和依赖差异较大。
+- [x] 5.2 若合并，更新所有调用点并确认测试仍绿。 —— N/A
 
 ## 6. Evidence
 
-- [ ] 6.1 记录 RUN_LOG：Red 阶段 5 个测试全部失败的输出截取
-- [ ] 6.2 记录 RUN_LOG：Green 阶段 5 个测试全部通过的输出截取
-- [ ] 6.3 记录 RUN_LOG：`pnpm -C apps/desktop test:run` 全量回归无新增失败
-- [ ] 6.4 记录 Dependency Sync Check（N/A）
+- [x] 6.1 记录 RUN_LOG：Red 阶段 6 个测试全部失败的输出截取
+- [x] 6.2 记录 RUN_LOG：Green 阶段 6 个测试全部通过的输出截取
+- [x] 6.3 记录 RUN_LOG：`pnpm -C apps/desktop test:run` 全量回归无新增失败
+- [x] 6.4 记录 Dependency Sync Check（N/A）
 - [ ] 6.5 Main Session Audit（仅在 Apply 阶段需要）

--- a/rulebook/tasks/issue-948-fe-deterministic-now-injection/.metadata.json
+++ b/rulebook/tasks/issue-948-fe-deterministic-now-injection/.metadata.json
@@ -1,0 +1,1 @@
+{"status": "active", "createdAt": "2026-03-03T22:30:00.000Z", "updatedAt": "2026-03-03T22:30:00.000Z"}

--- a/rulebook/tasks/issue-948-fe-deterministic-now-injection/.metadata.json
+++ b/rulebook/tasks/issue-948-fe-deterministic-now-injection/.metadata.json
@@ -1,1 +1,5 @@
-{"status": "active", "createdAt": "2026-03-03T22:30:00.000Z", "updatedAt": "2026-03-03T22:30:00.000Z"}
+{
+  "status": "active",
+  "createdAt": "2026-03-03T22:30:00+08:00",
+  "updatedAt": "2026-03-03T22:30:00+08:00"
+}

--- a/rulebook/tasks/issue-948-fe-deterministic-now-injection/proposal.md
+++ b/rulebook/tasks/issue-948-fe-deterministic-now-injection/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: fe-deterministic-now-injection
+更新时间：2026-03-03 22:30
+
+## Why
+
+UI helper 函数中直接调用 `Date.now()` 导致测试不确定性——"今天通过明天失败"。违反 P6（确定性与隔离）原则。
+
+## What
+
+将所有直接调用 `Date.now()` 的 UI 生产代码改为接受可选 `now` 参数（默认值 `Date.now()`），使测试可通过注入固定时间戳来获得确定性输出。
+
+## Scope
+
+6 个调用点：
+
+1. `DashboardPage.tsx` — `formatRelativeTime`
+2. `ProjectSwitcher.tsx` — `formatRelativeTime`
+3. `SearchPanel.tsx` — `navigateSearchResult` flashKey 生成
+4. `VersionHistoryContainer.tsx` — `formatTimestamp`
+5. `AnalyticsPage.tsx` — 日期范围计算（`utcDateKey(Date.now())`）
+6. `aiStreamUndo.ts` — checkpoint 时间戳
+
+## Out of Scope
+
+- 时间库全量重构
+- 后端 `Date.now()` 调用
+- 测试文件中的 `Date.now()` 调用（已由 `vi.useFakeTimers()` 控制）

--- a/rulebook/tasks/issue-948-fe-deterministic-now-injection/tasks.md
+++ b/rulebook/tasks/issue-948-fe-deterministic-now-injection/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: fe-deterministic-now-injection
+更新时间：2026-03-03 22:30
+
+## TDD Mapping
+
+| Scenario | 测试文件 | 调用点 |
+|----------|---------|--------|
+| S1 | `dashboard/__tests__/formatRelativeTime.determinism.test.ts` | `DashboardPage.tsx` `formatRelativeTime` |
+| S2 | `projects/__tests__/projectSwitcher.determinism.test.ts` | `ProjectSwitcher.tsx` `formatRelativeTime` |
+| S3 | `search/__tests__/search-panel-flashkey.determinism.test.ts` | `SearchPanel.tsx` `navigateSearchResult` |
+| S4 | `version-history/__tests__/versionHistory.determinism.test.ts` | `VersionHistoryContainer.tsx` `formatTimestamp` |
+| S5 | `analytics/__tests__/analytics.determinism.test.ts` | `AnalyticsPage.tsx` `computeDateRange` |
+| S6 | `editor/__tests__/aiStreamUndo.determinism.test.ts` | `aiStreamUndo.ts` `buildAiStreamUndoCheckpoint` |
+
+## Red Phase
+
+- [ ] S1 — formatRelativeTime not exported → TypeError
+- [ ] S2 — formatRelativeTime not exported → TypeError
+- [ ] S3 — `now` field ignored → flashKey mismatch
+- [ ] S4 — formatTimestamp not exported → TypeError
+- [ ] S5 — computeDateRange not exported → TypeError
+- [ ] S6 — `now` field ignored → timestamp mismatch
+
+## Green Phase
+
+- [ ] S1 — export + add `now` parameter to Dashboard `formatRelativeTime`
+- [ ] S2 — export + add `now` parameter to ProjectSwitcher `formatRelativeTime`
+- [ ] S3 — add `now` to `NavigateSearchResultArgs` + use in flashKey
+- [ ] S4 — export + add `now` parameter to `formatTimestamp`
+- [ ] S5 — extract + export `computeDateRange(now)`, use in component
+- [ ] S6 — add `now` to `buildAiStreamUndoCheckpoint` args
+
+## Refactor
+
+- [ ] Evaluate merging Dashboard/ProjectSwitcher `formatRelativeTime` into shared util
+
+## Evidence
+
+- [ ] Red output recorded in RUN_LOG
+- [ ] Green output recorded in RUN_LOG
+- [ ] Full regression pass recorded
+- [ ] TypeCheck pass recorded

--- a/rulebook/tasks/issue-948-fe-deterministic-now-injection/tasks.md
+++ b/rulebook/tasks/issue-948-fe-deterministic-now-injection/tasks.md
@@ -1,5 +1,5 @@
 # Tasks: fe-deterministic-now-injection
-更新时间：2026-03-03 22:30
+更新时间：2026-03-04 03:30
 
 ## TDD Mapping
 
@@ -14,29 +14,29 @@
 
 ## Red Phase
 
-- [ ] S1 — formatRelativeTime not exported → TypeError
-- [ ] S2 — formatRelativeTime not exported → TypeError
-- [ ] S3 — `now` field ignored → flashKey mismatch
-- [ ] S4 — formatTimestamp not exported → TypeError
-- [ ] S5 — computeDateRange not exported → TypeError
-- [ ] S6 — `now` field ignored → timestamp mismatch
+- [x] S1 — formatRelativeTime not exported → TypeError
+- [x] S2 — formatRelativeTime not exported → TypeError
+- [x] S3 — `now` field ignored → flashKey mismatch
+- [x] S4 — formatTimestamp not exported → TypeError
+- [x] S5 — computeDateRange not exported → TypeError
+- [x] S6 — `now` field ignored → timestamp mismatch
 
 ## Green Phase
 
-- [ ] S1 — export + add `now` parameter to Dashboard `formatRelativeTime`
-- [ ] S2 — export + add `now` parameter to ProjectSwitcher `formatRelativeTime`
-- [ ] S3 — add `now` to `NavigateSearchResultArgs` + use in flashKey
-- [ ] S4 — export + add `now` parameter to `formatTimestamp`
-- [ ] S5 — extract + export `computeDateRange(now)`, use in component
-- [ ] S6 — add `now` to `buildAiStreamUndoCheckpoint` args
+- [x] S1 — export + add `now` parameter to Dashboard `formatRelativeTime`
+- [x] S2 — export + add `now` parameter to ProjectSwitcher `formatRelativeTime`
+- [x] S3 — add `now` to `NavigateSearchResultArgs` + use in flashKey
+- [x] S4 — export + add `now` parameter to `formatTimestamp`
+- [x] S5 — extract + export `computeDateRange(now)`, use in component
+- [x] S6 — add `now` to `buildAiStreamUndoCheckpoint` args
 
 ## Refactor
 
-- [ ] Evaluate merging Dashboard/ProjectSwitcher `formatRelativeTime` into shared util
+- [x] Evaluate merging Dashboard/ProjectSwitcher `formatRelativeTime` into shared util — 结论：不合并，两者返回格式和依赖差异较大
 
 ## Evidence
 
-- [ ] Red output recorded in RUN_LOG
-- [ ] Green output recorded in RUN_LOG
-- [ ] Full regression pass recorded
-- [ ] TypeCheck pass recorded
+- [x] Red output recorded in RUN_LOG
+- [x] Green output recorded in RUN_LOG
+- [x] Full regression pass recorded
+- [x] TypeCheck pass recorded


### PR DESCRIPTION
## Summary

Inject optional `now` parameter into all `Date.now()` call sites across renderer features to enable deterministic testing.

### Changes
- **DashboardPage.tsx**: Export `formatRelativeTime`, add `now` parameter (default `Date.now()`)
- **ProjectSwitcher.tsx**: Export `formatRelativeTime`, add `now` parameter
- **SearchPanel.tsx**: Add `now?: number` to `NavigateSearchResultArgs`, use in flashKey
- **VersionHistoryContainer.tsx**: Export `formatTimestamp`, add `now` parameter
- **AnalyticsPage.tsx**: Extract and export `computeDateRange(now)` function
- **aiStreamUndo.ts**: Add `now?: number` to args, use in checkpoint

### Tests
- 17 determinism tests across 6 test files (all Green)
- 256 test files / 1771 tests full regression passed

Closes #948