### PR TITLE
补齐前端缺失 Design Token（Diff 语义色/按钮状态色/窗口控件色） (#966)

### DIFF
--- a/apps/desktop/renderer/src/features/diff/DiffView.tsx
+++ b/apps/desktop/renderer/src/features/diff/DiffView.tsx
@@ -246,8 +246,8 @@ export function UnifiedDiffView(props: {
             data-line-index={index}
             className={`
               flex group transition-colors
-              ${isRemoved ? "bg-[rgba(239,68,68,0.1)]" : ""}
-              ${isAdded ? "bg-[rgba(34,197,94,0.1)]" : ""}
+              ${isRemoved ? "bg-[var(--color-diff-removed-bg)]" : ""}
+              ${isAdded ? "bg-[var(--color-diff-added-bg)]" : ""}
               ${isContext ? "hover:bg-[var(--color-bg-hover)]" : ""}
               ${isCurrentChange ? "ring-1 ring-inset ring-[var(--color-accent)]" : ""}
             `}
@@ -256,8 +256,8 @@ export function UnifiedDiffView(props: {
             <div
               className={`
                 w-20 shrink-0 flex select-none text-[11px] border-r border-[var(--color-separator)]
-                ${isRemoved ? "bg-[rgba(239,68,68,0.05)]" : ""}
-                ${isAdded ? "bg-[rgba(34,197,94,0.05)]" : ""}
+                ${isRemoved ? "bg-[var(--color-diff-removed-gutter-bg)]" : ""}
+                ${isAdded ? "bg-[var(--color-diff-added-gutter-bg)]" : ""}
                 ${isContext ? "bg-[var(--color-bg-base)]" : ""}
               `}
             >
@@ -298,8 +298,8 @@ export function UnifiedDiffView(props: {
             <div
               className={`
                 flex-1 px-4 py-1 whitespace-pre-wrap break-words
-                ${isRemoved ? "text-[rgba(239,68,68,0.7)] line-through decoration-[rgba(239,68,68,0.4)]" : ""}
-                ${isAdded ? "text-[rgba(34,197,94,0.9)]" : ""}
+                ${isRemoved ? "text-[var(--color-diff-removed-text)] line-through decoration-[var(--color-diff-removed-decoration)]" : ""}
+                ${isAdded ? "text-[var(--color-diff-added-text)]" : ""}
                 ${(isRemoved || isAdded) && underlineClass ? underlineClass : ""}
                 ${isContext ? "text-[var(--color-fg-muted)]" : ""}
               `}

--- a/apps/desktop/renderer/src/features/diff/SplitDiffView.tsx
+++ b/apps/desktop/renderer/src/features/diff/SplitDiffView.tsx
@@ -185,7 +185,7 @@ export function SplitDiffView(props: SplitDiffViewProps): JSX.Element {
                 key={idx}
                 className={`
                   px-4 leading-6 whitespace-pre-wrap
-                  ${line.type === "removed" ? "bg-[rgba(239,68,68,0.1)] text-[rgba(239,68,68,0.7)] line-through decoration-[rgba(239,68,68,0.4)]" : ""}
+                  ${line.type === "removed" ? "bg-[var(--color-diff-removed-bg)] text-[var(--color-diff-removed-text)] line-through decoration-[var(--color-diff-removed-decoration)]" : ""}
                   ${line.type === "removed" && underlineClass ? underlineClass : ""}
                   ${line.type === "context" ? "text-[var(--color-fg-muted)]" : ""}
                   ${line.type === "empty" ? "text-transparent" : ""}
@@ -225,7 +225,7 @@ export function SplitDiffView(props: SplitDiffViewProps): JSX.Element {
                 key={idx}
                 className={`
                   px-4 leading-6 whitespace-pre-wrap
-                  ${line.type === "added" ? "bg-[rgba(34,197,94,0.1)] text-[rgba(34,197,94,0.9)]" : ""}
+                  ${line.type === "added" ? "bg-[var(--color-diff-added-bg)] text-[var(--color-diff-added-text)]" : ""}
                   ${line.type === "added" && underlineClass ? underlineClass : ""}
                   ${line.type === "context" ? "text-[var(--color-fg-muted)]" : ""}
                   ${line.type === "empty" ? "text-transparent" : ""}

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -217,7 +217,7 @@ textarea:focus-visible {
 }
 
 .cn-window-control-btn--close:hover {
-  background: #cc2b3e;
+  background: var(--color-window-close-hover);
   color: var(--color-fg-inverse);
 }
 

--- a/apps/desktop/renderer/src/styles/tokens.css
+++ b/apps/desktop/renderer/src/styles/tokens.css
@@ -227,6 +227,24 @@
   /* Editor selection & caret */
   --color-selection: rgba(96, 165, 250, 0.3);
   --color-caret: var(--color-fg-default);
+
+  /* Diff 语义色 */
+  --color-diff-added-bg: rgba(34, 197, 94, 0.15);
+  --color-diff-added-text: rgba(34, 197, 94, 0.9);
+  --color-diff-added-gutter-bg: rgba(34, 197, 94, 0.08);
+  --color-diff-removed-bg: rgba(239, 68, 68, 0.15);
+  --color-diff-removed-text: rgba(239, 68, 68, 0.7);
+  --color-diff-removed-gutter-bg: rgba(239, 68, 68, 0.08);
+  --color-diff-removed-decoration: rgba(239, 68, 68, 0.4);
+
+  /* 按钮状态色 */
+  --color-btn-danger-bg: var(--color-error);
+  --color-btn-danger-hover: #dc2626;
+  --color-btn-success-bg: var(--color-success);
+  --color-btn-success-hover: #16a34a;
+
+  /* 窗口控件色 */
+  --color-window-close-hover: #cc2b3e;
 }
 
 :root[data-theme="light"] {
@@ -274,6 +292,24 @@
   /* Editor selection & caret */
   --color-selection: rgba(59, 130, 246, 0.3);
   --color-caret: var(--color-fg-default);
+
+  /* Diff 语义色（浅色背景用柔和色） */
+  --color-diff-added-bg: rgba(34, 197, 94, 0.1);
+  --color-diff-added-text: #16a34a;
+  --color-diff-added-gutter-bg: rgba(34, 197, 94, 0.05);
+  --color-diff-removed-bg: rgba(239, 68, 68, 0.1);
+  --color-diff-removed-text: #dc2626;
+  --color-diff-removed-gutter-bg: rgba(239, 68, 68, 0.05);
+  --color-diff-removed-decoration: rgba(239, 68, 68, 0.3);
+
+  /* 按钮状态色 */
+  --color-btn-danger-bg: var(--color-error);
+  --color-btn-danger-hover: #b91c1c;
+  --color-btn-success-bg: var(--color-success);
+  --color-btn-success-hover: #15803d;
+
+  /* 窗口控件色 */
+  --color-window-close-hover: #cc2b3e;
 }
 
 /* Reduced motion override */

--- a/design/system/01-tokens.css
+++ b/design/system/01-tokens.css
@@ -51,6 +51,24 @@
   --color-accent-hover: rgba(255, 255, 255, 0.9);
   --color-accent-muted: rgba(255, 255, 255, 0.6);
   --color-accent-subtle: rgba(255, 255, 255, 0.1);
+
+  /* Diff 语义色 */
+  --color-diff-added-bg: rgba(34, 197, 94, 0.15);
+  --color-diff-added-text: rgba(34, 197, 94, 0.9);
+  --color-diff-added-gutter-bg: rgba(34, 197, 94, 0.08);
+  --color-diff-removed-bg: rgba(239, 68, 68, 0.15);
+  --color-diff-removed-text: rgba(239, 68, 68, 0.7);
+  --color-diff-removed-gutter-bg: rgba(239, 68, 68, 0.08);
+  --color-diff-removed-decoration: rgba(239, 68, 68, 0.4);
+
+  /* 按钮状态色 */
+  --color-btn-danger-bg: var(--color-error);
+  --color-btn-danger-hover: #dc2626;
+  --color-btn-success-bg: var(--color-success);
+  --color-btn-success-hover: #16a34a;
+
+  /* 窗口控件色 */
+  --color-window-close-hover: #cc2b3e;
 }
 
 /* ============================================
@@ -94,6 +112,24 @@
   --color-accent-hover: rgba(26, 26, 26, 0.9);
   --color-accent-muted: rgba(26, 26, 26, 0.6);
   --color-accent-subtle: rgba(26, 26, 26, 0.1);
+
+  /* Diff 语义色（浅色背景用柔和色） */
+  --color-diff-added-bg: rgba(34, 197, 94, 0.1);
+  --color-diff-added-text: #16a34a;
+  --color-diff-added-gutter-bg: rgba(34, 197, 94, 0.05);
+  --color-diff-removed-bg: rgba(239, 68, 68, 0.1);
+  --color-diff-removed-text: #dc2626;
+  --color-diff-removed-gutter-bg: rgba(239, 68, 68, 0.05);
+  --color-diff-removed-decoration: rgba(239, 68, 68, 0.3);
+
+  /* 按钮状态色 */
+  --color-btn-danger-bg: var(--color-error);
+  --color-btn-danger-hover: #b91c1c;
+  --color-btn-success-bg: var(--color-success);
+  --color-btn-success-hover: #15803d;
+
+  /* 窗口控件色 */
+  --color-window-close-hover: #cc2b3e;
 }
 
 /* ============================================


### PR DESCRIPTION
Closes #966

## 变更概要

来源：`docs/audit/amp-cn-frontend-issues-and-i18n-problems-analysis.md` §五（L323-332）

### 新增 Token（设计源 + 生产文件同步）

**Diff 语义色**（dark/light 主题分别定义）：
- `--color-diff-added-bg` / `--color-diff-added-text` / `--color-diff-added-gutter-bg`
- `--color-diff-removed-bg` / `--color-diff-removed-text` / `--color-diff-removed-gutter-bg`
- `--color-diff-removed-decoration`

**按钮状态色**：
- `--color-btn-danger-bg` / `--color-btn-danger-hover`
- `--color-btn-success-bg` / `--color-btn-success-hover`

**窗口控件色**：
- `--color-window-close-hover`

### 硬编码消除

| 文件 | 修改内容 |
|---|---|
| `DiffView.tsx` | 6 处 rgba 硬编码 → Token 引用 |
| `SplitDiffView.tsx` | 4 处 rgba 硬编码 → Token 引用 |
| `main.css` | 窗口关闭按钮 `#cc2b3e` → `var(--color-window-close-hover)` |

### 验证

- TypeScript 编译无错误
- 全部 261 测试文件 / 1778 测试用例通过
- 设计源和生产文件 Token 定义完全对齐