### PR TITLE
feat(renderer): i18n 全量覆盖——26 文件 CJK 硬编码全部抽取为 locale key

### DIFF
--- a/apps/desktop/renderer/src/__tests__/i18n-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/i18n-global-compliance.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Global i18n compliance test.
+ *
+ * Scans all production .tsx files under features/ and components/ for
+ * hardcoded CJK characters that should have been extracted to locale keys.
+ *
+ * Exclusions:
+ *  - *.test.* / *.stories.* / *.story.* files
+ *  - test-utils.tsx
+ *  - Comment lines (// or block comments)
+ *  - console.log / console.warn / console.error statements
+ *  - Import/export statements
+ *  - Type annotations and interfaces
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const RENDERER_SRC = resolve(CURRENT_DIR, "..");
+
+const SCAN_DIRS = [
+  join(RENDERER_SRC, "features"),
+  join(RENDERER_SRC, "components"),
+];
+
+/** CJK Unified Ideographs + common CJK punctuation */
+const CJK_REGEX =
+  /[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3000-\u303f\uff01-\uff5e]/;
+
+const SKIP_PATTERNS = [
+  /\.test\./,
+  /\.stories\./,
+  /\.story\./,
+  /test-utils\.tsx$/,
+];
+
+function collectTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectTsxFiles(fullPath));
+    } else if (
+      entry.name.endsWith(".tsx") &&
+      !SKIP_PATTERNS.some((p) => p.test(entry.name))
+    ) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Checks if a line is likely source code containing user-facing text
+ * (not a comment, import, type annotation, or debug statement).
+ */
+function isUserFacingLine(line: string): boolean {
+  const trimmed = line.trim();
+  // Skip comments (single-line, block, JSDoc)
+  if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return false;
+  // Skip JSX comments: {/* ... */}
+  if (/^\{\/\*.*\*\/\}$/.test(trimmed)) return false;
+  // Skip imports/exports
+  if (trimmed.startsWith("import ") || trimmed.startsWith("export type")) return false;
+  // Skip console statements
+  if (/console\.(log|warn|error|debug|info)\(/.test(trimmed)) return false;
+  // Skip regex patterns (data matching, not UI text)
+  if (/\/.*[\u4e00-\u9fff].*\//.test(trimmed) && trimmed.includes(".test(")) return false;
+  // Skip AI prompt templates (sent to LLM, not displayed as UI)
+  if (trimmed.includes("promptTemplate") && trimmed.includes("`")) return false;
+  // Skip keyword matching patterns (e.g. checking if input contains a specific word)
+  if (trimmed.includes(".includes(\"") && trimmed.includes("?")) return false;
+  return true;
+}
+
+describe("i18n global compliance: no hardcoded CJK in production files", () => {
+  const allFiles = SCAN_DIRS.flatMap((dir) => {
+    try {
+      return collectTsxFiles(dir);
+    } catch {
+      return [];
+    }
+  });
+
+  it("should find production .tsx files to scan", () => {
+    expect(allFiles.length).toBeGreaterThan(0);
+  });
+
+  const violatingFiles: Array<{ file: string; lines: Array<{ num: number; text: string }> }> = [];
+
+  for (const filePath of allFiles) {
+    const content = readFileSync(filePath, "utf8");
+    const lines = content.split("\n");
+    const violations: Array<{ num: number; text: string }> = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (CJK_REGEX.test(line) && isUserFacingLine(line)) {
+        violations.push({ num: i + 1, text: line.trim() });
+      }
+    }
+
+    if (violations.length > 0) {
+      violatingFiles.push({
+        file: relative(RENDERER_SRC, filePath),
+        lines: violations,
+      });
+    }
+  }
+
+  it("no production .tsx files should contain hardcoded CJK characters", () => {
+    if (violatingFiles.length > 0) {
+      const report = violatingFiles
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.lines.map((l) => `    L${l.num}: ${l.text}`).join("\n")}`,
+        )
+        .join("\n");
+      expect.fail(
+        `Found ${violatingFiles.length} file(s) with hardcoded CJK characters:\n${report}`,
+      );
+    }
+  });
+});

--- a/apps/desktop/renderer/src/__tests__/i18n-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/i18n-global-compliance.test.ts
@@ -12,8 +12,8 @@
  *  - Import/export statements
  *  - Type annotations and interfaces
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
@@ -504,6 +504,7 @@ export function SystemDialog({
         <DialogPrimitive.Overlay className={overlayStyles} />
         <DialogPrimitive.Content
           className={contentStyles}
+          data-testid={`system-dialog-${type}`}
           onKeyDown={handleKeyDown}
         >
           {/* Icon */}
@@ -530,6 +531,7 @@ export function SystemDialog({
               <>
                 <button
                   type="button"
+                  data-testid="system-dialog-secondary"
                   className={cancelButtonStyles}
                   onClick={handleSecondaryAction}
                   disabled={isLoading}
@@ -539,6 +541,7 @@ export function SystemDialog({
                 <button
                   ref={primaryButtonRef}
                   type="button"
+                  data-testid="system-dialog-primary"
                   className={deleteButtonStyles}
                   onClick={handlePrimaryAction}
                   disabled={isLoading}

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { useHotkey } from "../../../lib/hotkeys/useHotkey";
 import { GraphToolbar } from "./GraphToolbar";
 import { GraphCanvas } from "./GraphCanvas";
@@ -38,6 +39,7 @@ const mainStyles = ["flex-1", "relative", "overflow-hidden"].join(" ");
  * Empty state component
  */
 function EmptyState({ onAddNode }: { onAddNode: () => void }): JSX.Element {
+  const { t } = useTranslation();
   return (
     <div className="absolute inset-0 flex items-center justify-center">
       <div className="text-center space-y-4">
@@ -60,10 +62,10 @@ function EmptyState({ onAddNode }: { onAddNode: () => void }): JSX.Element {
         </div>
         <div>
           <p className="text-sm text-[var(--color-fg-muted)]">
-            暂无实体，点击添加你的第一个角色或地点
+            {t('kg.graph.emptyTitle')}
           </p>
           <p className="text-xs text-[var(--color-fg-subtle)] mt-1">
-            你可以在关系图中拖拽节点并建立关系
+            {t('kg.graph.emptyHint')}
           </p>
         </div>
         <button
@@ -81,7 +83,7 @@ function EmptyState({ onAddNode }: { onAddNode: () => void }): JSX.Element {
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          添加节点
+          {t('kg.graph.addNode')}
         </button>
       </div>
     </div>

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Button } from "../../primitives/Button";
 import { Avatar } from "../../primitives/Avatar";
 import { Badge } from "../../primitives/Badge";
@@ -64,6 +65,7 @@ export function NodeDetailCard({
   onDelete,
   onClose,
 }: NodeDetailCardProps): JSX.Element {
+  const { t } = useTranslation();
   const { label, type, avatar, metadata } = node;
   const { role, attributes, description } = metadata || {};
   const typeColor = typeColorVars[type];
@@ -111,7 +113,7 @@ export function NodeDetailCard({
               onClick={onDelete}
               className="p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
               aria-label="Delete node"
-              title="删除节点"
+              title={t('kg.nodeDetail.deleteNode')}
             >
               <svg
                 width="16"

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Dialog } from "../../primitives/Dialog";
 import { Button } from "../../primitives/Button";
 import { Input } from "../../primitives/Input";
@@ -7,31 +8,15 @@ import { Textarea } from "../../primitives/Textarea";
 import type { GraphNode, NodeEditDialogProps, NodeType } from "./types";
 
 /**
- * Node type options for the select dropdown
+ * Node type color variables
  */
-const nodeTypeOptions: Array<{
-  value: NodeType;
-  label: string;
-  colorVar: string;
-}> = [
-  {
-    value: "character",
-    label: "角色 (Character)",
-    colorVar: "var(--color-node-character)",
-  },
-  {
-    value: "location",
-    label: "地点 (Location)",
-    colorVar: "var(--color-node-location)",
-  },
-  { value: "event", label: "事件 (Event)", colorVar: "var(--color-node-event)" },
-  { value: "item", label: "物品 (Item)", colorVar: "var(--color-node-item)" },
-  {
-    value: "faction",
-    label: "阵营 (Faction)",
-    colorVar: "var(--color-node-other)",
-  },
-];
+const nodeTypeColorVars: Record<NodeType, string> = {
+  character: "var(--color-node-character)",
+  location: "var(--color-node-location)",
+  event: "var(--color-node-event)",
+  item: "var(--color-node-item)",
+  faction: "var(--color-node-other)",
+};
 
 /**
  * Label styles
@@ -59,6 +44,16 @@ export function NodeEditDialog({
   onSave,
   mode = "edit",
 }: NodeEditDialogProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const nodeTypeOptions = useMemo(() => [
+    { value: "character" as NodeType, label: t('kg.nodeEdit.typeCharacter'), colorVar: nodeTypeColorVars.character },
+    { value: "location" as NodeType, label: t('kg.nodeEdit.typeLocation'), colorVar: nodeTypeColorVars.location },
+    { value: "event" as NodeType, label: t('kg.nodeEdit.typeEvent'), colorVar: nodeTypeColorVars.event },
+    { value: "item" as NodeType, label: t('kg.nodeEdit.typeItem'), colorVar: nodeTypeColorVars.item },
+    { value: "faction" as NodeType, label: t('kg.nodeEdit.typeFaction'), colorVar: nodeTypeColorVars.faction },
+  ], [t]);
+
   // Form state - initialized from node prop (component is keyed by node.id)
   const [label, setLabel] = useState(node?.label ?? "");
   const [type, setType] = useState<NodeType>(node?.type ?? "character");
@@ -69,9 +64,7 @@ export function NodeEditDialog({
   const [attributes, setAttributes] = useState<
     Array<{ key: string; value: string }>
   >(node?.metadata?.attributes ?? []);
-  const typeColor =
-    nodeTypeOptions.find((o) => o.value === type)?.colorVar ??
-    "var(--color-fg-muted)";
+  const typeColor = nodeTypeColorVars[type] ?? "var(--color-fg-muted)";
 
   /**
    * Handle adding a new attribute
@@ -127,19 +120,19 @@ export function NodeEditDialog({
     onOpenChange(false);
   };
 
-  const title = mode === "create" ? "创建新节点" : `编辑节点: ${node?.label || ""}`;
-  const submitLabel = mode === "create" ? "创建" : "保存";
+  const title = mode === "create" ? t('kg.nodeEdit.createTitle') : t('kg.nodeEdit.editTitle', { label: node?.label || '' });
+  const submitLabel = mode === "create" ? t('kg.nodeEdit.create') : t('kg.nodeEdit.save');
 
   return (
     <Dialog
       open={open}
       onOpenChange={onOpenChange}
       title={title}
-      description={mode === "create" ? "添加一个新的知识图谱节点" : "修改节点的属性和信息"}
+      description={mode === "create" ? t('kg.nodeEdit.createDescription') : t('kg.nodeEdit.editDescription')}
       footer={
         <>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            取消
+            {t('kg.nodeEdit.cancel')}
           </Button>
           <Button variant="primary" onClick={handleSubmit} disabled={!label.trim()}>
             {submitLabel}
@@ -150,11 +143,11 @@ export function NodeEditDialog({
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         {/* Name */}
         <div>
-          <label className={labelStyles}>名称 *</label>
+          <label className={labelStyles}>{t('kg.nodeEdit.nameLabel')}</label>
           <Input
             value={label}
             onChange={(e) => setLabel(e.target.value)}
-            placeholder="输入节点名称..."
+            placeholder={t('kg.nodeEdit.namePlaceholder')}
             fullWidth
             autoFocus
           />
@@ -164,7 +157,7 @@ export function NodeEditDialog({
         <div>
           <label className={labelStyles}>
             <span className="flex items-center gap-2">
-              类型
+              {t('kg.nodeEdit.typeLabel')}
               <span
                 className="w-2 h-2 rounded-full"
                 style={{ backgroundColor: typeColor }}
@@ -183,11 +176,11 @@ export function NodeEditDialog({
         {/* Role (for characters) */}
         {(type === "character" || type === "faction") && (
           <div>
-            <label className={labelStyles}>角色定位</label>
+            <label className={labelStyles}>{t('kg.nodeEdit.roleLabel')}</label>
             <Input
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              placeholder="如: 主角、反派、导师..."
+              placeholder={t('kg.nodeEdit.rolePlaceholder')}
               fullWidth
             />
           </div>
@@ -195,11 +188,11 @@ export function NodeEditDialog({
 
         {/* Description */}
         <div>
-          <label className={labelStyles}>描述</label>
+          <label className={labelStyles}>{t('kg.nodeEdit.descriptionLabel')}</label>
           <Textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="输入节点的详细描述..."
+            placeholder={t('kg.nodeEdit.descriptionPlaceholder')}
             rows={3}
             fullWidth
             className="resize-none"
@@ -209,19 +202,19 @@ export function NodeEditDialog({
         {/* Attributes */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <label className={labelStyles + " mb-0"}>属性</label>
+            <label className={labelStyles + " mb-0"}>{t('kg.nodeEdit.propertiesLabel')}</label>
             <button
               type="button"
               onClick={handleAddAttribute}
               className="text-[11px] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
             >
-              + 添加属性
+              {t('kg.nodeEdit.addProperty')}
             </button>
           </div>
           
           {attributes.length === 0 ? (
             <p className="text-xs text-[var(--color-fg-subtle)] italic">
-              暂无属性，点击上方添加
+              {t('kg.nodeEdit.noProperties')}
             </p>
           ) : (
             <div className="flex flex-col gap-2">
@@ -230,21 +223,21 @@ export function NodeEditDialog({
                   <Input
                     value={attr.key}
                     onChange={(e) => handleUpdateAttribute(index, "key", e.target.value)}
-                    placeholder="属性名"
+                    placeholder={t('kg.nodeEdit.propertyNamePlaceholder')}
                     className="flex-1"
                   />
                   <span className="text-[var(--color-fg-subtle)]">:</span>
                   <Input
                     value={attr.value}
                     onChange={(e) => handleUpdateAttribute(index, "value", e.target.value)}
-                    placeholder="属性值"
+                    placeholder={t('kg.nodeEdit.propertyValuePlaceholder')}
                     className="flex-1"
                   />
                   <button
                     type="button"
                     onClick={() => handleRemoveAttribute(index)}
                     className="w-8 h-8 flex items-center justify-center text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
-                    aria-label="删除属性"
+                    aria-label={t('kg.nodeEdit.deleteProperty')}
                   >
                     <svg
                       width="14"

--- a/apps/desktop/renderer/src/components/patterns/EmptyState.tsx
+++ b/apps/desktop/renderer/src/components/patterns/EmptyState.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Button, Text, Heading } from "../primitives";
 
 /**
@@ -36,38 +37,39 @@ export interface EmptyStateProps {
 }
 
 /**
- * Default content for each variant (design spec §12.1)
+ * Build variant defaults using i18n translations (design spec §12.1)
  */
-const variantDefaults: Record<
-  EmptyStateVariant,
-  { title: string; description: string; actionLabel: string }
-> = {
-  project: {
-    title: "开始创建你的第一个文件",
-    description: "创建一个新文件开始你的创作之旅",
-    actionLabel: "新建文件",
-  },
-  files: {
-    title: "暂无文件",
-    description: "此文件夹中没有任何文件",
-    actionLabel: "新建文件",
-  },
-  search: {
-    title: "未找到匹配结果",
-    description: "尝试使用不同的关键词进行搜索",
-    actionLabel: "清除搜索",
-  },
-  characters: {
-    title: "暂无角色",
-    description: "创建角色来丰富你的故事",
-    actionLabel: "创建角色",
-  },
-  generic: {
-    title: "暂无内容",
-    description: "这里还没有任何内容",
-    actionLabel: "开始",
-  },
-};
+function getVariantDefaults(
+  t: (key: string) => string,
+): Record<EmptyStateVariant, { title: string; description: string; actionLabel: string }> {
+  return {
+    project: {
+      title: t('patterns.emptyState.firstFileTitle'),
+      description: t('patterns.emptyState.firstFileDescription'),
+      actionLabel: t('patterns.emptyState.firstFileAction'),
+    },
+    files: {
+      title: t('patterns.emptyState.noFiles'),
+      description: t('patterns.emptyState.noFilesDescription'),
+      actionLabel: t('patterns.emptyState.noFilesAction'),
+    },
+    search: {
+      title: t('patterns.emptyState.noSearchResults'),
+      description: t('patterns.emptyState.noSearchResultsDescription'),
+      actionLabel: t('patterns.emptyState.noSearchResultsAction'),
+    },
+    characters: {
+      title: t('patterns.emptyState.noCharacters'),
+      description: t('patterns.emptyState.noCharactersDescription'),
+      actionLabel: t('patterns.emptyState.noCharactersAction'),
+    },
+    generic: {
+      title: t('patterns.emptyState.noContent'),
+      description: t('patterns.emptyState.noContentDescription'),
+      actionLabel: t('patterns.emptyState.noContentAction'),
+    },
+  };
+}
 
 /**
  * Default illustration SVG component
@@ -179,7 +181,8 @@ export function EmptyState({
   onSecondaryAction,
   className = "",
 }: EmptyStateProps): JSX.Element {
-  const defaults = variantDefaults[variant];
+  const { t } = useTranslation();
+  const defaults = getVariantDefaults(t)[variant];
 
   // Use provided values or fall back to variant defaults
   const displayTitle = title ?? defaults.title;

--- a/apps/desktop/renderer/src/components/patterns/ErrorState.tsx
+++ b/apps/desktop/renderer/src/components/patterns/ErrorState.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Button, Text, Heading } from "../primitives";
 
 /**
@@ -144,6 +145,7 @@ function DismissButton({
   onClick: () => void;
   className?: string;
 }): JSX.Element {
+  const { t } = useTranslation();
   return (
     <button
       type="button"
@@ -162,7 +164,7 @@ function DismissButton({
       ]
         .filter(Boolean)
         .join(" ")}
-      aria-label="关闭"
+      aria-label={t('patterns.errorState.close')}
     >
       <svg
         className="w-4 h-4"
@@ -393,6 +395,7 @@ function FullPageError({
   ErrorStateProps,
   "variant" | "dismissible" | "onDismiss"
 >): JSX.Element {
+  const { t } = useTranslation();
   const colors = severityColors[severity ?? "error"];
 
   return (
@@ -421,7 +424,7 @@ function FullPageError({
 
       {/* Title */}
       <Heading level="h2" className="mb-3">
-        {title ?? "出错了"}
+        {title ?? t('patterns.errorState.defaultTitle')}
       </Heading>
 
       {/* Message */}

--- a/apps/desktop/renderer/src/components/primitives/ContextMenu.tsx
+++ b/apps/desktop/renderer/src/components/primitives/ContextMenu.tsx
@@ -134,6 +134,7 @@ export function ContextMenu({
           {items.map((item) => (
             <ContextMenuPrimitive.Item
               key={item.key}
+              data-testid={`context-menu-item-${item.key}`}
               className={item.destructive ? destructiveItemStyles : itemStyles}
               onSelect={item.onSelect}
               disabled={item.disabled}

--- a/apps/desktop/renderer/src/features/ai/AiNotConfiguredGuide.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiNotConfiguredGuide.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import { Button } from "../../components/primitives/Button";
 import { Card } from "../../components/primitives/Card";
 import { Text } from "../../components/primitives/Text";
@@ -11,6 +13,8 @@ import { Text } from "../../components/primitives/Text";
 export function AiNotConfiguredGuide(props: {
   onNavigateToSettings: () => void;
 }): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <Card
       data-testid="ai-not-configured-guide"
@@ -18,11 +22,11 @@ export function AiNotConfiguredGuide(props: {
       className="flex flex-col items-center gap-3 p-6 rounded-[var(--radius-lg)]"
     >
       <Text size="body" weight="bold">
-        请先在设置中配置 AI 服务
+        {t('ai.notConfigured.title')}
       </Text>
 
       <Text size="small" color="muted" className="text-center">
-        需要配置 API Key 才能使用 AI 功能。支持 OpenAI、Anthropic 及兼容代理。
+        {t('ai.notConfigured.description')}
       </Text>
 
       <Button
@@ -30,7 +34,7 @@ export function AiNotConfiguredGuide(props: {
         size="sm"
         onClick={props.onNavigateToSettings}
       >
-        前往设置
+        {t('ai.notConfigured.goToSettings')}
       </Button>
     </Card>
   );

--- a/apps/desktop/renderer/src/features/ai/SkillManagerDialog.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillManagerDialog.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { IpcError, IpcResponseData } from "@shared/types/ipc-generated";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { Dialog, Text } from "../../components/primitives";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
+import { i18n } from "../../i18n";
 import { invoke } from "../../lib/ipcClient";
 
 export type CustomSkillListItem =
@@ -38,7 +40,7 @@ function buildSkillDraftFromDescription(
   "name" | "description" | "promptTemplate" | "inputType" | "contextRulesText"
 > {
   const normalized = description.trim();
-  const shortName = normalized.slice(0, 16) || "AI 生成技能";
+  const shortName = normalized.slice(0, 16) || i18n.t("ai.skillManager.aiGeneratedSkill");
 
   return {
     name: shortName,
@@ -61,11 +63,11 @@ function parseContextRulesText(
       parsed === null ||
       Array.isArray(parsed)
     ) {
-      return { ok: false, message: "contextRules 必须是 JSON 对象" };
+      return { ok: false, message: i18n.t("ai.skillManager.contextRulesMustBeObject") };
     }
     return { ok: true, data: parsed as CustomSkillContextRules };
   } catch {
-    return { ok: false, message: "contextRules 不是合法 JSON" };
+    return { ok: false, message: i18n.t("ai.skillManager.contextRulesInvalidJson") };
   }
 }
 
@@ -100,10 +102,11 @@ export function SkillManagerDialog(props: {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const { confirm, dialogProps } = useConfirmDialog();
+  const { t } = useTranslation();
 
   const title = useMemo(
-    () => (editingId ? "编辑自定义技能" : "创建自定义技能"),
-    [editingId],
+    () => (editingId ? t("ai.skillManager.editTitle") : t("ai.skillManager.createTitle")),
+    [editingId, t],
   );
 
   async function loadCustomSkills(): Promise<void> {
@@ -140,7 +143,7 @@ export function SkillManagerDialog(props: {
   async function handleAiGenerate(): Promise<void> {
     const prompt = aiDescription.trim();
     if (prompt.length === 0) {
-      setFormError("请先输入技能需求描述");
+      setFormError(t("ai.skillManager.enterDescriptionFirst"));
       return;
     }
 
@@ -164,10 +167,10 @@ export function SkillManagerDialog(props: {
 
   async function handleDelete(item: CustomSkillListItem): Promise<void> {
     const confirmed = await confirm({
-      title: `确定删除技能"${item.name}"？`,
-      description: "此操作不可撤销",
-      primaryLabel: "删除",
-      secondaryLabel: "取消",
+      title: t("ai.skillManager.confirmDeleteTitle", { name: item.name }),
+      description: t("ai.skillManager.irreversible"),
+      primaryLabel: t("ai.skillManager.delete"),
+      secondaryLabel: t("ai.skillManager.cancel"),
     });
     if (!confirmed) {
       return;
@@ -273,8 +276,8 @@ export function SkillManagerDialog(props: {
             resetForm();
           }
         }}
-        title="技能管理"
-        description="手动创建、AI 辅助创建、编辑和删除自定义技能。"
+        title={t("ai.skillManager.dialogTitle")}
+        description={t("ai.skillManager.dialogDescription")}
         footer={
           <>
             <button
@@ -283,7 +286,7 @@ export function SkillManagerDialog(props: {
               onClick={resetForm}
               data-testid="skill-manager-reset"
             >
-              重置
+              {t("ai.skillManager.reset")}
             </button>
             <button
               type="button"
@@ -292,7 +295,7 @@ export function SkillManagerDialog(props: {
               disabled={submitting}
               data-testid="skill-manager-save"
             >
-              {submitting ? "保存中..." : editingId ? "保存修改" : "创建技能"}
+              {submitting ? t("ai.skillManager.saving") : editingId ? t("ai.skillManager.saveChanges") : t("ai.skillManager.createSkill")}
             </button>
           </>
         }
@@ -300,12 +303,12 @@ export function SkillManagerDialog(props: {
         <div className="space-y-4" data-testid="skill-manager-dialog">
           <section className="space-y-2">
             <Text size="tiny" color="muted" className="uppercase tracking-wide">
-              AI 辅助创建
+              {t("ai.skillManager.aiAssisted")}
             </Text>
             <textarea
               value={aiDescription}
               onChange={(e) => setAiDescription(e.target.value)}
-              placeholder="例如：创建一个技能，把选中文本改写成鲁迅风格"
+              placeholder={t("ai.skillManager.aiPlaceholder")}
               className="w-full min-h-20 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
               data-testid="skill-manager-ai-description"
             />
@@ -315,7 +318,7 @@ export function SkillManagerDialog(props: {
               onClick={() => void handleAiGenerate()}
               data-testid="skill-manager-ai-generate"
             >
-              AI 生成配置
+              {t("ai.skillManager.aiGenerateConfig")}
             </button>
           </section>
 
@@ -325,7 +328,7 @@ export function SkillManagerDialog(props: {
             </Text>
 
             <label className="block text-xs text-[var(--color-fg-muted)]">
-              名称
+              {t("ai.skillManager.fieldName")}
               <input
                 value={form.name}
                 onChange={(e) =>
@@ -342,7 +345,7 @@ export function SkillManagerDialog(props: {
             </label>
 
             <label className="block text-xs text-[var(--color-fg-muted)]">
-              描述
+              {t("ai.skillManager.fieldDescription")}
               <input
                 value={form.description}
                 onChange={(e) =>
@@ -359,7 +362,7 @@ export function SkillManagerDialog(props: {
             </label>
 
             <label className="block text-xs text-[var(--color-fg-muted)]">
-              Prompt 模板
+              {t("ai.skillManager.fieldPromptTemplate")}
               <textarea
                 value={form.promptTemplate}
                 onChange={(e) =>
@@ -368,7 +371,7 @@ export function SkillManagerDialog(props: {
                     promptTemplate: e.target.value,
                   }))
                 }
-                placeholder="包含 {{input}} 占位符"
+                placeholder={t("ai.skillManager.promptPlaceholder")}
                 className="mt-1 w-full min-h-20 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
                 data-testid="skill-form-prompt-template"
               />
@@ -384,7 +387,7 @@ export function SkillManagerDialog(props: {
 
             <div className="grid grid-cols-2 gap-2">
               <label className="block text-xs text-[var(--color-fg-muted)]">
-                输入类型
+                {t("ai.skillManager.fieldInputType")}
                 <select
                   value={form.inputType}
                   onChange={(e) =>
@@ -396,13 +399,13 @@ export function SkillManagerDialog(props: {
                   className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
                   data-testid="skill-form-input-type"
                 >
-                  <option value="selection">选中文本</option>
-                  <option value="document">文档上下文</option>
+                  <option value="selection">{t("ai.skillManager.inputTypeSelection")}</option>
+                  <option value="document">{t("ai.skillManager.inputTypeDocument")}</option>
                 </select>
               </label>
 
               <label className="block text-xs text-[var(--color-fg-muted)]">
-                作用域
+                {t("ai.skillManager.fieldScope")}
                 <select
                   value={form.scope}
                   onChange={(e) =>
@@ -414,8 +417,8 @@ export function SkillManagerDialog(props: {
                   className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
                   data-testid="skill-form-scope"
                 >
-                  <option value="project">项目级</option>
-                  <option value="global">全局</option>
+                  <option value="project">{t("ai.skillManager.scopeProject")}</option>
+                  <option value="global">{t("ai.skillManager.scopeGlobal")}</option>
                 </select>
               </label>
             </div>
@@ -449,7 +452,7 @@ export function SkillManagerDialog(props: {
                 }
                 data-testid="skill-form-enabled"
               />
-              启用技能
+              {t("ai.skillManager.enableSkill")}
             </label>
           </section>
 
@@ -464,15 +467,15 @@ export function SkillManagerDialog(props: {
 
           <section className="space-y-2">
             <Text size="tiny" color="muted" className="uppercase tracking-wide">
-              自定义技能列表
+              {t("ai.skillManager.customSkillList")}
             </Text>
             {loading ? (
               <Text size="small" color="muted">
-                加载中...
+                {t("ai.skillManager.loading")}
               </Text>
             ) : items.length === 0 ? (
               <Text size="small" color="muted">
-                暂无自定义技能
+                {t("ai.skillManager.noCustomSkills")}
               </Text>
             ) : (
               <div className="space-y-2" data-testid="skill-manager-list">
@@ -487,7 +490,7 @@ export function SkillManagerDialog(props: {
                           {item.name}
                         </Text>
                         <Text size="tiny" color="muted">
-                          {item.scope === "project" ? "项目级" : "全局"} ·{" "}
+                          {item.scope === "project" ? t("ai.skillManager.scopeProject") : t("ai.skillManager.scopeGlobal")} ·{" "}
                           {item.inputType}
                         </Text>
                       </div>
@@ -498,7 +501,7 @@ export function SkillManagerDialog(props: {
                           onClick={() => handleEdit(item)}
                           data-testid={`skill-item-edit-${item.id}`}
                         >
-                          编辑
+                          {t("ai.skillManager.edit")}
                         </button>
                         <button
                           type="button"
@@ -506,7 +509,7 @@ export function SkillManagerDialog(props: {
                           onClick={() => void handleDelete(item)}
                           data-testid={`skill-item-delete-${item.id}`}
                         >
-                          删除
+                          {t("ai.skillManager.delete")}
                         </button>
                       </div>
                     </div>

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
@@ -1,19 +1,11 @@
 import type { SkillListItem } from "../../stores/aiStore";
 
+import { useTranslation } from "react-i18next";
 import { Text } from "../../components/primitives";
 import { Tooltip } from "../../components/primitives/Tooltip";
 import { resolveSkillsForPicker } from "./scopeResolver";
 
 import { Plus } from "lucide-react";
-function scopeLabel(scope: SkillListItem["scope"]): string {
-  if (scope === "builtin") {
-    return "内置";
-  }
-  if (scope === "global") {
-    return "全局";
-  }
-  return "项目";
-}
 
 /**
  * SkillPicker renders grouped skill entries and scope controls.
@@ -29,6 +21,18 @@ export function SkillPicker(props: {
   onUpdateScope?: (skillId: string, scope: "global" | "project") => void;
   onCreateSkill?: () => void;
 }): JSX.Element | null {
+  const { t } = useTranslation();
+
+  function scopeLabel(scope: SkillListItem["scope"]): string {
+    if (scope === "builtin") {
+      return t("ai.skillPicker.builtin");
+    }
+    if (scope === "global") {
+      return t("ai.skillPicker.global");
+    }
+    return t("ai.skillPicker.project");
+  }
+
   if (!props.open) {
     return null;
   }
@@ -72,7 +76,7 @@ export function SkillPicker(props: {
         <div className="mt-2 max-h-72 overflow-auto space-y-3">
           <section>
             <Text size="tiny" color="muted" className="uppercase tracking-wide">
-              内置技能
+              {t("ai.skillPicker.builtinSkills")}
             </Text>
             <div className="mt-1.5 space-y-1.5">
               {grouped.builtin.map((item) => {
@@ -83,7 +87,7 @@ export function SkillPicker(props: {
                   : !item.valid
                     ? "Invalid"
                     : item.isProjectOverride
-                      ? "项目级覆盖"
+                      ? t("ai.skillPicker.projectOverride")
                       : scopeLabel(item.scope);
 
                 return (
@@ -134,7 +138,7 @@ export function SkillPicker(props: {
                           props.onToggleSkill?.(item.id, !item.enabled)
                         }
                       >
-                        {item.enabled ? "停用" : "启用"}
+                        {item.enabled ? t("ai.skillPicker.disable") : t("ai.skillPicker.enable")}
                       </button>
                     )}
                   </div>
@@ -145,13 +149,13 @@ export function SkillPicker(props: {
 
           <section>
             <Text size="tiny" color="muted" className="uppercase tracking-wide">
-              自定义技能
+              {t("ai.skillPicker.customSkills")}
             </Text>
 
             {!hasCustomSkills ? (
               <div className="mt-1.5 p-2 rounded-[10px] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-base)]">
                 <Text size="small" color="muted">
-                  暂无自定义技能，点击创建或用自然语言描述需求
+                  {t("ai.skillPicker.noCustomSkillsHint")}
                 </Text>
                 <button
                   type="button"
@@ -164,18 +168,18 @@ export function SkillPicker(props: {
                     props.onOpenSettings?.();
                   }}
                 >
-                  创建技能
+                  {t("ai.skillPicker.createSkill")}
                 </button>
               </div>
             ) : (
               <div className="mt-1.5 space-y-2">
                 <div>
                   <Text size="tiny" color="muted">
-                    全局技能
+                    {t("ai.skillPicker.globalSkills")}
                   </Text>
                   {grouped.global.length === 0 ? (
                     <Text size="tiny" color="muted" className="mt-1 block">
-                      暂无全局技能
+                      {t("ai.skillPicker.noGlobalSkills")}
                     </Text>
                   ) : (
                     <div className="mt-1 space-y-1.5">
@@ -234,7 +238,7 @@ export function SkillPicker(props: {
                                   props.onUpdateScope?.(item.id, "project")
                                 }
                               >
-                                降级为项目
+                                {t("ai.skillPicker.demoteToProject")}
                               </button>
                             )}
 
@@ -247,7 +251,7 @@ export function SkillPicker(props: {
                                   props.onToggleSkill?.(item.id, !item.enabled)
                                 }
                               >
-                                {item.enabled ? "停用" : "启用"}
+                                {item.enabled ? t("ai.skillPicker.disable") : t("ai.skillPicker.enable")}
                               </button>
                             )}
                           </div>
@@ -259,11 +263,11 @@ export function SkillPicker(props: {
 
                 <div>
                   <Text size="tiny" color="muted">
-                    项目技能
+                    {t("ai.skillPicker.projectSkills")}
                   </Text>
                   {grouped.project.length === 0 ? (
                     <Text size="tiny" color="muted" className="mt-1 block">
-                      暂无项目技能
+                      {t("ai.skillPicker.noProjectSkills")}
                     </Text>
                   ) : (
                     <div className="mt-1 space-y-1.5">
@@ -275,7 +279,7 @@ export function SkillPicker(props: {
                           : !item.valid
                             ? "Invalid"
                             : item.isProjectOverride
-                              ? "项目级覆盖"
+                              ? t("ai.skillPicker.projectOverride")
                               : scopeLabel(item.scope);
 
                         return (
@@ -324,7 +328,7 @@ export function SkillPicker(props: {
                                   props.onUpdateScope?.(item.id, "global")
                                 }
                               >
-                                提升为全局
+                                {t("ai.skillPicker.promoteToGlobal")}
                               </button>
                             )}
 
@@ -337,7 +341,7 @@ export function SkillPicker(props: {
                                   props.onToggleSkill?.(item.id, !item.enabled)
                                 }
                               >
-                                {item.enabled ? "停用" : "启用"}
+                                {item.enabled ? t("ai.skillPicker.disable") : t("ai.skillPicker.enable")}
                               </button>
                             )}
                           </div>

--- a/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import { EmptyState } from "../../components/composites/EmptyState";
 
 export interface CharacterCardSummary {
@@ -35,6 +37,8 @@ export function CharacterCardList({
   onCreateCharacter,
   className = "",
 }: CharacterCardListProps): JSX.Element {
+  const { t } = useTranslation();
+
   if (cards.length === 0) {
     return (
       <section
@@ -42,15 +46,15 @@ export function CharacterCardList({
         className={`h-full flex items-center justify-center p-4 bg-[var(--color-bg-base)] ${className}`}
       >
         <EmptyState
-          title="暂无角色"
-          description="开始创建你的第一个角色"
+          title={t('character.cardList.emptyTitle')}
+          description={t('character.cardList.emptyDescription')}
           action={
             <button
               type="button"
               onClick={onCreateCharacter}
               className="focus-ring px-4 py-2 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] transition-colors"
             >
-              创建角色
+              {t('character.cardList.createCharacter')}
             </button>
           }
         />

--- a/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
@@ -15,29 +16,36 @@ export interface CharacterCardListContainerProps {
   projectId: string;
 }
 
-function toSummary(character: Character): CharacterCardSummary {
+function toSummary(
+  character: Character,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): CharacterCardSummary {
   const keyAttributes: string[] = [];
 
   if (typeof character.age === "number") {
-    keyAttributes.push(`年龄: ${character.age}`);
+    keyAttributes.push(t('character.container.age', { value: character.age }));
   }
   if (character.role) {
-    keyAttributes.push(`定位: ${character.role}`);
+    keyAttributes.push(t('character.container.role', { value: character.role }));
   }
   if (character.traits.length > 0) {
-    keyAttributes.push(`特征: ${character.traits.slice(0, 2).join(" / ")}`);
+    keyAttributes.push(
+      t('character.container.traits', { value: character.traits.slice(0, 2).join(" / ") }),
+    );
   }
   if (keyAttributes.length === 0) {
-    keyAttributes.push("暂无关键属性");
+    keyAttributes.push(t('character.container.noKeyAttributes'));
   }
 
   return {
     id: character.id,
     name: character.name,
-    typeLabel: "角色",
+    typeLabel: t('character.container.typeLabel'),
     avatarUrl: character.avatarUrl,
     keyAttributes: keyAttributes.slice(0, 3),
-    relationSummary: `关系 ${character.relationships.length} 条`,
+    relationSummary: t('character.container.relationSummary', {
+      count: character.relationships.length,
+    }),
   };
 }
 
@@ -47,6 +55,7 @@ function toSummary(character: Character): CharacterCardSummary {
 export function CharacterCardListContainer({
   projectId,
 }: CharacterCardListContainerProps): JSX.Element {
+  const { t } = useTranslation();
   const bootstrapStatus = useKgStore((state) => state.bootstrapStatus);
   const entities = useKgStore((state) => state.entities);
   const relations = useKgStore((state) => state.relations);
@@ -72,8 +81,8 @@ export function CharacterCardListContainer({
   );
 
   const cardSummaries = React.useMemo(
-    () => characters.map(toSummary),
-    [characters],
+    () => characters.map((c) => toSummary(c, t)),
+    [characters, t],
   );
 
   const selectedCharacter = React.useMemo(
@@ -83,7 +92,7 @@ export function CharacterCardListContainer({
 
   const handleCreateCharacter = React.useCallback(async () => {
     const created = await entityCreate({
-      name: "新角色",
+      name: t('character.container.newCharacter'),
       type: "character",
       description: "",
     });
@@ -92,7 +101,7 @@ export function CharacterCardListContainer({
     }
     setSelectedId(created.data.id);
     setDialogOpen(true);
-  }, [entityCreate]);
+  }, [entityCreate, t]);
 
   const handleSaveCharacter = React.useCallback(
     async (character: Character) => {
@@ -113,12 +122,12 @@ export function CharacterCardListContainer({
       const target = characters.find(
         (character) => character.id === characterId,
       );
-      const label = target?.name ?? "该角色";
+      const label = target?.name ?? t('character.container.thisCharacter');
       const confirmed = await confirm({
-        title: "删除角色？",
-        description: `删除角色 "${label}" 将移除其关联关系，此操作不可撤销。`,
-        primaryLabel: "删除",
-        secondaryLabel: "取消",
+        title: t('character.container.deleteTitle'),
+        description: t('character.container.deleteDescription', { name: label }),
+        primaryLabel: t('character.container.delete'),
+        secondaryLabel: t('character.container.cancel'),
       });
       if (!confirmed) {
         return;
@@ -129,7 +138,7 @@ export function CharacterCardListContainer({
         setDialogOpen(false);
       }
     },
-    [characters, confirm, entityDelete, selectedId],
+    [characters, confirm, entityDelete, selectedId, t],
   );
 
   if (bootstrapStatus === "loading") {

--- a/apps/desktop/renderer/src/features/editor/EditorBubbleMenu.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorBubbleMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Editor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react";
+import { useTranslation } from 'react-i18next';
 
 import { InlineFormatButton } from "./InlineFormatButton";
 import { EDITOR_SHORTCUTS } from "../../config/shortcuts";
@@ -17,22 +18,22 @@ export const EDITOR_INLINE_BUBBLE_MENU_PLUGIN_KEY = "cn-editor-inline-bubble";
 const BUBBLE_AI_SKILLS = [
   {
     id: "builtin:polish",
-    label: "润色",
+    labelKey: "editor.bubbleMenu.polish",
     testId: "bubble-ai-polish",
   },
   {
     id: "builtin:rewrite",
-    label: "改写",
+    labelKey: "editor.bubbleMenu.rewrite",
     testId: "bubble-ai-rewrite",
   },
   {
     id: "builtin:describe",
-    label: "描写",
+    labelKey: "editor.bubbleMenu.describe",
     testId: "bubble-ai-describe",
   },
   {
     id: "builtin:dialogue",
-    label: "对白",
+    labelKey: "editor.bubbleMenu.dialogue",
     testId: "bubble-ai-dialogue",
   },
 ] as const;
@@ -86,6 +87,7 @@ export function EditorBubbleMenu(props: {
   editor: Editor | null;
 }): JSX.Element | null {
   const { editor } = props;
+  const { t } = useTranslation();
   const [visible, setVisible] = React.useState(false);
   const [placement, setPlacement] = React.useState<BubblePlacement>("top");
   const projectId = useEditorStore((s) => s.projectId);
@@ -256,12 +258,12 @@ export function EditorBubbleMenu(props: {
             key={skill.id}
             type="button"
             data-testid={skill.testId}
-            aria-label={`AI ${skill.label}`}
+            aria-label={`AI ${t(skill.labelKey)}`}
             disabled={aiDisabled}
             className="rounded-[var(--radius-sm)] px-2 py-1 text-xs text-[var(--color-fg-default)] transition-colors duration-[var(--duration-fast)] hover:bg-[var(--color-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring-focus)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--color-bg-raised)] disabled:cursor-not-allowed disabled:opacity-40"
             onClick={() => handleAiSkillClick(skill.id)}
           >
-            {skill.label}
+            {t(skill.labelKey)}
           </button>
         ))}
       </div>

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Underline from "@tiptap/extension-underline";
@@ -44,8 +45,6 @@ const IS_VITEST_RUNTIME =
 export const EDITOR_DOCUMENT_CHARACTER_LIMIT = 1_000_000;
 export const LARGE_PASTE_THRESHOLD_CHARS = 2 * 1024 * 1024;
 const LARGE_PASTE_CHUNK_SIZE = 64 * 1024;
-const CAPACITY_WARNING_TEXT =
-  "文档已达到 1000000 字符上限，建议拆分文档后继续写作。";
 const WRITE_CONTEXT_WINDOW = 240;
 const ENTITY_COMPLETION_LOOKBACK_CHARS = 96;
 const ENTITY_COMPLETION_TRIGGER = "@";
@@ -341,6 +340,7 @@ export function sanitizePastedHtml(inputHtml: string): string {
  * EditorPane mounts TipTap editor and wires autosave to the DB SSOT.
  */
 export function EditorPane(props: { projectId: string }): JSX.Element {
+  const { t } = useTranslation();
   const bootstrapStatus = useEditorStore((s) => s.bootstrapStatus);
   const documentId = useEditorStore((s) => s.documentId);
   const documentStatus = useEditorStore((s) => s.documentStatus);
@@ -391,10 +391,10 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
     (nextCount: number) => {
       setDocumentCharacterCount(nextCount);
       setCapacityWarning(
-        shouldWarnDocumentCapacity(nextCount) ? CAPACITY_WARNING_TEXT : null,
+        shouldWarnDocumentCapacity(nextCount) ? t('editor.pane.charLimitReached') : null,
       );
     },
-    [setCapacityWarning, setDocumentCharacterCount],
+    [setCapacityWarning, setDocumentCharacterCount, t],
   );
 
   React.useEffect(() => {
@@ -461,7 +461,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
         const shouldContinueOverflow =
           !overflow ||
           window.confirm(
-            "粘贴内容超过文档容量上限，超限部分需要确认继续。是否继续粘贴？",
+            t('editor.pane.pasteLimitExceeded'),
           );
 
         const allowedLength = shouldContinueOverflow
@@ -1014,17 +1014,17 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
           className="flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-raised)] px-4 py-2"
         >
           <Text size="small" color="muted">
-            正在预览 {previewTimestamp ?? "历史"} 的版本
+            {t('editor.pane.previewingVersion', { timestamp: previewTimestamp ?? t('editor.pane.history') })}
           </Text>
           <div className="flex items-center gap-2">
-            <Tooltip content="将在 version-control-p2 中接入完整恢复流程">
+            <Tooltip content={t('editor.pane.restoreTooltip')}>
               <Button
                 data-testid="preview-restore-placeholder"
                 variant="secondary"
                 size="sm"
                 disabled={true}
               >
-                恢复到此版本
+                {t('editor.pane.restoreVersion')}
               </Button>
             </Tooltip>
             <Button
@@ -1033,7 +1033,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
               size="sm"
               onClick={exitPreview}
             >
-              返回当前版本
+              {t('editor.pane.backToCurrent')}
             </Button>
           </div>
         </div>

--- a/apps/desktop/renderer/src/features/editor/WriteButton.tsx
+++ b/apps/desktop/renderer/src/features/editor/WriteButton.tsx
@@ -1,6 +1,5 @@
+import { useTranslation } from 'react-i18next';
 import { Tooltip } from "../../components/primitives/Tooltip";
-
-export const WRITE_BUTTON_LABEL = "续写";
 
 export function WriteButton(props: {
   visible: boolean;
@@ -8,6 +7,8 @@ export function WriteButton(props: {
   running?: boolean;
   onClick: () => void;
 }): JSX.Element | null {
+  const { t } = useTranslation();
+
   if (!props.visible) {
     return null;
   }
@@ -17,7 +18,7 @@ export function WriteButton(props: {
       data-testid="write-button-group"
       className="pointer-events-none absolute bottom-3 right-3 z-[var(--z-dropdown)]"
     >
-      <Tooltip content={props.running ? "生成中..." : "触发续写技能"}>
+      <Tooltip content={props.running ? t('editor.writeButton.generating') : t('editor.writeButton.tooltip')}>
         <button
           type="button"
           data-testid="write-button-trigger"
@@ -32,7 +33,7 @@ export function WriteButton(props: {
             }
           `}
         >
-          {props.running ? "续写中..." : WRITE_BUTTON_LABEL}
+          {props.running ? t('editor.writeButton.writing') : t('editor.writeButton.label')}
         </button>
       </Tooltip>
     </div>

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.context-menu.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.context-menu.test.tsx
@@ -120,17 +120,17 @@ describe("FileTreePanel context menu actions", () => {
       fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
     });
 
-    const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
-    const deleteItem = await screen.findByRole("menuitem", { name: "Delete" });
-    const copyItem = await screen.findByRole("menuitem", { name: "Copy" });
+    const renameItem = await screen.findByRole("menuitem", { name: "重命名" });
+    const deleteItem = await screen.findByRole("menuitem", { name: "删除" });
+    const copyItem = await screen.findByRole("menuitem", { name: "复制" });
     const moveItem = await screen.findByRole("menuitem", {
-      name: "Move to Folder",
+      name: "移动到文件夹",
     });
     const historyItem = await screen.findByRole("menuitem", {
-      name: "Version History",
+      name: "版本历史",
     });
     const statusItem = await screen.findByRole("menuitem", {
-      name: "Mark as Final",
+      name: "标记为定稿",
     });
 
     expect(renameItem).toBeInTheDocument();
@@ -146,14 +146,14 @@ describe("FileTreePanel context menu actions", () => {
     expect(createAndSetCurrent).toHaveBeenCalledWith({
       projectId: "proj-1",
       type: "chapter",
-      title: "未命名章节 Copy",
+      title: "未命名章节 副本",
     });
 
     await act(async () => {
       fireEvent.contextMenu(screen.getByTestId("file-row-doc-1"));
     });
 
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Move to Folder" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "移动到文件夹" }));
     await flushFileTreeAsyncUpdates();
 
     expect(moveToFolder).toHaveBeenCalledWith({

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
@@ -55,14 +55,14 @@ describe("FileTreePanel", () => {
     it("应该显示 Files 标题", () => {
       render(<FileTreePanel projectId="test-project" />);
 
-      expect(screen.getByText("Files")).toBeInTheDocument();
+      expect(screen.getByText("文件")).toBeInTheDocument();
     });
 
     it("应该显示 New 按钮", () => {
       render(<FileTreePanel projectId="test-project" />);
 
       expect(screen.getByTestId("file-create")).toBeInTheDocument();
-      expect(screen.getByText("New")).toBeInTheDocument();
+      expect(screen.getByText("新建")).toBeInTheDocument();
     });
   });
 
@@ -112,7 +112,7 @@ describe("FileTreePanel", () => {
 
       render(<FileTreePanel projectId="test-project" />);
 
-      expect(screen.getByText("Loading files…")).toBeInTheDocument();
+      expect(screen.getByText("加载文件中…")).toBeInTheDocument();
     });
   });
 
@@ -148,7 +148,7 @@ describe("FileTreePanel", () => {
 
       expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
-      expect(screen.getByText("Dismiss")).toBeInTheDocument();
+      expect(screen.getByText("关闭")).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import {
   Button,
@@ -82,24 +83,24 @@ function iconForType(type: DocumentType): string {
 }
 
 /**
- * Resolve untitled title by document type.
+ * Resolve untitled title i18n key by document type.
  *
  * Why: new document enters rename mode and needs deterministic initial text.
  */
-function defaultTitleByType(type: DocumentType): string {
+function defaultTitleI18nKey(type: DocumentType): string {
   switch (type) {
     case "chapter":
-      return "Untitled Chapter";
+      return "files.tree.untitledChapter";
     case "note":
-      return "Untitled Note";
+      return "files.tree.untitledNote";
     case "setting":
-      return "Untitled Setting";
+      return "files.tree.untitledSetting";
     case "timeline":
-      return "Untitled Timeline";
+      return "files.tree.untitledTimeline";
     case "character":
-      return "Untitled Character";
+      return "files.tree.untitledCharacter";
     default:
-      return "Untitled";
+      return "files.tree.untitled";
   }
 }
 
@@ -280,6 +281,7 @@ function buildReorderedDocumentIds(args: {
  * Why: P1 requires sortable tree hierarchy with keyboard/context interactions.
  */
 export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
+  const { t } = useTranslation();
   const items = useFileStore((s) => s.items);
   const currentDocumentId = useFileStore((s) => s.currentDocumentId);
   const bootstrapStatus = useFileStore((s) => s.bootstrapStatus);
@@ -459,7 +461,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
     setEditing({
       mode: "rename",
       documentId: res.data.documentId,
-      title: defaultTitleByType(type),
+      title: t(defaultTitleI18nKey(type)),
     });
   }
 
@@ -467,7 +469,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
     const res = await createAndSetCurrent({
       projectId: props.projectId,
       type: item.type,
-      title: `${item.title} Copy`,
+      title: t('files.tree.copySuffix', { title: item.title }),
     });
     if (!res.ok) {
       return;
@@ -515,11 +517,10 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
 
   async function onDelete(documentId: string): Promise<void> {
     const confirmed = await confirm({
-      title: "Delete Document?",
-      description:
-        "This action cannot be undone. The document and its version history will be permanently deleted.",
-      primaryLabel: "Delete",
-      secondaryLabel: "Cancel",
+      title: t('files.tree.deleteTitle'),
+      description: t('files.tree.deleteDescription'),
+      primaryLabel: t('files.tree.deleteConfirm'),
+      secondaryLabel: t('files.tree.deleteCancel'),
     });
     if (!confirmed) {
       return;
@@ -733,7 +734,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
   return (
     <PanelContainer
       data-testid="sidebar-files"
-      title="Files"
+      title={t('files.tree.panelTitle')}
       actions={
         <>
           <Button
@@ -742,7 +743,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             size="sm"
             onClick={() => void onCreate("chapter")}
           >
-            New
+            {t('files.tree.newButton')}
           </Button>
           <Button
             data-testid="file-create-note"
@@ -750,7 +751,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             size="sm"
             onClick={() => void onCreate("note")}
           >
-            Note
+            {t('files.tree.noteButton')}
           </Button>
         </>
       }
@@ -765,7 +766,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             {lastError.code}: {lastError.message}
           </Text>
           <Button variant="secondary" size="sm" onClick={() => clearError()}>
-            Dismiss
+            {t('files.tree.dismiss')}
           </Button>
         </div>
       ) : null}
@@ -779,12 +780,12 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
       >
         {bootstrapStatus !== "ready" ? (
           <Text size="small" color="muted" className="p-3 block">
-            Loading files…
+            {t('files.tree.loading')}
           </Text>
         ) : items.length === 0 ? (
           <EmptyState
-            title="暂无文件"
-            description="开始创建你的第一个文件"
+            title={t('files.tree.emptyTitle')}
+            description={t('files.tree.emptyDescription')}
             action={
               <Button
                 data-testid="file-create-empty"
@@ -792,7 +793,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                 size="sm"
                 onClick={() => void onCreate("chapter")}
               >
-                新建文件
+                {t('files.tree.newFile')}
               </Button>
             }
           />
@@ -822,7 +823,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
               const contextMenuItems: ContextMenuItem[] = [
                 {
                   key: "rename",
-                  label: "Rename",
+                  label: t('files.tree.rename'),
                   onSelect: () => {
                     setEditing({
                       mode: "rename",
@@ -833,12 +834,12 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                 },
                 {
                   key: "copy",
-                  label: "Copy",
+                  label: t('files.tree.copy'),
                   onSelect: () => void onCopy(item),
                 },
                 {
                   key: "move",
-                  label: "Move to Folder",
+                  label: t('files.tree.moveToFolder'),
                   disabled: moveToFolderDisabled,
                   onSelect: () => {
                     if (!moveTargetFolderId) {
@@ -852,13 +853,13 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                 },
                 {
                   key: "delete",
-                  label: "Delete",
+                  label: t('files.tree.delete'),
                   onSelect: () => void onDelete(item.documentId),
                   destructive: true,
                 },
                 {
                   key: "version-history",
-                  label: "Version History",
+                  label: t('files.tree.versionHistory'),
                   onSelect: () => {
                     props.onOpenVersionHistory?.(item.documentId);
                   },
@@ -866,7 +867,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                 {
                   key: "status",
                   label:
-                    item.status === "final" ? "Mark as Draft" : "Mark as Final",
+                    item.status === "final" ? t('files.tree.markAsDraft') : t('files.tree.markAsFinal'),
                   onSelect: () =>
                     void onToggleStatus({
                       documentId: item.documentId,
@@ -1009,8 +1010,8 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                           className="shrink-0 w-4 text-[10px] text-[var(--color-fg-muted)]"
                           aria-label={
                             expandedFolderIds.has(item.documentId)
-                              ? "Collapse"
-                              : "Expand"
+                              ? t('files.tree.collapse')
+                              : t('files.tree.expand')
                           }
                         >
                           {expandedFolderIds.has(item.documentId) ? "▾" : "▸"}
@@ -1067,7 +1068,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                               }}
                               className="justify-start w-full"
                             >
-                              Rename
+                              {t('files.tree.rename')}
                             </Button>
                           </PopoverClose>
                           <PopoverClose asChild>
@@ -1078,7 +1079,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                               onClick={() => void onCopy(item)}
                               className="justify-start w-full"
                             >
-                              Copy
+                              {t('files.tree.copy')}
                             </Button>
                           </PopoverClose>
                           <PopoverClose asChild>
@@ -1098,7 +1099,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                               }}
                               className="justify-start w-full"
                             >
-                              Move to Folder
+                              {t('files.tree.moveToFolder')}
                             </Button>
                           </PopoverClose>
                           <PopoverClose asChild>
@@ -1116,8 +1117,8 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                               className="justify-start w-full"
                             >
                               {item.status === "final"
-                                ? "Mark as Draft"
-                                : "Mark as Final"}
+                                ? t('files.tree.markAsDraft')
+                                : t('files.tree.markAsFinal')}
                             </Button>
                           </PopoverClose>
                           <PopoverClose asChild>
@@ -1128,7 +1129,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                               onClick={() => void onDelete(item.documentId)}
                               className="justify-start w-full text-[var(--color-error)]"
                             >
-                              Delete
+                              {t('files.tree.delete')}
                             </Button>
                           </PopoverClose>
                         </div>

--- a/apps/desktop/renderer/src/features/kg/TimelineView.tsx
+++ b/apps/desktop/renderer/src/features/kg/TimelineView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export interface TimelineEventItem {
   id: string;
@@ -55,6 +56,7 @@ export function TimelineView({
   onOpenEvent,
   className = "",
 }: TimelineViewProps): JSX.Element {
+  const { t } = useTranslation();
   const [orderedEvents, setOrderedEvents] = React.useState<TimelineEventItem[]>(
     () => sortEvents(events),
   );
@@ -88,9 +90,9 @@ export function TimelineView({
         className={`h-full flex items-center justify-center bg-[var(--color-bg-base)] ${className}`}
       >
         <div className="text-center space-y-2">
-          <p className="text-sm text-[var(--color-fg-muted)]">暂无事件时间线</p>
+          <p className="text-sm text-[var(--color-fg-muted)]">{t('kg.timeline.empty')}</p>
           <p className="text-xs text-[var(--color-fg-subtle)]">
-            创建事件实体后可按章节组织并拖拽排序
+            {t('kg.timeline.emptyHint')}
           </p>
         </div>
       </section>

--- a/apps/desktop/renderer/src/features/memory/MemoryCreateDialog.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemoryCreateDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button, Select, Text, Textarea } from "../../components/primitives";
 import { Dialog } from "../../components/primitives/Dialog";
@@ -21,6 +22,7 @@ export function MemoryCreateDialog(props: {
   scope: MemoryScope;
   scopeLabel: string;
 }): JSX.Element {
+  const { t } = useTranslation();
   const create = useMemoryStore((s) => s.create);
 
   const [type, setType] = React.useState<MemoryType>("preference");
@@ -56,8 +58,8 @@ export function MemoryCreateDialog(props: {
     <Dialog
       open={props.open}
       onOpenChange={props.onOpenChange}
-      title="添加新记忆"
-      description={`这条记忆将保存在「${props.scopeLabel}」层级`}
+      title={t('memory.create.title')}
+      description={t('memory.create.description', { scope: props.scopeLabel })}
       footer={
         <div className="flex gap-2 justify-end">
           <Button
@@ -65,7 +67,7 @@ export function MemoryCreateDialog(props: {
             size="md"
             onClick={() => props.onOpenChange(false)}
           >
-            取消
+            {t('memory.create.cancel')}
           </Button>
           <Button
             variant="primary"
@@ -73,7 +75,7 @@ export function MemoryCreateDialog(props: {
             onClick={() => void handleSubmit()}
             disabled={!content.trim() || isSubmitting}
           >
-            {isSubmitting ? "保存中..." : "保存"}
+            {isSubmitting ? t('memory.create.saving') : t('memory.create.save')}
           </Button>
         </div>
       }
@@ -82,16 +84,16 @@ export function MemoryCreateDialog(props: {
         {/* Type selector */}
         <div className="flex flex-col gap-2">
           <Text size="small" color="muted">
-            记忆类型
+            {t('memory.create.type')}
           </Text>
           <Select
             data-testid="memory-create-type"
             value={type}
             onValueChange={(value) => setType(value as MemoryType)}
             options={[
-              { value: "preference", label: "偏好 — 写作风格、语言习惯" },
-              { value: "fact", label: "事实 — 角色设定、世界观" },
-              { value: "note", label: "笔记 — 临时提醒、待办事项" },
+              { value: "preference", label: t('memory.create.typePreference') },
+              { value: "fact", label: t('memory.create.typeFact') },
+              { value: "note", label: t('memory.create.typeNote') },
             ]}
             className="w-full"
           />
@@ -100,7 +102,7 @@ export function MemoryCreateDialog(props: {
         {/* Content input */}
         <div className="flex flex-col gap-2">
           <Text size="small" color="muted">
-            记忆内容
+            {t('memory.create.content')}
           </Text>
           <Textarea
             data-testid="memory-create-content"
@@ -108,10 +110,10 @@ export function MemoryCreateDialog(props: {
             onChange={(e) => setContent(e.target.value)}
             placeholder={
               type === "preference"
-                ? "例如：我喜欢简洁有力的文风，避免过多形容词堆砌"
+                ? t('memory.create.examplePreference')
                 : type === "fact"
-                  ? "例如：主角陈默是一名 35 岁的刑警，性格沉稳但有心理创伤"
-                  : "例如：记得在第七章增加一个误导性嫌疑人"
+                  ? t('memory.create.exampleFact')
+                  : t('memory.create.exampleNote')
             }
             className="min-h-[120px]"
           />
@@ -120,8 +122,7 @@ export function MemoryCreateDialog(props: {
         {/* Scope info */}
         <div className="flex items-center gap-2 p-2 rounded bg-[var(--color-bg-subtle)]">
           <Text size="tiny" color="muted">
-            💡 记忆层级由当前选中的 Tab 决定。切换 Tab
-            后添加的记忆会保存到对应层级。
+            {t('memory.create.layerHint')}
           </Text>
         </div>
       </div>

--- a/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import type { IpcError, IpcResponseData } from "@shared/types/ipc-generated";
 import { Button, Card, Text } from "../../components/primitives";
@@ -12,18 +13,18 @@ type MemorySettings = IpcResponseData<"memory:settings:get">;
 
 type CategoryGroup = {
   category: SemanticCategory;
-  label: string;
+  labelKey: string;
 };
 
 const CATEGORY_GROUPS: CategoryGroup[] = [
-  { category: "style", label: "写作风格" },
-  { category: "structure", label: "叙事结构" },
-  { category: "character", label: "角色偏好" },
-  { category: "pacing", label: "节奏偏好" },
-  { category: "vocabulary", label: "词汇偏好" },
+  { category: "style", labelKey: "memory.panel.categoryStyle" },
+  { category: "structure", labelKey: "memory.panel.categoryStructure" },
+  { category: "character", labelKey: "memory.panel.categoryCharacter" },
+  { category: "pacing", labelKey: "memory.panel.categoryPacing" },
+  { category: "vocabulary", labelKey: "memory.panel.categoryVocabulary" },
 ];
 
-function normalizePanelLoadError(cause: unknown): IpcError {
+function normalizePanelLoadError(cause: unknown, fallbackMessage: string): IpcError {
   if (
     typeof cause === "object" &&
     cause !== null &&
@@ -38,7 +39,7 @@ function normalizePanelLoadError(cause: unknown): IpcError {
   }
   return {
     code: "INTERNAL_ERROR",
-    message: "Memory 面板加载失败",
+    message: fallbackMessage,
   };
 }
 
@@ -56,6 +57,7 @@ function formatUpdatedAt(ts: number | null): string {
  * directly user-controllable and decoupled from legacy entry CRUD workflows.
  */
 export function MemoryPanel(): JSX.Element {
+  const { t } = useTranslation();
   const projectId = useProjectStore(
     (state) => state.current?.projectId ?? null,
   );
@@ -117,9 +119,9 @@ export function MemoryPanel(): JSX.Element {
       setStatus("ready");
     } catch (cause) {
       setStatus("error");
-      setError(normalizePanelLoadError(cause));
+      setError(normalizePanelLoadError(cause, t('memory.panel.loadError')));
     }
-  }, [projectId]);
+  }, [projectId, t]);
 
   React.useEffect(() => {
     void loadPanelData();
@@ -205,7 +207,7 @@ export function MemoryPanel(): JSX.Element {
 
     const normalized = editingText.trim();
     if (normalized.length === 0) {
-      setError({ code: "INVALID_ARGUMENT", message: "规则文本不能为空" });
+      setError({ code: "INVALID_ARGUMENT", message: t('memory.panel.ruleTextRequired') });
       return;
     }
 
@@ -235,7 +237,7 @@ export function MemoryPanel(): JSX.Element {
       return;
     }
 
-    const confirmed = window.confirm("确认删除这条偏好规则吗？");
+    const confirmed = window.confirm(t('memory.panel.confirmDeleteRule'));
     if (!confirmed) {
       return;
     }
@@ -256,7 +258,7 @@ export function MemoryPanel(): JSX.Element {
 
     const normalized = draftRule.trim();
     if (normalized.length === 0) {
-      setError({ code: "INVALID_ARGUMENT", message: "规则文本不能为空" });
+      setError({ code: "INVALID_ARGUMENT", message: t('memory.panel.ruleTextRequired') });
       return;
     }
 
@@ -345,7 +347,7 @@ export function MemoryPanel(): JSX.Element {
           }`}
           onClick={() => setActiveScope("global")}
         >
-          全局
+          {t('memory.panel.globalTab')}
         </button>
         <button
           type="button"
@@ -358,7 +360,7 @@ export function MemoryPanel(): JSX.Element {
           } disabled:opacity-50 disabled:cursor-not-allowed`}
           onClick={() => setActiveScope("project")}
         >
-          本项目
+          {t('memory.panel.projectTab')}
         </button>
       </div>
 
@@ -369,7 +371,7 @@ export function MemoryPanel(): JSX.Element {
           className="shrink-0 px-2.5 py-2 border-[var(--color-warning)] text-[var(--color-warning)]"
         >
           <Text size="small" className="text-[var(--color-warning)]">
-            学习已暂停：新情景仍记录，但不会触发蒸馏更新
+            {t('memory.panel.learningPaused')}
           </Text>
         </Card>
       ) : null}
@@ -381,7 +383,7 @@ export function MemoryPanel(): JSX.Element {
           className="shrink-0 px-2.5 py-2 border-[var(--color-warning)] text-[var(--color-warning)]"
         >
           <Text size="small" className="text-[var(--color-warning)]">
-            检测到 {conflictCount} 条偏好冲突，请优先处理。
+            {t('memory.panel.conflictsDetected', { count: conflictCount })}
           </Text>
         </Card>
       ) : null}
@@ -414,7 +416,7 @@ export function MemoryPanel(): JSX.Element {
         {status === "loading" ? (
           <div className="h-full flex items-center justify-center">
             <Text size="small" color="muted">
-              加载中...
+              {t('memory.panel.loading')}
             </Text>
           </div>
         ) : filteredRules.length === 0 ? (
@@ -423,10 +425,10 @@ export function MemoryPanel(): JSX.Element {
               ✦
             </div>
             <Text size="small" color="muted">
-              AI 正在学习你的写作偏好，使用越多越精准
+              {t('memory.panel.aiLearningHint')}
             </Text>
             <Button size="sm" onClick={() => setComposerOpen(true)}>
-              手动添加规则
+              {t('memory.panel.addRuleManually')}
             </Button>
           </div>
         ) : (
@@ -434,7 +436,7 @@ export function MemoryPanel(): JSX.Element {
             {groupedRules.map((group) => (
               <div key={group.category} className="flex flex-col gap-2">
                 <Text size="small" color="muted">
-                  {group.label}
+                  {t(group.labelKey)}
                 </Text>
                 {group.items.map((rule) => {
                   const isEditing = editingRuleId === rule.id;
@@ -453,11 +455,11 @@ export function MemoryPanel(): JSX.Element {
                                 className="text-xs text-[var(--color-fg-muted)]"
                                 htmlFor={`memory-edit-${rule.id}`}
                               >
-                                规则文本
+                                {t('memory.panel.ruleText')}
                               </label>
                               <textarea
                                 id={`memory-edit-${rule.id}`}
-                                aria-label="规则文本"
+                                aria-label={t('memory.panel.ruleText')}
                                 value={editingText}
                                 onChange={(event) =>
                                   setEditingText(event.target.value)
@@ -469,7 +471,7 @@ export function MemoryPanel(): JSX.Element {
                                   size="sm"
                                   onClick={() => void handleSaveEdit(rule.id)}
                                 >
-                                  保存修改
+                                  {t('memory.panel.saveChanges')}
                                 </Button>
                                 <Button
                                   size="sm"
@@ -479,7 +481,7 @@ export function MemoryPanel(): JSX.Element {
                                     setEditingText("");
                                   }}
                                 >
-                                  取消
+                                  {t('memory.panel.cancel')}
                                 </Button>
                               </div>
                             </div>
@@ -493,12 +495,12 @@ export function MemoryPanel(): JSX.Element {
                               </Text>
                               <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-fg-muted)]">
                                 <span>
-                                  置信度 {Math.round(rule.confidence * 100)}%
+                                  {t('memory.panel.confidence', { value: Math.round(rule.confidence * 100) })}
                                 </span>
                                 {rule.userConfirmed ? (
-                                  <span>已确认</span>
+                                  <span>{t('memory.panel.confirmed')}</span>
                                 ) : null}
-                                {rule.userModified ? <span>已修改</span> : null}
+                                {rule.userModified ? <span>{t('memory.panel.modified')}</span> : null}
                               </div>
                             </>
                           )}
@@ -512,21 +514,21 @@ export function MemoryPanel(): JSX.Element {
                               disabled={rule.userConfirmed}
                               onClick={() => void handleConfirmRule(rule.id)}
                             >
-                              确认
+                              {t('memory.panel.confirm')}
                             </Button>
                             <Button
                               size="sm"
                               variant="ghost"
                               onClick={() => startEdit(rule)}
                             >
-                              修改
+                              {t('memory.panel.modify')}
                             </Button>
                             <Button
                               size="sm"
                               variant="danger"
                               onClick={() => void handleDeleteRule(rule.id)}
                             >
-                              删除
+                              {t('memory.panel.delete')}
                             </Button>
                           </div>
                         ) : null}
@@ -545,14 +547,14 @@ export function MemoryPanel(): JSX.Element {
         className="shrink-0 p-2.5 bg-[var(--color-bg-raised)] rounded-[var(--radius-sm)]"
       >
         <div className="flex items-center justify-between text-xs text-[var(--color-fg-muted)]">
-          <span>交互记录数 {interactionCount}</span>
-          <span>最近更新 {formatUpdatedAt(latestUpdateAt)}</span>
+          <span>{t('memory.panel.interactionCount', { count: interactionCount })}</span>
+          <span>{t('memory.panel.lastUpdate', { time: formatUpdatedAt(latestUpdateAt) })}</span>
         </div>
       </Card>
 
       <div className="shrink-0 flex items-center gap-2">
         <Button size="sm" onClick={() => setComposerOpen(true)}>
-          手动添加规则
+          {t('memory.panel.addRuleManually')}
         </Button>
         <Button
           size="sm"
@@ -560,7 +562,7 @@ export function MemoryPanel(): JSX.Element {
           loading={distilling}
           onClick={() => void handleDistill()}
         >
-          更新偏好
+          {t('memory.panel.updatePreferences')}
         </Button>
         <Button
           size="sm"
@@ -568,8 +570,8 @@ export function MemoryPanel(): JSX.Element {
           onClick={() => void handleLearningToggle()}
         >
           {settings?.preferenceLearningEnabled === false
-            ? "恢复学习"
-            : "暂停学习"}
+            ? t('memory.panel.resumeLearning')
+            : t('memory.panel.pauseLearning')}
         </Button>
       </div>
 
@@ -583,11 +585,11 @@ export function MemoryPanel(): JSX.Element {
               className="text-xs text-[var(--color-fg-muted)]"
               htmlFor="memory-rule-create-input"
             >
-              新增规则
+              {t('memory.panel.addRule')}
             </label>
             <textarea
               id="memory-rule-create-input"
-              aria-label="新增规则"
+              aria-label={t('memory.panel.addRule')}
               value={draftRule}
               onChange={(event) => setDraftRule(event.target.value)}
               className="min-h-[72px] rounded-[var(--radius-sm)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5 text-sm"
@@ -596,7 +598,7 @@ export function MemoryPanel(): JSX.Element {
               className="text-xs text-[var(--color-fg-muted)]"
               htmlFor="memory-rule-category"
             >
-              分类
+              {t('memory.panel.category')}
             </label>
             <select
               id="memory-rule-category"
@@ -608,13 +610,13 @@ export function MemoryPanel(): JSX.Element {
             >
               {CATEGORY_GROUPS.map((group) => (
                 <option key={group.category} value={group.category}>
-                  {group.label}
+                  {t(group.labelKey)}
                 </option>
               ))}
             </select>
             <div className="flex items-center gap-2">
               <Button size="sm" onClick={() => void handleCreateRule()}>
-                保存规则
+                {t('memory.panel.saveRule')}
               </Button>
               <Button
                 size="sm"
@@ -624,7 +626,7 @@ export function MemoryPanel(): JSX.Element {
                   setDraftRule("");
                 }}
               >
-                取消
+                {t('memory.panel.cancel')}
               </Button>
             </div>
           </div>

--- a/apps/desktop/renderer/src/features/memory/MemorySettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemorySettingsDialog.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+
 import { Button, Checkbox, Input, Text } from "../../components/primitives";
 import { Dialog } from "../../components/primitives/Dialog";
 import { useMemoryStore } from "../../stores/memoryStore";
@@ -15,6 +17,7 @@ export function MemorySettingsDialog(props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }): JSX.Element {
+  const { t } = useTranslation();
   const settings = useMemoryStore((s) => s.settings);
   const updateSettings = useMemoryStore((s) => s.updateSettings);
 
@@ -22,15 +25,15 @@ export function MemorySettingsDialog(props: {
     <Dialog
       open={props.open}
       onOpenChange={props.onOpenChange}
-      title="记忆设置"
-      description="控制 AI 如何使用和学习你的记忆"
+      title={t('memory.settings.title')}
+      description={t('memory.settings.description')}
       footer={
         <Button
           variant="primary"
           size="md"
           onClick={() => props.onOpenChange(false)}
         >
-          完成
+          {t('memory.settings.done')}
         </Button>
       }
     >
@@ -44,10 +47,10 @@ export function MemorySettingsDialog(props: {
             })
           }
           disabled={!settings}
-          label="启用记忆注入"
+          label={t('memory.settings.enableInjection')}
         />
         <Text size="tiny" color="muted" className="-mt-2 ml-6">
-          AI 在写作时会参考你的记忆
+          {t('memory.settings.injectionDesc')}
         </Text>
 
         <Checkbox
@@ -59,10 +62,10 @@ export function MemorySettingsDialog(props: {
             })
           }
           disabled={!settings}
-          label="启用偏好学习"
+          label={t('memory.settings.enableLearning')}
         />
         <Text size="tiny" color="muted" className="-mt-2 ml-6">
-          AI 会从你的反馈中学习写作偏好
+          {t('memory.settings.learningDesc')}
         </Text>
 
         <Checkbox
@@ -74,15 +77,15 @@ export function MemorySettingsDialog(props: {
             })
           }
           disabled={!settings}
-          label="隐私模式"
+          label={t('memory.settings.privacyMode')}
         />
         <Text size="tiny" color="muted" className="-mt-2 ml-6">
-          减少存储可识别的内容片段
+          {t('memory.settings.privacyDesc')}
         </Text>
 
         <div className="flex items-center gap-3 mt-2">
           <Text size="small" color="muted">
-            学习阈值
+            {t('memory.settings.learningThreshold')}
           </Text>
           <Input
             data-testid="memory-settings-threshold"
@@ -100,7 +103,7 @@ export function MemorySettingsDialog(props: {
           />
         </div>
         <Text size="tiny" color="muted" className="-mt-2">
-          收到多少次相同信号后触发学习（默认 3）
+          {t('memory.settings.thresholdDesc')}
         </Text>
       </div>
     </Dialog>

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button } from "../../components/primitives/Button";
 import { Dialog } from "../../components/primitives/Dialog";
@@ -344,6 +345,8 @@ export function CreateProjectDialog({
   open,
   onOpenChange,
 }: CreateProjectDialogProps): JSX.Element {
+  const { t } = useTranslation();
+
   // Project store
   const createAndSetCurrent = useProjectStore((s) => s.createAndSetCurrent);
   const createAiAssistDraft = useProjectStore((s) => s.createAiAssistDraft);
@@ -489,7 +492,7 @@ export function CreateProjectDialog({
         const message =
           error instanceof Error && error.message.length > 0
             ? error.message
-            : "项目创建失败，请重试";
+            : t('projects.create.createFailed');
         setSubmitError({ code, message });
         console.error("[CreateProjectDialog] createProject failed:", {
           operation: "createAndSetCurrent",
@@ -505,7 +508,7 @@ export function CreateProjectDialog({
 
   const handleAiGenerate = useCallback(async () => {
     if (aiPrompt.trim().length === 0) {
-      setAiErrorMessage("请先输入创作意图");
+      setAiErrorMessage(t('projects.create.enterIntentFirst'));
       return;
     }
 
@@ -514,7 +517,7 @@ export function CreateProjectDialog({
     try {
       const res = await createAiAssistDraft({ prompt: aiPrompt });
       if (!res.ok) {
-        setAiErrorMessage("AI 辅助创建暂时不可用，请手动创建或稍后重试");
+        setAiErrorMessage(t('projects.create.aiUnavailable'));
         return;
       }
 
@@ -565,7 +568,7 @@ export function CreateProjectDialog({
       >
         {open ? (
           <div className="space-y-4">
-            <div role="tablist" aria-label="创建模式" className="flex gap-2">
+            <div role="tablist" aria-label={t('projects.create.modeLabel')} className="flex gap-2">
               <button
                 type="button"
                 role="tab"
@@ -573,7 +576,7 @@ export function CreateProjectDialog({
                 onClick={() => setMode("manual")}
                 className="h-8 px-3 text-xs rounded-[var(--radius-sm)] border border-[var(--color-border-default)]"
               >
-                手动创建
+                {t('projects.create.manualCreate')}
               </button>
               <button
                 type="button"
@@ -582,7 +585,7 @@ export function CreateProjectDialog({
                 onClick={() => setMode("ai-assist")}
                 className="h-8 px-3 text-xs rounded-[var(--radius-sm)] border border-[var(--color-border-default)]"
               >
-                AI 辅助
+                {t('projects.create.aiAssisted')}
               </button>
             </div>
 
@@ -606,7 +609,7 @@ export function CreateProjectDialog({
                   data-testid="create-project-ai-prompt"
                   value={aiPrompt}
                   onChange={(e) => setAiPrompt(e.target.value)}
-                  placeholder="例如：帮我创建一部校园推理小说，主角是高中女生侦探"
+                  placeholder={t('projects.create.aiPlaceholder')}
                   rows={4}
                   fullWidth
                 />
@@ -617,7 +620,7 @@ export function CreateProjectDialog({
                   loading={aiGenerating}
                   onClick={() => void handleAiGenerate()}
                 >
-                  {aiGenerating ? "生成中…" : "生成草案"}
+                  {aiGenerating ? t('projects.create.generating') : t('projects.create.generateDraft')}
                 </Button>
 
                 {aiErrorMessage ? (
@@ -634,18 +637,17 @@ export function CreateProjectDialog({
                 {aiDraft ? (
                   <div className="space-y-2 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] p-3">
                     <Text size="small" color="default">
-                      {aiDraft.name}（{aiDraft.type}）
+                      {t('projects.create.draftInfo', { name: aiDraft.name, type: aiDraft.type })}
                     </Text>
                     <Text size="small" color="muted">
-                      章节：{aiDraft.chapterOutlines.length}，角色：
-                      {aiDraft.characters.length}
+                      {t('projects.create.draftStats', { chapters: aiDraft.chapterOutlines.length, characters: aiDraft.characters.length })}
                     </Text>
                     <Button
                       size="sm"
                       variant="ghost"
                       onClick={() => setMode("manual")}
                     >
-                      使用此草案继续手动创建
+                      {t('projects.create.useDraft')}
                     </Button>
                   </div>
                 ) : null}

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -503,7 +503,7 @@ export function CreateProjectDialog({
         setSubmitting(false);
       }
     },
-    [createAndSetCurrent, customs, onOpenChange, presets],
+    [createAndSetCurrent, customs, onOpenChange, presets, t],
   );
 
   const handleAiGenerate = useCallback(async () => {
@@ -525,7 +525,7 @@ export function CreateProjectDialog({
     } finally {
       setAiGenerating(false);
     }
-  }, [aiPrompt, createAiAssistDraft]);
+  }, [aiPrompt, createAiAssistDraft, t]);
 
   const handleTemplateCreated = useCallback(
     (_id: string) => {

--- a/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/DeleteProjectDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button, Dialog, Input, Text } from "../../components/primitives";
 
@@ -17,6 +18,7 @@ export interface DeleteProjectDialogProps {
  * Why: PM-2 requires explicit second confirmation to prevent accidental purge.
  */
 export function DeleteProjectDialog(props: DeleteProjectDialogProps): JSX.Element {
+  const { t } = useTranslation();
   const [typedName, setTypedName] = React.useState("");
 
   React.useEffect(() => {
@@ -27,13 +29,13 @@ export function DeleteProjectDialog(props: DeleteProjectDialogProps): JSX.Elemen
 
   const canDelete = typedName === props.projectName && !props.submitting;
 
-  const description = `删除项目"${props.projectName}"将永久删除所有文档（${props.documentCount} 篇）、知识图谱数据和版本历史。请输入项目名称确认删除。`;
+  const description = t('projects.delete.description', { name: props.projectName, count: props.documentCount });
 
   return (
     <Dialog
       open={props.open}
       onOpenChange={props.onOpenChange}
-      title="确认删除项目"
+      title={t('projects.delete.title')}
       description={description}
       footer={
         <>
@@ -43,7 +45,7 @@ export function DeleteProjectDialog(props: DeleteProjectDialogProps): JSX.Elemen
             onClick={() => props.onOpenChange(false)}
             disabled={Boolean(props.submitting)}
           >
-            取消
+            {t('projects.delete.cancel')}
           </Button>
           <Button
             data-testid="delete-project-confirm-button"
@@ -58,14 +60,14 @@ export function DeleteProjectDialog(props: DeleteProjectDialogProps): JSX.Elemen
               void props.onConfirm();
             }}
           >
-            确认删除
+            {t('projects.delete.confirm')}
           </Button>
         </>
       }
     >
       <div className="space-y-3">
         <Text size="small" color="muted">
-          请输入项目名以确认：
+          {t('projects.delete.inputHint')}
         </Text>
         <Input
           data-testid="delete-project-name-input"

--- a/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
+++ b/apps/desktop/renderer/src/features/projects/ProjectSwitcher.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import type { ProjectListItem } from "../../stores/projectStore";
 
@@ -66,6 +67,7 @@ export function formatRelativeTime(
  * Why: PM-2 requires a visible loading indicator when switching takes >1s.
  */
 export function ProjectSwitcher(props: ProjectSwitcherProps): JSX.Element {
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
   const [debouncedQuery, setDebouncedQuery] = React.useState("");
@@ -198,7 +200,7 @@ export function ProjectSwitcher(props: ProjectSwitcherProps): JSX.Element {
             data-testid="project-switcher-current-name"
             className="truncate text-left"
           >
-            {currentProject?.name ?? "选择项目"}
+            {currentProject?.name ?? t('projects.switcher.selectProject')}
           </span>
         </span>
         <span
@@ -220,20 +222,20 @@ export function ProjectSwitcher(props: ProjectSwitcherProps): JSX.Element {
               data-testid="project-switcher-search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="搜索项目"
+              placeholder={t('projects.switcher.searchPlaceholder')}
               className="h-7 w-full rounded-[var(--radius-sm)] border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2 text-xs text-[var(--color-fg-default)] placeholder:text-[var(--color-fg-muted)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]"
             />
           </div>
 
           {filteredProjects.length === 0 ? (
             <div className="space-y-2 p-3 text-xs text-[var(--color-fg-muted)]">
-              <div>暂无项目</div>
+              <div>{t('projects.switcher.noProjects')}</div>
               <button
                 type="button"
                 onClick={handleCreateProject}
                 className="h-7 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] px-2 text-xs text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
               >
-                创建新项目
+                {t('projects.switcher.createNew')}
               </button>
             </div>
           ) : (

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Avatar, Button, Text } from "../../components/primitives";
 
 /**
@@ -60,8 +61,6 @@ const cardStyles = [
   "bg-[var(--color-bg-raised)]",
 ].join(" ");
 
-const accountActionComingSoonLabel = "即将推出";
-
 /**
  * Plan badge component
  */
@@ -104,6 +103,7 @@ export function SettingsAccount({
   onLogout: _onLogout,
   onDeleteAccount,
 }: SettingsAccountProps): JSX.Element {
+  const { t } = useTranslation();
   void _onLogout; // Reserved for future use
   return (
     <div className="max-w-[560px]">
@@ -172,7 +172,7 @@ export function SettingsAccount({
             )}
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
-            {accountActionComingSoonLabel}
+            {t('settingsDialog.account.comingSoon')}
           </Text>
         </div>
       </div>
@@ -203,7 +203,7 @@ export function SettingsAccount({
             </Button>
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
-            {accountActionComingSoonLabel}
+            {t('settingsDialog.account.comingSoon')}
           </Text>
         </div>
       </div>

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { Toggle } from "../../components/primitives/Toggle";
 import { Slider } from "../../components/primitives/Slider";
@@ -78,14 +79,6 @@ const typographyOptions = [
 ];
 
 /**
- * Language options
- */
-const languageOptions = [
-  { value: "zh-CN", label: "中文 (简体)" },
-  { value: "en", label: "English" },
-];
-
-/**
  * SettingsGeneral page component
  *
  * General settings page with Writing Experience, Data & Storage, and Editor Defaults sections.
@@ -97,6 +90,13 @@ export function SettingsGeneral({
   onShowAiMarksChange,
   onSettingsChange,
 }: SettingsGeneralProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const languageOptions = React.useMemo(() => [
+    { value: "zh-CN", label: t('settingsDialog.general.zhCN') },
+    { value: "en", label: "English" },
+  ], [t]);
+
   const [currentLanguage, setCurrentLanguage] = React.useState(
     () => getLanguagePreference(),
   );
@@ -207,7 +207,7 @@ export function SettingsGeneral({
         <div className="flex flex-col gap-8 mb-8">
           <Toggle
             label="Differentiate AI edits"
-            description="When enabled, AI-generated entries in Version History show an extra “AI 修改” marker."
+            description={`When enabled, AI-generated entries in Version History show an extra \u201c${t('settingsDialog.general.aiModifyMarker')}\u201d marker.`}
             checked={showAiMarks}
             onCheckedChange={onShowAiMarksChange}
           />

--- a/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import type { IpcResponseData } from "@shared/types/ipc-generated";
 
 import { Button } from "../../components/primitives/Button";
@@ -19,6 +20,7 @@ type AiSettings = IpcResponseData<"ai:config:get">;
  * Design reference: audit/06 §3.1 — AI configuration interface.
  */
 export function AiSettingsSection(): JSX.Element {
+  const { t } = useTranslation();
   const [status, setStatus] = React.useState<"idle" | "loading">("idle");
   const [settings, setSettings] = React.useState<AiSettings | null>(null);
   const [providerMode, setProviderMode] = React.useState<
@@ -60,15 +62,15 @@ export function AiSettingsSection(): JSX.Element {
 
   function resolveApiKeyPlaceholder(): string {
     if (!settings) {
-      return "未配置";
+      return t('settings.ai.notConfigured');
     }
     if (providerMode === "anthropic-byok") {
-      return settings.anthropicByokApiKeyConfigured ? "已配置" : "未配置";
+      return settings.anthropicByokApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
     }
     if (providerMode === "openai-byok") {
-      return settings.openAiByokApiKeyConfigured ? "已配置" : "未配置";
+      return settings.openAiByokApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
     }
-    return settings.openAiCompatibleApiKeyConfigured ? "已配置" : "未配置";
+    return settings.openAiCompatibleApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
   }
 
   async function onSave(): Promise<void> {
@@ -121,7 +123,7 @@ export function AiSettingsSection(): JSX.Element {
     }
 
     if (res.data.ok) {
-      setTestResult(`连接成功 (${res.data.latencyMs}ms)`);
+      setTestResult(t('settings.ai.connectionSuccess', { latency: res.data.latencyMs }));
       return;
     }
 
@@ -137,7 +139,7 @@ export function AiSettingsSection(): JSX.Element {
       className="flex flex-col gap-2.5 p-3 rounded-[var(--radius-lg)]"
     >
       <Text size="body" weight="bold">
-        AI 配置
+        {t('settings.ai.title')}
       </Text>
 
       <div className="flex flex-col gap-1.5">
@@ -210,7 +212,7 @@ export function AiSettingsSection(): JSX.Element {
           onClick={() => void onSave()}
           disabled={status === "loading"}
         >
-          保存
+          {t('settings.ai.save')}
         </Button>
         <Button
           data-testid="ai-test-btn"
@@ -219,7 +221,7 @@ export function AiSettingsSection(): JSX.Element {
           onClick={() => void onTest()}
           disabled={status === "loading"}
         >
-          测试连接
+          {t('settings.ai.testConnection')}
         </Button>
       </div>
     </Card>

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -319,7 +319,7 @@ export function VersionHistoryContainer(
       const timestamp = item ? formatTimestamp(item.createdAt) : t("versionHistory.container.history");
       void startPreview(documentId, { versionId, timestamp });
     },
-    [documentId, items, startPreview],
+    [documentId, items, startPreview, t],
   );
 
   React.useEffect(() => {

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import {
   VersionHistoryPanelContent,
   type TimeGroup,
@@ -16,6 +17,7 @@ import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { RESTORE_VERSION_CONFIRM_COPY } from "./restoreConfirmCopy";
 import { useVersionPreferencesStore } from "../../stores/versionPreferencesStore";
+import { i18n } from "../../i18n";
 
 /**
  * Map backend actor to UI author type.
@@ -110,24 +112,24 @@ function getTimeGroupLabel(createdAt: number): string {
  */
 function getDescription(reason: string): string {
   if (reason === "autosave") {
-    return "自动保存";
+    return i18n.t("versionHistory.container.autosave");
   }
   if (reason === "manual-save") {
-    return "手动保存";
+    return i18n.t("versionHistory.container.manualSave");
   }
   if (reason === "status-change") {
-    return "状态变更";
+    return i18n.t("versionHistory.container.statusChange");
   }
   if (reason === "ai-accept") {
-    return "AI 修改";
+    return i18n.t("versionHistory.container.aiModify");
   }
   if (reason === "restore") {
-    return "恢复版本";
+    return i18n.t("versionHistory.container.restoreVersion");
   }
   if (reason.startsWith("ai-apply:")) {
-    return "AI 修改";
+    return i18n.t("versionHistory.container.aiModify");
   }
-  return reason || "版本快照";
+  return reason || i18n.t("versionHistory.container.versionSnapshot");
 }
 
 /**
@@ -192,6 +194,7 @@ type VersionHistoryContainerProps = {
 export function VersionHistoryContainer(
   props: VersionHistoryContainerProps,
 ): JSX.Element {
+  const { t } = useTranslation();
   const documentId = useEditorStore((s) => s.documentId);
   const bootstrapEditor = useEditorStore((s) => s.bootstrapForProject);
   const { startCompare } = useVersionCompare();
@@ -313,7 +316,7 @@ export function VersionHistoryContainer(
       if (!documentId) return;
 
       const item = items.find((candidate) => candidate.versionId === versionId);
-      const timestamp = item ? formatTimestamp(item.createdAt) : "历史";
+      const timestamp = item ? formatTimestamp(item.createdAt) : t("versionHistory.container.history");
       void startPreview(documentId, { versionId, timestamp });
     },
     [documentId, items, startPreview],

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import { Bot, Columns2, Eye, RotateCcw, Shield, User, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Button } from "../../components/primitives";
 import { Tooltip } from "../../components/primitives/Tooltip";
 
@@ -236,12 +237,13 @@ function AuthorBadge({
  * Explicit AI modification marker shown only when user enables the preference.
  */
 function AiMarkTag(props: { versionId: string }): JSX.Element {
+  const { t } = useTranslation();
   return (
     <span
       data-testid={`ai-mark-tag-${props.versionId}`}
       className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-[var(--color-info)] text-[var(--color-bg-surface)]"
     >
-      AI 修改
+      {t("versionHistory.panel.aiModify")}
     </span>
   );
 }
@@ -256,17 +258,18 @@ function VersionMeta({
   reason?: string;
   affectedParagraphs?: number;
 }) {
+  const { t } = useTranslation();
   if (!reason && affectedParagraphs === undefined) {
     return null;
   }
 
   // Map raw reason to human-readable text
   const getReasonText = (r: string): string => {
-    if (r === "autosave") return "自动保存";
-    if (r === "manual-save") return "手动保存";
-    if (r === "status-change") return "状态变更";
-    if (r === "ai-accept") return "AI 修改";
-    if (r.startsWith("ai-apply:")) return "AI 修改";
+    if (r === "autosave") return t("versionHistory.panel.autosave");
+    if (r === "manual-save") return t("versionHistory.panel.manualSave");
+    if (r === "status-change") return t("versionHistory.panel.statusChange");
+    if (r === "ai-accept") return t("versionHistory.panel.aiModify");
+    if (r.startsWith("ai-apply:")) return t("versionHistory.panel.aiModify");
     return r;
   };
 
@@ -274,14 +277,14 @@ function VersionMeta({
     <div className="flex items-center gap-2 text-[10px] text-[var(--color-fg-placeholder)] mt-1">
       {reason && (
         <span className="flex items-center gap-1">
-          <span className="opacity-60">原因:</span>
+          <span className="opacity-60">{t("versionHistory.panel.reason")}</span>
           <span>{getReasonText(reason)}</span>
         </span>
       )}
       {affectedParagraphs !== undefined && affectedParagraphs > 0 && (
         <>
           {reason && <span className="opacity-40">·</span>}
-          <span>{affectedParagraphs} 段落受影响</span>
+          <span>{t("versionHistory.panel.affectedParagraphs", { count: affectedParagraphs })}</span>
         </>
       )}
     </div>
@@ -292,12 +295,13 @@ function VersionMeta({
  * Diff summary preview
  */
 function DiffSummaryPreview({ summary }: { summary?: string }) {
+  const { t } = useTranslation();
   if (!summary) return null;
 
   return (
     <div className="mt-2 p-2 bg-[var(--color-bg-raised)] rounded border border-[var(--color-separator)] text-[11px] text-[var(--color-fg-muted)] font-mono leading-relaxed">
       <span className="text-[var(--color-fg-placeholder)] text-[9px] uppercase tracking-wider block mb-1">
-        变更预览
+        {t("versionHistory.panel.changePreview")}
       </span>
       <span className="line-clamp-2">{summary}</span>
     </div>
@@ -416,6 +420,7 @@ function VersionCard({
   onPreview?: (id: string) => void;
   showAiMarks?: boolean;
 }) {
+  const { t } = useTranslation();
   const baseCardStyles = [
     "group",
     "relative",
@@ -553,7 +558,7 @@ function VersionCard({
       {version.affectedParagraphs !== undefined &&
         version.affectedParagraphs > 0 && (
           <div className="text-[10px] text-[var(--color-fg-placeholder)] mt-1 mb-1">
-            {version.affectedParagraphs} 段落受影响
+            {t("versionHistory.panel.affectedParagraphs", { count: version.affectedParagraphs })}
           </div>
         )}
 

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -50,6 +50,27 @@
       "underline": "Underline",
       "aiPolish": "Polish",
       "aiRewrite": "Rewrite"
+    },
+    "bubbleMenu": {
+      "polish": "Polish",
+      "rewrite": "Rewrite",
+      "describe": "Describe",
+      "dialogue": "Dialogue"
+    },
+    "writeButton": {
+      "label": "Continue Writing",
+      "generating": "Generating...",
+      "tooltip": "Trigger continue-writing skill",
+      "writing": "Writing..."
+    },
+    "pane": {
+      "charLimitReached": "Document has reached the 1,000,000 character limit. Consider splitting the document to continue writing.",
+      "pasteLimitExceeded": "Pasted content exceeds the document capacity limit. Continue pasting?",
+      "previewingVersion": "Previewing version from {{timestamp}}",
+      "history": "history",
+      "restoreTooltip": "Full restore flow will be available in version-control-p2",
+      "restoreVersion": "Restore to this version",
+      "backToCurrent": "Back to current version"
     }
   },
   "dashboard": {
@@ -159,7 +180,66 @@
     "usageOutput": "Output:",
     "usageSessionTotal": "Session total:",
     "usageCostEstimate": "Cost estimate:",
-    "appliedSaved": "Applied & saved"
+    "appliedSaved": "Applied & saved",
+    "notConfigured": {
+      "title": "Please configure AI service in Settings first",
+      "description": "An API Key is required to use AI features. Supports OpenAI, Anthropic, and compatible proxies.",
+      "goToSettings": "Go to Settings"
+    },
+    "skillPicker": {
+      "builtin": "Built-in",
+      "global": "Global",
+      "project": "Project",
+      "builtinSkills": "Built-in Skills",
+      "projectOverride": "Project Override",
+      "disable": "Disable",
+      "enable": "Enable",
+      "customSkills": "Custom Skills",
+      "noCustomSkillsHint": "No custom skills yet. Click to create or describe your needs in natural language.",
+      "createSkill": "Create Skill",
+      "globalSkills": "Global Skills",
+      "noGlobalSkills": "No global skills",
+      "demoteToProject": "Demote to Project",
+      "projectSkills": "Project Skills",
+      "noProjectSkills": "No project skills",
+      "promoteToGlobal": "Promote to Global"
+    },
+    "skillManager": {
+      "aiGeneratedSkill": "AI Generated Skill",
+      "contextRulesMustBeObject": "contextRules must be a JSON object",
+      "contextRulesInvalidJson": "contextRules is not valid JSON",
+      "editTitle": "Edit Custom Skill",
+      "createTitle": "Create Custom Skill",
+      "enterDescriptionFirst": "Please enter a skill description first",
+      "confirmDeleteTitle": "Delete skill \"{{name}}\"?",
+      "irreversible": "This action cannot be undone",
+      "delete": "Delete",
+      "cancel": "Cancel",
+      "dialogTitle": "Skill Manager",
+      "dialogDescription": "Create manually, create with AI assistance, edit and delete custom skills.",
+      "reset": "Reset",
+      "saving": "Saving...",
+      "saveChanges": "Save Changes",
+      "createSkill": "Create Skill",
+      "aiAssisted": "AI Assisted",
+      "aiPlaceholder": "E.g.: Create a skill to rewrite selected text in Lu Xun's style",
+      "aiGenerateConfig": "AI Generate Config",
+      "fieldName": "Name",
+      "fieldDescription": "Description",
+      "fieldPromptTemplate": "Prompt Template",
+      "promptPlaceholder": "Contains {{input}} placeholder",
+      "fieldInputType": "Input Type",
+      "inputTypeSelection": "Selected Text",
+      "inputTypeDocument": "Document Context",
+      "fieldScope": "Scope",
+      "scopeProject": "Project",
+      "scopeGlobal": "Global",
+      "enableSkill": "Enable Skill",
+      "customSkillList": "Custom Skill List",
+      "loading": "Loading...",
+      "noCustomSkills": "No custom skills yet",
+      "edit": "Edit"
+    }
   },
   "onboarding": {
     "welcome": "Welcome to CreoNow",
@@ -186,6 +266,256 @@
       "subtitle": "Choose a folder as your creative workspace. CreoNow will manage your projects and documents here.",
       "openFolder": "Open Folder",
       "skipLater": "Skip, choose later"
+    }
+  },
+  "character": {
+    "cardList": {
+      "emptyTitle": "No Characters",
+      "emptyDescription": "Create your first character",
+      "createCharacter": "Create Character"
+    },
+    "container": {
+      "age": "Age: {{value}}",
+      "role": "Role: {{value}}",
+      "traits": "Traits: {{value}}",
+      "noKeyAttributes": "No key attributes",
+      "typeLabel": "Character",
+      "relationSummary": "{{count}} relationship(s)",
+      "newCharacter": "New Character",
+      "thisCharacter": "This character",
+      "deleteTitle": "Delete character?",
+      "deleteDescription": "Deleting character \"{{name}}\" will remove its associated relationships. This action cannot be undone.",
+      "delete": "Delete",
+      "cancel": "Cancel"
+    }
+  },
+  "memory": {
+    "create": {
+      "title": "Add New Memory",
+      "description": "This memory will be saved at the \"{{scope}}\" level",
+      "cancel": "Cancel",
+      "saving": "Saving...",
+      "save": "Save",
+      "type": "Memory Type",
+      "typePreference": "Preference — Writing style, language habits",
+      "typeFact": "Fact — Character settings, world-building",
+      "typeNote": "Note — Temporary reminders, to-dos",
+      "content": "Memory Content",
+      "examplePreference": "e.g. I prefer concise, powerful prose — avoid excessive adjective stacking",
+      "exampleFact": "e.g. Protagonist Chen Mo is a 35-year-old detective, calm but psychologically scarred",
+      "exampleNote": "e.g. Remember to add a misleading suspect in Chapter 7",
+      "layerHint": "💡 Memory level is determined by the currently selected Tab. Memories added after switching Tabs will be saved to the corresponding level."
+    },
+    "panel": {
+      "categoryStyle": "Writing Style",
+      "categoryStructure": "Narrative Structure",
+      "categoryCharacter": "Character Preferences",
+      "categoryPacing": "Pacing Preferences",
+      "categoryVocabulary": "Vocabulary Preferences",
+      "loadError": "Memory panel failed to load",
+      "ruleTextRequired": "Rule text cannot be empty",
+      "confirmDeleteRule": "Are you sure you want to delete this preference rule?",
+      "globalTab": "Global",
+      "projectTab": "This Project",
+      "learningPaused": "Learning paused: new episodes are still recorded, but distillation updates will not be triggered",
+      "conflictsDetected": "{{count}} preference conflicts detected — please resolve them first.",
+      "loading": "Loading...",
+      "aiLearningHint": "AI is learning your writing preferences — the more you use it, the more accurate it becomes",
+      "addRuleManually": "Add Rule Manually",
+      "ruleText": "Rule Text",
+      "saveChanges": "Save Changes",
+      "cancel": "Cancel",
+      "confidence": "Confidence {{value}}%",
+      "confirmed": "Confirmed",
+      "modified": "Modified",
+      "confirm": "Confirm",
+      "modify": "Edit",
+      "delete": "Delete",
+      "interactionCount": "Interactions: {{count}}",
+      "lastUpdate": "Last updated: {{time}}",
+      "updatePreferences": "Update Preferences",
+      "resumeLearning": "Resume Learning",
+      "pauseLearning": "Pause Learning",
+      "addRule": "New Rule",
+      "category": "Category",
+      "saveRule": "Save Rule"
+    },
+    "settings": {
+      "title": "Memory Settings",
+      "description": "Control how AI uses and learns from your memories",
+      "done": "Done",
+      "enableInjection": "Enable Memory Injection",
+      "injectionDesc": "AI will reference your memories when writing",
+      "enableLearning": "Enable Preference Learning",
+      "learningDesc": "AI will learn writing preferences from your feedback",
+      "privacyMode": "Privacy Mode",
+      "privacyDesc": "Reduce storage of identifiable content fragments",
+      "learningThreshold": "Learning Threshold",
+      "thresholdDesc": "How many identical signals before triggering learning (default 3)"
+    }
+  },
+  "projects": {
+    "create": {
+      "createFailed": "Failed to create project, please try again",
+      "enterIntentFirst": "Please enter your creative intent first",
+      "aiUnavailable": "AI-assisted creation is temporarily unavailable. Please create manually or try again later",
+      "modeLabel": "Creation mode",
+      "manualCreate": "Manual",
+      "aiAssisted": "AI Assisted",
+      "aiPlaceholder": "e.g., Create a campus mystery novel with a high school girl detective as the protagonist",
+      "generating": "Generating…",
+      "generateDraft": "Generate Draft",
+      "draftInfo": "{{name}} ({{type}})",
+      "draftStats": "Chapters: {{chapters}}, Characters: {{characters}}",
+      "useDraft": "Use this draft to continue manually"
+    },
+    "delete": {
+      "description": "Deleting project \"{{name}}\" will permanently remove all documents ({{count}} total), knowledge graph data, and version history. Please enter the project name to confirm.",
+      "title": "Confirm Delete Project",
+      "cancel": "Cancel",
+      "confirm": "Confirm Delete",
+      "inputHint": "Enter the project name to confirm:"
+    },
+    "switcher": {
+      "selectProject": "Select Project",
+      "searchPlaceholder": "Search projects",
+      "noProjects": "No projects",
+      "createNew": "Create New Project"
+    }
+  },
+  "files": {
+    "tree": {
+      "panelTitle": "Files",
+      "newButton": "New",
+      "noteButton": "Note",
+      "dismiss": "Dismiss",
+      "loading": "Loading files…",
+      "emptyTitle": "No Files",
+      "emptyDescription": "Start by creating your first file",
+      "newFile": "New File",
+      "untitledChapter": "Untitled Chapter",
+      "untitledNote": "Untitled Note",
+      "untitledSetting": "Untitled Setting",
+      "untitledTimeline": "Untitled Timeline",
+      "untitledCharacter": "Untitled Character",
+      "untitled": "Untitled",
+      "copySuffix": "{{title}} Copy",
+      "deleteTitle": "Delete Document?",
+      "deleteDescription": "This action cannot be undone. The document and its version history will be permanently deleted.",
+      "deleteConfirm": "Delete",
+      "deleteCancel": "Cancel",
+      "rename": "Rename",
+      "copy": "Copy",
+      "moveToFolder": "Move to Folder",
+      "delete": "Delete",
+      "versionHistory": "Version History",
+      "markAsDraft": "Mark as Draft",
+      "markAsFinal": "Mark as Final",
+      "collapse": "Collapse",
+      "expand": "Expand"
+    }
+  },
+  "versionHistory": {
+    "container": {
+      "autosave": "Auto Save",
+      "manualSave": "Manual Save",
+      "statusChange": "Status Change",
+      "aiModify": "AI Modification",
+      "restoreVersion": "Restore Version",
+      "versionSnapshot": "Version Snapshot",
+      "history": "History"
+    },
+    "panel": {
+      "aiModify": "AI Modification",
+      "autosave": "Auto Save",
+      "manualSave": "Manual Save",
+      "statusChange": "Status Change",
+      "reason": "Reason:",
+      "affectedParagraphs": "{{count}} paragraphs affected",
+      "changePreview": "Change Preview"
+    }
+  },
+  "settings": {
+    "ai": {
+      "notConfigured": "Not configured",
+      "configured": "Configured",
+      "connectionSuccess": "Connection successful ({{latency}}ms)",
+      "title": "AI Configuration",
+      "save": "Save",
+      "testConnection": "Test Connection"
+    }
+  },
+  "settingsDialog": {
+    "account": {
+      "comingSoon": "Coming Soon"
+    },
+    "general": {
+      "zhCN": "Chinese (Simplified)",
+      "aiModifyMarker": "AI Modification"
+    }
+  },
+  "kg": {
+    "timeline": {
+      "empty": "No event timeline yet",
+      "emptyHint": "Create event entities to organize by chapter and drag to reorder"
+    },
+    "graph": {
+      "emptyTitle": "No entities yet. Click to add your first character or location",
+      "emptyHint": "You can drag nodes and create relationships in the graph",
+      "addNode": "Add Node"
+    },
+    "nodeDetail": {
+      "deleteNode": "Delete Node"
+    },
+    "nodeEdit": {
+      "typeCharacter": "Character",
+      "typeLocation": "Location",
+      "typeEvent": "Event",
+      "typeItem": "Item",
+      "typeFaction": "Faction",
+      "createTitle": "Create New Node",
+      "editTitle": "Edit Node: {{label}}",
+      "create": "Create",
+      "save": "Save",
+      "createDescription": "Add a new knowledge graph node",
+      "editDescription": "Modify node properties and information",
+      "cancel": "Cancel",
+      "nameLabel": "Name *",
+      "namePlaceholder": "Enter node name...",
+      "typeLabel": "Type",
+      "roleLabel": "Role",
+      "rolePlaceholder": "E.g.: Protagonist, Villain, Mentor...",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Enter detailed description of the node...",
+      "propertiesLabel": "Properties",
+      "addProperty": "+ Add Property",
+      "noProperties": "No properties yet. Click above to add",
+      "propertyNamePlaceholder": "Property name",
+      "propertyValuePlaceholder": "Property value",
+      "deleteProperty": "Delete property"
+    }
+  },
+  "patterns": {
+    "emptyState": {
+      "firstFileTitle": "Create your first file",
+      "firstFileDescription": "Create a new file to start your creative journey",
+      "firstFileAction": "New File",
+      "noFiles": "No Files",
+      "noFilesDescription": "No files in this folder",
+      "noFilesAction": "New File",
+      "noSearchResults": "No matching results",
+      "noSearchResultsDescription": "Try searching with different keywords",
+      "noSearchResultsAction": "Clear Search",
+      "noCharacters": "No Characters",
+      "noCharactersDescription": "Create characters to enrich your story",
+      "noCharactersAction": "Create Character",
+      "noContent": "No Content",
+      "noContentDescription": "There's no content here yet",
+      "noContentAction": "Get Started"
+    },
+    "errorState": {
+      "close": "Close",
+      "defaultTitle": "Something went wrong"
     }
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -50,6 +50,27 @@
       "underline": "下划线",
       "aiPolish": "润色",
       "aiRewrite": "改写"
+    },
+    "bubbleMenu": {
+      "polish": "润色",
+      "rewrite": "改写",
+      "describe": "描写",
+      "dialogue": "对白"
+    },
+    "writeButton": {
+      "label": "续写",
+      "generating": "生成中...",
+      "tooltip": "触发续写技能",
+      "writing": "续写中..."
+    },
+    "pane": {
+      "charLimitReached": "文档已达到 1000000 字符上限，建议拆分文档后继续写作。",
+      "pasteLimitExceeded": "粘贴内容超过文档容量上限，超限部分需要确认继续。是否继续粘贴？",
+      "previewingVersion": "正在预览 {{timestamp}} 的版本",
+      "history": "历史",
+      "restoreTooltip": "将在 version-control-p2 中接入完整恢复流程",
+      "restoreVersion": "恢复到此版本",
+      "backToCurrent": "返回当前版本"
     }
   },
   "dashboard": {
@@ -159,7 +180,66 @@
     "usageOutput": "输出：",
     "usageSessionTotal": "本会话累计：",
     "usageCostEstimate": "费用估算：",
-    "appliedSaved": "已应用并保存"
+    "appliedSaved": "已应用并保存",
+    "notConfigured": {
+      "title": "请先在设置中配置 AI 服务",
+      "description": "需要配置 API Key 才能使用 AI 功能。支持 OpenAI、Anthropic 及兼容代理。",
+      "goToSettings": "前往设置"
+    },
+    "skillPicker": {
+      "builtin": "内置",
+      "global": "全局",
+      "project": "项目",
+      "builtinSkills": "内置技能",
+      "projectOverride": "项目级覆盖",
+      "disable": "停用",
+      "enable": "启用",
+      "customSkills": "自定义技能",
+      "noCustomSkillsHint": "暂无自定义技能，点击创建或用自然语言描述需求",
+      "createSkill": "创建技能",
+      "globalSkills": "全局技能",
+      "noGlobalSkills": "暂无全局技能",
+      "demoteToProject": "降级为项目",
+      "projectSkills": "项目技能",
+      "noProjectSkills": "暂无项目技能",
+      "promoteToGlobal": "提升为全局"
+    },
+    "skillManager": {
+      "aiGeneratedSkill": "AI 生成技能",
+      "contextRulesMustBeObject": "contextRules 必须是 JSON 对象",
+      "contextRulesInvalidJson": "contextRules 不是合法 JSON",
+      "editTitle": "编辑自定义技能",
+      "createTitle": "创建自定义技能",
+      "enterDescriptionFirst": "请先输入技能需求描述",
+      "confirmDeleteTitle": "确定删除技能\"{{name}}\"？",
+      "irreversible": "此操作不可撤销",
+      "delete": "删除",
+      "cancel": "取消",
+      "dialogTitle": "技能管理",
+      "dialogDescription": "手动创建、AI 辅助创建、编辑和删除自定义技能。",
+      "reset": "重置",
+      "saving": "保存中...",
+      "saveChanges": "保存修改",
+      "createSkill": "创建技能",
+      "aiAssisted": "AI 辅助创建",
+      "aiPlaceholder": "例如：创建一个技能，把选中文本改写成鲁迅风格",
+      "aiGenerateConfig": "AI 生成配置",
+      "fieldName": "名称",
+      "fieldDescription": "描述",
+      "fieldPromptTemplate": "Prompt 模板",
+      "promptPlaceholder": "包含 {{input}} 占位符",
+      "fieldInputType": "输入类型",
+      "inputTypeSelection": "选中文本",
+      "inputTypeDocument": "文档上下文",
+      "fieldScope": "作用域",
+      "scopeProject": "项目级",
+      "scopeGlobal": "全局",
+      "enableSkill": "启用技能",
+      "customSkillList": "自定义技能列表",
+      "loading": "加载中...",
+      "noCustomSkills": "暂无自定义技能",
+      "edit": "编辑"
+    }
   },
   "onboarding": {
     "welcome": "欢迎使用 CreoNow",
@@ -186,6 +266,256 @@
       "subtitle": "选择一个文件夹作为你的创作工作区，CreoNow 会在此管理你的项目与文档。",
       "openFolder": "打开文件夹",
       "skipLater": "跳过，稍后再选"
+    }
+  },
+  "character": {
+    "cardList": {
+      "emptyTitle": "暂无角色",
+      "emptyDescription": "开始创建你的第一个角色",
+      "createCharacter": "创建角色"
+    },
+    "container": {
+      "age": "年龄: {{value}}",
+      "role": "定位: {{value}}",
+      "traits": "特征: {{value}}",
+      "noKeyAttributes": "暂无关键属性",
+      "typeLabel": "角色",
+      "relationSummary": "关系 {{count}} 条",
+      "newCharacter": "新角色",
+      "thisCharacter": "该角色",
+      "deleteTitle": "删除角色？",
+      "deleteDescription": "删除角色 \"{{name}}\" 将移除其关联关系，此操作不可撤销。",
+      "delete": "删除",
+      "cancel": "取消"
+    }
+  },
+  "memory": {
+    "create": {
+      "title": "添加新记忆",
+      "description": "这条记忆将保存在「{{scope}}」层级",
+      "cancel": "取消",
+      "saving": "保存中...",
+      "save": "保存",
+      "type": "记忆类型",
+      "typePreference": "偏好 — 写作风格、语言习惯",
+      "typeFact": "事实 — 角色设定、世界观",
+      "typeNote": "笔记 — 临时提醒、待办事项",
+      "content": "记忆内容",
+      "examplePreference": "例如：我喜欢简洁有力的文风，避免过多形容词堆砌",
+      "exampleFact": "例如：主角陈默是一名 35 岁的刑警，性格沉稳但有心理创伤",
+      "exampleNote": "例如：记得在第七章增加一个误导性嫌疑人",
+      "layerHint": "💡 记忆层级由当前选中的 Tab 决定。切换 Tab 后添加的记忆会保存到对应层级。"
+    },
+    "panel": {
+      "categoryStyle": "写作风格",
+      "categoryStructure": "叙事结构",
+      "categoryCharacter": "角色偏好",
+      "categoryPacing": "节奏偏好",
+      "categoryVocabulary": "词汇偏好",
+      "loadError": "Memory 面板加载失败",
+      "ruleTextRequired": "规则文本不能为空",
+      "confirmDeleteRule": "确认删除这条偏好规则吗？",
+      "globalTab": "全局",
+      "projectTab": "本项目",
+      "learningPaused": "学习已暂停：新情景仍记录，但不会触发蒸馏更新",
+      "conflictsDetected": "检测到 {{count}} 条偏好冲突，请优先处理。",
+      "loading": "加载中...",
+      "aiLearningHint": "AI 正在学习你的写作偏好，使用越多越精准",
+      "addRuleManually": "手动添加规则",
+      "ruleText": "规则文本",
+      "saveChanges": "保存修改",
+      "cancel": "取消",
+      "confidence": "置信度 {{value}}%",
+      "confirmed": "已确认",
+      "modified": "已修改",
+      "confirm": "确认",
+      "modify": "修改",
+      "delete": "删除",
+      "interactionCount": "交互记录数 {{count}}",
+      "lastUpdate": "最近更新 {{time}}",
+      "updatePreferences": "更新偏好",
+      "resumeLearning": "恢复学习",
+      "pauseLearning": "暂停学习",
+      "addRule": "新增规则",
+      "category": "分类",
+      "saveRule": "保存规则"
+    },
+    "settings": {
+      "title": "记忆设置",
+      "description": "控制 AI 如何使用和学习你的记忆",
+      "done": "完成",
+      "enableInjection": "启用记忆注入",
+      "injectionDesc": "AI 在写作时会参考你的记忆",
+      "enableLearning": "启用偏好学习",
+      "learningDesc": "AI 会从你的反馈中学习写作偏好",
+      "privacyMode": "隐私模式",
+      "privacyDesc": "减少存储可识别的内容片段",
+      "learningThreshold": "学习阈值",
+      "thresholdDesc": "收到多少次相同信号后触发学习（默认 3）"
+    }
+  },
+  "projects": {
+    "create": {
+      "createFailed": "项目创建失败，请重试",
+      "enterIntentFirst": "请先输入创作意图",
+      "aiUnavailable": "AI 辅助创建暂时不可用，请手动创建或稍后重试",
+      "modeLabel": "创建模式",
+      "manualCreate": "手动创建",
+      "aiAssisted": "AI 辅助",
+      "aiPlaceholder": "例如：帮我创建一部校园推理小说，主角是高中女生侦探",
+      "generating": "生成中…",
+      "generateDraft": "生成草案",
+      "draftInfo": "{{name}}（{{type}}）",
+      "draftStats": "章节：{{chapters}}，角色：{{characters}}",
+      "useDraft": "使用此草案继续手动创建"
+    },
+    "delete": {
+      "description": "删除项目\"{{name}}\"将永久删除所有文档（{{count}} 篇）、知识图谱数据和版本历史。请输入项目名称确认删除。",
+      "title": "确认删除项目",
+      "cancel": "取消",
+      "confirm": "确认删除",
+      "inputHint": "请输入项目名以确认："
+    },
+    "switcher": {
+      "selectProject": "选择项目",
+      "searchPlaceholder": "搜索项目",
+      "noProjects": "暂无项目",
+      "createNew": "创建新项目"
+    }
+  },
+  "files": {
+    "tree": {
+      "panelTitle": "文件",
+      "newButton": "新建",
+      "noteButton": "笔记",
+      "dismiss": "关闭",
+      "loading": "加载文件中…",
+      "emptyTitle": "暂无文件",
+      "emptyDescription": "开始创建你的第一个文件",
+      "newFile": "新建文件",
+      "untitledChapter": "未命名章节",
+      "untitledNote": "未命名笔记",
+      "untitledSetting": "未命名设定",
+      "untitledTimeline": "未命名时间线",
+      "untitledCharacter": "未命名角色",
+      "untitled": "未命名",
+      "copySuffix": "{{title}} 副本",
+      "deleteTitle": "删除文档？",
+      "deleteDescription": "此操作不可撤销。文档及其版本历史将被永久删除。",
+      "deleteConfirm": "删除",
+      "deleteCancel": "取消",
+      "rename": "重命名",
+      "copy": "复制",
+      "moveToFolder": "移动到文件夹",
+      "delete": "删除",
+      "versionHistory": "版本历史",
+      "markAsDraft": "标记为草稿",
+      "markAsFinal": "标记为定稿",
+      "collapse": "收起",
+      "expand": "展开"
+    }
+  },
+  "versionHistory": {
+    "container": {
+      "autosave": "自动保存",
+      "manualSave": "手动保存",
+      "statusChange": "状态变更",
+      "aiModify": "AI 修改",
+      "restoreVersion": "恢复版本",
+      "versionSnapshot": "版本快照",
+      "history": "历史"
+    },
+    "panel": {
+      "aiModify": "AI 修改",
+      "autosave": "自动保存",
+      "manualSave": "手动保存",
+      "statusChange": "状态变更",
+      "reason": "原因:",
+      "affectedParagraphs": "{{count}} 段落受影响",
+      "changePreview": "变更预览"
+    }
+  },
+  "settings": {
+    "ai": {
+      "notConfigured": "未配置",
+      "configured": "已配置",
+      "connectionSuccess": "连接成功 ({{latency}}ms)",
+      "title": "AI 配置",
+      "save": "保存",
+      "testConnection": "测试连接"
+    }
+  },
+  "settingsDialog": {
+    "account": {
+      "comingSoon": "即将推出"
+    },
+    "general": {
+      "zhCN": "中文 (简体)",
+      "aiModifyMarker": "AI 修改"
+    }
+  },
+  "kg": {
+    "timeline": {
+      "empty": "暂无事件时间线",
+      "emptyHint": "创建事件实体后可按章节组织并拖拽排序"
+    },
+    "graph": {
+      "emptyTitle": "暂无实体，点击添加你的第一个角色或地点",
+      "emptyHint": "你可以在关系图中拖拽节点并建立关系",
+      "addNode": "添加节点"
+    },
+    "nodeDetail": {
+      "deleteNode": "删除节点"
+    },
+    "nodeEdit": {
+      "typeCharacter": "角色 (Character)",
+      "typeLocation": "地点 (Location)",
+      "typeEvent": "事件 (Event)",
+      "typeItem": "物品 (Item)",
+      "typeFaction": "阵营 (Faction)",
+      "createTitle": "创建新节点",
+      "editTitle": "编辑节点: {{label}}",
+      "create": "创建",
+      "save": "保存",
+      "createDescription": "添加一个新的知识图谱节点",
+      "editDescription": "修改节点的属性和信息",
+      "cancel": "取消",
+      "nameLabel": "名称 *",
+      "namePlaceholder": "输入节点名称...",
+      "typeLabel": "类型",
+      "roleLabel": "角色定位",
+      "rolePlaceholder": "如: 主角、反派、导师...",
+      "descriptionLabel": "描述",
+      "descriptionPlaceholder": "输入节点的详细描述...",
+      "propertiesLabel": "属性",
+      "addProperty": "+ 添加属性",
+      "noProperties": "暂无属性，点击上方添加",
+      "propertyNamePlaceholder": "属性名",
+      "propertyValuePlaceholder": "属性值",
+      "deleteProperty": "删除属性"
+    }
+  },
+  "patterns": {
+    "emptyState": {
+      "firstFileTitle": "开始创建你的第一个文件",
+      "firstFileDescription": "创建一个新文件开始你的创作之旅",
+      "firstFileAction": "新建文件",
+      "noFiles": "暂无文件",
+      "noFilesDescription": "此文件夹中没有任何文件",
+      "noFilesAction": "新建文件",
+      "noSearchResults": "未找到匹配结果",
+      "noSearchResultsDescription": "尝试使用不同的关键词进行搜索",
+      "noSearchResultsAction": "清除搜索",
+      "noCharacters": "暂无角色",
+      "noCharactersDescription": "创建角色来丰富你的故事",
+      "noCharactersAction": "创建角色",
+      "noContent": "暂无内容",
+      "noContentDescription": "这里还没有任何内容",
+      "noContentAction": "开始"
+    },
+    "errorState": {
+      "close": "关闭",
+      "defaultTitle": "出错了"
     }
   }
 }

--- a/apps/desktop/tests/e2e/documents-filetree.spec.ts
+++ b/apps/desktop/tests/e2e/documents-filetree.spec.ts
@@ -50,14 +50,14 @@ function parseDocumentId(testId: string): string {
 async function invokeFileRowContextAction(args: {
   page: Page;
   documentId: string;
-  actionLabel: "Rename" | "Delete";
+  actionKey: "rename" | "delete";
 }): Promise<void> {
   const row = args.page.getByTestId(`file-row-${args.documentId}`);
   await expect(row).toBeVisible();
   await row.scrollIntoViewIfNeeded();
   await row.click({ button: "right" });
 
-  const menuItem = args.page.getByRole("menuitem", { name: args.actionLabel });
+  const menuItem = args.page.getByTestId(`context-menu-item-${args.actionKey}`);
   await expect(menuItem).toBeVisible();
   await menuItem.click();
 }
@@ -102,7 +102,7 @@ test("documents filetree: create/switch/rename/delete + current restore", async 
   await invokeFileRowContextAction({
     page,
     documentId: docAId,
-    actionLabel: "Rename",
+    actionKey: "rename",
   });
   await page.getByTestId(`file-rename-input-${docAId}`).fill("Doc A");
   await page.getByTestId(`file-rename-confirm-${docAId}`).click();
@@ -233,12 +233,12 @@ test("documents filetree: create/switch/rename/delete + current restore", async 
   await invokeFileRowContextAction({
     page,
     documentId: docBId,
-    actionLabel: "Delete",
+    actionKey: "delete",
   });
 
-  const dialog = page.getByRole("dialog");
+  const dialog = page.getByTestId("system-dialog-delete");
   await expect(dialog).toBeVisible();
-  await dialog.getByRole("button", { name: "Delete" }).click();
+  await dialog.getByTestId("system-dialog-primary").click();
   await expect(dialog).not.toBeVisible();
 
   await expect(page.getByTestId(`file-row-${docBId}`)).toHaveCount(0);

--- a/apps/desktop/tests/e2e/system-dialog.spec.ts
+++ b/apps/desktop/tests/e2e/system-dialog.spec.ts
@@ -50,14 +50,14 @@ function parseDocumentId(testId: string): string {
 async function invokeFileRowContextAction(args: {
   page: Page;
   documentId: string;
-  actionLabel: "Delete";
+  actionKey: "delete";
 }): Promise<void> {
   const row = args.page.getByTestId(`file-row-${args.documentId}`);
   await expect(row).toBeVisible();
   await row.scrollIntoViewIfNeeded();
   await row.click({ button: "right" });
 
-  const menuItem = args.page.getByRole("menuitem", { name: args.actionLabel });
+  const menuItem = args.page.getByTestId(`context-menu-item-${args.actionKey}`);
   await expect(menuItem).toBeVisible();
   await menuItem.click();
 }
@@ -123,24 +123,23 @@ test("system dialog: cancel/confirm across file tree + knowledge graph", async (
   await invokeFileRowContextAction({
     page,
     documentId: docToDeleteId,
-    actionLabel: "Delete",
+    actionKey: "delete",
   });
 
-  const documentDialog = page.getByRole("dialog", { name: "Delete Document?" });
+  const documentDialog = page.getByTestId("system-dialog-delete");
   await expect(documentDialog).toBeVisible();
-  await expect(documentDialog.getByText("Delete Document?")).toBeVisible();
-  await documentDialog.getByRole("button", { name: "Cancel" }).click();
+  await documentDialog.getByTestId("system-dialog-secondary").click();
   await expect(documentDialog).not.toBeVisible();
   await expect(page.getByTestId(`file-row-${docToDeleteId}`)).toBeVisible();
 
   await invokeFileRowContextAction({
     page,
     documentId: docToDeleteId,
-    actionLabel: "Delete",
+    actionKey: "delete",
   });
 
   await expect(documentDialog).toBeVisible();
-  await documentDialog.getByRole("button", { name: "Delete" }).click();
+  await documentDialog.getByTestId("system-dialog-primary").click();
   await expect(documentDialog).not.toBeVisible();
   await expect(page.getByTestId(`file-row-${docToDeleteId}`)).toHaveCount(0);
 


### PR DESCRIPTION
## Summary

Closes #968

**范围：CJK 硬编码全量覆盖**（26 个 .tsx 文件）。英文硬编码抽取另见 follow-up #970。

### Changes

**新增测试：**
- `i18n-global-compliance.test.ts` — 全局扫描 features/ 和 components/ 下所有 .tsx 文件，检测残留 CJK 硬编码

**国际化覆盖模块（26 文件）：**

| 模块 | 文件数 | 新增 key |
|------|--------|----------|
| ai (AiNotConfiguredGuide, SkillManagerDialog, SkillPicker) | 3 | ~50 |
| character (CharacterCardList, CharacterCardListContainer) | 2 | ~15 |
| editor (EditorBubbleMenu, EditorPane, WriteButton) | 3 | ~11 |
| files (FileTreePanel) | 1 | ~28 |
| kg (TimelineView) + KG components (KnowledgeGraph, NodeDetailCard, NodeEditDialog) | 4 | ~25 |
| memory (MemoryCreateDialog, MemoryPanel, MemorySettingsDialog) | 3 | ~50 |
| projects (CreateProjectDialog, DeleteProjectDialog, ProjectSwitcher) | 3 | ~18 |
| settings (AiSettingsSection) + settings-dialog (SettingsAccount, SettingsGeneral) | 3 | ~8 |
| version-history (VersionHistoryContainer, VersionHistoryPanel) | 2 | ~14 |
| patterns (EmptyState, ErrorState) | 2 | ~17 |

**Locale 文件：**
- en.json: 191 → 397 keys (+206)
- zh-CN.json: 191 → 397 keys (+206)
- 双语 key 数量严格对齐（parity guard 通过）

**E2E 改进（审计修复）：**
- ContextMenu.Item 添加 `data-testid=context-menu-item-{key}`
- SystemDialog 添加 `data-testid=system-dialog-{type|primary|secondary}`
- E2E spec 全部改为 testid 定位，脱离文案语言耦合

**测试更新：**
- FileTreePanel.test.tsx / FileTreePanel.context-menu.test.tsx 断言更新为 zh-CN 翻译文本

### 验证
- [x] 全局 i18n 合规测试通过（Red → Green）
- [x] 全部 1780 测试通过，262 测试文件
- [x] en.json / zh-CN.json 397 key 严格对齐
- [x] lint:warning-budget PASS（552→441，delta=-111）
- [x] typecheck 通过
- [x] windows-e2E 通过

### 已知保留项（→ #970）
- 英文硬编码（ExportDialog、SystemDialog defaultContent、KnowledgeGraphPanel 等）
- AI prompt 模板中的 CJK（发给 LLM 的指令，非 UI 文本）
- FileTreePanel 中的 `/卷|folder/` 正则（数据模式匹配，非 UI 文本）

> 「纸上得来终觉浅，绝知此事要躬行。」——陆游