### PR TITLE
feat(renderer): Shadow + 颜色硬编码迁移至 Design Token (#972)

### DIFF
--- a/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
@@ -28,10 +28,7 @@ import { describe, expect, it } from "vitest";
 const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
 const RENDERER_SRC = resolve(CURRENT_DIR, "..");
 
-const SCAN_DIRS = [
-  join(RENDERER_SRC, "features"),
-  join(RENDERER_SRC, "components"),
-];
+const SCAN_DIRS = [RENDERER_SRC];
 
 const SKIP_FILE_PATTERNS = [
   /\.test\./,
@@ -40,11 +37,22 @@ const SKIP_FILE_PATTERNS = [
   /test-utils\.tsx$/,
 ];
 
+const SKIP_DIR_NAMES = new Set([
+  "__tests__",
+  "test-utils",
+  "styles",
+  "i18n",
+  "contexts",
+  "hooks",
+  "types",
+]);
+
 /**
- * Files where hardcoded colors are intentional and allowlisted.
- * Each entry maps a filename pattern to line-level comment requirements.
+ * Files where hardcoded hex/rgba are intentional (theme preview swatches).
+ * Only exempts hardcoded-hex and hardcoded-rgba checks;
+ * shadow and Tailwind raw color rules still apply.
  */
-const ALLOWLISTED_FILES = [
+const HEX_RGBA_ALLOWLISTED_FILES = [
   /SettingsAppearancePage\.tsx$/,
 ];
 
@@ -110,6 +118,7 @@ function collectTsxFiles(dir: string): string[] {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {
+        if (SKIP_DIR_NAMES.has(entry.name)) continue;
         results.push(...collectTsxFiles(fullPath));
       } else if (
         entry.name.endsWith(".tsx") &&
@@ -133,8 +142,8 @@ function isCodeLine(line: string): boolean {
   return true;
 }
 
-function isAllowlisted(filePath: string): boolean {
-  return ALLOWLISTED_FILES.some((p) => p.test(filePath));
+function isHexRgbaAllowlisted(filePath: string): boolean {
+  return HEX_RGBA_ALLOWLISTED_FILES.some((p) => p.test(filePath));
 }
 
 type ViolationType = "bare-shadow" | "raw-tailwind-color" | "bare-white-black" | "hardcoded-hex" | "hardcoded-rgba";
@@ -214,8 +223,12 @@ describe("Token global compliance: no style bypass in production files", () => {
   const allViolations: FileViolations[] = [];
 
   for (const filePath of allFiles) {
-    if (isAllowlisted(filePath)) continue;
-    const violations = scanFile(filePath);
+    const violations = scanFile(filePath).filter((v) => {
+      if (isHexRgbaAllowlisted(filePath)) {
+        return v.type !== "hardcoded-hex" && v.type !== "hardcoded-rgba";
+      }
+      return true;
+    });
     if (violations.length > 0) {
       allViolations.push({
         file: relative(RENDERER_SRC, filePath),

--- a/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Global Design Token compliance test.
+ *
+ * Scans all production .tsx files under features/ and components/ for
+ * styling violations that bypass the Design Token system:
+ *
+ *   1. Tailwind built-in shadows (shadow-lg, shadow-xl, shadow-2xl)
+ *      → must use shadow-[var(--shadow-*)]
+ *   2. Tailwind raw color utilities (bg-red-600, text-green-500, etc.)
+ *      → must use semantic Token via var(--)
+ *   3. Hardcoded hex (#xxx, #xxxxxx) or rgba() values in className / style
+ *      → must use var(--color-*)
+ *
+ * Allowlisted files:
+ *   - SettingsAppearancePage.tsx: theme preview swatches (intentional hex)
+ *
+ * Exclusions:
+ *   - *.test.* / *.stories.* / *.story.* / test-utils.tsx
+ *   - Comments (// or block)
+ *   - Import / export / type statements
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const RENDERER_SRC = resolve(CURRENT_DIR, "..");
+
+const SCAN_DIRS = [
+  join(RENDERER_SRC, "features"),
+  join(RENDERER_SRC, "components"),
+];
+
+const SKIP_FILE_PATTERNS = [
+  /\.test\./,
+  /\.stories\./,
+  /\.story\./,
+  /test-utils\.tsx$/,
+];
+
+/**
+ * Files where hardcoded colors are intentional and allowlisted.
+ * Each entry maps a filename pattern to line-level comment requirements.
+ */
+const ALLOWLISTED_FILES = [
+  /SettingsAppearancePage\.tsx$/,
+];
+
+// ─── Violation patterns ───
+
+/**
+ * Tailwind built-in shadow classes that bypass the Token shadow system.
+ * Matches: shadow-lg, shadow-xl, shadow-2xl (and hover/focus variants)
+ * Does NOT match: shadow-[var(--shadow-lg)] (token-wrapped)
+ */
+const BARE_SHADOW_REGEX =
+  /(?<!\[var\(--shadow-)(?:^|[\s"'`])(?:!?(?:hover:|focus:|active:|group-hover:)*)(!?shadow-(?:lg|xl|2xl))\b(?!\])/;
+
+/**
+ * Tailwind raw color utilities (not wrapped in var(--)).
+ * Matches: bg-red-600, text-green-500, border-gray-200, hover:bg-yellow-400
+ * Does NOT match: bg-[var(--color-*)], text-[var(--color-*)]
+ *
+ * Excluded from detection:
+ *   - bg-transparent, text-transparent
+ *   - bg-current, text-current
+ *   - bg-inherit, text-inherit
+ */
+const TAILWIND_COLOR_NAMES = [
+  "red", "orange", "amber", "yellow", "lime", "green", "emerald", "teal",
+  "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia", "pink",
+  "rose", "slate", "gray", "zinc", "neutral", "stone",
+];
+const TAILWIND_RAW_COLOR_REGEX = new RegExp(
+  `(?:^|[\\s"'\`])!?(?:hover:|focus:|active:|group-hover:)*!?(?:bg|text|border|ring|shadow|outline|decoration|from|to|via)-(?:${TAILWIND_COLOR_NAMES.join("|")})-\\d{2,3}(?:\\/\\d+)?\\b`,
+);
+
+/**
+ * Bare white/black Tailwind utilities that should use semantic tokens.
+ * Matches: text-white, bg-black, bg-white, text-black, border-white, border-black
+ *          and their opacity variants (text-white/50, bg-black/60, etc.)
+ * Does NOT match: var(--...) wrapped values.
+ */
+const BARE_WHITE_BLACK_REGEX =
+  /(?:^|[\s"'`])!?(?:hover:|focus:|active:|group-hover:)*!?(?:bg|text|border)-(?:white|black)(?:\/\d+)?\b/;
+
+/**
+ * Hardcoded hex values in className or style context.
+ * Matches: #fff, #ffffff, #cc2b3e, bg-[#121212], text-[#bfbfbf]
+ * Does NOT match: hex values inside var() or CSS custom property definitions
+ */
+const HARDCODED_HEX_REGEX =
+  /(?:^|[\s"'`=:,])#(?:[0-9a-fA-F]{3}){1,2}\b/;
+
+/**
+ * Hardcoded rgba() values in className or style context.
+ * Matches: rgba(255,255,255,0.5), rgba(34, 197, 94, 0.4)
+ * Does NOT match: rgba inside var() definitions
+ */
+const HARDCODED_RGBA_REGEX =
+  /rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}/;
+
+// ─── Helpers ───
+
+function collectTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...collectTsxFiles(fullPath));
+      } else if (
+        entry.name.endsWith(".tsx") &&
+        !SKIP_FILE_PATTERNS.some((p) => p.test(entry.name))
+      ) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // directory doesn't exist yet — fine
+  }
+  return results;
+}
+
+function isCodeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("//")) return false;
+  if (trimmed.startsWith("*") || trimmed.startsWith("/*")) return false;
+  if (/^\{\/\*.*\*\/\}$/.test(trimmed)) return false;
+  if (trimmed.startsWith("import ") || trimmed.startsWith("export type")) return false;
+  return true;
+}
+
+function isAllowlisted(filePath: string): boolean {
+  return ALLOWLISTED_FILES.some((p) => p.test(filePath));
+}
+
+type ViolationType = "bare-shadow" | "raw-tailwind-color" | "bare-white-black" | "hardcoded-hex" | "hardcoded-rgba";
+interface Violation {
+  type: ViolationType;
+  line: number;
+  text: string;
+}
+interface FileViolations {
+  file: string;
+  violations: Violation[];
+}
+
+function scanFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, "utf8");
+  const lines = content.split("\n");
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!isCodeLine(line)) continue;
+
+    // 1. Bare shadows
+    if (BARE_SHADOW_REGEX.test(line)) {
+      violations.push({ type: "bare-shadow", line: i + 1, text: line.trim() });
+    }
+
+    // 2. Raw Tailwind color utilities
+    if (TAILWIND_RAW_COLOR_REGEX.test(line)) {
+      violations.push({ type: "raw-tailwind-color", line: i + 1, text: line.trim() });
+    }
+
+    // 3. Bare white/black
+    if (BARE_WHITE_BLACK_REGEX.test(line)) {
+      violations.push({ type: "bare-white-black", line: i + 1, text: line.trim() });
+    }
+
+    // 4-5. Hardcoded hex/rgba — only in className or style contexts
+    const hasStyleContext =
+      line.includes("className") ||
+      line.includes("style") ||
+      line.includes("class=") ||
+      /["'`].*#[0-9a-fA-F]/.test(line) ||
+      /["'`].*rgba?\(/.test(line) ||
+      /shadow-\[/.test(line);
+
+    if (hasStyleContext) {
+      if (HARDCODED_HEX_REGEX.test(line)) {
+        // exclude CSS variable references like var(--color-xxx)
+        const withoutVars = line.replace(/var\(--[^)]+\)/g, "");
+        if (HARDCODED_HEX_REGEX.test(withoutVars)) {
+          violations.push({ type: "hardcoded-hex", line: i + 1, text: line.trim() });
+        }
+      }
+      if (HARDCODED_RGBA_REGEX.test(line)) {
+        const withoutVars = line.replace(/var\(--[^)]+\)/g, "");
+        if (HARDCODED_RGBA_REGEX.test(withoutVars)) {
+          violations.push({ type: "hardcoded-rgba", line: i + 1, text: line.trim() });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ─── Tests ───
+
+describe("Token global compliance: no style bypass in production files", () => {
+  const allFiles = SCAN_DIRS.flatMap((d) => collectTsxFiles(d));
+
+  it("should find production .tsx files to scan", () => {
+    expect(allFiles.length).toBeGreaterThan(0);
+  });
+
+  // Collect violations across all non-allowlisted files
+  const allViolations: FileViolations[] = [];
+
+  for (const filePath of allFiles) {
+    if (isAllowlisted(filePath)) continue;
+    const violations = scanFile(filePath);
+    if (violations.length > 0) {
+      allViolations.push({
+        file: relative(RENDERER_SRC, filePath),
+        violations,
+      });
+    }
+  }
+
+  it("no production files should use bare Tailwind shadow classes (shadow-lg/xl/2xl)", () => {
+    const shadowViolations = allViolations
+      .map((f) => ({
+        file: f.file,
+        violations: f.violations.filter((v) => v.type === "bare-shadow"),
+      }))
+      .filter((f) => f.violations.length > 0);
+
+    if (shadowViolations.length > 0) {
+      const report = shadowViolations
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.violations.map((l) => `    L${l.line}: ${l.text}`).join("\n")}`,
+        )
+        .join("");
+      expect.fail(
+        `Found ${shadowViolations.reduce((n, v) => n + v.violations.length, 0)} bare shadow violation(s) in ${shadowViolations.length} file(s).\n` +
+          `Use shadow-[var(--shadow-lg)] instead of shadow-lg.\n${report}`,
+      );
+    }
+  });
+
+  it("no production files should use Tailwind raw color utilities (bg-red-600, etc.)", () => {
+    const colorViolations = allViolations
+      .map((f) => ({
+        file: f.file,
+        violations: f.violations.filter((v) => v.type === "raw-tailwind-color"),
+      }))
+      .filter((f) => f.violations.length > 0);
+
+    if (colorViolations.length > 0) {
+      const report = colorViolations
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.violations.map((l) => `    L${l.line}: ${l.text}`).join("\n")}`,
+        )
+        .join("");
+      expect.fail(
+        `Found ${colorViolations.reduce((n, v) => n + v.violations.length, 0)} raw Tailwind color violation(s) in ${colorViolations.length} file(s).\n` +
+          `Use bg-[var(--color-*)] instead of bg-red-600.\n${report}`,
+      );
+    }
+  });
+
+  it("no production files should use bare text-white/bg-black utilities", () => {
+    const wbViolations = allViolations
+      .map((f) => ({
+        file: f.file,
+        violations: f.violations.filter((v) => v.type === "bare-white-black"),
+      }))
+      .filter((f) => f.violations.length > 0);
+
+    if (wbViolations.length > 0) {
+      const report = wbViolations
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.violations.map((l) => `    L${l.line}: ${l.text}`).join("\n")}`,
+        )
+        .join("");
+      expect.fail(
+        `Found ${wbViolations.reduce((n, v) => n + v.violations.length, 0)} bare white/black violation(s) in ${wbViolations.length} file(s).\n` +
+          `Use text-[var(--color-fg-on-accent)] or bg-[var(--color-scrim)] instead.\n${report}`,
+      );
+    }
+  });
+
+  it("no production files should use hardcoded hex colors in className/style", () => {
+    const hexViolations = allViolations
+      .map((f) => ({
+        file: f.file,
+        violations: f.violations.filter((v) => v.type === "hardcoded-hex"),
+      }))
+      .filter((f) => f.violations.length > 0);
+
+    if (hexViolations.length > 0) {
+      const report = hexViolations
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.violations.map((l) => `    L${l.line}: ${l.text}`).join("\n")}`,
+        )
+        .join("");
+      expect.fail(
+        `Found ${hexViolations.reduce((n, v) => n + v.violations.length, 0)} hardcoded hex violation(s) in ${hexViolations.length} file(s).\n` +
+          `Use var(--color-*) tokens instead of #hex values.\n${report}`,
+      );
+    }
+  });
+
+  it("no production files should use hardcoded rgba() in className/style", () => {
+    const rgbaViolations = allViolations
+      .map((f) => ({
+        file: f.file,
+        violations: f.violations.filter((v) => v.type === "hardcoded-rgba"),
+      }))
+      .filter((f) => f.violations.length > 0);
+
+    if (rgbaViolations.length > 0) {
+      const report = rgbaViolations
+        .map(
+          (v) =>
+            `\n  ${v.file}:\n${v.violations.map((l) => `    L${l.line}: ${l.text}`).join("\n")}`,
+        )
+        .join("");
+      expect.fail(
+        `Found ${rgbaViolations.reduce((n, v) => n + v.violations.length, 0)} hardcoded rgba() violation(s) in ${rgbaViolations.length} file(s).\n` +
+          `Use var(--color-*) tokens instead of rgba() values.\n${report}`,
+      );
+    }
+  });
+});

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -388,7 +388,7 @@ const upgradeButtonStyles = [
 
   "bg-[var(--color-warning)]",
 
-  "hover:bg-yellow-400",
+  "hover:bg-[var(--color-warning)]/80",
 
   "px-3",
 

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
@@ -319,11 +319,10 @@ const cancelButtonStyles = [
 const deleteButtonStyles = [
   buttonBaseStyles,
   "flex-1",
-  "bg-[var(--color-error)]",
-  "hover:bg-red-600",
-  "text-white",
-  "shadow-lg",
-  "shadow-red-500/20",
+  "bg-[var(--color-btn-danger-bg)]",
+  "hover:bg-[var(--color-btn-danger-hover)]",
+  "text-[var(--color-fg-on-accent)]",
+  "shadow-[var(--shadow-lg)]",
 ].join(" ");
 
 /**
@@ -345,7 +344,7 @@ const saveButtonStyles = [
   buttonBaseStyles,
   "px-4",
   "bg-[var(--color-fg-default)]",
-  "hover:bg-gray-200",
+  "hover:bg-[var(--color-bg-hover)]",
   "text-[var(--color-fg-inverse)]",
 ].join(" ");
 
@@ -368,11 +367,10 @@ const doneButtonStyles = [
 const openFileButtonStyles = [
   buttonBaseStyles,
   "flex-1",
-  "bg-[var(--color-success)]",
-  "hover:bg-green-500",
-  "text-[var(--color-fg-inverse)]",
-  "shadow-lg",
-  "shadow-green-500/20",
+  "bg-[var(--color-btn-success-bg)]",
+  "hover:bg-[var(--color-btn-success-hover)]",
+  "text-[var(--color-fg-on-accent)]",
+  "shadow-[var(--shadow-lg)]",
 ].join(" ");
 
 /**

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -226,7 +226,7 @@ export function GraphNode({
       {/* Dragging indicator */}
       {dragging && (
         <span
-          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-white rounded"
+          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--color-fg-on-accent)] rounded"
           style={{ backgroundColor: color }}
         >
           {t('kg.graph.dragging')}

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -408,7 +408,7 @@ export function KnowledgeGraph({
             <div className="absolute bottom-6 left-6 z-30">
               <button
                 onClick={handleAddNode}
-                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
+                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
                 aria-label={t('kg.graph.addNode')}
               >
                 <svg

--- a/apps/desktop/renderer/src/components/layout/LeftPanelDialogShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/LeftPanelDialogShell.tsx
@@ -36,7 +36,7 @@ const contentStyles = [
   "border",
   "border-[var(--color-border-default)]",
   "rounded-[var(--radius-lg)]",
-  "shadow-2xl",
+  "shadow-[var(--shadow-xl)]",
   "flex",
   "flex-col",
   "overflow-hidden",

--- a/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
@@ -89,7 +89,7 @@ function getContentStyles(hasContainer: boolean): string {
     "border",
     "border-[var(--color-border-default)]",
     "rounded-[var(--radius-xl)]",
-    "shadow-2xl",
+    "shadow-[var(--shadow-xl)]",
     "flex",
     "flex-col",
     "overflow-hidden",
@@ -209,7 +209,7 @@ function ChevronDownIcon({ className }: { className?: string }): JSX.Element {
  * Camera icon for avatar upload
  */
 function CameraIcon() {
-  return <Camera className="text-white w-5 h-5 drop-shadow-md" size={20} strokeWidth={1.5} />;
+  return <Camera className="text-[var(--color-fg-on-accent)] w-5 h-5 drop-shadow-md" size={20} strokeWidth={1.5} />;
 }
 
 /**

--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -594,7 +594,7 @@ export function CommandPalette({
         aria-modal="true"
         aria-label={t('workbench.commandPalette.ariaLabel')}
         onClick={(e) => e.stopPropagation()}
-        className="w-[600px] max-w-[90vw] flex flex-col bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-xl overflow-hidden"
+        className="w-[600px] max-w-[90vw] flex flex-col bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[var(--shadow-xl)] overflow-hidden"
       >
         {/* Header: 搜索框 */}
         <div className="h-14 flex items-center px-4 border-b border-[var(--color-border-default)]">

--- a/apps/desktop/renderer/src/features/diff/DiffViewPanel.tsx
+++ b/apps/desktop/renderer/src/features/diff/DiffViewPanel.tsx
@@ -145,7 +145,7 @@ export function DiffViewPanel(props: DiffViewPanelProps): JSX.Element {
 
   return (
     <div
-      className="flex flex-col bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-xl shadow-2xl overflow-hidden"
+      className="flex flex-col bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-xl shadow-[var(--shadow-xl)] overflow-hidden"
       style={{
         width: props.width ?? "100%",
         height: props.height ?? "100%",

--- a/apps/desktop/renderer/src/features/diff/MultiVersionCompare.tsx
+++ b/apps/desktop/renderer/src/features/diff/MultiVersionCompare.tsx
@@ -61,7 +61,7 @@ export function MultiVersionCompare(
   return (
     <div
       data-testid="multi-version-compare"
-      className="flex flex-col bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-xl shadow-2xl overflow-hidden"
+      className="flex flex-col bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-xl shadow-[var(--shadow-xl)] overflow-hidden"
       style={{
         width: props.width ?? "100%",
         height: props.height ?? "100%",

--- a/apps/desktop/renderer/src/features/diff/VersionPane.tsx
+++ b/apps/desktop/renderer/src/features/diff/VersionPane.tsx
@@ -68,7 +68,7 @@ export function VersionPane(props: VersionPaneProps): JSX.Element {
         <div className="flex items-center gap-2">
           {/* Version type indicator */}
           {props.version.type === "current" && (
-            <div className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] shadow-[0_0_6px_rgba(34,197,94,0.4)]" />
+            <div className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] shadow-[0_0_6px_var(--color-success-subtle)]" />
           )}
           <span className="text-xs font-medium text-[var(--color-fg-default)]">
             {props.version.label}

--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -204,7 +204,7 @@ const contentStyles = [
   "border",
   "border-[var(--color-border-default)]",
   "rounded-[var(--radius-lg)]",
-  "shadow-2xl",
+  "shadow-[var(--shadow-xl)]",
   "flex",
   "flex-col",
   "max-h-[90vh]",
@@ -269,7 +269,7 @@ const formatCardStyles = (args: { isSelected: boolean; disabled: boolean }) =>
 
 const radioIndicatorStyles = (isSelected: boolean) =>
   isSelected
-    ? "w-4 h-4 rounded-full bg-white"
+    ? "w-4 h-4 rounded-full bg-[var(--color-fg-on-accent)]"
     : "w-4 h-4 rounded-full border border-[var(--color-border-default)] opacity-0";
 
 // ============================================================================
@@ -378,7 +378,7 @@ function PreviewThumbnail({
           <div className="h-2 w-5/6 bg-[var(--color-fg-placeholder)]/20 rounded mb-3" />
           <div className="h-2 w-full bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
           <div className="h-2 w-4/5 bg-[var(--color-fg-placeholder)]/20 rounded mb-1.5" />
-          <div className="w-full h-16 bg-[var(--color-fg-placeholder)]/10 rounded mt-4 border border-white/5" />
+          <div className="w-full h-16 bg-[var(--color-fg-placeholder)]/10 rounded mt-4 border border-[var(--color-separator)]" />
         </div>
         <div className="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-[var(--color-bg-base)] to-transparent" />
       </div>
@@ -658,7 +658,7 @@ function SuccessView(props: {
         data-testid="export-done"
         variant="primary"
         onClick={props.onDone}
-        className="!bg-white !text-black hover:!bg-gray-200"
+        className="!bg-[var(--color-bg-base)] !text-[var(--color-fg-default)] hover:!bg-[var(--color-bg-hover)]"
       >
         {t('export.action.done')}
       </Button>

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -791,7 +791,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
       >
         <button
           aria-label="Add Node"
-          class="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
+          class="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
         >
           <svg
             fill="none"
@@ -1286,7 +1286,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
       >
         <button
           aria-label="Add Node"
-          class="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
+          class="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
         >
           <svg
             fill="none"

--- a/apps/desktop/renderer/src/features/quality-gates/QualityGatesPanel.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityGatesPanel.tsx
@@ -191,7 +191,7 @@ const panelContainerStyles = [
   "flex",
   "flex-col",
   "h-full",
-  "shadow-2xl",
+  "shadow-[var(--shadow-xl)]",
   "shrink-0",
 ].join(" ");
 

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -120,8 +120,8 @@ function CategoryButton(props: {
       onClick={props.onClick}
       className={`!px-3 !py-1 !h-auto !text-xs !font-medium !rounded-full whitespace-nowrap ${
         props.active
-          ? "!bg-[var(--color-info)] !text-white shadow-lg shadow-[var(--color-info-subtle)]"
-          : "!bg-[var(--color-separator)] !text-[var(--color-fg-muted)] !border !border-transparent hover:!border-white/10 hover:!text-white hover:!bg-white/10"
+          ? "!bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] shadow-[var(--shadow-lg)] shadow-[var(--color-info-subtle)]"
+          : "!bg-[var(--color-separator)] !text-[var(--color-fg-muted)] !border !border-transparent hover:!border-[var(--color-bg-overlay)] hover:!text-[var(--color-fg-default)] hover:!bg-[var(--color-bg-overlay)]"
       }`}
     >
       {props.label}
@@ -161,8 +161,8 @@ function DocumentResultItem(props: {
       <div
         className={`mt-1 w-8 h-8 rounded flex items-center justify-center border border-[var(--color-separator)] shrink-0 transition-colors ${
           isActive
-            ? "bg-[var(--color-separator)] text-white"
-            : "bg-[var(--color-separator)] text-[var(--color-fg-muted)] group-hover:text-white"
+            ? "bg-[var(--color-separator)] text-[var(--color-fg-default)]"
+            : "bg-[var(--color-separator)] text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)]"
         }`}
       >
         <FileText className="w-4 h-4" size={16} strokeWidth={1.5} />
@@ -173,7 +173,7 @@ function DocumentResultItem(props: {
         <div className="flex items-center justify-between gap-2 mb-0.5">
           <h4
             className={`text-sm font-medium truncate transition-colors ${
-              isActive ? "text-white" : "text-[var(--color-fg-muted)] group-hover:text-white"
+              isActive ? "text-[var(--color-fg-default)]" : "text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)]"
             }`}
           >
             <HighlightText text={item.title} query={query} />
@@ -235,14 +235,14 @@ function MemoryResultItem(props: {
       className="group w-full text-left mx-2 mt-1 !p-2 !h-auto !rounded-lg border border-transparent hover:!bg-[var(--color-separator)] hover:border-[var(--color-separator)] !items-start !gap-3"
     >
       {/* Icon */}
-      <div className="mt-1 w-8 h-8 rounded flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
+      <div className="mt-1 w-8 h-8 rounded flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)] border border-[var(--color-separator)] shrink-0 transition-colors">
         <Lightbulb className="w-4 h-4" size={16} strokeWidth={1.5} />
       </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-2 mb-0.5">
-          <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-white transition-colors truncate">
+          <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)] transition-colors truncate">
             <HighlightText text={item.title} query={query} />
           </h4>
           <span className="text-[10px] font-mono text-[var(--color-success)] bg-[var(--color-success-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-success-subtle)] opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
@@ -281,13 +281,13 @@ function KnowledgeResultItem(props: {
       className="group w-full text-left mx-2 !p-2 !h-auto !rounded-lg border border-transparent hover:!bg-[var(--color-separator)] hover:border-[var(--color-separator)] !items-start !gap-3"
     >
       {/* Icon */}
-      <div className="mt-1 w-8 h-8 rounded bg-[var(--color-separator)] flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-white border border-[var(--color-separator)] shrink-0 transition-colors">
+      <div className="mt-1 w-8 h-8 rounded bg-[var(--color-separator)] flex items-center justify-center text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)] border border-[var(--color-separator)] shrink-0 transition-colors">
         <Share2 className="w-4 h-4" size={16} strokeWidth={1.5} />
       </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-white transition-colors truncate mb-1">
+        <h4 className="text-sm font-medium text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)] transition-colors truncate mb-1">
           <HighlightText text={item.title} query={query} />
         </h4>
         {item.meta && (
@@ -340,7 +340,7 @@ function KeyHint(props: {
 }): JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-white/10 border border-[var(--color-separator)] text-[10px] text-[var(--color-fg-muted)] font-mono">
+      <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-[var(--color-bg-overlay)] border border-[var(--color-separator)] text-[10px] text-[var(--color-fg-muted)] font-mono">
         {props.icon || props.text}
       </span>
       <span className="text-[10px] text-[var(--color-fg-placeholder)] ml-1">{props.label}</span>
@@ -518,7 +518,7 @@ export function SearchPanel(props: {
       {/* Backdrop with blur */}
       <div
         data-testid="search-backdrop"
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-[var(--color-scrim)] backdrop-blur-sm"
         onClick={onClose}
       />
 
@@ -541,7 +541,7 @@ export function SearchPanel(props: {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleInputKeyDown}
               placeholder={t("search.placeholder")}
-              className="flex-1 !bg-transparent !border-none !outline-none !text-lg !text-white !placeholder-[var(--color-fg-placeholder)] !font-[var(--font-family-ui)] !font-light !h-8 !px-0 !rounded-none"
+              className="flex-1 !bg-transparent !border-none !outline-none !text-lg !text-[var(--color-fg-default)] !placeholder-[var(--color-fg-placeholder)] !font-[var(--font-family-ui)] !font-light !h-8 !px-0 !rounded-none"
             />
             {effectiveStatus === "loading" && <Spinner size="sm" />}
             {onClose && (
@@ -549,7 +549,7 @@ export function SearchPanel(props: {
                 variant="ghost"
                 size="sm"
                 onClick={onClose}
-                className="!p-1 !h-auto !rounded-md !text-[var(--color-fg-placeholder)] hover:!text-white hover:!bg-[var(--color-separator)]"
+                className="!p-1 !h-auto !rounded-md !text-[var(--color-fg-placeholder)] hover:!text-[var(--color-fg-default)] hover:!bg-[var(--color-separator)]"
               >
                 <X className="w-5 h-5" size={20} strokeWidth={1.5} />
               </Button>
@@ -611,7 +611,7 @@ export function SearchPanel(props: {
               <Button
                 variant="ghost"
                 size="sm"
-                className="!flex !items-center !gap-1.5 !px-2 !py-1 !h-auto !rounded !bg-[var(--color-separator)] !border !border-[var(--color-separator)] !text-xs !text-[var(--color-fg-muted)] hover:!text-white hover:!border-white/10"
+                className="!flex !items-center !gap-1.5 !px-2 !py-1 !h-auto !rounded !bg-[var(--color-separator)] !border !border-[var(--color-separator)] !text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-fg-default)] hover:!border-[var(--color-bg-overlay)]"
               >
                 <span>{t("search.filters.currentProject")}</span>
                 <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
@@ -637,7 +637,7 @@ export function SearchPanel(props: {
             /* Reindex rebuilding state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <RefreshCw className="w-16 h-16 text-[var(--color-info)] mb-4 motion-safe:animate-pulse" size={24} strokeWidth={1.5} />
-              <p className="text-sm font-medium text-white text-center mb-2">
+              <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
                 {t("search.rebuildingIndex")}
               </p>
               <p className="text-xs text-[var(--color-fg-muted)] text-center">
@@ -648,7 +648,7 @@ export function SearchPanel(props: {
             /* Search error state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <TriangleAlert className="w-16 h-16 text-[var(--color-error)] mb-4" size={24} strokeWidth={1.5} />
-              <p className="text-sm font-medium text-white text-center mb-2">
+              <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
                 {t("search.errorTitle")}
               </p>
               <p className="text-xs text-[var(--color-fg-muted)] text-center">
@@ -657,7 +657,7 @@ export function SearchPanel(props: {
               <Button
                 variant="primary"
                 onClick={handleRetrySearch}
-                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-white !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
+                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
               >
                 {t("search.retrySearch")}
               </Button>
@@ -666,7 +666,7 @@ export function SearchPanel(props: {
             /* No results state */
             <div className="flex flex-col items-center justify-center py-16 px-8">
               <Frown className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4" size={24} strokeWidth={1.5} />
-              <p className="text-sm font-medium text-white text-center mb-2">
+              <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
                 {t("search.noResults")}
               </p>
               <p className="text-xs text-[var(--color-fg-muted)] text-center">
@@ -682,7 +682,7 @@ export function SearchPanel(props: {
               </div>
               <Button
                 variant="primary"
-                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-white !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
+                className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
               >
                 <Globe className="w-4 h-4" size={16} strokeWidth={1.5} />
                 {t("search.searchAllProjects")}
@@ -690,7 +690,7 @@ export function SearchPanel(props: {
               <Button
                 variant="ghost"
                 onClick={() => setQuery("")}
-                className="mt-3 !h-auto !text-xs !text-[var(--color-fg-muted)] hover:!text-white"
+                className="mt-3 !h-auto !text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-fg-default)]"
               >
                 {t("search.clearSearch")}
               </Button>
@@ -784,7 +784,7 @@ export function SearchPanel(props: {
                 <span className="text-xs text-[var(--color-fg-muted)] font-medium">
                   {t("search.results.result", { count: totalResults })}
                 </span>
-                <div className="h-3 w-px bg-white/10" />
+                <div className="h-3 w-px bg-[var(--color-bg-overlay)]" />
                 <span className="text-[10px] text-[var(--color-fg-placeholder)]">
                   {t("search.results.searchTime", { time: "0.04s" })}
                 </span>

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
@@ -70,6 +70,7 @@ type TFunction = (key: string, options?: Record<string, unknown>) => string;
 
 /**
  * Accent color options
+ * intentional: theme preview swatches — hex values are the actual color choices
  */
 function getAccentColors(t: TFunction) {
   return [
@@ -87,6 +88,7 @@ function getAccentColors(t: TFunction) {
  */
 function ThemePreview({ mode }: { mode: ThemeMode }): JSX.Element {
   const isDark = mode === "dark" || mode === "system";
+  // intentional: theme preview swatch — hex values represent actual theme appearance
   const bgColor = isDark ? "#0f0f0f" : "#ffffff";
   const fgColor = isDark ? "#ffffff" : "#1a1a1a";
   const mutedColor = isDark ? "#666666" : "#888888";

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -91,7 +91,7 @@ const contentStyles = [
   "border",
   "border-[var(--color-border-default)]",
   "rounded-[var(--radius-lg)]",
-  "shadow-2xl",
+  "shadow-[var(--shadow-xl)]",
   "flex",
   "overflow-hidden",
   // Animation

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -139,7 +139,7 @@ const panelStyles = [
   "flex",
   "flex-col",
   "h-full",
-  "shadow-2xl",
+  "shadow-[var(--shadow-xl)]",
   "shrink-0",
 ].join(" ");
 


### PR DESCRIPTION
Closes #972

## 概要

将生产 .tsx 文件中所有绕过 Design Token 系统的阴影和颜色硬编码迁移为语义化 Token。

## 变更内容

### 1. 新增全局 Token 合规测试
- `token-global-compliance.test.ts` — 扫描 features/ 和 components/ 下所有生产 .tsx 文件
- 检测五类违规：裸 Tailwind 阴影、原始色值工具类、裸 white/black、硬编码 hex、硬编码 rgba
- SettingsAppearancePage.tsx 已 allowlist（主题预览色板）

### 2. Shadow 迁移（13 处 / 11 文件）
| 原始写法 | 迁移后 |
|---|---|
| `shadow-lg` | `shadow-[var(--shadow-lg)]` |
| `shadow-xl` | `shadow-[var(--shadow-xl)]` |
| `shadow-2xl` | `shadow-[var(--shadow-xl)]` ※无 `--shadow-2xl` token，降级 |

涉及文件：CommandPalette, KnowledgeGraph, SystemDialog, SearchPanel, CharacterDetailDialog, DiffViewPanel, MultiVersionCompare, ExportDialog, QualityGatesPanel, SettingsDialog, VersionHistoryPanel, LeftPanelDialogShell

### 3. 颜色硬编码修复（7 文件 / ~30 处）
| 文件 | 修复 |
|---|---|
| SystemDialog.tsx | `bg-red-600/green-500/gray-200` → `btn-danger/success/bg-hover` Token |
| AiErrorCard.tsx | `hover:bg-yellow-400` → `warning/80` Token |
| SearchPanel.tsx | 20 处 `text-white/bg-black/bg-white` → 对应语义 Token |
| CharacterDetailDialog.tsx | `text-white` → `fg-on-accent` |
| GraphNode.tsx | `text-white` → `fg-on-accent` |
| VersionPane.tsx | 硬编码 rgba → `success-subtle` Token |

### 4. 快照更新
- kg-views snapshot 更新以反映 shadow token 变更

## 测试结果
- 264 test files, 1791 tests — all passed ✅
- TypeScript `--noEmit` — zero errors ✅

## 注意
- SettingsAppearancePage.tsx 的 hex 值为主题预览色板（intentional），已加注释并在测试中 allowlist
- Story 文件的硬编码颜色本次未迁移（非关键）