### PR TITLE
test: 补齐后端测试覆盖 — search/memory/shared/stats/judge 五大模块

### DIFF
--- a/apps/desktop/main/src/services/judge/__tests__/judgeService.test.ts
+++ b/apps/desktop/main/src/services/judge/__tests__/judgeService.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+
+import type { Logger } from "../../../logging/logger";
+import { createJudgeService } from "../judgeService";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+async function runTests(): Promise<void> {
+  // ── S1: getState initially not_ready ──
+  {
+    const svc = createJudgeService({
+      logger: createLogger(),
+      isE2E: true,
+    });
+
+    const state = svc.getState();
+    assert.equal(state.status, "not_ready");
+  }
+
+  // ── S2: ensure in E2E mode → transitions to ready ──
+  {
+    const svc = createJudgeService({
+      logger: createLogger(),
+      isE2E: true,
+      defaultTimeoutMs: 5000,
+    });
+
+    const result = await svc.ensure();
+
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.data.status, "ready");
+    assert.equal(svc.getState().status, "ready");
+  }
+
+  // ── S3: ensure in non-E2E mode → returns MODEL_NOT_READY ──
+  {
+    const svc = createJudgeService({
+      logger: createLogger(),
+      isE2E: false,
+    });
+
+    const result = await svc.ensure();
+
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("unreachable");
+    assert.equal(result.error.code, "MODEL_NOT_READY");
+  }
+
+  console.log("judgeService.test.ts: all assertions passed");
+}
+
+void runTests();

--- a/apps/desktop/main/src/services/memory/__tests__/episodicMemoryHelpers.test.ts
+++ b/apps/desktop/main/src/services/memory/__tests__/episodicMemoryHelpers.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+
+import {
+  calculateDecayScore,
+  classifyDecayLevel,
+  resolveImplicitFeedback,
+  assembleMemoryLayers,
+  IMPLICIT_SIGNAL_WEIGHTS,
+} from "../episodicMemoryHelpers";
+import type {
+  WorkingMemoryLayerItem,
+  EpisodeRecord,
+  SemanticMemoryRulePlaceholder,
+} from "../episodicMemoryService";
+
+// ── IMPLICIT_SIGNAL_WEIGHTS sanity ──────────────────────────────
+
+{
+  assert.equal(IMPLICIT_SIGNAL_WEIGHTS.DIRECT_ACCEPT, 1);
+  assert.equal(IMPLICIT_SIGNAL_WEIGHTS.UNDO_AFTER_ACCEPT, -1);
+  assert.equal(IMPLICIT_SIGNAL_WEIGHTS.FULL_REJECT, -0.8);
+}
+
+// ── S1: calculateDecayScore — fresh episode ─────────────────────
+
+{
+  const score = calculateDecayScore({
+    ageInDays: 0,
+    recallCount: 0,
+    importance: 0,
+  });
+  // exp(0) * 1 * 1 = 1
+  assert.equal(score, 1);
+}
+
+// ── S2: calculateDecayScore — old episode fully decayed ─────────
+
+{
+  const score = calculateDecayScore({
+    ageInDays: 30,
+    recallCount: 0,
+    importance: 0,
+  });
+  // exp(-3) ≈ 0.0498
+  assert.ok(score < 0.1, `expected score < 0.1, got ${score}`);
+  assert.ok(score > 0, "score must be positive");
+}
+
+// ── S3: calculateDecayScore — old with high recall & importance ─
+
+{
+  const scoreBarren = calculateDecayScore({
+    ageInDays: 30,
+    recallCount: 0,
+    importance: 0,
+  });
+  const scoreBoosted = calculateDecayScore({
+    ageInDays: 30,
+    recallCount: 10,
+    importance: 1,
+  });
+  // boosted = exp(-3) * (1 + 2) * (1 + 0.3) = exp(-3) * 3.9 ≈ 0.194
+  assert.ok(
+    scoreBoosted > scoreBarren * 3,
+    `boosted (${scoreBoosted}) should be much larger than barren (${scoreBarren})`,
+  );
+}
+
+// ── S4: calculateDecayScore — negative & out-of-range clamping ──
+
+{
+  const scoreNegAge = calculateDecayScore({
+    ageInDays: -5,
+    recallCount: 0,
+    importance: 0,
+  });
+  // age clamped to 0 → same as fresh
+  assert.equal(scoreNegAge, 1);
+
+  const scoreHighImp = calculateDecayScore({
+    ageInDays: 0,
+    recallCount: 0,
+    importance: 2,
+  });
+  // importance clamped to 1 → exp(0) * 1 * 1.3 = min(1, 1.3) = 1
+  assert.equal(scoreHighImp, 1);
+}
+
+// ── S5: classifyDecayLevel — active ─────────────────────────────
+
+{
+  assert.equal(classifyDecayLevel(0.8), "active");
+  assert.equal(classifyDecayLevel(0.7), "active");
+  assert.equal(classifyDecayLevel(1.0), "active");
+}
+
+// ── S6: classifyDecayLevel — decaying ───────────────────────────
+
+{
+  assert.equal(classifyDecayLevel(0.5), "decaying");
+  assert.equal(classifyDecayLevel(0.3), "decaying");
+  assert.equal(classifyDecayLevel(0.69), "decaying");
+}
+
+// ── S7: classifyDecayLevel — to_compress ────────────────────────
+
+{
+  assert.equal(classifyDecayLevel(0.15), "to_compress");
+  assert.equal(classifyDecayLevel(0.1), "to_compress");
+  assert.equal(classifyDecayLevel(0.29), "to_compress");
+}
+
+// ── S8: classifyDecayLevel — to_evict ───────────────────────────
+
+{
+  assert.equal(classifyDecayLevel(0.05), "to_evict");
+  assert.equal(classifyDecayLevel(0.0), "to_evict");
+  assert.equal(classifyDecayLevel(0.09), "to_evict");
+}
+
+// ── S9: resolveImplicitFeedback — undo after accept ─────────────
+
+{
+  const result = resolveImplicitFeedback({
+    selectedIndex: 0,
+    candidateCount: 3,
+    editDistance: 0,
+    undoAfterAccept: true,
+  });
+  assert.equal(result.signal, "UNDO_AFTER_ACCEPT");
+  assert.equal(result.weight, -1);
+}
+
+// ── S10: resolveImplicitFeedback — full reject ──────────────────
+
+{
+  const result = resolveImplicitFeedback({
+    selectedIndex: -1,
+    candidateCount: 3,
+    editDistance: 0,
+  });
+  assert.equal(result.signal, "FULL_REJECT");
+  assert.equal(result.weight, -0.8);
+}
+
+// ── S11: resolveImplicitFeedback — direct accept ────────────────
+
+{
+  const result = resolveImplicitFeedback({
+    selectedIndex: 0,
+    candidateCount: 3,
+    editDistance: 0,
+  });
+  assert.equal(result.signal, "DIRECT_ACCEPT");
+  assert.equal(result.weight, 1);
+}
+
+// ── S12: resolveImplicitFeedback — light edit ───────────────────
+
+{
+  const result = resolveImplicitFeedback({
+    selectedIndex: 0,
+    candidateCount: 3,
+    editDistance: 0.1,
+  });
+  assert.equal(result.signal, "LIGHT_EDIT");
+  assert.equal(result.weight, 0.45);
+}
+
+// ── S13: resolveImplicitFeedback — heavy rewrite ────────────────
+
+{
+  const result = resolveImplicitFeedback({
+    selectedIndex: 0,
+    candidateCount: 3,
+    editDistance: 0.8,
+  });
+  assert.equal(result.signal, "HEAVY_REWRITE");
+  assert.equal(result.weight, -0.45);
+}
+
+// ── S14: assembleMemoryLayers — structure assembly ──────────────
+
+{
+  const working = [
+    { id: "w1", content: "ctx" },
+  ] as unknown as WorkingMemoryLayerItem[];
+  const episodes = [{ id: "e1" }] as unknown as EpisodeRecord[];
+  const rules = [
+    { id: "r1", rule: "short sentences" },
+  ] as unknown as SemanticMemoryRulePlaceholder[];
+
+  const result = assembleMemoryLayers({
+    projectId: "proj-1",
+    sessionId: "sess-1",
+    working,
+    episodes,
+    semanticRules: rules,
+    memoryDegraded: true,
+    fallbackRules: ["rule-a"],
+  });
+
+  assert.equal(result.immediate.projectId, "proj-1");
+  assert.equal(result.immediate.sessionId, "sess-1");
+  assert.equal(result.immediate.items.length, 1);
+  assert.equal(result.episodic.items.length, 1);
+  assert.equal(result.settings.rules.length, 1);
+  assert.equal(result.settings.memoryDegraded, true);
+  assert.deepEqual(result.settings.fallbackRules, ["rule-a"]);
+
+  // arrays are copies, not references
+  assert.notEqual(result.immediate.items, working);
+  assert.notEqual(result.episodic.items, episodes);
+  assert.notEqual(result.settings.rules, rules);
+}
+
+console.log("episodicMemoryHelpers.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/memory/__tests__/memoryService.crud.test.ts
+++ b/apps/desktop/main/src/services/memory/__tests__/memoryService.crud.test.ts
@@ -1,0 +1,539 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import { createMemoryService } from "../memoryService";
+
+type MemoryRow = {
+  memoryId: string;
+  type: string;
+  scope: string;
+  projectId: string | null;
+  documentId: string | null;
+  origin: string;
+  sourceRef: string | null;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+};
+
+type SettingsRow = {
+  scope: string;
+  key: string;
+  valueJson: string;
+};
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+/**
+ * DB stub for CRUD + settings scenarios.
+ *
+ * Tracks inserts/updates via closures so tests can inspect what was written.
+ */
+function createCrudDbStub(args?: {
+  memories?: MemoryRow[];
+  settings?: SettingsRow[];
+  onInsertMemory?: (params: unknown[]) => void;
+  onUpdateMemory?: (params: unknown[]) => void;
+  onSoftDelete?: (params: unknown[]) => void;
+  onWriteSetting?: (params: unknown[]) => void;
+}): Database.Database {
+  const memories = [...(args?.memories ?? [])];
+  const settings = [...(args?.settings ?? [])];
+
+  const db = {
+    prepare: (sql: string) => {
+      // --- settings read ---
+      if (
+        sql.includes("FROM settings WHERE scope = ?") &&
+        sql.includes("key = ?")
+      ) {
+        return {
+          get: (scope: string, key: string) => {
+            const row = settings.find(
+              (s) => s.scope === scope && s.key === key,
+            );
+            return row ? { valueJson: row.valueJson } : undefined;
+          },
+        };
+      }
+
+      // --- settings upsert ---
+      if (sql.includes("INSERT INTO settings")) {
+        return {
+          run: (...params: unknown[]) => {
+            const [scope, key, valueJson] = params as [string, string, string];
+            const idx = settings.findIndex(
+              (s) => s.scope === scope && s.key === key,
+            );
+            if (idx >= 0) {
+              settings[idx] = { scope, key, valueJson };
+            } else {
+              settings.push({ scope, key, valueJson });
+            }
+            args?.onWriteSetting?.(params);
+            return { changes: 1 };
+          },
+        };
+      }
+
+      // --- document existence check ---
+      if (
+        sql.includes("FROM documents WHERE document_id = ?") &&
+        sql.includes("project_id = ?")
+      ) {
+        return {
+          get: () => ({ exists: 1 }),
+        };
+      }
+
+      // --- memory insert ---
+      if (sql.includes("INSERT INTO user_memory")) {
+        return {
+          run: (...params: unknown[]) => {
+            const [
+              memoryId,
+              type,
+              scope,
+              projectId,
+              documentId,
+              content,
+              createdAt,
+              updatedAt,
+            ] = params as [
+              string,
+              string,
+              string,
+              string | null,
+              string | null,
+              string,
+              number,
+              number,
+            ];
+            memories.push({
+              memoryId,
+              type,
+              scope,
+              projectId,
+              documentId,
+              origin: "manual",
+              sourceRef: null,
+              content,
+              createdAt,
+              updatedAt,
+              deletedAt: null,
+            });
+            args?.onInsertMemory?.(params);
+            return { changes: 1 };
+          },
+        };
+      }
+
+      // --- memory select by id (full row) ---
+      if (
+        sql.includes("memory_id as memoryId") &&
+        sql.includes("FROM user_memory WHERE memory_id = ?")
+      ) {
+        return {
+          get: (id: string) => {
+            return memories.find((m) => m.memoryId === id) ?? undefined;
+          },
+        };
+      }
+
+      // --- delete: select deleted_at only ---
+      if (
+        sql.includes("deleted_at as deletedAt") &&
+        sql.includes("FROM user_memory WHERE memory_id = ?") &&
+        !sql.includes("memory_id as memoryId")
+      ) {
+        return {
+          get: (id: string) => {
+            const m = memories.find((r) => r.memoryId === id);
+            return m ? { deletedAt: m.deletedAt } : undefined;
+          },
+        };
+      }
+
+      // --- soft delete ---
+      if (
+        sql.includes("UPDATE user_memory SET deleted_at") &&
+        sql.includes("WHERE memory_id = ?")
+      ) {
+        return {
+          run: (...params: unknown[]) => {
+            const [ts, _updatedAt, memoryId] = params as [
+              number,
+              number,
+              string,
+            ];
+            const m = memories.find((r) => r.memoryId === memoryId);
+            if (m) {
+              m.deletedAt = ts;
+              m.updatedAt = ts;
+            }
+            args?.onSoftDelete?.(params);
+            return { changes: m ? 1 : 0 };
+          },
+        };
+      }
+
+      // --- memory update ---
+      if (
+        sql.includes("UPDATE user_memory SET") &&
+        sql.includes("WHERE memory_id = ?")
+      ) {
+        return {
+          run: (...params: unknown[]) => {
+            const [type, scope, projectId, documentId, content, updatedAt, id] =
+              params as [
+                string,
+                string,
+                string | null,
+                string | null,
+                string,
+                number,
+                string,
+              ];
+            const m = memories.find((r) => r.memoryId === id);
+            if (m) {
+              m.type = type;
+              m.scope = scope;
+              m.projectId = projectId;
+              m.documentId = documentId;
+              m.content = content;
+              m.updatedAt = updatedAt;
+            }
+            args?.onUpdateMemory?.(params);
+            return { changes: m ? 1 : 0 };
+          },
+        };
+      }
+
+      // --- list (with deleted_at IS NULL) ---
+      if (
+        sql.includes("FROM user_memory") &&
+        sql.includes("deleted_at IS NULL")
+      ) {
+        return {
+          all: (...params: unknown[]) => {
+            const alive = memories.filter((m) => m.deletedAt === null);
+            if (params.length === 0) {
+              return alive.filter((m) => m.scope === "global");
+            }
+            if (params.length === 1) {
+              const pid = params[0] as string;
+              return alive.filter(
+                (m) =>
+                  m.scope === "global" ||
+                  (m.scope === "project" && m.projectId === pid),
+              );
+            }
+            const pid = params[0] as string;
+            const did = params[2] as string;
+            return alive.filter(
+              (m) =>
+                m.scope === "global" ||
+                (m.scope === "project" && m.projectId === pid) ||
+                (m.scope === "document" &&
+                  m.projectId === pid &&
+                  m.documentId === did),
+            );
+          },
+        };
+      }
+
+      // --- list (includeDeleted — no deleted_at filter) ---
+      if (sql.includes("FROM user_memory") && sql.includes("WHERE 1=1")) {
+        return {
+          all: (...params: unknown[]) => {
+            if (params.length === 0) {
+              return memories.filter((m) => m.scope === "global");
+            }
+            if (params.length === 1) {
+              const pid = params[0] as string;
+              return memories.filter(
+                (m) =>
+                  m.scope === "global" ||
+                  (m.scope === "project" && m.projectId === pid),
+              );
+            }
+            const pid = params[0] as string;
+            const did = params[2] as string;
+            return memories.filter(
+              (m) =>
+                m.scope === "global" ||
+                (m.scope === "project" && m.projectId === pid) ||
+                (m.scope === "document" &&
+                  m.projectId === pid &&
+                  m.documentId === did),
+            );
+          },
+        };
+      }
+
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+
+    transaction: (fn: () => void) => {
+      return () => fn();
+    },
+  } as unknown as Database.Database;
+
+  return db;
+}
+
+// ── S1: create happy path — returns UserMemoryItem with generated memoryId ──
+{
+  const svc = createMemoryService({
+    db: createCrudDbStub(),
+    logger: createLogger(),
+  });
+
+  const result = svc.create({
+    type: "preference",
+    scope: "global",
+    content: "偏好短句叙事",
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(typeof result.data.memoryId, "string");
+    assert.ok(result.data.memoryId.length > 0, "memoryId should be non-empty");
+    assert.equal(result.data.type, "preference");
+    assert.equal(result.data.scope, "global");
+    assert.equal(result.data.origin, "manual");
+    assert.equal(result.data.content, "偏好短句叙事");
+    assert.equal(typeof result.data.createdAt, "number");
+    assert.equal(result.data.createdAt, result.data.updatedAt);
+    assert.equal(result.data.projectId, undefined);
+    assert.equal(result.data.documentId, undefined);
+  }
+}
+
+// ── S2: create with empty content — returns INVALID_ARGUMENT ──
+{
+  const svc = createMemoryService({
+    db: createCrudDbStub(),
+    logger: createLogger(),
+  });
+
+  const result = svc.create({
+    type: "fact",
+    scope: "global",
+    content: "   ",
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "INVALID_ARGUMENT");
+    assert.ok(
+      result.error.message.toLowerCase().includes("content"),
+      "error message should mention content",
+    );
+  }
+}
+
+// ── S3: list returns stored memories ──
+{
+  const memories: MemoryRow[] = [
+    {
+      memoryId: "m-1",
+      type: "preference",
+      scope: "global",
+      projectId: null,
+      documentId: null,
+      origin: "manual",
+      sourceRef: null,
+      content: "第一条记忆",
+      createdAt: 100,
+      updatedAt: 100,
+      deletedAt: null,
+    },
+    {
+      memoryId: "m-2",
+      type: "note",
+      scope: "project",
+      projectId: "proj-1",
+      documentId: null,
+      origin: "manual",
+      sourceRef: null,
+      content: "项目级记忆",
+      createdAt: 200,
+      updatedAt: 200,
+      deletedAt: null,
+    },
+  ];
+
+  const svc = createMemoryService({
+    db: createCrudDbStub({ memories }),
+    logger: createLogger(),
+  });
+
+  const result = svc.list({ projectId: "proj-1" });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.data.items.length, 2);
+    const contents = result.data.items.map((i) => i.content);
+    assert.ok(contents.includes("第一条记忆"));
+    assert.ok(contents.includes("项目级记忆"));
+  }
+}
+
+// ── S4: update happy path — returns updated item ──
+{
+  const memories: MemoryRow[] = [
+    {
+      memoryId: "u-1",
+      type: "fact",
+      scope: "global",
+      projectId: null,
+      documentId: null,
+      origin: "manual",
+      sourceRef: null,
+      content: "原始内容",
+      createdAt: 100,
+      updatedAt: 100,
+      deletedAt: null,
+    },
+  ];
+
+  const svc = createMemoryService({
+    db: createCrudDbStub({ memories }),
+    logger: createLogger(),
+  });
+
+  const result = svc.update({
+    memoryId: "u-1",
+    patch: { content: "更新后的内容" },
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.data.memoryId, "u-1");
+    assert.equal(result.data.content, "更新后的内容");
+    assert.equal(result.data.type, "fact");
+    assert.equal(result.data.scope, "global");
+    assert.ok(
+      result.data.updatedAt >= 100,
+      "updatedAt should be >= original",
+    );
+  }
+}
+
+// ── S5: update non-existent memoryId — returns NOT_FOUND ──
+{
+  const svc = createMemoryService({
+    db: createCrudDbStub(),
+    logger: createLogger(),
+  });
+
+  const result = svc.update({
+    memoryId: "does-not-exist",
+    patch: { content: "不存在的记忆" },
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "NOT_FOUND");
+  }
+}
+
+// ── S6: delete happy path — returns { deleted: true } ──
+{
+  const memories: MemoryRow[] = [
+    {
+      memoryId: "d-1",
+      type: "note",
+      scope: "global",
+      projectId: null,
+      documentId: null,
+      origin: "manual",
+      sourceRef: null,
+      content: "待删除",
+      createdAt: 100,
+      updatedAt: 100,
+      deletedAt: null,
+    },
+  ];
+
+  const svc = createMemoryService({
+    db: createCrudDbStub({ memories }),
+    logger: createLogger(),
+  });
+
+  const result = svc.delete({ memoryId: "d-1" });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.data, { deleted: true });
+  }
+
+  // verify soft-delete took effect in the stub
+  assert.ok(memories[0]!.deletedAt !== null, "deletedAt should be set");
+}
+
+// ── S7: getSettings returns defaults when no settings stored ──
+{
+  const svc = createMemoryService({
+    db: createCrudDbStub(),
+    logger: createLogger(),
+  });
+
+  const result = svc.getSettings();
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.data.injectionEnabled, true);
+    assert.equal(result.data.preferenceLearningEnabled, true);
+    assert.equal(result.data.privacyModeEnabled, false);
+    assert.equal(result.data.preferenceLearningThreshold, 3);
+  }
+}
+
+// ── S8: updateSettings persists and returns merged settings ──
+{
+  const writtenKeys: string[] = [];
+
+  const svc = createMemoryService({
+    db: createCrudDbStub({
+      onWriteSetting: (params) => {
+        writtenKeys.push((params as string[])[1]!);
+      },
+    }),
+    logger: createLogger(),
+  });
+
+  const result = svc.updateSettings({
+    patch: { injectionEnabled: false, preferenceLearningThreshold: 5 },
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.data.injectionEnabled, false);
+    assert.equal(result.data.preferenceLearningThreshold, 5);
+    // untouched fields keep defaults
+    assert.equal(result.data.preferenceLearningEnabled, true);
+    assert.equal(result.data.privacyModeEnabled, false);
+  }
+
+  assert.ok(
+    writtenKeys.some((k) => k.includes("injectionEnabled")),
+    "should have written injectionEnabled",
+  );
+  assert.ok(
+    writtenKeys.some((k) => k.includes("preferenceLearningThreshold")),
+    "should have written preferenceLearningThreshold",
+  );
+}
+
+console.log("memoryService.crud.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/memory/__tests__/preferenceLearning.test.ts
+++ b/apps/desktop/main/src/services/memory/__tests__/preferenceLearning.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import type { MemorySettings } from "../memoryService";
+import {
+  recordSkillFeedbackAndLearn,
+  type PreferenceLearningOutcome,
+  type ServiceResult,
+} from "../preferenceLearning";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function defaultSettings(
+  overrides?: Partial<MemorySettings>,
+): MemorySettings {
+  return {
+    memoryEnabled: true,
+    preferenceLearningEnabled: true,
+    preferenceLearningThreshold: 3,
+    privacyModeEnabled: false,
+    ...overrides,
+  } as MemorySettings;
+}
+
+/**
+ * Minimal DB stub for preferenceLearning scenarios.
+ *
+ * Tracks INSERT statements and provides configurable SELECT results
+ * so tests can verify exactly what was written.
+ */
+function createDbStub(args?: {
+  acceptedCount?: number;
+  existingLearnedMemoryId?: string | null;
+  onInsertFeedback?: (params: unknown[]) => void;
+  onInsertMemory?: (params: unknown[]) => void;
+  onUpdateMemory?: (params: unknown[]) => void;
+}): Database.Database {
+  const acceptedCount = args?.acceptedCount ?? 0;
+  const existingId = args?.existingLearnedMemoryId ?? null;
+
+  const db = {
+    prepare: (sql: string) => {
+      // --- INSERT skill_feedback ---
+      if (sql.includes("INSERT INTO skill_feedback")) {
+        return {
+          run: (...params: unknown[]) => {
+            args?.onInsertFeedback?.(params);
+          },
+        };
+      }
+
+      // --- COUNT accepted signals ---
+      if (
+        sql.includes("SELECT COUNT(*)") &&
+        sql.includes("skill_feedback") &&
+        sql.includes("accept")
+      ) {
+        return {
+          get: () => ({ count: acceptedCount }),
+        };
+      }
+
+      // --- SELECT existing learned memory ---
+      if (
+        sql.includes("SELECT memory_id") &&
+        sql.includes("user_memory") &&
+        sql.includes("source_ref")
+      ) {
+        return {
+          get: () =>
+            existingId ? { memoryId: existingId } : undefined,
+        };
+      }
+
+      // --- INSERT user_memory ---
+      if (sql.includes("INSERT INTO user_memory")) {
+        return {
+          run: (...params: unknown[]) => {
+            args?.onInsertMemory?.(params);
+          },
+        };
+      }
+
+      // --- UPDATE user_memory ---
+      if (sql.includes("UPDATE user_memory")) {
+        return {
+          run: (...params: unknown[]) => {
+            args?.onUpdateMemory?.(params);
+          },
+        };
+      }
+
+      // Fallback: no-op statement
+      return { run: () => {}, get: () => undefined };
+    },
+  } as unknown as Database.Database;
+
+  return db;
+}
+
+function ok(
+  r: ServiceResult<PreferenceLearningOutcome>,
+): PreferenceLearningOutcome {
+  assert.equal(r.ok, true, "expected ok result");
+  return (r as { ok: true; data: PreferenceLearningOutcome }).data;
+}
+
+// ─── S1: Record accept feedback → recorded, not ignored ────────────────────
+{
+  const inserted: unknown[][] = [];
+  const db = createDbStub({
+    acceptedCount: 1, // below threshold of 3
+    onInsertFeedback: (p) => inserted.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings(),
+    runId: "run-001",
+    action: "accept",
+    evidenceRef: "prefer-short-sentences",
+    ts: 1000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, false);
+  assert.equal(outcome.learned, false, "below threshold → not learned");
+  assert.equal(outcome.signalCount, 1);
+  assert.equal(outcome.threshold, 3);
+  assert.equal(inserted.length, 1, "one feedback row inserted");
+
+  // Verify the inserted row carries the right action and evidence_ref
+  const row = inserted[0]!;
+  assert.equal(row[2], "accept"); // action
+  assert.equal(row[3], "prefer-short-sentences"); // evidence_ref
+  assert.equal(row[4], 0); // ignored = false → 0
+}
+
+// ─── S2: preferenceLearningEnabled=false → ignored ─────────────────────────
+{
+  const inserted: unknown[][] = [];
+  const db = createDbStub({
+    onInsertFeedback: (p) => inserted.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings({ preferenceLearningEnabled: false }),
+    runId: "run-002",
+    action: "accept",
+    evidenceRef: "use-active-voice",
+    ts: 2000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, true);
+  assert.equal(outcome.ignoredReason, "learning_disabled");
+  assert.equal(outcome.learned, false);
+  assert.equal(inserted.length, 1);
+
+  const row = inserted[0]!;
+  assert.equal(row[3], null, "evidenceRef stored as null when disabled");
+  assert.equal(row[4], 1, "ignored flag = 1");
+}
+
+// ─── S3: Empty evidenceRef → recorded with evidenceRef=null, ignored ───────
+{
+  const inserted: unknown[][] = [];
+  const db = createDbStub({
+    onInsertFeedback: (p) => inserted.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings(),
+    runId: "run-003",
+    action: "accept",
+    evidenceRef: "",
+    ts: 3000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, true);
+  assert.equal(outcome.ignoredReason, "empty");
+  assert.equal(outcome.learned, false);
+
+  const row = inserted[0]!;
+  assert.equal(row[3], null, "evidenceRef is null for empty input");
+}
+
+// ─── S4: Privacy mode rejects non-alphanumeric evidenceRef ─────────────────
+{
+  const inserted: unknown[][] = [];
+  const db = createDbStub({
+    onInsertFeedback: (p) => inserted.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings({ privacyModeEnabled: true }),
+    runId: "run-004",
+    action: "accept",
+    evidenceRef: "contains spaces!", // fails PRIVACY_TOKEN_RE
+    ts: 4000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, true);
+  assert.equal(outcome.ignoredReason, "privacy_mode_reject");
+  assert.equal(outcome.learned, false);
+
+  const row = inserted[0]!;
+  assert.equal(row[3], null, "evidenceRef null when privacy rejects");
+}
+
+// ─── S5: Threshold reached → learned=true, learnedMemoryId exists ──────────
+{
+  const insertedMemories: unknown[][] = [];
+  const db = createDbStub({
+    acceptedCount: 3, // equals threshold
+    existingLearnedMemoryId: null, // no prior learned memory → INSERT path
+    onInsertMemory: (p) => insertedMemories.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings({ preferenceLearningThreshold: 3 }),
+    runId: "run-005",
+    action: "accept",
+    evidenceRef: "prefer-metaphors",
+    ts: 5000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, false);
+  assert.equal(outcome.learned, true);
+  assert.ok(outcome.learnedMemoryId, "learnedMemoryId should be present");
+  assert.equal(outcome.signalCount, 3);
+  assert.equal(outcome.threshold, 3);
+  assert.equal(insertedMemories.length, 1, "one user_memory row inserted");
+}
+
+// ─── S6: Reject action → recorded, ignored as unsupported, not learned ─────
+{
+  const inserted: unknown[][] = [];
+  const db = createDbStub({
+    onInsertFeedback: (p) => inserted.push(p),
+  });
+
+  const result = recordSkillFeedbackAndLearn({
+    db,
+    logger: createLogger(),
+    settings: defaultSettings(),
+    runId: "run-006",
+    action: "reject",
+    evidenceRef: "avoid-passive-voice",
+    ts: 6000,
+  });
+
+  const outcome = ok(result);
+  assert.equal(outcome.recorded, true);
+  assert.equal(outcome.ignored, true);
+  assert.equal(outcome.ignoredReason, "unsupported_action");
+  assert.equal(outcome.learned, false);
+
+  const row = inserted[0]!;
+  assert.equal(row[2], "reject"); // action preserved
+  assert.equal(row[3], null, "evidenceRef null for non-accept action");
+  assert.equal(row[4], 1, "ignored = 1");
+}
+
+console.log("preferenceLearning.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/search/__tests__/ftsService.test.ts
+++ b/apps/desktop/main/src/services/search/__tests__/ftsService.test.ts
@@ -1,0 +1,335 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import { createFtsService } from "../ftsService";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+type FulltextRow = {
+  projectId: string;
+  documentId: string;
+  documentTitle: string;
+  documentType: string;
+  snippet: string;
+  score: number;
+  updatedAt: number;
+};
+
+function createDbStub(args?: {
+  searchRows?: FulltextRow[];
+  countRow?: { total: number };
+  searchError?: Error;
+  reindexChanges?: number;
+  reindexError?: Error;
+}): Database.Database {
+  const searchRows = args?.searchRows ?? [];
+  const countRow = args?.countRow ?? { total: searchRows.length };
+  const searchError = args?.searchError;
+  const reindexChanges = args?.reindexChanges ?? 0;
+  const reindexError = args?.reindexError;
+
+  return {
+    prepare: (sql: string) => {
+      if (sql.includes("SELECT COUNT(*)")) {
+        return {
+          get: (..._params: unknown[]) => {
+            if (searchError) {
+              throw searchError;
+            }
+            return countRow;
+          },
+        };
+      }
+
+      if (sql.includes("FROM documents_fts") && sql.includes("MATCH")) {
+        return {
+          all: (..._params: unknown[]) => {
+            if (searchError) {
+              throw searchError;
+            }
+            return searchRows;
+          },
+        };
+      }
+
+      if (sql.includes("DELETE FROM documents_fts")) {
+        return {
+          run: (..._params: unknown[]) => {
+            if (reindexError) {
+              throw reindexError;
+            }
+            return { changes: 0 };
+          },
+        };
+      }
+
+      if (sql.includes("INSERT OR REPLACE INTO documents_fts")) {
+        return {
+          run: (..._params: unknown[]) => {
+            if (reindexError) {
+              throw reindexError;
+            }
+            return { changes: reindexChanges };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+  } as unknown as Database.Database;
+}
+
+// S1: search returns results with highlights and pagination
+{
+  const rows: FulltextRow[] = [
+    {
+      projectId: "proj-1",
+      documentId: "doc-1",
+      documentTitle: "第一章",
+      documentType: "chapter",
+      snippet: "月光照在古道上",
+      score: 1.5,
+      updatedAt: 1000,
+    },
+    {
+      projectId: "proj-1",
+      documentId: "doc-2",
+      documentTitle: "第二章",
+      documentType: "chapter",
+      snippet: "月光穿过窗棂",
+      score: 1.2,
+      updatedAt: 2000,
+    },
+  ];
+  const svc = createFtsService({
+    db: createDbStub({ searchRows: rows, countRow: { total: 5 } }),
+    logger: createLogger(),
+  });
+
+  const res = svc.search({ projectId: "proj-1", query: "月光", limit: 2, offset: 0 });
+  assert.equal(res.ok, true);
+  if (!res.ok) throw new Error("unreachable");
+
+  assert.equal(res.data.results.length, 2);
+  assert.equal(res.data.total, 5);
+  assert.equal(res.data.hasMore, true);
+  assert.equal(res.data.indexState, "ready");
+
+  const first = res.data.results[0]!;
+  assert.equal(first.documentId, "doc-1");
+  assert.equal(first.snippet, "月光照在古道上");
+  assert.ok(first.highlights.length > 0, "should have highlights");
+  assert.equal(first.highlights[0]!.start, 0);
+  assert.deepStrictEqual(first.anchor, { start: 0, end: 2 });
+}
+
+// S2: search with empty projectId returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  const res = svc.search({ projectId: "", query: "test" });
+  assert.equal(res.ok, false);
+  if (res.ok) throw new Error("unreachable");
+  assert.equal(res.error.code, "INVALID_ARGUMENT");
+  assert.ok(res.error.message.toLowerCase().includes("projectid"));
+}
+
+// S3: search with empty query returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  const res = svc.search({ projectId: "proj-1", query: "   " });
+  assert.equal(res.ok, false);
+  if (res.ok) throw new Error("unreachable");
+  assert.equal(res.error.code, "INVALID_ARGUMENT");
+  assert.ok(res.error.message.toLowerCase().includes("query"));
+}
+
+// S4: search with query too long returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  const longQuery = "a".repeat(1025);
+  const res = svc.search({ projectId: "proj-1", query: longQuery });
+  assert.equal(res.ok, false);
+  if (res.ok) throw new Error("unreachable");
+  assert.equal(res.error.code, "INVALID_ARGUMENT");
+  assert.ok(res.error.message.toLowerCase().includes("too long"));
+}
+
+// S5: search with invalid limit returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  // limit = 0
+  const r1 = svc.search({ projectId: "proj-1", query: "test", limit: 0 });
+  assert.equal(r1.ok, false);
+  if (!r1.ok) assert.equal(r1.error.code, "INVALID_ARGUMENT");
+
+  // negative limit
+  const r2 = svc.search({ projectId: "proj-1", query: "test", limit: -5 });
+  assert.equal(r2.ok, false);
+  if (!r2.ok) assert.equal(r2.error.code, "INVALID_ARGUMENT");
+
+  // limit exceeds max (100)
+  const r3 = svc.search({ projectId: "proj-1", query: "test", limit: 101 });
+  assert.equal(r3.ok, false);
+  if (!r3.ok) assert.equal(r3.error.code, "INVALID_ARGUMENT");
+
+  // non-integer limit
+  const r4 = svc.search({ projectId: "proj-1", query: "test", limit: 2.5 });
+  assert.equal(r4.ok, false);
+  if (!r4.ok) assert.equal(r4.error.code, "INVALID_ARGUMENT");
+
+  // NaN limit
+  const r5 = svc.search({ projectId: "proj-1", query: "test", limit: NaN });
+  assert.equal(r5.ok, false);
+  if (!r5.ok) assert.equal(r5.error.code, "INVALID_ARGUMENT");
+
+  // negative offset
+  const r6 = svc.search({ projectId: "proj-1", query: "test", offset: -1 });
+  assert.equal(r6.ok, false);
+  if (!r6.ok) assert.equal(r6.error.code, "INVALID_ARGUMENT");
+
+  // non-integer offset
+  const r7 = svc.search({ projectId: "proj-1", query: "test", offset: 1.5 });
+  assert.equal(r7.ok, false);
+  if (!r7.ok) assert.equal(r7.error.code, "INVALID_ARGUMENT");
+}
+
+// S6: FTS syntax error from DB returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub({ searchError: new Error("fts5: syntax error near 'AND'") }),
+    logger: createLogger(),
+  });
+
+  const res = svc.search({ projectId: "proj-1", query: "AND OR NOT" });
+  assert.equal(res.ok, false);
+  if (res.ok) throw new Error("unreachable");
+  assert.equal(res.error.code, "INVALID_ARGUMENT");
+  assert.ok(res.error.message.toLowerCase().includes("syntax"));
+}
+
+// S7: FTS corruption triggers reindex and returns rebuilding state
+{
+  let reindexCalled = false;
+  const db = {
+    prepare: (sql: string) => {
+      if (sql.includes("FROM documents_fts") && sql.includes("MATCH")) {
+        return {
+          all: () => {
+            throw new Error("database disk image is malformed");
+          },
+        };
+      }
+      if (sql.includes("SELECT COUNT(*)")) {
+        return {
+          get: () => {
+            throw new Error("database disk image is malformed");
+          },
+        };
+      }
+      if (sql.includes("DELETE FROM documents_fts")) {
+        reindexCalled = true;
+        return { run: () => ({ changes: 0 }) };
+      }
+      if (sql.includes("INSERT OR REPLACE INTO documents_fts")) {
+        return { run: () => ({ changes: 3 }) };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+  } as unknown as Database.Database;
+
+  const svc = createFtsService({ db, logger: createLogger() });
+
+  const res = svc.search({ projectId: "proj-1", query: "test" });
+  assert.equal(res.ok, true);
+  if (!res.ok) throw new Error("unreachable");
+  assert.equal(res.data.indexState, "rebuilding");
+  assert.equal(res.data.results.length, 0);
+  assert.equal(res.data.total, 0);
+  assert.equal(res.data.hasMore, false);
+  assert.ok(reindexCalled, "reindex should have been triggered");
+}
+
+// S8: reindex happy path returns correct count
+{
+  const svc = createFtsService({
+    db: createDbStub({ reindexChanges: 42 }),
+    logger: createLogger(),
+  });
+
+  const res = svc.reindex({ projectId: "proj-1" });
+  assert.equal(res.ok, true);
+  if (!res.ok) throw new Error("unreachable");
+  assert.equal(res.data.indexState, "ready");
+  assert.equal(res.data.reindexed, 42);
+}
+
+// S8b: reindex with empty projectId returns INVALID_ARGUMENT
+{
+  const svc = createFtsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  const res = svc.reindex({ projectId: "  " });
+  assert.equal(res.ok, false);
+  if (res.ok) throw new Error("unreachable");
+  assert.equal(res.error.code, "INVALID_ARGUMENT");
+}
+
+// S9: searchFulltext maps results to FulltextSearchItem format
+{
+  const rows: FulltextRow[] = [
+    {
+      projectId: "proj-1",
+      documentId: "doc-1",
+      documentTitle: "序章",
+      documentType: "chapter",
+      snippet: "白日依山尽",
+      score: 2.0,
+      updatedAt: 3000,
+    },
+  ];
+  const svc = createFtsService({
+    db: createDbStub({ searchRows: rows, countRow: { total: 1 } }),
+    logger: createLogger(),
+  });
+
+  const res = svc.searchFulltext({ projectId: "proj-1", query: "白日" });
+  assert.equal(res.ok, true);
+  if (!res.ok) throw new Error("unreachable");
+  assert.equal(res.data.items.length, 1);
+
+  const item = res.data.items[0]!;
+  assert.equal(item.projectId, "proj-1");
+  assert.equal(item.documentId, "doc-1");
+  assert.equal(item.title, "序章");
+  assert.equal(item.snippet, "白日依山尽");
+  assert.equal(item.score, 2.0);
+  assert.equal(item.updatedAt, 3000);
+}
+
+console.log("ftsService.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/search/__tests__/hybridRankingService.test.ts
+++ b/apps/desktop/main/src/services/search/__tests__/hybridRankingService.test.ts
@@ -1,0 +1,392 @@
+import assert from "node:assert/strict";
+
+import type { Logger } from "../../../logging/logger";
+import type { FtsSearchResult } from "../ftsService";
+import type { FtsService } from "../ftsService";
+import {
+  createHybridRankingService,
+  type SemanticRetriever,
+  type SemanticRetrieveItem,
+  type HybridRankingService,
+  type ServiceResult,
+} from "../hybridRankingService";
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+function createLogger(): Logger {
+  return { logPath: "<test>", info: () => {}, error: () => {} };
+}
+
+function makeFtsResult(overrides?: Partial<FtsSearchResult>): FtsSearchResult {
+  return {
+    projectId: "proj-1",
+    documentId: "doc-1",
+    documentTitle: "Test Doc",
+    documentType: "chapter",
+    snippet: "hello world",
+    highlights: [{ start: 0, end: 5 }],
+    anchor: { start: 0, end: 100 },
+    score: 5.0,
+    updatedAt: 1_700_000_000,
+    ...overrides,
+  };
+}
+
+function makeSemanticItem(
+  overrides?: Partial<SemanticRetrieveItem>,
+): SemanticRetrieveItem {
+  return {
+    projectId: "proj-1",
+    documentId: "doc-1",
+    chunkId: "chunk-1",
+    snippet: "hello world",
+    score: 0.9,
+    updatedAt: 1_700_000_000,
+    ...overrides,
+  };
+}
+
+function createFtsStub(results: FtsSearchResult[]): FtsService {
+  return {
+    search: () => ({
+      ok: true as const,
+      data: {
+        results,
+        total: results.length,
+        hasMore: false,
+        indexState: "ready" as const,
+      },
+    }),
+    reindex: () => ({
+      ok: true as const,
+      data: { indexState: "ready" as const, reindexed: 0 },
+    }),
+    searchFulltext: () => ({
+      ok: true as const,
+      data: { items: [] },
+    }),
+  };
+}
+
+function createSemanticStub(items: SemanticRetrieveItem[]): SemanticRetriever {
+  return { search: () => ({ ok: true as const, data: { items } }) };
+}
+
+function createService(overrides?: {
+  fts?: FtsService;
+  semantic?: SemanticRetriever;
+}): HybridRankingService {
+  return createHybridRankingService({
+    ftsService: overrides?.fts ?? createFtsStub([]),
+    semanticRetriever: overrides?.semantic ?? createSemanticStub([]),
+    logger: createLogger(),
+  });
+}
+
+// ── Scenario 1: input validation ────────────────────────────────────────
+{
+  const svc = createService();
+
+  // empty projectId
+  const r1 = svc.queryByStrategy({
+    projectId: "",
+    query: "hello",
+    strategy: "fts",
+  });
+  assert.equal(r1.ok, false);
+  if (!r1.ok) assert.equal(r1.error.code, "INVALID_ARGUMENT");
+
+  // empty query
+  const r2 = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "   ",
+    strategy: "fts",
+  });
+  assert.equal(r2.ok, false);
+  if (!r2.ok) assert.equal(r2.error.code, "INVALID_ARGUMENT");
+
+  // invalid strategy
+  const r3 = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "bogus" as "fts",
+  });
+  assert.equal(r3.ok, false);
+  if (!r3.ok) assert.equal(r3.error.code, "INVALID_ARGUMENT");
+
+  // limit too large
+  const r4 = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+    limit: 999,
+  });
+  assert.equal(r4.ok, false);
+  if (!r4.ok) assert.equal(r4.error.code, "INVALID_ARGUMENT");
+
+  // negative offset
+  const r5 = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+    offset: -1,
+  });
+  assert.equal(r5.ok, false);
+  if (!r5.ok) assert.equal(r5.error.code, "INVALID_ARGUMENT");
+
+  // rankExplain: same validation
+  const r6 = svc.rankExplain({
+    projectId: "",
+    query: "hello",
+    strategy: "fts",
+  });
+  assert.equal(r6.ok, false);
+  if (!r6.ok) assert.equal(r6.error.code, "INVALID_ARGUMENT");
+}
+
+// ── Scenario 2: FTS-only strategy ──────────────────────────────────────
+{
+  let semanticCalled = false;
+  const fts = createFtsStub([
+    makeFtsResult({ documentId: "d1", score: 10.0, updatedAt: 1_700_000_002 }),
+    makeFtsResult({ documentId: "d2", score: 10.0, updatedAt: 1_700_000_001 }),
+  ]);
+  const semantic: SemanticRetriever = {
+    search: () => {
+      semanticCalled = true;
+      return { ok: true as const, data: { items: [] } };
+    },
+  };
+
+  const svc = createService({ fts, semantic });
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+  });
+
+  assert.equal(res.ok, true);
+  assert.equal(semanticCalled, false, "semantic should not be called for fts strategy");
+  if (res.ok) {
+    assert.equal(res.data.strategy, "fts");
+    assert.equal(res.data.fallback, "none");
+    assert.equal(res.data.results.length, 2);
+    // same BM25 but d1 has more recent updatedAt → first
+    assert.equal(res.data.results[0].documentId, "d1");
+    assert.equal(res.data.results[1].documentId, "d2");
+  }
+}
+
+// ── Scenario 3: semantic-only strategy ─────────────────────────────────
+{
+  let ftsCalled = false;
+  const fts: FtsService = {
+    search: () => {
+      ftsCalled = true;
+      return {
+        ok: true as const,
+        data: { results: [], total: 0, hasMore: false, indexState: "ready" as const },
+      };
+    },
+    reindex: () => ({
+      ok: true as const,
+      data: { indexState: "ready" as const, reindexed: 0 },
+    }),
+    searchFulltext: () => ({
+      ok: true as const,
+      data: { items: [] },
+    }),
+  };
+  const semantic = createSemanticStub([
+    makeSemanticItem({ documentId: "s1", chunkId: "c1", score: 0.95 }),
+    makeSemanticItem({ documentId: "s2", chunkId: "c2", score: 0.80 }),
+  ]);
+
+  const svc = createService({ fts, semantic });
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "semantic",
+  });
+
+  assert.equal(res.ok, true);
+  assert.equal(ftsCalled, false, "fts should not be called for semantic strategy");
+  if (res.ok) {
+    assert.equal(res.data.strategy, "semantic");
+    assert.equal(res.data.results.length, 2);
+    // higher semantic score → first
+    assert.equal(res.data.results[0].documentId, "s1");
+  }
+}
+
+// ── Scenario 4: hybrid strategy merges FTS + semantic ──────────────────
+{
+  const fts = createFtsStub([
+    makeFtsResult({ documentId: "d1", score: 10.0, updatedAt: 1_700_000_100 }),
+  ]);
+  const semantic = createSemanticStub([
+    makeSemanticItem({
+      documentId: "d1",
+      chunkId: "fts:d1:0",
+      score: 0.9,
+      updatedAt: 1_700_000_100,
+    }),
+    makeSemanticItem({
+      documentId: "d2",
+      chunkId: "c2",
+      score: 0.85,
+      updatedAt: 1_700_000_050,
+    }),
+  ]);
+
+  const svc = createService({ fts, semantic });
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "hybrid",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.strategy, "hybrid");
+    assert.equal(res.data.fallback, "none");
+    // d1 appears in both FTS and semantic → merged with both scores
+    // d2 appears only in semantic
+    assert.ok(res.data.results.length >= 1, "should have at least 1 result");
+    // d1 with merged BM25+semantic should rank higher
+    const d1Item = res.data.results.find((r) => r.documentId === "d1");
+    assert.ok(d1Item, "d1 should appear in results");
+    assert.ok(d1Item.scoreBreakdown.bm25 > 0, "d1 should have bm25 score");
+    assert.ok(d1Item.scoreBreakdown.semantic > 0, "d1 should have semantic score");
+  }
+}
+
+// ── Scenario 5: semantic timeout in hybrid → degrades to FTS ───────────
+{
+  const fts = createFtsStub([
+    makeFtsResult({ documentId: "d1", score: 8.0 }),
+  ]);
+  const semantic: SemanticRetriever = {
+    search: () => ({
+      ok: false as const,
+      error: { code: "TIMEOUT" as const, message: "timed out" },
+    }),
+  };
+
+  const svc = createService({ fts, semantic });
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "hybrid",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.fallback, "fts");
+    assert.ok(res.data.notice, "should have a degradation notice");
+    assert.ok(res.data.results.length > 0, "should still return FTS results");
+  }
+}
+
+// ── Scenario 6: semantic failure in semantic-only → error ──────────────
+{
+  const semantic: SemanticRetriever = {
+    search: () => ({
+      ok: false as const,
+      error: { code: "INTERNAL" as const, message: "boom" },
+    }),
+  };
+
+  const svc = createService({ semantic });
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "semantic",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "INTERNAL");
+  }
+}
+
+// ── Scenario 7: pagination (offset / limit) ───────────────────────────
+{
+  const items = Array.from({ length: 5 }, (_, i) =>
+    makeFtsResult({
+      documentId: `d${i}`,
+      score: 10.0,
+      updatedAt: 1_700_000_000 + i,
+    }),
+  );
+  const svc = createService({ fts: createFtsStub(items) });
+
+  const full = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+  });
+  assert.equal(full.ok, true);
+  if (full.ok) assert.equal(full.data.total, 5);
+
+  const page = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+    limit: 2,
+    offset: 1,
+  });
+  assert.equal(page.ok, true);
+  if (page.ok) {
+    assert.equal(page.data.results.length, 2);
+    assert.equal(page.data.total, 5);
+    assert.equal(page.data.hasMore, true);
+  }
+}
+
+// ── Scenario 8: cross-project FTS result → SEARCH_PROJECT_FORBIDDEN ───
+{
+  const fts = createFtsStub([
+    makeFtsResult({ projectId: "other-project", documentId: "d1", score: 5 }),
+  ]);
+  const svc = createService({ fts });
+
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "fts",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "SEARCH_PROJECT_FORBIDDEN");
+  }
+}
+
+// ── Scenario 9: score filtering — items below SCORE_THRESHOLD ─────────
+{
+  // A single FTS item with very low score. After min-max normalization with
+  // only one candidate, BM25 normalizes to 1. finalScore = 0.55*1 + 0.35*0 + 0.1*1 = 0.65
+  // so a single item always passes. We need items whose weighted total < 0.25.
+  // With semantic-only: semantic score IS the raw 0..1 value used directly.
+  // finalScore = 0.35 * score + 0.1 * recency. If score=0.2 and single item → recency=1:
+  // finalScore = 0.35*0.2 + 0.1*1 = 0.17 → below 0.25 → filtered.
+  const semantic = createSemanticStub([
+    makeSemanticItem({ documentId: "low", chunkId: "c-low", score: 0.2 }),
+  ]);
+  const svc = createService({ semantic });
+
+  const res = svc.queryByStrategy({
+    projectId: "proj-1",
+    query: "hello",
+    strategy: "semantic",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.results.length, 0, "low-score item should be filtered out");
+    assert.equal(res.data.total, 0);
+  }
+}
+
+console.log("hybridRankingService.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/search/__tests__/hybridRankingService.test.ts
+++ b/apps/desktop/main/src/services/search/__tests__/hybridRankingService.test.ts
@@ -8,7 +8,6 @@ import {
   type SemanticRetriever,
   type SemanticRetrieveItem,
   type HybridRankingService,
-  type ServiceResult,
 } from "../hybridRankingService";
 
 // ── helpers ─────────────────────────────────────────────────────────────

--- a/apps/desktop/main/src/services/search/__tests__/searchReplaceService.test.ts
+++ b/apps/desktop/main/src/services/search/__tests__/searchReplaceService.test.ts
@@ -1,0 +1,439 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import { createSearchReplaceService } from "../searchReplaceService";
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+function createLogger(): Logger {
+  return { logPath: "<test>", info: () => {}, error: () => {} };
+}
+
+type DocumentRow = {
+  documentId: string;
+  projectId: string;
+  title: string;
+  contentJson: string;
+  contentText: string;
+  contentMd: string;
+  contentHash: string;
+  type: string;
+  updatedAt: number;
+};
+
+function makeDocRow(overrides?: Partial<DocumentRow>): DocumentRow {
+  const text = overrides?.contentText ?? "Hello world";
+  return {
+    documentId: "doc-1",
+    projectId: "proj-1",
+    title: "Test Document",
+    contentJson: JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text }],
+        },
+      ],
+    }),
+    contentText: text,
+    contentMd: text,
+    contentHash: "hash-stub",
+    type: "chapter",
+    updatedAt: 1_700_000_000,
+    ...overrides,
+  };
+}
+
+function createDbStub(args?: {
+  singleRow?: DocumentRow | undefined;
+  allRows?: DocumentRow[];
+  updateChanges?: number;
+  latestRowAfterConflict?: DocumentRow | undefined;
+}): Database.Database {
+  const singleRow = args?.singleRow ?? makeDocRow();
+  const allRows = args?.allRows ?? (singleRow ? [singleRow] : []);
+  const updateChanges = args?.updateChanges ?? 1;
+  const latestRowAfterConflict = args?.latestRowAfterConflict;
+
+  let updateCallCount = 0;
+
+  return {
+    prepare: (sql: string) => {
+      if (sql.includes("FROM documents") && sql.includes("document_id = ?")) {
+        return {
+          get: (..._params: unknown[]) => {
+            // After a failed update (changes=0), service re-queries to decide conflict vs not-found
+            if (updateCallCount > 0 && updateChanges === 0) {
+              return latestRowAfterConflict;
+            }
+            return singleRow;
+          },
+        };
+      }
+
+      if (sql.includes("FROM documents") && sql.includes("ORDER BY")) {
+        return {
+          all: (..._params: unknown[]) => allRows,
+        };
+      }
+
+      if (sql.includes("UPDATE documents SET")) {
+        return {
+          run: (..._params: unknown[]) => {
+            updateCallCount += 1;
+            return { changes: updateChanges };
+          },
+        };
+      }
+
+      if (sql.includes("INSERT INTO document_versions")) {
+        return {
+          run: (..._params: unknown[]) => ({ changes: 1 }),
+        };
+      }
+
+      if (sql.includes("DELETE FROM documents_fts")) {
+        return {
+          run: (..._params: unknown[]) => ({ changes: 0 }),
+        };
+      }
+
+      if (sql.includes("INSERT OR REPLACE INTO documents_fts")) {
+        return {
+          run: (..._params: unknown[]) => ({ changes: 1 }),
+        };
+      }
+
+      return {
+        get: () => undefined,
+        all: () => [],
+        run: () => ({ changes: 0 }),
+      };
+    },
+    transaction: (fn: () => void) => {
+      return () => {
+        fn();
+      };
+    },
+  } as unknown as Database.Database;
+}
+
+// ── Scenario 1: preview — empty projectId → INVALID_ARGUMENT ────────────
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "",
+    scope: "currentDocument",
+    query: "hello",
+    replaceWith: "hi",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+    assert.ok(res.error.message.includes("projectId"));
+  }
+}
+
+// ── Scenario 2: preview — empty query → INVALID_ARGUMENT ───────────────
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    scope: "currentDocument",
+    query: "   ",
+    replaceWith: "hi",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+    assert.ok(res.error.message.includes("query"));
+  }
+}
+
+// ── Scenario 3: preview — invalid scope → INVALID_ARGUMENT ─────────────
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    scope: "bogusScope" as "currentDocument",
+    query: "hello",
+    replaceWith: "hi",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+    assert.ok(res.error.message.includes("scope"));
+  }
+}
+
+// ── Scenario 4: preview — currentDocument happy path ────────────────────
+
+{
+  const row = makeDocRow({ contentText: "Hello world, Hello again" });
+  const svc = createSearchReplaceService({
+    db: createDbStub({ singleRow: row }),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "Hello",
+    replaceWith: "Hi",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.affectedDocuments, 1);
+    assert.equal(res.data.totalMatches, 2);
+    assert.equal(res.data.items.length, 1);
+    assert.equal(res.data.items[0].documentId, "doc-1");
+    assert.equal(res.data.items[0].matchCount, 2);
+    assert.ok(res.data.items[0].sample.length > 0);
+    assert.equal(res.data.previewId, undefined);
+  }
+}
+
+// ── Scenario 5: preview — no matches → 0 totals ────────────────────────
+
+{
+  const row = makeDocRow({ contentText: "Nothing relevant here" });
+  const svc = createSearchReplaceService({
+    db: createDbStub({ singleRow: row }),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "ZZZZZ",
+    replaceWith: "abc",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.affectedDocuments, 0);
+    assert.equal(res.data.totalMatches, 0);
+    assert.equal(res.data.items.length, 0);
+  }
+}
+
+// ── Scenario 6: preview — wholeProject returns previewId ────────────────
+
+{
+  const rows = [
+    makeDocRow({ documentId: "doc-1", contentText: "apple banana" }),
+    makeDocRow({ documentId: "doc-2", contentText: "apple pie" }),
+  ];
+  const previewStore = new Map();
+  const svc = createSearchReplaceService({
+    db: createDbStub({ allRows: rows }),
+    logger: createLogger(),
+    previewStore,
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    scope: "wholeProject",
+    query: "apple",
+    replaceWith: "orange",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.affectedDocuments, 2);
+    assert.equal(res.data.totalMatches, 2);
+    assert.ok(typeof res.data.previewId === "string");
+    assert.ok(res.data.previewId!.length > 0);
+    // previewStore should hold the entry
+    assert.equal(previewStore.size, 1);
+  }
+}
+
+// ── Scenario 7: execute — currentDocument happy path ────────────────────
+
+{
+  const row = makeDocRow({ contentText: "Hello world" });
+  const svc = createSearchReplaceService({
+    db: createDbStub({ singleRow: row, updateChanges: 1 }),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.execute({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "Hello",
+    replaceWith: "Hi",
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.replacedCount, 1);
+    assert.equal(res.data.affectedDocumentCount, 1);
+    assert.equal(res.data.skipped.length, 0);
+  }
+}
+
+// ── Scenario 8: execute — wholeProject without confirmed → VALIDATION_ERROR ─
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.execute({
+    projectId: "proj-1",
+    scope: "wholeProject",
+    query: "hello",
+    replaceWith: "hi",
+    confirmed: false,
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "VALIDATION_ERROR");
+    assert.ok(res.error.message.includes("confirmation"));
+  }
+}
+
+// ── Scenario 9: execute — wholeProject without previewId → VALIDATION_ERROR ─
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.execute({
+    projectId: "proj-1",
+    scope: "wholeProject",
+    query: "hello",
+    replaceWith: "hi",
+    confirmed: true,
+    previewId: "",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "VALIDATION_ERROR");
+    assert.ok(res.error.message.includes("previewId"));
+  }
+}
+
+// ── Scenario 10: execute — concurrent write conflict ────────────────────
+
+{
+  const row = makeDocRow({ contentText: "Hello world" });
+  const conflictRow = makeDocRow({
+    contentText: "Hello world modified",
+    updatedAt: 1_700_000_001,
+  });
+
+  const svc = createSearchReplaceService({
+    db: createDbStub({
+      singleRow: row,
+      updateChanges: 0,
+      latestRowAfterConflict: conflictRow,
+    }),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.execute({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "Hello",
+    replaceWith: "Hi",
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "SEARCH_CONCURRENT_WRITE_CONFLICT");
+  }
+}
+
+// ── Scenario 11: preview — invalid regex → INVALID_ARGUMENT ────────────
+
+{
+  const svc = createSearchReplaceService({
+    db: createDbStub(),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "[invalid((",
+    replaceWith: "x",
+    regex: true,
+  });
+
+  assert.equal(res.ok, false);
+  if (!res.ok) {
+    assert.equal(res.error.code, "INVALID_ARGUMENT");
+  }
+}
+
+// ── Scenario 12: preview — regex=true matches regex pattern ─────────────
+
+{
+  const row = makeDocRow({ contentText: "cat bat hat" });
+  const svc = createSearchReplaceService({
+    db: createDbStub({ singleRow: row }),
+    logger: createLogger(),
+    previewStore: new Map(),
+  });
+
+  const res = svc.preview({
+    projectId: "proj-1",
+    documentId: "doc-1",
+    scope: "currentDocument",
+    query: "[cbh]at",
+    replaceWith: "dog",
+    regex: true,
+  });
+
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.equal(res.data.totalMatches, 3);
+    assert.equal(res.data.affectedDocuments, 1);
+  }
+}
+
+console.log("searchReplaceService.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/shared/__tests__/concurrency.test.ts
+++ b/apps/desktop/main/src/services/shared/__tests__/concurrency.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { createKeyedMutex, createKeyedSingleflight } from "../concurrency";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// S1: Same-key tasks run serially
+// ---------------------------------------------------------------------------
+async function sameKeyRunsSerially(): Promise<void> {
+  const mutex = createKeyedMutex();
+  const order: number[] = [];
+
+  const t1 = mutex.runExclusive("k", async () => {
+    await delay(30);
+    order.push(1);
+  });
+  const t2 = mutex.runExclusive("k", async () => {
+    order.push(2);
+  });
+
+  await Promise.all([t1, t2]);
+  assert.deepStrictEqual(order, [1, 2], "same-key tasks must execute in order");
+}
+
+// ---------------------------------------------------------------------------
+// S2: Different-key tasks can run concurrently
+// ---------------------------------------------------------------------------
+async function differentKeysRunConcurrently(): Promise<void> {
+  const mutex = createKeyedMutex();
+  let concurrentPeak = 0;
+  let running = 0;
+
+  const task = async () => {
+    running++;
+    if (running > concurrentPeak) concurrentPeak = running;
+    await delay(20);
+    running--;
+  };
+
+  await Promise.all([
+    mutex.runExclusive("a", task),
+    mutex.runExclusive("b", task),
+  ]);
+
+  assert.equal(concurrentPeak, 2, "different keys should run concurrently");
+}
+
+// ---------------------------------------------------------------------------
+// S3: Empty key bypasses locking
+// ---------------------------------------------------------------------------
+async function emptyKeyBypassesLocking(): Promise<void> {
+  const mutex = createKeyedMutex();
+  let concurrentPeak = 0;
+  let running = 0;
+
+  const task = async () => {
+    running++;
+    if (running > concurrentPeak) concurrentPeak = running;
+    await delay(20);
+    running--;
+  };
+
+  await Promise.all([
+    mutex.runExclusive("", task),
+    mutex.runExclusive("", task),
+  ]);
+
+  assert.equal(concurrentPeak, 2, "empty key should allow concurrent execution");
+}
+
+// ---------------------------------------------------------------------------
+// S4: Prior task error is reported via callback
+// ---------------------------------------------------------------------------
+async function priorTaskErrorReportedViaCallback(): Promise<void> {
+  const reported: Array<{ key: string; error: unknown }> = [];
+  const mutex = createKeyedMutex({
+    onPriorTaskError: (args) => reported.push(args),
+  });
+
+  const boom = new Error("boom");
+
+  // First task throws
+  await assert.rejects(
+    () => mutex.runExclusive("k", () => { throw boom; }),
+    (err: unknown) => err === boom,
+  );
+
+  // Second task triggers callback before executing
+  const result = await mutex.runExclusive("k", () => 42);
+  assert.equal(result, 42);
+  assert.equal(reported.length, 1, "callback should be invoked once");
+  assert.equal(reported[0].key, "k");
+  assert.equal(reported[0].error, boom);
+}
+
+// ---------------------------------------------------------------------------
+// S5: Singleflight deduplicates concurrent same-key calls
+// ---------------------------------------------------------------------------
+async function singleflightDeduplicates(): Promise<void> {
+  const sf = createKeyedSingleflight();
+  let computeCount = 0;
+
+  const compute = async () => {
+    computeCount++;
+    await delay(30);
+    return "result";
+  };
+
+  const [r1, r2] = await Promise.all([
+    sf.run("k", compute),
+    sf.run("k", compute),
+  ]);
+
+  assert.equal(computeCount, 1, "compute should run only once");
+  assert.equal(r1, "result");
+  assert.equal(r2, "result");
+
+  // After resolution, next call starts fresh
+  const r3 = await sf.run("k", compute);
+  assert.equal(computeCount, 2, "new call after resolution should compute again");
+  assert.equal(r3, "result");
+}
+
+// ---------------------------------------------------------------------------
+// Run all tests
+// ---------------------------------------------------------------------------
+void (async () => {
+  await sameKeyRunsSerially();
+  await differentKeysRunConcurrently();
+  await emptyKeyBypassesLocking();
+  await priorTaskErrorReportedViaCallback();
+  await singleflightDeduplicates();
+  console.log("concurrency.test.ts: all assertions passed");
+})();

--- a/apps/desktop/main/src/services/shared/__tests__/ipcResult.test.ts
+++ b/apps/desktop/main/src/services/shared/__tests__/ipcResult.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
+import { ipcOk, ipcError } from "../ipcResult";
+
+// ---------------------------------------------------------------------------
+// S1: ipcOk wraps data correctly
+// ---------------------------------------------------------------------------
+{
+  const result = ipcOk(42);
+  assert.equal(result.ok, true);
+  assert.equal(result.data, 42);
+
+  const objResult = ipcOk({ name: "test" });
+  assert.equal(objResult.ok, true);
+  assert.deepStrictEqual(objResult.data, { name: "test" });
+}
+
+// ---------------------------------------------------------------------------
+// S2: ipcError creates correct error structure
+// ---------------------------------------------------------------------------
+{
+  const code: IpcErrorCode = "INTERNAL_ERROR";
+  const result = ipcError(code, "something broke", { extra: 1 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, "INTERNAL_ERROR");
+  assert.equal(result.error.message, "something broke");
+  assert.deepStrictEqual(result.error.details, { extra: 1 });
+  assert.equal(result.error.traceId, undefined);
+  assert.equal(result.error.retryable, undefined);
+}
+
+// ---------------------------------------------------------------------------
+// S3: ipcError with traceId and retryable options
+// ---------------------------------------------------------------------------
+{
+  const code: IpcErrorCode = "INTERNAL_ERROR";
+  const result = ipcError(code, "transient", undefined, {
+    traceId: "trace-123",
+    retryable: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.traceId, "trace-123");
+  assert.equal(result.error.retryable, true);
+
+  // retryable=false should also be included
+  const result2 = ipcError(code, "permanent", undefined, {
+    retryable: false,
+  });
+  assert.equal(result2.error.retryable, false);
+  assert.equal(result2.error.traceId, undefined);
+}
+
+console.log("ipcResult.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/skills/skillScheduler.ts
+++ b/apps/desktop/main/src/services/skills/skillScheduler.ts
@@ -112,7 +112,7 @@ function buildTaskErrorContext(args: {
 }
 
 function buildTaskPathError(args: {
-  logger?: SchedulerLogger;
+  logger: SchedulerLogger;
   task: SkillTask<unknown>;
   errorSource: SchedulerErrorSource;
   error: unknown;
@@ -126,11 +126,7 @@ function buildTaskPathError(args: {
     errorSource: args.errorSource,
     error: args.error,
   });
-  if (args.logger) {
-    args.logger.error(event, context);
-  } else {
-    console.error(event, context);
-  }
+  args.logger.error(event, context);
   return ipcError("INTERNAL", "Skill scheduler task failed", context);
 }
 
@@ -236,7 +232,11 @@ export function createSkillScheduler(args?: {
   const sessions = new Map<string, SessionQueueState>();
   const readySessionQueue: string[] = [];
   const readySessionSet = new Set<string>();
-  const logger = args?.logger;
+  const logger: SchedulerLogger = args?.logger ?? {
+    error: (event, data) => {
+      process.stderr.write(`${JSON.stringify({ event, ...data })}\n`);
+    },
+  };
   let globalRunning = 0;
 
   function getSessionState(sessionKey: string): SessionQueueState {

--- a/apps/desktop/main/src/services/stats/__tests__/statsService.test.ts
+++ b/apps/desktop/main/src/services/stats/__tests__/statsService.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+
+import type Database from "better-sqlite3";
+
+import type { Logger } from "../../../logging/logger";
+import { createStatsService } from "../statsService";
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+type StatsRow = {
+  date: string;
+  wordsWritten: number;
+  writingSeconds: number;
+  skillsUsed: number;
+  documentsCreated: number;
+};
+
+function createDbStub(args?: {
+  runError?: Error;
+  getRow?: StatsRow | undefined;
+  allRows?: StatsRow[];
+  getAllError?: Error;
+}): Database.Database {
+  const runError = args?.runError;
+  const getRow = args?.getRow;
+  const allRows = args?.allRows ?? [];
+  const getAllError = args?.getAllError;
+
+  return {
+    prepare: (sql: string) => {
+      if (sql.includes("INSERT INTO stats_daily")) {
+        return {
+          run: (..._params: unknown[]) => {
+            if (runError) {
+              throw runError;
+            }
+            return { changes: 1 };
+          },
+        };
+      }
+
+      if (sql.includes("FROM stats_daily WHERE date = ?")) {
+        return {
+          get: (..._params: unknown[]) => {
+            if (getAllError) {
+              throw getAllError;
+            }
+            return getRow;
+          },
+        };
+      }
+
+      if (sql.includes("FROM stats_daily WHERE date >= ?")) {
+        return {
+          all: (..._params: unknown[]) => {
+            if (getAllError) {
+              throw getAllError;
+            }
+            return allRows;
+          },
+        };
+      }
+
+      return { run: () => ({ changes: 0 }), get: () => undefined, all: () => [] };
+    },
+  } as unknown as Database.Database;
+}
+
+// ── S1: increment happy path → returns { updated: true, date } ──
+{
+  const svc = createStatsService({
+    db: createDbStub(),
+    logger: createLogger(),
+  });
+
+  const ts = new Date("2025-06-15T10:30:00Z").getTime();
+  const result = svc.increment({
+    ts,
+    delta: { wordsWritten: 42, writingSeconds: 300 },
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error("unreachable");
+  assert.equal(result.data.updated, true);
+  assert.equal(result.data.date, "2025-06-15");
+}
+
+// ── S2: increment with DB error → returns DB_ERROR ──
+{
+  const svc = createStatsService({
+    db: createDbStub({ runError: new Error("disk full") }),
+    logger: createLogger(),
+  });
+
+  const ts = new Date("2025-06-15T10:30:00Z").getTime();
+  const result = svc.increment({
+    ts,
+    delta: { wordsWritten: 10 },
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) throw new Error("unreachable");
+  assert.equal(result.error.code, "DB_ERROR");
+}
+
+// ── S3: getToday with no data → returns zero summary ──
+{
+  const svc = createStatsService({
+    db: createDbStub({ getRow: undefined }),
+    logger: createLogger(),
+  });
+
+  const ts = new Date("2025-06-15T10:30:00Z").getTime();
+  const result = svc.getToday({ ts });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error("unreachable");
+  assert.equal(result.data.date, "2025-06-15");
+  assert.equal(result.data.summary.wordsWritten, 0);
+  assert.equal(result.data.summary.writingSeconds, 0);
+  assert.equal(result.data.summary.skillsUsed, 0);
+  assert.equal(result.data.summary.documentsCreated, 0);
+}
+
+// ── S4: getRange returns aggregated summary across multiple days ──
+{
+  const rows: StatsRow[] = [
+    { date: "2025-06-14", wordsWritten: 100, writingSeconds: 600, skillsUsed: 2, documentsCreated: 1 },
+    { date: "2025-06-15", wordsWritten: 200, writingSeconds: 900, skillsUsed: 3, documentsCreated: 0 },
+  ];
+
+  const svc = createStatsService({
+    db: createDbStub({ allRows: rows }),
+    logger: createLogger(),
+  });
+
+  const result = svc.getRange({ from: "2025-06-14", to: "2025-06-15" });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error("unreachable");
+  assert.equal(result.data.from, "2025-06-14");
+  assert.equal(result.data.to, "2025-06-15");
+  assert.equal(result.data.days.length, 2);
+  assert.equal(result.data.summary.wordsWritten, 300);
+  assert.equal(result.data.summary.writingSeconds, 1500);
+  assert.equal(result.data.summary.skillsUsed, 5);
+  assert.equal(result.data.summary.documentsCreated, 1);
+}
+
+console.log("statsService.test.ts: all assertions passed");


### PR DESCRIPTION
## 概要

补齐 backend-code-analysis.md §5 (Task 8) 中标记为零测试覆盖的五大后端模块测试。

## 变更内容

### 新增 10 个测试文件，共 73 个场景

| 优先级 | 文件 | 场景数 | 说明 |
|--------|------|--------|------|
| P0 | ftsService.test.ts | 9 | 搜索高亮/分页/空查询/FTS语法错误/重建索引 |
| P0 | hybridRankingService.test.ts | 9 | 输入校验/FTS-only/semantic-only/混合排名/语义降级 |
| P0 | searchReplaceService.test.ts | 12 | 预览/执行/并发写入冲突/正则匹配/输入校验 |
| P0 | episodicMemoryHelpers.test.ts | 14 | 衰减计算/等级分类/隐式反馈/记忆层组装 |
| P0 | memoryService.crud.test.ts | 8 | CRUD 全路径/空内容/软删除/设置合并 |
| P0 | preferenceLearning.test.ts | 6 | 反馈接受/学习禁用/隐私拒绝/阈值学习 |
| P1 | concurrency.test.ts | 5 | 同键串行/异键并发/空键旁路/错误回调/singleflight去重 |
| P1 | ipcResult.test.ts | 3 | ipcOk/ipcError/traceId+retryable |
| P2 | statsService.test.ts | 4 | 递增/DB错误/当日空/范围聚合 |
| P2 | judgeService.test.ts | 3 | 初始not_ready/E2E就绪/非E2E拒绝 |

### 生产代码修复 (P3)

- `skillScheduler.ts`: 消除 `console.error` 回退路径，改为结构化 `logger.error`
  - `buildTaskPathError` 的 `logger` 参数从可选改为必传
  - 工厂函数提供默认 `SchedulerLogger` (写入 `process.stderr`)

## 审计摘要

主会话对全部 10 个子代理产出进行了逐文件审计：
- 5 个文件一次通过
- 4 个文件发现轻微问题（冗余断言），已修复
- 1 个生产代码修复已验证

## 验证

```
pnpm test:unit → ALL PASSED
- tsx runner: 所有 bare-assert 测试通过
- vitest: Test Files 10 passed (10), Tests 36 passed (36)
```

---
**不要自动合并**，等待独立审计 Agent 给出审计意见。