### PR TITLE
Unify GitHub delivery control plane (#1005)

### DIFF
--- a/.github/agents/creonow-delivery.agent.md
+++ b/.github/agents/creonow-delivery.agent.md
@@ -1,0 +1,16 @@
+---
+description: "CreoNow delivery agent for GitHub Issue/PR handoff, audit-first merge flow, and tool-capability fallback"
+target: "vscode"
+---
+
+You are the CreoNow delivery agent.
+
+Your job is to carry tasks from issue intake to PR handoff without leaving GitHub delivery steps ambiguous.
+
+Always:
+- Read `AGENTS.md`, `openspec/project.md`, relevant `openspec/specs/<module>/spec.md`, and `docs/delivery-skill.md`.
+- Run `python3 scripts/agent_github_delivery.py capabilities` before any GitHub Issue / PR / comment action.
+- Prefer repository scripts and structured payload helpers over ad-hoc command composition.
+- Keep auto-merge disabled by default.
+- Only enable auto-merge after the designated audit agent has posted a `FINAL-VERDICT` comment with `ACCEPT`.
+- If delivery cannot proceed, report the exact blocker (`missing_tool`, `missing_auth`, or `missing_permission`) and the next concrete action.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# CreoNow Copilot Instructions
+
+在这个仓库里，VS Code / GitHub Copilot Agent 不应把 GitHub 交付理解成“用户手动补最后一步”。请遵守以下规则：
+
+- 先读 `AGENTS.md`、`openspec/project.md`、相关 `openspec/specs/<module>/spec.md`、`docs/delivery-skill.md`。
+- 优先复用仓库脚本，而不是即兴拼命令：
+  - `scripts/agent_worktree_setup.sh`
+  - `scripts/agent_pr_preflight.sh`
+  - `scripts/agent_pr_automerge_and_sync.sh`
+  - `python3 scripts/agent_github_delivery.py capabilities|pr-payload|comment-payload|audit-pass`
+- 发起 GitHub Issue / PR / comment 之前，先运行：
+  - `python3 scripts/agent_github_delivery.py capabilities`
+- 通道选择规则：
+  - `selected_channel=gh`：继续使用本地 `gh` / 仓库脚本。
+  - `selected_channel=mcp`：改用 GitHub MCP / API，并继续复用 `agent_github_delivery.py` 生成 payload。
+  - `selected_channel=none`：明确报告 `missing_tool / missing_auth / missing_permission`，不要只说“没有 gh 上下文”。
+- 默认策略：**只创建 / 更新 PR，不自动开启 auto-merge**。
+  - auto-merge 默认关闭。
+  - 只有在指定审计 Agent 已发布 `FINAL-VERDICT` 且结论为 `ACCEPT` 后，才允许显式执行 `scripts/agent_pr_automerge_and_sync.sh --enable-auto-merge`。
+- 不要在尚未尝试 `gh` 与 GitHub MCP 两条通道前，把 PR 创建、PR 评论、Issue 更新甩回给用户手工完成。
+- PR 文案必须遵循 `.github/pull_request_template.md`：包含 `Closes #N`、验证证据、回滚点、审计门禁。
+- 修改 GitHub 交付脚本或文档时，要同步维护 `AGENTS.md`、`CLAUDE.md`、`docs/delivery-skill.md`、`docs/references/toolchain.md`、`scripts/README.md` 的一致性。
+
+可在 VS Code Chat Diagnostics 中确认这些 instructions / prompt files / agents 是否已加载。

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "docs/**/*.md"
+description: "CreoNow governed delivery documentation rules"
+---
+
+- `docs/delivery-skill.md` 与 `docs/references/toolchain.md` 属于交付契约，改动 GitHub / PR / audit 流程时必须同步更新。
+- 受治理文档必须维护时间戳，并通过 `python3 scripts/check_doc_timestamps.py` 校验。
+- 若顶层 `AGENTS.md` / `CLAUDE.md` 与文档规则冲突，必须在同一变更中一并修正。

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".github/**"
+description: "CreoNow GitHub contract and PR template rules"
+---
+
+- `.github` 下的模板与 workflow 文案必须和 `docs/delivery-skill.md` 保持一致。
+- PR 模板必须要求 `Closes #N`、验证证据、回滚点、审计门禁。
+- 不得重新引入“auto-merge 默认开启”的旧规则；当前规则是审计先行、显式开启。

--- a/.github/instructions/scripts.instructions.md
+++ b/.github/instructions/scripts.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "scripts/**"
+description: "CreoNow delivery and automation script rules"
+---
+
+- 把 `scripts/` 视为交付控制面，不是一次性 glue code。
+- 保持 `set -euo pipefail`、退出码 `0/1/2`、输出前缀 `[OK]/[FAIL]/[SKIP]/[WARN]` 约定。
+- 改动 GitHub 交付逻辑时，必须同步更新 `scripts/tests/` 与 `scripts/README.md`。
+- 优先复用 `agent_github_delivery.py` 的结构化 payload，避免在 shell 中散落重复 PR/评论模板。

--- a/.github/prompts/creonow-delivery.prompt.md
+++ b/.github/prompts/creonow-delivery.prompt.md
@@ -1,0 +1,25 @@
+---
+mode: 'agent'
+description: 'Create or update a CreoNow delivery PR with the repo audit-first GitHub flow.'
+---
+
+请按 CreoNow 的交付链路完成任务，重点解决 GitHub Issue / PR / comment / merge 相关动作，不要把最后一步留给用户手工补。
+
+先阅读：
+- [AGENTS.md](../../AGENTS.md)
+- [OpenSpec 项目索引](../../openspec/project.md)
+- [交付规则主源](../../docs/delivery-skill.md)
+- [工具链说明](../../docs/references/toolchain.md)
+- [脚本说明](../../scripts/README.md)
+
+然后严格执行：
+1. 运行 `python3 scripts/agent_github_delivery.py capabilities` 判定当前使用 `gh`、GitHub MCP，还是应当阻断。
+2. 如需新任务，确认 / 创建 Issue，并使用 `scripts/agent_worktree_setup.sh <N> <slug>` 建立隔离 worktree。
+3. 在提交前运行 `scripts/agent_pr_preflight.sh`。
+4. 创建或更新 PR 时，使用 `python3 scripts/agent_github_delivery.py pr-payload ...` 生成 title/body，保持与仓库模板一致。
+5. 若需发布 blocker 评论，使用 `python3 scripts/agent_github_delivery.py comment-payload ...` 生成文案。
+6. 默认只创建 / 更新 PR，不自动开启 auto-merge。
+7. 只有在指定审计 Agent 已发布 `FINAL-VERDICT` 且结论为 `ACCEPT` 后，才允许显式执行 `scripts/agent_pr_automerge_and_sync.sh --enable-auto-merge`。
+8. 若两条通道都不可用，必须清楚说明阻断原因是 `missing_tool`、`missing_auth` 还是 `missing_permission`。
+
+输出时请包含：Issue 号、分支名、验证命令、PR 链接、当前 merge blocker。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,3 +26,7 @@ Skip-Reason: <必填，按上方示例替换>
 ## 回滚点
 - 回滚 commit/分支：
 - 回滚后需要恢复的数据或配置：
+
+## 审计门禁
+- [ ] 指定审计 Agent 已发布 `FINAL-VERDICT` 评论
+- [ ] `FINAL-VERDICT` 的最终判定为 `ACCEPT`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Skip-Reason: <必填，按上方示例替换>
 - 简要说明本次改动解决的问题
 
 ## 关联 Issue
-- Fixes #<issue_number>
+- Closes #<issue_number>
 
 ## 用户影响
 - 本次改动对用户/交付链路的影响

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ apps/desktop/dist/
 apps/desktop/dist-electron/
 
 # IDE
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "chat.agent.enabled": true,
+  "chat.useAgentsMdFile": true,
+  "chat.includeApplyingInstructions": true,
+  "chat.includeReferencedInstructions": true,
+  "chat.instructionsFilesLocations": [
+    ".github/instructions"
+  ],
+  "chat.promptFilesLocations": [
+    ".github/prompts"
+  ],
+  "github.copilot.chat.codeGeneration.useInstructionFilesAutomatically": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@
 
 ### P3. Gates（门禁全绿）
 
-PR 必须通过所有 required checks 且使用 auto-merge。
+PR 必须通过所有 required checks；auto-merge 默认关闭，仅可在指定审计 Agent 已发布 `FINAL-VERDICT` 且结论为 `ACCEPT` 后显式开启。
 - Required checks：`ci`、`merge-serial`
+- GitHub 远程动作前先运行 `python3 scripts/agent_github_delivery.py capabilities`
 - CI 不绿不合并，不得「先合并再修」
 - 交付完成 = 代码已合并到 `main`
 
@@ -103,7 +104,7 @@ PR 必须通过所有 required checks 且使用 auto-merge。
 |------|----------|
 | **准备** | Issue 已创建；spec 已阅读（如需变更则已更新）；分支已创建 |
 | **实现** | 按 TDD 循环实现；所有测试通过；前端任务有视觉验收 |
-| **交付** | PR 已创建（含 `Closes #N`）；auto-merge 已开启；CI 全绿；已合并到 main |
+| **交付** | PR 已创建（含 `Closes #N`）；auto-merge 默认关闭；仅在指定审计 Agent 已发布 `FINAL-VERDICT` + `ACCEPT` 评论后显式开启；CI 全绿；已合并到 main |
 
 规则冲突时，以 `docs/delivery-skill.md` 为主源。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@
 
 ### P3. Gates（门禁全绿）
 
-PR 必须通过所有 required checks 且使用 auto-merge。
+PR 必须通过所有 required checks；auto-merge 默认关闭，仅可在指定审计 Agent 已发布 `FINAL-VERDICT` 且结论为 `ACCEPT` 后显式开启。
 - Required checks：`ci`、`merge-serial`
+- GitHub 远程动作前先运行 `python3 scripts/agent_github_delivery.py capabilities`
 - CI 不绿不合并，不得「先合并再修」
 - 交付完成 = 代码已合并到 `main`
 
@@ -103,7 +104,7 @@ PR 必须通过所有 required checks 且使用 auto-merge。
 |------|----------|
 | **准备** | Issue 已创建；spec 已阅读（如需变更则已更新）；分支已创建 |
 | **实现** | 按 TDD 循环实现；所有测试通过；前端任务有视觉验收 |
-| **交付** | PR 已创建（含 `Closes #N`）；auto-merge 已开启；CI 全绿；已合并到 main |
+| **交付** | PR 已创建（含 `Closes #N`）；auto-merge 默认关闭；仅在指定审计 Agent 已发布 `FINAL-VERDICT` + `ACCEPT` 评论后显式开启；CI 全绿；已合并到 main |
 
 规则冲突时，以 `docs/delivery-skill.md` 为主源。
 

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -32,7 +32,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 3. **依赖同步检查**：若 change 依赖其他 change，进入实现前必须确认上游状态，发现漂移先更新文档再继续。
 4. **证据落盘**：CI 失败和修复过程必须记录在 PR comment 中，禁止 silent failure。
 5. **门禁一致**：文档契约与 GitHub required checks 必须一致；不一致时必须阻断并升级。
-6. **门禁全绿 + 串行合并**：PR 必须通过 `ci`、`merge-serial`，并启用 auto-merge。
+6. **门禁全绿 + 串行合并**：PR 必须通过 `ci`、`merge-serial`；auto-merge 仅可在指定审计 Agent 已发布 `FINAL-VERDICT` + `ACCEPT` 评论后显式开启。
 7. **控制面收口**：所有变更提交后必须合并回控制面 `main`，仅停留在 `task/*` 分支不算交付完成。
 8. **Issue 新鲜度强制**：新任务必须使用当前 OPEN Issue；禁止复用已关闭或历史 Issue。
 9. **环境基线强制**：创建 `task/*` 分支和 worktree 前，必须先同步控制面到最新 `origin/main`。
@@ -43,7 +43,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 ### GitHub 控制面选择
 
 - `auto`：优先 `gh`；若 `gh` 不可用或未认证，则在 GitHub MCP 可写时回退到 GitHub MCP。
-- `gh`：仅当 `gh auth status` 正常时允许继续。
+- `gh`：仅当 `gh auth status` 正常时允许继续；默认只创建/更新 PR，不自动开启 auto-merge。
 - `mcp`：仅当当前会话具备 GitHub MCP 写权限时允许继续；当前主要覆盖远程 Issue / PR / comment 动作。
 - 若两条通道都不可写，必须立即阻断，并在交付记录中写清缺失的是 tool / auth / permission 哪一项。
 
@@ -55,7 +55,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | 2. 规格制定   | OpenSpec spec 已编写或更新；若有上游依赖则已确认上游状态                                                     |
 | 3. 环境隔离   | 控制面 `origin/main` 已同步，Worktree 已创建，工作目录已切换                                                       |
 | 4. 实现与测试 | 按 TDD 循环实现；所有测试通过                                            |
-| 5. 提交与合并 | PR 已创建；所选 GitHub 通道已确认；gh 通道时 auto-merge 已开启；CI 全绿；PR 已确认合并                     |
+| 5. 提交与合并 | PR 已创建；所选 GitHub 通道已确认；指定审计 Agent 的 `FINAL-VERDICT` + `ACCEPT` 评论已存在后，gh 通道方可显式开启 auto-merge；CI 全绿；PR 已确认合并                     |
 | 6. 收口与归档 | 控制面 `main` 已包含任务提交；worktree 已清理                                                                       |
 
 ---
@@ -67,6 +67,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | `gh` 命令超时                        | 最多重试 3 次（间隔 10s），仍失败则在 GitHub MCP 可写时切到 MCP；否则必须记录并升级                              |
 | `gh` 缺失 / 未认证                    | 立即运行 `agent_github_delivery.py capabilities` 复核；若 MCP 可写则切换通道，否则阻断并升级                              |
 | PR 需要 review                       | 记录 blocker，通知 reviewer，等待处理，禁止 silent abandonment                              |
+| 审计通过评论缺失                      | 禁止开启 auto-merge；等待指定审计 Agent 发布 `FINAL-VERDICT` + `ACCEPT` 评论                              |
 | checks 失败                          | 修复后重新 push，重跑并记录失败原因和修复证据                                               |
 | Spec 不存在或不完整                  | 必须先补 spec 并确认，禁止猜测实现                                                          |
 | 上游依赖与当前 change 假设不一致 | 先更新 proposal/spec/tasks 再进入实现                                                         |

--- a/docs/delivery-skill.md
+++ b/docs/delivery-skill.md
@@ -1,6 +1,6 @@
 # OpenSpec + GitHub 交付规则
 
-更新时间：2026-03-05 12:00
+更新时间：2026-03-06 22:35
 
 本文件是 CreoNow 的交付规则主源（Source of Truth）。
 本文件只定义约束条件和验收标准，不定义具体命令和脚本参数。
@@ -26,6 +26,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 
 ## 二、交付规则（硬约束）
 
+0. **GitHub 能力探测强制**：发起 Issue / PR / comment 前，必须先运行 `python3 scripts/agent_github_delivery.py capabilities`，明确当前使用 `gh` 还是 GitHub MCP 通道。
 1. **Spec-first**：任何功能变更必须先有 OpenSpec spec。
 2. **红灯先行**：测试必须先失败再通过（Red → Green → Refactor），禁止先写实现再补测试。
 3. **依赖同步检查**：若 change 依赖其他 change，进入实现前必须确认上游状态，发现漂移先更新文档再继续。
@@ -39,6 +40,13 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 
 ---
 
+### GitHub 控制面选择
+
+- `auto`：优先 `gh`；若 `gh` 不可用或未认证，则在 GitHub MCP 可写时回退到 GitHub MCP。
+- `gh`：仅当 `gh auth status` 正常时允许继续。
+- `mcp`：仅当当前会话具备 GitHub MCP 写权限时允许继续；当前主要覆盖远程 Issue / PR / comment 动作。
+- 若两条通道都不可写，必须立即阻断，并在交付记录中写清缺失的是 tool / auth / permission 哪一项。
+
 ## 三、工作流阶段
 
 | 阶段          | 完成条件                                                                                                           |
@@ -47,7 +55,7 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 | 2. 规格制定   | OpenSpec spec 已编写或更新；若有上游依赖则已确认上游状态                                                     |
 | 3. 环境隔离   | 控制面 `origin/main` 已同步，Worktree 已创建，工作目录已切换                                                       |
 | 4. 实现与测试 | 按 TDD 循环实现；所有测试通过                                            |
-| 5. 提交与合并 | PR 已创建；auto-merge 已开启；CI 全绿；PR 已确认合并                     |
+| 5. 提交与合并 | PR 已创建；所选 GitHub 通道已确认；gh 通道时 auto-merge 已开启；CI 全绿；PR 已确认合并                     |
 | 6. 收口与归档 | 控制面 `main` 已包含任务提交；worktree 已清理                                                                       |
 
 ---
@@ -56,7 +64,8 @@ Commit type：`feat` / `fix` / `refactor` / `test` / `docs` / `chore` / `ci`
 
 | 情况                                 | 规则                                                                                        |
 | ------------------------------------ | --------------------------------------------------------------------------------------- |
-| `gh` 命令超时                        | 最多重试 3 次（间隔 10s），仓失败必须在 PR comment 记录并升级                              |
+| `gh` 命令超时                        | 最多重试 3 次（间隔 10s），仍失败则在 GitHub MCP 可写时切到 MCP；否则必须记录并升级                              |
+| `gh` 缺失 / 未认证                    | 立即运行 `agent_github_delivery.py capabilities` 复核；若 MCP 可写则切换通道，否则阻断并升级                              |
 | PR 需要 review                       | 记录 blocker，通知 reviewer，等待处理，禁止 silent abandonment                              |
 | checks 失败                          | 修复后重新 push，重跑并记录失败原因和修复证据                                               |
 | Spec 不存在或不完整                  | 必须先补 spec 并确认，禁止猜测实现                                                          |

--- a/docs/references/toolchain.md
+++ b/docs/references/toolchain.md
@@ -46,7 +46,7 @@
 | `agent_worktree_setup.sh`        | 创建 `.worktrees/issue-<N>-<slug>`         |
 | `agent_worktree_cleanup.sh`      | 清理 worktree                              |
 | `agent_pr_preflight.py`          | PR 提交前校验（Branch、Issue）         |
-| `agent_pr_automerge_and_sync.sh` | 创建 PR + 开启 auto-merge（仅 gh 通道） |
+| `agent_pr_automerge_and_sync.sh` | 创建 PR；默认不开 auto-merge，显式开启时需审计通过（仅 gh 通道） |
 | `agent_github_delivery.py`        | GitHub 能力探测、PR/评论模板、gh/MCP 通道选择 |
 | `ipc-acceptance-gate.ts`         | IPC 契约验收门禁                           |
 | `contract-generate.ts`           | IPC 契约代码生成                           |
@@ -55,7 +55,7 @@
 
 - GitHub 交付前必须先运行 `python3 scripts/agent_github_delivery.py capabilities`，显式确认当前使用 `gh` 还是 GitHub MCP 通道。
 - `auto` 模式默认优先 `gh`；若 `gh` 缺失或未认证，但 GitHub MCP 具备写权限，则回退到 GitHub MCP。
-- Shell 脚本 `agent_pr_automerge_and_sync.sh` 仅负责 `gh` 通道；GitHub MCP 通道应复用 `agent_github_delivery.py` 生成的 payload，并通过会话内 GitHub 工具执行远程 PR/评论操作。
+- Shell 脚本 `agent_pr_automerge_and_sync.sh` 仅负责 `gh` 通道；默认只创建/更新 PR。若要开启 auto-merge，必须显式传入 `--enable-auto-merge`，且 PR 上已存在指定审计 Agent 的 `FINAL-VERDICT` + `ACCEPT` 评论。GitHub MCP 通道应复用 `agent_github_delivery.py` 生成的 payload，并通过会话内 GitHub 工具执行远程 PR/评论操作。
 
 - 所有脚本使用 `set -euo pipefail`
 - 退出码：`0` 成功，`1` 可恢复失败，`2` 不可恢复失败

--- a/docs/references/toolchain.md
+++ b/docs/references/toolchain.md
@@ -1,6 +1,6 @@
 # 工具链
 
-更新时间：2026-03-04 16:00
+更新时间：2026-03-06 22:35
 
 ## 包管理与构建
 
@@ -46,11 +46,16 @@
 | `agent_worktree_setup.sh`        | 创建 `.worktrees/issue-<N>-<slug>`         |
 | `agent_worktree_cleanup.sh`      | 清理 worktree                              |
 | `agent_pr_preflight.py`          | PR 提交前校验（Branch、Issue）         |
-| `agent_pr_automerge_and_sync.sh` | 创建 PR + 开启 auto-merge              |
+| `agent_pr_automerge_and_sync.sh` | 创建 PR + 开启 auto-merge（仅 gh 通道） |
+| `agent_github_delivery.py`        | GitHub 能力探测、PR/评论模板、gh/MCP 通道选择 |
 | `ipc-acceptance-gate.ts`         | IPC 契约验收门禁                           |
 | `contract-generate.ts`           | IPC 契约代码生成                           |
 
 脚本约定：
+
+- GitHub 交付前必须先运行 `python3 scripts/agent_github_delivery.py capabilities`，显式确认当前使用 `gh` 还是 GitHub MCP 通道。
+- `auto` 模式默认优先 `gh`；若 `gh` 缺失或未认证，但 GitHub MCP 具备写权限，则回退到 GitHub MCP。
+- Shell 脚本 `agent_pr_automerge_and_sync.sh` 仅负责 `gh` 通道；GitHub MCP 通道应复用 `agent_github_delivery.py` 生成的 payload，并通过会话内 GitHub 工具执行远程 PR/评论操作。
 
 - 所有脚本使用 `set -euo pipefail`
 - 退出码：`0` 成功，`1` 可恢复失败，`2` 不可恢复失败

--- a/docs/references/toolchain.md
+++ b/docs/references/toolchain.md
@@ -1,6 +1,6 @@
 # 工具链
 
-更新时间：2026-03-06 22:35
+更新时间：2026-03-06 23:20
 
 ## 包管理与构建
 
@@ -37,6 +37,16 @@
 | `ci`                 | `.github/workflows/ci.yml`                 | lint + typecheck + test + build |
 | `merge-serial`       | `.github/workflows/merge-serial.yml`       | 串行合并队列                    |
 | 合并策略             | auto-merge                                 | 禁止手动合并                    |
+
+## VS Code / Copilot Agent 定制
+
+| 入口 | 路径 | 用途 |
+| ---- | ---- | ---- |
+| Repo-wide instructions | `.github/copilot-instructions.md` | 对整个 workspace 生效的常驻规则 |
+| File-based instructions | `.github/instructions/*.instructions.md` | 针对脚本 / `.github` / 文档的条件指令 |
+| Prompt files | `.github/prompts/*.prompt.md` | 作为 slash command 运行的交付流程模板 |
+| Custom agents | `.github/agents/*.agent.md` | 在 VS Code Agent picker 中提供专项角色 |
+| Workspace settings | `.vscode/settings.json` | 显式开启 AGENTS / instructions / prompt files 加载 |
 
 ## 自动化脚本
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@
 | `agent_controlplane_sync.sh`       | 同步控制面的 main 到最新                        | 阶段 3 前 + 阶段 6 |
 | `agent_worktree_setup.sh`          | 创建 worktree 隔离环境                          | 阶段 3：环境隔离   |
 | `agent_pr_preflight.sh`            | 提交前 / PR 前的预检查                          | 阶段 5：提交前     |
-| `agent_pr_automerge_and_sync.sh`   | 创建 PR + auto-merge + 等待（仅 gh 通道）       | 阶段 5：提交与合并 |
+| `agent_pr_automerge_and_sync.sh`   | 创建 PR；默认不开 auto-merge，显式开启时需审计通过（仅 gh 通道） | 阶段 5：提交与合并 |
 | `agent_github_delivery.py`        | GitHub 能力探测、PR/评论模板、gh/MCP 通道选择   | 阶段 5：提交与合并 |
 | `agent_worktree_cleanup.sh`        | 清理 worktree                                   | 阶段 6：收口       |
 | `ipc-acceptance-gate.ts`           | IPC acceptance SLO 门禁                         | 阶段 4：实现与测试 |
@@ -32,7 +32,7 @@
 - 一键提交前预检命令（可直接复制）：
   - `scripts/agent_pr_preflight.sh`
 - `agent_worktree_setup.sh` 默认会在新 worktree 内执行 `pnpm install --frozen-lockfile`（可用 `--no-bootstrap` 关闭）。
-- `agent_pr_automerge_and_sync.sh` 在 preflight 通过后执行 auto-merge；遇到 `REVIEW_REQUIRED` 会阻断并提示先完成评审。
+- `agent_pr_automerge_and_sync.sh` 默认只创建/更新 PR，不自动开启 auto-merge；必须在指定审计 Agent 留下 `FINAL-VERDICT` + `ACCEPT` 评论后，显式传入 `--enable-auto-merge` 才会继续。
 - `agent_pr_automerge_and_sync.sh` 在 GitHub TLS 抖动时会标记 `transient` 并自动重试，必要时回退到 `gh run list` 快照通道。
 - `agent_github_delivery.py capabilities` 会输出结构化能力探测结果：`gh` 是否安装/认证、GitHub MCP 是否可用/可写、以及当前应选通道。
 - `agent_pr_automerge_and_sync.sh` 进入 GitHub 远程操作前会先校验所选通道；若结果不是 `gh`，会明确阻断并提示改用 GitHub MCP + `agent_github_delivery.py` 生成的 payload。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,8 @@
 | `agent_controlplane_sync.sh`       | 同步控制面的 main 到最新                        | 阶段 3 前 + 阶段 6 |
 | `agent_worktree_setup.sh`          | 创建 worktree 隔离环境                          | 阶段 3：环境隔离   |
 | `agent_pr_preflight.sh`            | 提交前 / PR 前的预检查                          | 阶段 5：提交前     |
-| `agent_pr_automerge_and_sync.sh`   | 创建 PR + auto-merge + 等待                     | 阶段 5：提交与合并 |
+| `agent_pr_automerge_and_sync.sh`   | 创建 PR + auto-merge + 等待（仅 gh 通道）       | 阶段 5：提交与合并 |
+| `agent_github_delivery.py`        | GitHub 能力探测、PR/评论模板、gh/MCP 通道选择   | 阶段 5：提交与合并 |
 | `agent_worktree_cleanup.sh`        | 清理 worktree                                   | 阶段 6：收口       |
 | `ipc-acceptance-gate.ts`           | IPC acceptance SLO 门禁                         | 阶段 4：实现与测试 |
 | `contract-generate.ts`             | 生成 IPC 契约类型定义                           | CI / 手动          |
@@ -33,3 +34,8 @@
 - `agent_worktree_setup.sh` 默认会在新 worktree 内执行 `pnpm install --frozen-lockfile`（可用 `--no-bootstrap` 关闭）。
 - `agent_pr_automerge_and_sync.sh` 在 preflight 通过后执行 auto-merge；遇到 `REVIEW_REQUIRED` 会阻断并提示先完成评审。
 - `agent_pr_automerge_and_sync.sh` 在 GitHub TLS 抖动时会标记 `transient` 并自动重试，必要时回退到 `gh run list` 快照通道。
+- `agent_github_delivery.py capabilities` 会输出结构化能力探测结果：`gh` 是否安装/认证、GitHub MCP 是否可用/可写、以及当前应选通道。
+- `agent_pr_automerge_and_sync.sh` 进入 GitHub 远程操作前会先校验所选通道；若结果不是 `gh`，会明确阻断并提示改用 GitHub MCP + `agent_github_delivery.py` 生成的 payload。
+- GitHub MCP 回退路径依赖环境变量：`CODEX_GITHUB_CHANNEL`（`auto|gh|mcp|none`）、`CODEX_GITHUB_MCP_AVAILABLE`、`CODEX_GITHUB_MCP_WRITE_CAPABLE`。
+- `agent_github_delivery.py pr-payload` / `comment-payload` 负责统一 PR title/body 与阻断评论文案，避免不同通道各写一套模板。
+- 可选环境变量：`AGENT_PR_SUMMARY`、`AGENT_PR_USER_IMPACT`、`AGENT_PR_WORST_CASE`、`AGENT_PR_ROLLBACK_REF`，用于在自动创建 PR 时覆盖默认占位文案。

--- a/scripts/agent_github_delivery.py
+++ b/scripts/agent_github_delivery.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Helpers for agent GitHub delivery control-plane selection and templates."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Callable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class CmdResult:
+    code: int
+    out: str
+
+
+@dataclass(frozen=True)
+class DeliveryCapabilities:
+    override: str
+    gh_installed: bool
+    gh_authenticated: bool
+    mcp_available: bool
+    mcp_write_capable: bool
+    selected_channel: str
+    blocker: str | None
+    reason: str
+
+
+TRUTHY = {"1", "true", "yes", "on"}
+DEFAULT_VERIFICATION_COMMANDS = (
+    "pnpm typecheck",
+    "pnpm lint",
+    "pnpm test:unit",
+)
+
+
+def run(cmd: Sequence[str], *, cwd: str | None = None) -> CmdResult:
+    proc = subprocess.run(
+        list(cmd),
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return CmdResult(code=proc.returncode, out=proc.stdout)
+
+
+def parse_env_bool(env: Mapping[str, str], key: str) -> bool:
+    value = env.get(key, "")
+    return value.strip().lower() in TRUTHY
+
+
+def detect_gh_installed(which: Callable[[str], str | None] = shutil.which) -> bool:
+    return which("gh") is not None
+
+
+def detect_gh_authenticated(
+    *,
+    repo_root: str | None = None,
+    run_command: Callable[[Sequence[str]], CmdResult] | None = None,
+) -> bool:
+    if run_command is None:
+        def _run(cmd: Sequence[str]) -> CmdResult:
+            return run(cmd, cwd=repo_root)
+        run_command = _run
+    result = run_command(("gh", "auth", "status"))
+    return result.code == 0
+
+
+def select_channel(
+    *,
+    override: str,
+    gh_installed: bool,
+    gh_authenticated: bool,
+    mcp_available: bool,
+    mcp_write_capable: bool,
+) -> DeliveryCapabilities:
+    normalized_override = override.lower()
+
+    if normalized_override == "gh":
+        if not gh_installed:
+            return DeliveryCapabilities(
+                override=normalized_override,
+                gh_installed=gh_installed,
+                gh_authenticated=gh_authenticated,
+                mcp_available=mcp_available,
+                mcp_write_capable=mcp_write_capable,
+                selected_channel="none",
+                blocker="missing_tool",
+                reason="`gh` 未安装，无法按强制 gh 通道执行。",
+            )
+        if not gh_authenticated:
+            return DeliveryCapabilities(
+                override=normalized_override,
+                gh_installed=gh_installed,
+                gh_authenticated=gh_authenticated,
+                mcp_available=mcp_available,
+                mcp_write_capable=mcp_write_capable,
+                selected_channel="none",
+                blocker="missing_auth",
+                reason="`gh` 已安装但未认证，无法按强制 gh 通道执行。",
+            )
+        return DeliveryCapabilities(
+            override=normalized_override,
+            gh_installed=gh_installed,
+            gh_authenticated=gh_authenticated,
+            mcp_available=mcp_available,
+            mcp_write_capable=mcp_write_capable,
+            selected_channel="gh",
+            blocker=None,
+            reason="`gh` 已安装且已认证。",
+        )
+
+    if normalized_override == "mcp":
+        if not mcp_available:
+            return DeliveryCapabilities(
+                override=normalized_override,
+                gh_installed=gh_installed,
+                gh_authenticated=gh_authenticated,
+                mcp_available=mcp_available,
+                mcp_write_capable=mcp_write_capable,
+                selected_channel="none",
+                blocker="missing_tool",
+                reason="当前会话未暴露 GitHub MCP 能力。",
+            )
+        if not mcp_write_capable:
+            return DeliveryCapabilities(
+                override=normalized_override,
+                gh_installed=gh_installed,
+                gh_authenticated=gh_authenticated,
+                mcp_available=mcp_available,
+                mcp_write_capable=mcp_write_capable,
+                selected_channel="none",
+                blocker="missing_permission",
+                reason="GitHub MCP 可见但不具备写权限。",
+            )
+        return DeliveryCapabilities(
+            override=normalized_override,
+            gh_installed=gh_installed,
+            gh_authenticated=gh_authenticated,
+            mcp_available=mcp_available,
+            mcp_write_capable=mcp_write_capable,
+            selected_channel="mcp",
+            blocker=None,
+            reason="按要求强制使用 GitHub MCP 通道。",
+        )
+
+    if normalized_override == "none":
+        return DeliveryCapabilities(
+            override=normalized_override,
+            gh_installed=gh_installed,
+            gh_authenticated=gh_authenticated,
+            mcp_available=mcp_available,
+            mcp_write_capable=mcp_write_capable,
+            selected_channel="none",
+            blocker="missing_tool",
+            reason="显式关闭 GitHub 交付通道。",
+        )
+
+    if gh_installed and gh_authenticated:
+        return DeliveryCapabilities(
+            override="auto",
+            gh_installed=gh_installed,
+            gh_authenticated=gh_authenticated,
+            mcp_available=mcp_available,
+            mcp_write_capable=mcp_write_capable,
+            selected_channel="gh",
+            blocker=None,
+            reason="auto 模式下优先选择已就绪的 `gh`。",
+        )
+
+    if mcp_available and mcp_write_capable:
+        fallback_reason = "auto 模式下 `gh` 不可用，回退到 GitHub MCP。"
+        if gh_installed and not gh_authenticated:
+            fallback_reason = "auto 模式下 `gh` 未认证，回退到 GitHub MCP。"
+        return DeliveryCapabilities(
+            override="auto",
+            gh_installed=gh_installed,
+            gh_authenticated=gh_authenticated,
+            mcp_available=mcp_available,
+            mcp_write_capable=mcp_write_capable,
+            selected_channel="mcp",
+            blocker=None,
+            reason=fallback_reason,
+        )
+
+    blocker = "missing_tool"
+    reason = "`gh` 未安装，且无 GitHub MCP 写通道。"
+    if gh_installed and not gh_authenticated:
+        blocker = "missing_auth"
+        reason = "`gh` 已安装但未认证，且无 GitHub MCP 写通道。"
+    elif mcp_available and not mcp_write_capable:
+        blocker = "missing_permission"
+        reason = "GitHub MCP 可见但不具备写权限，同时 `gh` 不可用。"
+
+    return DeliveryCapabilities(
+        override="auto",
+        gh_installed=gh_installed,
+        gh_authenticated=gh_authenticated,
+        mcp_available=mcp_available,
+        mcp_write_capable=mcp_write_capable,
+        selected_channel="none",
+        blocker=blocker,
+        reason=reason,
+    )
+
+
+def build_pr_title(title: str, issue_number: str) -> str:
+    suffix = f"(#{issue_number})"
+    stripped = title.strip()
+    if suffix in stripped:
+        return stripped
+    return f"{stripped} {suffix}".strip()
+
+
+def build_pr_body(
+    *,
+    issue_number: str,
+    summary: str,
+    user_impact: str,
+    worst_case: str,
+    verification_commands: Sequence[str],
+    rollback_ref: str,
+    skip_reason: str = "N/A (task branch)",
+    recovery_note: str = "无",
+) -> str:
+    verification_lines = [f"- [ ] `{command}`" for command in verification_commands]
+    verification_block = "\n".join(verification_lines)
+    return f"""Skip-Reason: {skip_reason}
+
+## 主题
+- {summary}
+
+## 关联 Issue
+- Closes #{issue_number}
+
+## 用户影响
+- {user_impact}
+
+## 不修最坏后果
+- {worst_case}
+
+## 验证证据
+{verification_block}
+- 其他补充验证：
+
+## 回滚点
+- 回滚 commit/分支：{rollback_ref}
+- 回滚后需要恢复的数据或配置：{recovery_note}
+""".strip() + "\n"
+
+
+def build_blocker_comment(
+    *,
+    kind: str,
+    pr_url: str,
+    merge_state: str | None = None,
+    review_decision: str | None = None,
+    timeout_seconds: int | None = None,
+) -> str:
+    normalized_kind = kind.lower()
+    if normalized_kind == "review-required":
+        return (
+            "PR is blocked by `reviewDecision=REVIEW_REQUIRED`. "
+            f"Complete independent review before merge. PR: {pr_url}"
+        )
+    if normalized_kind == "changes-requested":
+        return (
+            "PR is blocked by `reviewDecision=CHANGES_REQUESTED`; cannot auto-merge. "
+            f"PR: {pr_url}"
+        )
+    if normalized_kind == "merge-conflicts":
+        merge_state_value = merge_state or "DIRTY"
+        return (
+            f"PR is blocked by merge conflicts (`mergeStateStatus={merge_state_value}`). "
+            f"Manual conflict resolution is required. PR: {pr_url}"
+        )
+    if normalized_kind == "merge-timeout":
+        timeout_value = timeout_seconds if timeout_seconds is not None else 0
+        review_value = review_decision or ""
+        merge_value = merge_state or ""
+        status_line = f"mergeState={merge_value} reviewDecision={review_value}".strip()
+        return (
+            "Auto-merge is enabled and checks are green, but the PR has not merged "
+            f"after {timeout_value}s. Current status: {status_line}. PR: {pr_url}"
+        )
+    raise ValueError(f"Unsupported blocker comment kind: {kind}")
+
+
+def detect_capabilities_from_environment(
+    *,
+    override: str,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    run_command: Callable[[Sequence[str]], CmdResult] | None = None,
+    repo_root: str | None = None,
+) -> DeliveryCapabilities:
+    current_env = os.environ if env is None else env
+    gh_installed = detect_gh_installed(which)
+    gh_authenticated = False
+    if gh_installed:
+        gh_authenticated = detect_gh_authenticated(repo_root=repo_root, run_command=run_command)
+    mcp_available = parse_env_bool(current_env, "CODEX_GITHUB_MCP_AVAILABLE")
+    mcp_write_capable = parse_env_bool(current_env, "CODEX_GITHUB_MCP_WRITE_CAPABLE")
+    return select_channel(
+        override=override,
+        gh_installed=gh_installed,
+        gh_authenticated=gh_authenticated,
+        mcp_available=mcp_available,
+        mcp_write_capable=mcp_write_capable,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GitHub delivery helpers for agents.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capabilities_parser = subparsers.add_parser("capabilities", help="Detect delivery channel.")
+    capabilities_parser.add_argument(
+        "--channel",
+        default=os.environ.get("CODEX_GITHUB_CHANNEL", "auto"),
+        choices=["auto", "gh", "mcp", "none"],
+        help="Preferred GitHub delivery channel.",
+    )
+
+    pr_payload_parser = subparsers.add_parser("pr-payload", help="Build PR title/body payload.")
+    pr_payload_parser.add_argument("--issue-number", required=True)
+    pr_payload_parser.add_argument("--title", required=True)
+    pr_payload_parser.add_argument("--summary", required=True)
+    pr_payload_parser.add_argument("--user-impact", required=True)
+    pr_payload_parser.add_argument("--worst-case", required=True)
+    pr_payload_parser.add_argument("--rollback-ref", required=True)
+    pr_payload_parser.add_argument(
+        "--verification-command",
+        action="append",
+        dest="verification_commands",
+        default=list(DEFAULT_VERIFICATION_COMMANDS),
+        help="Repeatable verification command entry.",
+    )
+    pr_payload_parser.add_argument(
+        "--skip-reason",
+        default="N/A (task branch)",
+    )
+    pr_payload_parser.add_argument(
+        "--recovery-note",
+        default="无",
+    )
+
+    comment_parser = subparsers.add_parser("comment-payload", help="Build blocker comment.")
+    comment_parser.add_argument(
+        "--kind",
+        required=True,
+        choices=["review-required", "changes-requested", "merge-conflicts", "merge-timeout"],
+    )
+    comment_parser.add_argument("--pr-url", required=True)
+    comment_parser.add_argument("--merge-state", default=None)
+    comment_parser.add_argument("--review-decision", default=None)
+    comment_parser.add_argument("--timeout-seconds", type=int, default=None)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "capabilities":
+        capabilities = detect_capabilities_from_environment(override=args.channel)
+        print(json.dumps(asdict(capabilities), ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "pr-payload":
+        payload = {
+            "title": build_pr_title(args.title, args.issue_number),
+            "body": build_pr_body(
+                issue_number=args.issue_number,
+                summary=args.summary,
+                user_impact=args.user_impact,
+                worst_case=args.worst_case,
+                verification_commands=args.verification_commands,
+                rollback_ref=args.rollback_ref,
+                skip_reason=args.skip_reason,
+                recovery_note=args.recovery_note,
+            ),
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "comment-payload":
+        payload = {
+            "body": build_blocker_comment(
+                kind=args.kind,
+                pr_url=args.pr_url,
+                merge_state=args.merge_state,
+                review_decision=args.review_decision,
+                timeout_seconds=args.timeout_seconds,
+            )
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_github_delivery.py
+++ b/scripts/agent_github_delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass
@@ -35,6 +36,9 @@ DEFAULT_VERIFICATION_COMMANDS = (
     "pnpm lint",
     "pnpm test:unit",
 )
+
+
+AUDIT_PASS_COMMENT_PATTERN = re.compile(r"FINAL-VERDICT[\s\S]*?\bACCEPT\b", re.IGNORECASE)
 
 
 def run(cmd: Sequence[str], *, cwd: str | None = None) -> CmdResult:
@@ -253,6 +257,10 @@ def build_pr_body(
 """.strip() + "\n"
 
 
+def has_audit_pass_comment(comment_bodies: Sequence[str]) -> bool:
+    return any(AUDIT_PASS_COMMENT_PATTERN.search(body) for body in comment_bodies)
+
+
 def build_blocker_comment(
     *,
     kind: str,
@@ -286,6 +294,12 @@ def build_blocker_comment(
         return (
             "Auto-merge is enabled and checks are green, but the PR has not merged "
             f"after {timeout_value}s. Current status: {status_line}. PR: {pr_url}"
+        )
+    if normalized_kind == "audit-required":
+        return (
+            "Auto-merge remains disabled until the designated audit agent posts a "
+            "`FINAL-VERDICT` comment with `ACCEPT`. "
+            f"PR: {pr_url}"
         )
     raise ValueError(f"Unsupported blocker comment kind: {kind}")
 
@@ -349,11 +363,14 @@ def build_parser() -> argparse.ArgumentParser:
         default="无",
     )
 
+    audit_parser = subparsers.add_parser("audit-pass", help="Check whether audit-pass comment exists.")
+    audit_parser.add_argument("--comments-json", required=True, help="JSON array of PR comment bodies.")
+
     comment_parser = subparsers.add_parser("comment-payload", help="Build blocker comment.")
     comment_parser.add_argument(
         "--kind",
         required=True,
-        choices=["review-required", "changes-requested", "merge-conflicts", "merge-timeout"],
+        choices=["review-required", "changes-requested", "merge-conflicts", "merge-timeout", "audit-required"],
     )
     comment_parser.add_argument("--pr-url", required=True)
     comment_parser.add_argument("--merge-state", default=None)
@@ -387,6 +404,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
         }
         print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "audit-pass":
+        comments = json.loads(args.comments_json)
+        if not isinstance(comments, list) or not all(isinstance(item, str) for item in comments):
+            raise SystemExit("comments-json must be a JSON array of strings")
+        print(json.dumps({"audit_pass": has_audit_pass_comment(comments)}, ensure_ascii=False, indent=2))
         return 0
 
     if args.command == "comment-payload":

--- a/scripts/agent_pr_automerge_and_sync.sh
+++ b/scripts/agent_pr_automerge_and_sync.sh
@@ -11,11 +11,13 @@ Behavior:
   - Runs preflight: scripts/agent_pr_preflight.sh (unless --skip-preflight)
     - If preflight fails: creates/keeps PR as draft and waits by default
   - Ensures a PR exists (creates one unless --no-create)
-  - Enables auto-merge (squash), waits checks, waits merge
+  - Keeps auto-merge disabled by default; only enables it when --enable-auto-merge is passed
+  - --enable-auto-merge requires a designated audit comment with FINAL-VERDICT + ACCEPT
   - Syncs local controlplane main to origin/main (unless --no-sync)
 
 Options:
   --skip-preflight           Skip preflight entirely
+  --enable-auto-merge        Explicitly enable auto-merge after audit-pass comment is present
   --force                   Proceed even if preflight fails
   --no-wait-preflight        Fail fast if preflight fails (still creates draft PR)
   --wait-interval <seconds>  Preflight polling interval (default: 60)
@@ -30,6 +32,7 @@ PR_NUMBER=""
 NO_CREATE="false"
 NO_SYNC="false"
 SKIP_PREFLIGHT="false"
+ENABLE_AUTO_MERGE="false"
 FORCE="false"
 WAIT_PREFLIGHT="true"
 WAIT_INTERVAL_SECONDS="60"
@@ -55,7 +58,10 @@ payload = json.loads(os.environ["JSON_PAYLOAD"])
 value = payload[sys.argv[1]]
 if value is None:
     raise SystemExit(0)
-print(value, end="")
+if isinstance(value, bool):
+    print(str(value).lower(), end="")
+else:
+    print(value, end="")
 PY2
 }
 
@@ -113,6 +119,24 @@ comment_pr_with_kind() {
   payload="$("${command[@]}")"
   body="$(json_get body <<<"$payload")"
   comment_pr "$pr_number" "$body"
+}
+
+require_audit_pass_comment() {
+  local pr_number="$1"
+  local pr_url="$2"
+  local comments_json audit_payload audit_pass
+
+  comments_json="$(run_gh_with_retry gh pr view "$pr_number" --json comments --jq '.comments | map(.body // "")')"
+  audit_payload="$(python3 scripts/agent_github_delivery.py audit-pass --comments-json "$comments_json")"
+  audit_pass="$(json_get audit_pass <<<"$audit_payload")"
+
+  if [[ "$audit_pass" == "true" ]]; then
+    return 0
+  fi
+
+  echo "ERROR: PR #${pr_number} has no audit-pass comment (`FINAL-VERDICT` + `ACCEPT`); designated audit must finish before auto-merge." >&2
+  comment_pr_with_kind "$pr_number" "audit-required" "$pr_url"
+  exit 1
 }
 
 is_transient_gh_error() {
@@ -247,6 +271,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_PREFLIGHT="true"
       shift 1
       ;;
+    --enable-auto-merge)
+      ENABLE_AUTO_MERGE="true"
+      shift 1
+      ;;
     --force)
       FORCE="true"
       shift 1
@@ -369,6 +397,15 @@ if [[ $PREFLIGHT_RC -ne 0 && "$FORCE" != "true" ]]; then
     sleep "$WAIT_INTERVAL_SECONDS"
   done
 fi
+
+PR_URL="$(run_gh_with_retry gh pr view "$PR_NUMBER" --json url --jq '.url')"
+
+if [[ "$ENABLE_AUTO_MERGE" != "true" ]]; then
+  echo "INFO: PR #${PR_NUMBER} is ready. Auto-merge is disabled by default; rerun with --enable-auto-merge after the designated audit comment (`FINAL-VERDICT` + `ACCEPT`) is present." >&2
+  exit 0
+fi
+
+require_audit_pass_comment "$PR_NUMBER" "$PR_URL"
 
 IS_DRAFT="$(run_gh_with_retry gh pr view "$PR_NUMBER" --json isDraft --jq '.isDraft')"
 if [[ "$IS_DRAFT" == "true" ]]; then

--- a/scripts/agent_pr_automerge_and_sync.sh
+++ b/scripts/agent_pr_automerge_and_sync.sh
@@ -42,6 +42,79 @@ GH_RETRY_MAX_SECONDS="30"
 GH_RETRY_MAX_ATTEMPTS="5"
 GH_LAST_TRANSIENT="false"
 
+json_get() {
+  local field="$1"
+  local payload
+  payload="$(cat)"
+  JSON_PAYLOAD="$payload" python3 - "$field" <<'PY2'
+import json
+import os
+import sys
+
+payload = json.loads(os.environ["JSON_PAYLOAD"])
+value = payload[sys.argv[1]]
+if value is None:
+    raise SystemExit(0)
+print(value, end="")
+PY2
+}
+
+require_gh_channel() {
+  local capabilities_json selected_channel blocker reason
+  capabilities_json="$(python3 scripts/agent_github_delivery.py capabilities --channel "${CODEX_GITHUB_CHANNEL:-auto}")"
+  selected_channel="$(json_get selected_channel <<<"$capabilities_json")"
+  blocker="$(json_get blocker <<<"$capabilities_json" || true)"
+  reason="$(json_get reason <<<"$capabilities_json")"
+
+  if [[ "$selected_channel" == "gh" ]]; then
+    return 0
+  fi
+
+  echo "ERROR: selected GitHub delivery channel is ${selected_channel:-none}; this shell entrypoint only supports gh." >&2
+  if [[ -n "$blocker" ]]; then
+    echo "INFO: blocker=${blocker}" >&2
+  fi
+  echo "INFO: ${reason}" >&2
+  echo "HINT: if GitHub MCP is available, use scripts/agent_github_delivery.py pr-payload / comment-payload with GitHub MCP tools for PR and comment operations." >&2
+  exit 1
+}
+
+build_pr_payload() {
+  local issue_number="$1"
+  local raw_title="$2"
+  local summary="${AGENT_PR_SUMMARY:-${raw_title}}"
+  local user_impact="${AGENT_PR_USER_IMPACT:-See linked issue #${issue_number} and verification evidence for concrete impact.}"
+  local worst_case="${AGENT_PR_WORST_CASE:-The task remains blocked on manual GitHub handoff in mixed agent environments.}"
+  local rollback_ref="${AGENT_PR_ROLLBACK_REF:-git revert <merge-commit>}"
+
+  python3 scripts/agent_github_delivery.py pr-payload     --issue-number "$issue_number"     --title "$raw_title"     --summary "$summary"     --user-impact "$user_impact"     --worst-case "$worst_case"     --rollback-ref "$rollback_ref"
+}
+
+comment_pr_with_kind() {
+  local pr_number="$1"
+  local kind="$2"
+  local pr_url="$3"
+  local merge_state="${4:-}"
+  local review_decision="${5:-}"
+  local timeout_seconds="${6:-}"
+  local -a command=(python3 scripts/agent_github_delivery.py comment-payload --kind "$kind" --pr-url "$pr_url")
+  local payload body
+
+  if [[ -n "$merge_state" ]]; then
+    command+=(--merge-state "$merge_state")
+  fi
+  if [[ -n "$review_decision" ]]; then
+    command+=(--review-decision "$review_decision")
+  fi
+  if [[ -n "$timeout_seconds" ]]; then
+    command+=(--timeout-seconds "$timeout_seconds")
+  fi
+
+  payload="$("${command[@]}")"
+  body="$(json_get body <<<"$payload")"
+  comment_pr "$pr_number" "$body"
+}
+
 is_transient_gh_error() {
   local output="$1"
   grep -qiE "TLS handshake timeout|i/o timeout|connection reset by peer|context deadline exceeded|unexpected EOF|temporary failure" <<<"$output"
@@ -223,6 +296,8 @@ fi
 ISSUE_NUMBER="${BASH_REMATCH[1]}"
 SLUG="${BASH_REMATCH[2]}"
 
+require_gh_channel
+
 PREFLIGHT_RC=0
 if [[ "$SKIP_PREFLIGHT" != "true" ]]; then
   set +e
@@ -242,19 +317,9 @@ if [[ -z "$PR_NUMBER" ]]; then
   fi
 
   TITLE="$(git log -1 --pretty=%s)"
-  BODY=$(
-    cat <<EOF
-Closes #${ISSUE_NUMBER}
-
-## Summary
-- (fill)
-
-## Test plan
-- \`pnpm typecheck\`
-- \`pnpm lint\`
-- \`pnpm test:unit\`
-EOF
-  )
+  PR_PAYLOAD="$(build_pr_payload "$ISSUE_NUMBER" "$TITLE")"
+  TITLE="$(json_get title <<<"$PR_PAYLOAD")"
+  BODY="$(json_get body <<<"$PR_PAYLOAD")"
 
   DRAFT_FLAG=""
   if [[ $PREFLIGHT_RC -ne 0 && "$FORCE" != "true" ]]; then
@@ -344,13 +409,13 @@ while true; do
 
   if [[ "$REVIEW_DECISION" == "REVIEW_REQUIRED" ]]; then
     echo "ERROR: PR #${PR_NUMBER} is blocked by review requirement; independent review must be completed before merge." >&2
-    comment_pr "$PR_NUMBER" "PR is blocked by \`reviewDecision=REVIEW_REQUIRED\`. Complete independent review before merge. PR: ${PR_URL}"
+    comment_pr_with_kind "$PR_NUMBER" "review-required" "$PR_URL"
     exit 1
   fi
 
   if [[ "$REVIEW_DECISION" == "CHANGES_REQUESTED" ]]; then
     echo "ERROR: PR #${PR_NUMBER} has changes requested; resolve the review feedback before merging." >&2
-    comment_pr "$PR_NUMBER" "PR is blocked by \`reviewDecision=CHANGES_REQUESTED\`; cannot auto-merge. PR: ${PR_URL}"
+    comment_pr_with_kind "$PR_NUMBER" "changes-requested" "$PR_URL"
     exit 1
   fi
 
@@ -364,7 +429,7 @@ while true; do
 
   if [[ "$MERGE_STATE" == "DIRTY" ]]; then
     echo "ERROR: PR #${PR_NUMBER} has merge conflicts; resolve conflicts then rerun checks." >&2
-    comment_pr "$PR_NUMBER" "PR is blocked by merge conflicts (\`mergeStateStatus=DIRTY\`). Manual conflict resolution is required. PR: ${PR_URL}"
+    comment_pr_with_kind "$PR_NUMBER" "merge-conflicts" "$PR_URL" "$MERGE_STATE"
     exit 1
   fi
 
@@ -372,7 +437,7 @@ while true; do
     NOW_TS="$(date +%s)"
     if (( NOW_TS - START_MERGE_TS >= MERGE_TIMEOUT_SECONDS )); then
       echo "ERROR: PR still not merged after ${MERGE_TIMEOUT_SECONDS}s: #${PR_NUMBER}" >&2
-      comment_pr "$PR_NUMBER" "Auto-merge is enabled and checks are green, but the PR has not merged after ${MERGE_TIMEOUT_SECONDS}s. Current status: ${STATUS_LINE}. PR: ${PR_URL}"
+      comment_pr_with_kind "$PR_NUMBER" "merge-timeout" "$PR_URL" "$MERGE_STATE" "$REVIEW_DECISION" "$MERGE_TIMEOUT_SECONDS"
       exit 1
     fi
   fi

--- a/scripts/agent_pr_preflight.py
+++ b/scripts/agent_pr_preflight.py
@@ -64,7 +64,13 @@ def current_branch(repo_root: str) -> str:
 
 
 def run_gh_json(repo: str, cmd: list[str], *, error_hint: str) -> object:
-    result = run(cmd, cwd=repo)
+    try:
+        result = run(cmd, cwd=repo)
+    except FileNotFoundError as exc:
+        missing_bin = cmd[0] if cmd else "command"
+        raise RuntimeError(
+            f"{error_hint}; GitHub CLI `{missing_bin}` is unavailable. If GitHub MCP is available in this session, switch to the MCP fallback for remote Issue/PR checks."
+        ) from exc
     print_command_and_output(cmd, result)
     if result.code != 0:
         raise RuntimeError(error_hint)

--- a/scripts/cc_codex_controller_prompt.md
+++ b/scripts/cc_codex_controller_prompt.md
@@ -11,7 +11,7 @@ Delegate all implementation to Codex via `scripts/cc_codex_worker.py`.
 python3 scripts/agent_github_delivery.py capabilities
 ```
 
-- If `selected_channel=gh`, continue using the local `gh`-based delivery scripts.
+- If `selected_channel=gh`, continue using the local `gh`-based delivery scripts, but keep auto-merge off by default; only pass `--enable-auto-merge` after the designated audit agent has posted a `FINAL-VERDICT` comment with `ACCEPT`.
 - If `selected_channel=mcp`, use GitHub MCP tools for remote Issue / PR / comment operations, and reuse `scripts/agent_github_delivery.py pr-payload` / `comment-payload` so the content matches the repository contract.
 - If `selected_channel=none`, stop and report the missing capability (`missing_tool` / `missing_auth` / `missing_permission`) instead of asking the human to infer it.
 

--- a/scripts/cc_codex_controller_prompt.md
+++ b/scripts/cc_codex_controller_prompt.md
@@ -5,6 +5,16 @@ Delegate all implementation to Codex via `scripts/cc_codex_worker.py`.
 
 ## Workflow
 
+0. Before any GitHub delivery action, detect the available control plane:
+
+```bash
+python3 scripts/agent_github_delivery.py capabilities
+```
+
+- If `selected_channel=gh`, continue using the local `gh`-based delivery scripts.
+- If `selected_channel=mcp`, use GitHub MCP tools for remote Issue / PR / comment operations, and reuse `scripts/agent_github_delivery.py pr-payload` / `comment-payload` so the content matches the repository contract.
+- If `selected_channel=none`, stop and report the missing capability (`missing_tool` / `missing_auth` / `missing_permission`) instead of asking the human to infer it.
+
 1. Convert the user request into two files:
 - `./.agent-bus/input/task.md`
 - `./.agent-bus/input/acceptance.md`

--- a/scripts/tests/test_agent_github_delivery.py
+++ b/scripts/tests/test_agent_github_delivery.py
@@ -77,5 +77,33 @@ class CommentTemplateTests(unittest.TestCase):
         self.assertIn("https://github.com/Leeky1017/CreoNow/pull/1006", body)
 
 
+class AuditGateTests(unittest.TestCase):
+    def test_has_audit_pass_comment_should_require_final_verdict_accept(self) -> None:
+        self.assertTrue(
+            agent_github_delivery.has_audit_pass_comment(
+                [
+                    "## FINAL-VERDICT：Issue #1005\n\n### 最终判定：ACCEPT",
+                ]
+            )
+        )
+        self.assertFalse(
+            agent_github_delivery.has_audit_pass_comment(
+                [
+                    "## PRE-AUDIT：Issue #1005\n\n### 初始阻断结论：REJECT",
+                    "## FINAL-VERDICT：Issue #1005\n\n### 最终判定：REJECT",
+                ]
+            )
+        )
+
+    def test_build_blocker_comment_should_explain_audit_requirement(self) -> None:
+        body = agent_github_delivery.build_blocker_comment(
+            kind="audit-required",
+            pr_url="https://github.com/Leeky1017/CreoNow/pull/1006",
+        )
+        self.assertIn("FINAL-VERDICT", body)
+        self.assertIn("ACCEPT", body)
+        self.assertIn("https://github.com/Leeky1017/CreoNow/pull/1006", body)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_agent_github_delivery.py
+++ b/scripts/tests/test_agent_github_delivery.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import agent_github_delivery  # noqa: E402
+
+
+class ChannelSelectionTests(unittest.TestCase):
+    def test_select_channel_should_prefer_gh_when_cli_is_ready(self) -> None:
+        capabilities = agent_github_delivery.select_channel(
+            override="auto",
+            gh_installed=True,
+            gh_authenticated=True,
+            mcp_available=True,
+            mcp_write_capable=True,
+        )
+        self.assertEqual("gh", capabilities.selected_channel)
+        self.assertIsNone(capabilities.blocker)
+
+    def test_select_channel_should_fallback_to_mcp_when_gh_missing(self) -> None:
+        capabilities = agent_github_delivery.select_channel(
+            override="auto",
+            gh_installed=False,
+            gh_authenticated=False,
+            mcp_available=True,
+            mcp_write_capable=True,
+        )
+        self.assertEqual("mcp", capabilities.selected_channel)
+        self.assertIsNone(capabilities.blocker)
+
+    def test_select_channel_should_report_missing_auth_when_no_fallback_exists(self) -> None:
+        capabilities = agent_github_delivery.select_channel(
+            override="auto",
+            gh_installed=True,
+            gh_authenticated=False,
+            mcp_available=False,
+            mcp_write_capable=False,
+        )
+        self.assertEqual("none", capabilities.selected_channel)
+        self.assertEqual("missing_auth", capabilities.blocker)
+
+
+class PullRequestTemplateTests(unittest.TestCase):
+    def test_build_pr_title_should_append_issue_suffix_once(self) -> None:
+        self.assertEqual(
+            "Unify delivery control plane (#1005)",
+            agent_github_delivery.build_pr_title("Unify delivery control plane", "1005"),
+        )
+        self.assertEqual(
+            "Unify delivery control plane (#1005)",
+            agent_github_delivery.build_pr_title("Unify delivery control plane (#1005)", "1005"),
+        )
+
+    def test_build_pr_body_should_follow_repository_contract(self) -> None:
+        body = agent_github_delivery.build_pr_body(
+            issue_number="1005",
+            summary="统一 Agent 的 GitHub 交付控制面。",
+            user_impact="Agent 可自行完成 PR 与评论收口。",
+            worst_case="不同环境下继续出现 PR 交付半途而废。",
+            verification_commands=["pytest -q scripts/tests/test_agent_github_delivery.py"],
+            rollback_ref="git revert HEAD",
+        )
+        self.assertIn("Skip-Reason: N/A (task branch)", body)
+        self.assertIn("Closes #1005", body)
+        self.assertIn("## 验证证据", body)
+        self.assertIn("`pytest -q scripts/tests/test_agent_github_delivery.py`", body)
+
+
+class CommentTemplateTests(unittest.TestCase):
+    def test_build_blocker_comment_should_include_status_and_pr_url(self) -> None:
+        body = agent_github_delivery.build_blocker_comment(
+            kind="review-required",
+            pr_url="https://github.com/Leeky1017/CreoNow/pull/1006",
+        )
+        self.assertIn("reviewDecision=REVIEW_REQUIRED", body)
+        self.assertIn("https://github.com/Leeky1017/CreoNow/pull/1006", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_agent_pr_preflight.py
+++ b/scripts/tests/test_agent_pr_preflight.py
@@ -80,6 +80,15 @@ class IssueStateTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, r"\[ISSUE\].*CLOSED.*expected OPEN"):
                 agent_pr_preflight.validate_issue_is_open("/tmp/repo", "42")
 
+    def test_validate_issue_is_open_should_fail_with_fallback_hint_when_gh_missing(self) -> None:
+        with mock.patch.object(
+            agent_pr_preflight,
+            "run",
+            side_effect=FileNotFoundError("gh"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, r"GitHub CLI `gh` is unavailable.*GitHub MCP"):
+                agent_pr_preflight.validate_issue_is_open("/tmp/repo", "99")
+
     def test_validate_issue_is_open_should_fail_when_gh_errors(self) -> None:
         with mock.patch.object(
             agent_pr_preflight,

--- a/scripts/tests/test_vscode_agent_guidance.py
+++ b/scripts/tests/test_vscode_agent_guidance.py
@@ -1,0 +1,67 @@
+import json
+import subprocess
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class VsCodeAgentGuidanceTests(unittest.TestCase):
+    def test_workspace_settings_should_enable_instruction_loading(self) -> None:
+        settings_path = REPO_ROOT / ".vscode" / "settings.json"
+        self.assertTrue(settings_path.exists(), ".vscode/settings.json must exist")
+
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertTrue(settings.get("chat.useAgentsMdFile"))
+        self.assertTrue(settings.get("chat.includeApplyingInstructions"))
+        self.assertTrue(settings.get("chat.includeReferencedInstructions"))
+        self.assertIn(
+            ".github/instructions",
+            settings.get("chat.instructionsFilesLocations", []),
+        )
+
+
+    def test_workspace_settings_should_not_be_gitignored(self) -> None:
+        proc = subprocess.run(
+            ["git", "check-ignore", ".vscode/settings.json"],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertNotEqual(0, proc.returncode, ".vscode/settings.json must be committable")
+
+    def test_repo_wide_copilot_instructions_should_cover_github_delivery(self) -> None:
+        path = REPO_ROOT / ".github" / "copilot-instructions.md"
+        self.assertTrue(path.exists(), ".github/copilot-instructions.md must exist")
+        text = path.read_text(encoding="utf-8")
+        self.assertIn("python3 scripts/agent_github_delivery.py capabilities", text)
+        self.assertIn("FINAL-VERDICT", text)
+        self.assertIn("--enable-auto-merge", text)
+        self.assertIn("missing_tool / missing_auth / missing_permission", text)
+
+    def test_delivery_prompt_should_exist_for_vscode_agent_mode(self) -> None:
+        path = REPO_ROOT / ".github" / "prompts" / "creonow-delivery.prompt.md"
+        self.assertTrue(path.exists(), ".github/prompts/creonow-delivery.prompt.md must exist")
+        text = path.read_text(encoding="utf-8")
+        self.assertIn("scripts/agent_worktree_setup.sh", text)
+        self.assertIn("scripts/agent_pr_preflight.sh", text)
+        self.assertIn("scripts/agent_github_delivery.py pr-payload", text)
+        self.assertIn("FINAL-VERDICT", text)
+
+    def test_agents_and_claude_should_match_audit_first_policy(self) -> None:
+        expected_phrases = (
+            "auto-merge 默认关闭",
+            "FINAL-VERDICT",
+            "ACCEPT",
+        )
+        for relative_path in ("AGENTS.md", "CLAUDE.md"):
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            for phrase in expected_phrases:
+                with self.subTest(path=relative_path, phrase=phrase):
+                    self.assertIn(phrase, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题
- 引入 `scripts/agent_github_delivery.py`，统一 GitHub 能力探测、PR/评论模板与审计通过检测
- `agent_pr_preflight.py` 在 `gh` 缺失时给出 GitHub MCP fallback 提示
- `agent_pr_automerge_and_sync.sh` 改为默认只创建 / 更新 PR；只有在审计通过后显式传入 `--enable-auto-merge` 才会继续
- 同步更新 `AGENTS.md` / `CLAUDE.md` / delivery/toolchain/scripts 文档契约
- 新增 VS Code / Copilot 的 repo-wide instructions、file-based instructions、prompt file、custom delivery agent 与共享 workspace settings

## 关联 Issue
- Closes #1005

## 用户影响
- Agent 能先判断 `gh` / GitHub MCP 能力，再决定如何发 PR / 评论；VS Code 里的 Agent 也会自动加载仓库交付规则，不再只会模糊地说“没有 gh 上下文”或把最后一步甩回给用户

## 不修最坏后果
- 混合运行环境中的 Agent 仍会在 GitHub 交付链路半途停住；VS Code Agent 继续因规则漂移与指令入口缺失而在工具调用上显得呆板

## 验证证据
- [x] `pytest -q scripts/tests`
- [x] `bash -n scripts/agent_pr_automerge_and_sync.sh`
- [x] `python3 -m py_compile scripts/agent_github_delivery.py scripts/agent_pr_preflight.py scripts/check_doc_timestamps.py scripts/cc_codex_worker.py`
- [x] `python3 scripts/check_doc_timestamps.py`
- [x] `CODEX_GITHUB_MCP_AVAILABLE=1 CODEX_GITHUB_MCP_WRITE_CAPABLE=1 scripts/agent_pr_automerge_and_sync.sh --no-create --skip-preflight`
- [x] `python3 scripts/agent_github_delivery.py audit-pass --comments-json '["## FINAL-VERDICT：Issue #1005\n\n### 最终判定：ACCEPT"]'`
- [x] `pytest -q scripts/tests/test_vscode_agent_guidance.py scripts/tests/test_agent_github_delivery.py scripts/tests/test_agent_pr_preflight.py`
- 其他补充验证：
  - `python3 scripts/agent_github_delivery.py capabilities`
  - `python3 scripts/agent_github_delivery.py pr-payload --issue-number 1005 ...`

## 回滚点
- 回滚 commit/分支：`230147c3` / `task/1005-agent-github-delivery-control-plane`
- 回滚后需要恢复的数据或配置：若回滚 `.vscode/settings.json` 与 `.github/copilot-instructions.md`，VS Code / Copilot Agent 将失去仓库级交付引导

## 审计门禁
- [x] 指定审计 Agent 已发布 `FINAL-VERDICT` 评论
- [x] `FINAL-VERDICT` 的最终判定为 `ACCEPT`