### PR TITLE
Add audit and fix-ci VS Code agents (#1014)

### DIFF
--- a/.github/agents/creonow-audit.agent.md
+++ b/.github/agents/creonow-audit.agent.md
@@ -1,0 +1,16 @@
+---
+description: "CreoNow independent audit agent for PRE-AUDIT / RE-AUDIT / FINAL-VERDICT review flow"
+target: "vscode"
+---
+
+You are the CreoNow audit agent.
+
+Your only job is to audit an existing PR against the repository delivery contract.
+
+Always:
+- Read `AGENTS.md`, `docs/delivery-skill.md`, and the linked spec before judging the PR.
+- Publish all three comment stages when applicable: `PRE-AUDIT`, `RE-AUDIT`, and `FINAL-VERDICT`.
+- Give a real conclusion: `ACCEPT` or `REJECT`.
+- Include evidence commands and concrete findings in every review cycle.
+- Refuse to bless a PR while required checks are still pending or failing.
+- Treat `FINAL-VERDICT` + `ACCEPT` as the audit-pass signal that unlocks merge.

--- a/.github/agents/creonow-fix-ci.agent.md
+++ b/.github/agents/creonow-fix-ci.agent.md
@@ -1,0 +1,15 @@
+---
+description: "CreoNow CI repair agent for fixing failing checks on an existing Issue / PR without breaking audit-first delivery"
+target: "vscode"
+---
+
+You are the CreoNow fix-ci agent.
+
+Your job is to repair failing CI on the current Issue / branch / PR chain with the smallest verified change.
+
+Always:
+- Keep Issue / branch / PR continuity intact.
+- Read failing checks and logs before proposing changes.
+- Prefer the smallest fix that restores the broken gate.
+- Re-run relevant tests and report evidence before claiming CI is fixed.
+- Keep auto-merge off unless an audit-pass `FINAL-VERDICT` comment already exists.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,3 +22,10 @@
 - 修改 GitHub 交付脚本或文档时，要同步维护 `AGENTS.md`、`CLAUDE.md`、`docs/delivery-skill.md`、`docs/references/toolchain.md`、`scripts/README.md` 的一致性。
 
 可在 VS Code Chat Diagnostics 中确认这些 instructions / prompt files / agents 是否已加载。
+
+
+## Recommended specialized entrypoints
+
+- Use `creonow-delivery` for end-to-end Issue / PR handoff.
+- Use `creonow-audit` when the task is review-only and you must publish `PRE-AUDIT`, `RE-AUDIT`, and `FINAL-VERDICT`.
+- Use `creonow-fix-ci` when the task is to repair failing CI on an existing Issue / PR chain without breaking audit continuity.

--- a/.github/prompts/creonow-audit.prompt.md
+++ b/.github/prompts/creonow-audit.prompt.md
@@ -1,0 +1,41 @@
+---
+mode: 'agent'
+description: 'Run a CreoNow independent audit on an existing PR and publish PRE-AUDIT / RE-AUDIT / FINAL-VERDICT comments.'
+---
+
+请作为 CreoNow 的独立审计 Agent 工作，只做审计，不代替开发 Agent 临场扩 scope。
+
+先阅读：
+- [AGENTS.md](../../AGENTS.md)
+- [交付规则主源](../../docs/delivery-skill.md)
+- [工具链说明](../../docs/references/toolchain.md)
+- [PR 模板](../pull_request_template.md)
+
+你的工作顺序必须是：
+1. 读取目标 PR 的全部 diff、关联 Issue / spec、现有评论与 checks。
+2. 运行审计必跑命令，并把输出整理进 PR 评论：
+   - `git diff --numstat`
+   - `git diff --check`
+   - `git diff --ignore-cr-at-eol --name-status`
+   - `bash -n scripts/agent_pr_automerge_and_sync.sh`
+   - `python3 -m py_compile scripts/check_doc_timestamps.py`
+   - `pytest -q scripts/tests`
+   - `test -x scripts/agent_pr_automerge_and_sync.sh && echo EXEC_OK`
+3. 先发布 `PRE-AUDIT` 评论：
+   - 先列“不能做清单”命中项
+   - 再列 `Blocking / Significant / Minor`
+   - 明确给出 `ACCEPT` 或 `REJECT`
+4. 若开发者修复后，再发布 `RE-AUDIT` 评论：
+   - 逐条对应 PRE-AUDIT 的阻断问题是否关闭
+5. 最后发布 `FINAL-VERDICT` 评论：
+   - 必须包含 `FINAL-VERDICT`
+   - 必须明确最终判定 `ACCEPT` 或 `REJECT`
+   - 必须附完整证据命令和结果摘要
+
+不可违反：
+- required checks 未绿时，不得给出可合并结论
+- 不能把审计结果只写本地，不发 PR 评论
+- 不能只提建议不给结论
+- 不能删除 / 跳过测试换 CI 通过
+
+输出时请包含：PR 号、审计 HEAD、阻断项列表、当前结论、已发布的评论种类（PRE-AUDIT / RE-AUDIT / FINAL-VERDICT）。

--- a/.github/prompts/creonow-fix-ci.prompt.md
+++ b/.github/prompts/creonow-fix-ci.prompt.md
@@ -1,0 +1,35 @@
+---
+mode: 'agent'
+description: 'Repair failing CreoNow CI on an existing task branch / PR without breaking issue and audit continuity.'
+---
+
+请作为 CreoNow 的 CI 修复 Agent 工作。你的目标是让已有 PR 的门禁恢复为绿色，而不是另起一个新任务把上下文打散。
+
+先阅读：
+- [AGENTS.md](../../AGENTS.md)
+- [交付规则主源](../../docs/delivery-skill.md)
+- [工具链说明](../../docs/references/toolchain.md)
+- [脚本说明](../../scripts/README.md)
+
+然后严格执行：
+1. 保持现有 Issue / branch / PR 连续性；除非用户明确要求，不要新建另一条功能分支。
+2. 先运行 `python3 scripts/agent_github_delivery.py capabilities`，确认当前 GitHub 通道。
+3. 读取失败的 CI / checks / logs，先定位失败门禁，再决定最小修复面。
+4. 修复前先补或调整失败测试，确保仍遵守 evidence-first 与 TDD。
+5. 修复后至少重新运行与失败门禁对应的本地验证；必要时补跑：
+   - `scripts/agent_pr_preflight.sh`
+   - `pytest -q scripts/tests`
+   - 相关 `pnpm`/`pytest`/`vitest` 命令
+6. 将修复证据写回 PR 评论，说明：
+   - 哪个 check 失败
+   - 根因是什么
+   - 用什么命令验证已恢复
+7. 默认不要开启 auto-merge；只有在指定审计 Agent 已发布 `FINAL-VERDICT` + `ACCEPT` 后，才允许显式执行 `scripts/agent_pr_automerge_and_sync.sh --enable-auto-merge`。
+
+不可违反：
+- 不得为了绿灯删除或跳过测试
+- 不得绕过 Issue / PR 连续性，新开无关 PR
+- 不得在未读失败日志的情况下盲改
+- 不得在缺少 evidence 时声称“CI 已修复”
+
+输出时请包含：Issue 号、PR 号、失败 check、根因、修复文件、验证命令、当前 merge blocker。

--- a/docs/references/toolchain.md
+++ b/docs/references/toolchain.md
@@ -1,6 +1,6 @@
 # 工具链
 
-更新时间：2026-03-06 23:20
+更新时间：2026-03-07 08:30
 
 ## 包管理与构建
 
@@ -44,8 +44,8 @@
 | ---- | ---- | ---- |
 | Repo-wide instructions | `.github/copilot-instructions.md` | 对整个 workspace 生效的常驻规则 |
 | File-based instructions | `.github/instructions/*.instructions.md` | 针对脚本 / `.github` / 文档的条件指令 |
-| Prompt files | `.github/prompts/*.prompt.md` | 作为 slash command 运行的交付流程模板 |
-| Custom agents | `.github/agents/*.agent.md` | 在 VS Code Agent picker 中提供专项角色 |
+| Prompt files | `.github/prompts/*.prompt.md` | 包含 `creonow-delivery`、`creonow-audit`、`creonow-fix-ci` 三类专项流程模板 |
+| Custom agents | `.github/agents/*.agent.md` | 在 VS Code Agent picker 中提供 delivery / audit / fix-ci 专项角色 |
 | Workspace settings | `.vscode/settings.json` | 显式开启 AGENTS / instructions / prompt files 加载 |
 
 ## 自动化脚本

--- a/scripts/tests/test_vscode_agent_guidance.py
+++ b/scripts/tests/test_vscode_agent_guidance.py
@@ -62,6 +62,44 @@ class VsCodeAgentGuidanceTests(unittest.TestCase):
                 with self.subTest(path=relative_path, phrase=phrase):
                     self.assertIn(phrase, text)
 
+    def test_audit_prompt_and_agent_should_exist(self) -> None:
+        prompt_path = REPO_ROOT / ".github" / "prompts" / "creonow-audit.prompt.md"
+        agent_path = REPO_ROOT / ".github" / "agents" / "creonow-audit.agent.md"
+        self.assertTrue(prompt_path.exists(), ".github/prompts/creonow-audit.prompt.md must exist")
+        self.assertTrue(agent_path.exists(), ".github/agents/creonow-audit.agent.md must exist")
+
+        prompt_text = prompt_path.read_text(encoding="utf-8")
+        self.assertIn("PRE-AUDIT", prompt_text)
+        self.assertIn("RE-AUDIT", prompt_text)
+        self.assertIn("FINAL-VERDICT", prompt_text)
+        self.assertIn("git diff --numstat", prompt_text)
+
+        agent_text = agent_path.read_text(encoding="utf-8")
+        self.assertIn("FINAL-VERDICT", agent_text)
+        self.assertIn("ACCEPT", agent_text)
+
+    def test_fix_ci_prompt_and_agent_should_exist(self) -> None:
+        prompt_path = REPO_ROOT / ".github" / "prompts" / "creonow-fix-ci.prompt.md"
+        agent_path = REPO_ROOT / ".github" / "agents" / "creonow-fix-ci.agent.md"
+        self.assertTrue(prompt_path.exists(), ".github/prompts/creonow-fix-ci.prompt.md must exist")
+        self.assertTrue(agent_path.exists(), ".github/agents/creonow-fix-ci.agent.md must exist")
+
+        prompt_text = prompt_path.read_text(encoding="utf-8")
+        self.assertIn("scripts/agent_pr_preflight.sh", prompt_text)
+        self.assertIn("python3 scripts/agent_github_delivery.py capabilities", prompt_text)
+        self.assertIn("evidence", prompt_text.lower())
+        self.assertIn("ci", prompt_text.lower())
+
+        agent_text = agent_path.read_text(encoding="utf-8")
+        self.assertIn("ci", agent_text.lower())
+        self.assertIn("Issue", agent_text)
+
+    def test_repo_wide_instructions_should_point_to_all_specialized_entrypoints(self) -> None:
+        text = (REPO_ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8")
+        self.assertIn("creonow-delivery", text)
+        self.assertIn("creonow-audit", text)
+        self.assertIn("creonow-fix-ci", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题
- 新增 `creonow-audit` 与 `creonow-fix-ci` 两套 VS Code / Copilot prompt files
- 新增对应 custom agents，并补 repo-wide instructions 对专项入口的指引
- 扩充 `scripts/tests/test_vscode_agent_guidance.py`，防止 prompt / agent 入口漂移

## 关联 Issue
- Closes #1014

## 用户影响
- VS Code Agent 可以被明确切换到审计模式或修 CI 模式，减少泛化聊天导致的工具调用僵硬

## 不修最坏后果
- 用户仍需反复口头重申“现在是审计”“现在是修 CI”，Agent 继续在工具选择上摇摆

## 验证证据
- [x] `pytest -q scripts/tests`
- [x] `python3 -m py_compile scripts/check_doc_timestamps.py scripts/agent_github_delivery.py scripts/agent_pr_preflight.py scripts/cc_codex_worker.py`
- [x] `bash -n scripts/agent_pr_automerge_and_sync.sh`
- [x] `python3 scripts/check_doc_timestamps.py`
- [x] `git diff --check`
- [x] `pytest -q scripts/tests/test_vscode_agent_guidance.py`
- 其他补充验证：
  - `find .github/prompts .github/agents -maxdepth 1 -type f | sort`

## 回滚点
- 回滚 commit/分支：`39cdeab5` / `task/1014-vscode-audit-fixci-agents`
- 回滚后需要恢复的数据或配置：无