### PR TITLE
Migrate weak testing samples and register testing-governance change (#1021)

### DIFF
--- a/apps/desktop/renderer/src/features/onboarding/OnboardingPage.test.tsx
+++ b/apps/desktop/renderer/src/features/onboarding/OnboardingPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../i18n/languagePreference", () => ({
   getLanguagePreference: vi.fn(() => "zh-CN"),
@@ -15,28 +16,44 @@ vi.mock("../../lib/ipcClient", () => ({
 }));
 
 import { OnboardingPage } from "./OnboardingPage";
+import { setLanguagePreference } from "../../i18n/languagePreference";
+import { i18n } from "../../i18n";
 
 describe("OnboardingPage", () => {
-  it("renders the onboarding page with logo and title", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the onboarding shell and starts on step 1", () => {
     const onComplete = vi.fn();
     render(<OnboardingPage onComplete={onComplete} />);
 
     expect(screen.getByTestId("onboarding-page")).toBeInTheDocument();
     expect(screen.getByTestId("onboarding-logo")).toBeInTheDocument();
-    expect(screen.getByText("Welcome to CreoNow")).toBeInTheDocument();
-  });
-
-  it("starts on step 1 by default", () => {
-    const onComplete = vi.fn();
-    render(<OnboardingPage onComplete={onComplete} />);
-
     expect(screen.getByTestId("onboarding-step-1")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-next")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-step-indicator")).toBeInTheDocument();
   });
 
-  it("renders step indicator", () => {
+  it("persists language selection when a language option is clicked", async () => {
+    const user = userEvent.setup();
     const onComplete = vi.fn();
     render(<OnboardingPage onComplete={onComplete} />);
 
-    expect(screen.getByTestId("onboarding-step-indicator")).toBeInTheDocument();
+    await user.click(screen.getByTestId("onboarding-lang-en"));
+
+    expect(setLanguagePreference).toHaveBeenCalledWith("en");
+    expect(i18n.changeLanguage).toHaveBeenCalledWith("en");
+  });
+
+  it("advances from step 1 to step 2 when next is clicked", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<OnboardingPage onComplete={onComplete} />);
+
+    await user.click(screen.getByTestId("onboarding-next"));
+
+    expect(screen.getByTestId("onboarding-step-2")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-ai-skip")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/tests/unit/document-ipc-contract.test.ts
+++ b/apps/desktop/tests/unit/document-ipc-contract.test.ts
@@ -1,9 +1,10 @@
-import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
 
 import { ipcContract } from "../../main/src/ipc/contract/ipc-contract";
 
 type IpcChannelMap = Record<string, unknown>;
 type ObjectSchema = { kind: "object"; fields: Record<string, unknown> };
+type ContractChannel = { request: unknown; response: unknown };
 
 function asObjectSchema(value: unknown): ObjectSchema {
   if (
@@ -16,309 +17,156 @@ function asObjectSchema(value: unknown): ObjectSchema {
   return value as ObjectSchema;
 }
 
-/**
- * S1: CRUD IPC channels match P0 baseline naming and remove legacy aliases.
- */
-{
-  const channels = Object.keys(ipcContract.channels as IpcChannelMap);
-  const required = [
-    "file:document:create",
-    "file:document:read",
-    "file:document:update",
-    "file:document:save",
-    "file:document:delete",
-    "file:document:list",
-    "file:document:getcurrent",
-    "file:document:reorder",
-    "file:document:updatestatus",
-    "version:snapshot:create",
-    "version:snapshot:list",
-    "version:snapshot:read",
-    "version:snapshot:diff",
-    "version:snapshot:rollback",
-    "version:branch:create",
-    "version:branch:list",
-    "version:branch:switch",
-    "version:branch:merge",
-    "version:conflict:resolve",
-  ] as const;
-  const legacy = ["file:document:rename", "file:document:write"] as const;
+const channels = ipcContract.channels as unknown as Record<
+  string,
+  ContractChannel
+>;
+const errorCodes = ipcContract.errorCodes as readonly string[];
 
-  for (const channel of required) {
-    assert.equal(
-      channels.includes(channel),
-      true,
-      `missing required channel: ${channel}`,
+function hasField(schema: ObjectSchema, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(schema.fields, field);
+}
+
+describe("document IPC contract", () => {
+  it("should keep required CRUD and version channels while removing legacy aliases", () => {
+    const channelNames = Object.keys(ipcContract.channels as IpcChannelMap);
+    const required = [
+      "file:document:create",
+      "file:document:read",
+      "file:document:update",
+      "file:document:save",
+      "file:document:delete",
+      "file:document:list",
+      "file:document:getcurrent",
+      "file:document:reorder",
+      "file:document:updatestatus",
+      "version:snapshot:create",
+      "version:snapshot:list",
+      "version:snapshot:read",
+      "version:snapshot:diff",
+      "version:snapshot:rollback",
+      "version:branch:create",
+      "version:branch:list",
+      "version:branch:switch",
+      "version:branch:merge",
+      "version:conflict:resolve",
+    ] as const;
+    const legacy = ["file:document:rename", "file:document:write"] as const;
+
+    for (const channel of required) {
+      expect(channelNames.includes(channel)).toBe(true);
+    }
+
+    for (const channel of legacy) {
+      expect(channelNames.includes(channel)).toBe(false);
+    }
+  });
+
+  it("should expose hardening error codes", () => {
+    const required = [
+      "VERSION_SNAPSHOT_COMPACTED",
+      "VERSION_DIFF_PAYLOAD_TOO_LARGE",
+      "VERSION_ROLLBACK_CONFLICT",
+    ] as const;
+
+    for (const code of required) {
+      expect(errorCodes.includes(code)).toBe(true);
+    }
+  });
+
+  it("should expose branch merge and conflict request core fields", () => {
+    const createReq = asObjectSchema(
+      channels["version:branch:create"]?.request,
     );
-  }
+    expect(hasField(createReq, "documentId")).toBe(true);
+    expect(hasField(createReq, "name")).toBe(true);
 
-  for (const channel of legacy) {
-    assert.equal(
-      channels.includes(channel),
-      false,
-      `legacy channel should be removed: ${channel}`,
+    const listReq = asObjectSchema(channels["version:branch:list"]?.request);
+    expect(hasField(listReq, "documentId")).toBe(true);
+
+    const switchReq = asObjectSchema(
+      channels["version:branch:switch"]?.request,
     );
-  }
-}
+    expect(hasField(switchReq, "documentId")).toBe(true);
+    expect(hasField(switchReq, "name")).toBe(true);
 
-/**
- * P4 contract: hardening error codes must be present.
- */
-{
-  const errorCodes = ipcContract.errorCodes as readonly string[];
-  const required = [
-    "VERSION_SNAPSHOT_COMPACTED",
-    "VERSION_DIFF_PAYLOAD_TOO_LARGE",
-    "VERSION_ROLLBACK_CONFLICT",
-  ] as const;
-  for (const code of required) {
-    assert.equal(
-      errorCodes.includes(code),
-      true,
-      `missing hardening error code: ${code}`,
+    const mergeReq = asObjectSchema(channels["version:branch:merge"]?.request);
+    expect(hasField(mergeReq, "documentId")).toBe(true);
+    expect(hasField(mergeReq, "sourceBranchName")).toBe(true);
+    expect(hasField(mergeReq, "targetBranchName")).toBe(true);
+
+    const resolveReq = asObjectSchema(
+      channels["version:conflict:resolve"]?.request,
     );
-  }
-}
+    expect(hasField(resolveReq, "documentId")).toBe(true);
+    expect(hasField(resolveReq, "mergeSessionId")).toBe(true);
+    expect(hasField(resolveReq, "resolutions")).toBe(true);
+  });
 
-/**
- * P3 contract: branch merge/conflict channels must exist with core fields.
- */
-{
-  const channels = ipcContract.channels as unknown as Record<
-    string,
-    { request: unknown; response: unknown }
-  >;
+  it("should expose snapshot diff and rollback schemas", () => {
+    const diffReq = asObjectSchema(channels["version:snapshot:diff"]?.request);
+    expect(hasField(diffReq, "documentId")).toBe(true);
+    expect(hasField(diffReq, "baseVersionId")).toBe(true);
 
-  const createReq = asObjectSchema(channels["version:branch:create"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "documentId"),
-    true,
-    "version:branch:create request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "name"),
-    true,
-    "version:branch:create request should include name",
-  );
+    const diffRes = asObjectSchema(channels["version:snapshot:diff"]?.response);
+    expect(hasField(diffRes, "diffText")).toBe(true);
+    expect(hasField(diffRes, "hasDifferences")).toBe(true);
+    expect(hasField(diffRes, "stats")).toBe(true);
 
-  const listReq = asObjectSchema(channels["version:branch:list"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(listReq.fields, "documentId"),
-    true,
-    "version:branch:list request should include documentId",
-  );
+    const rollbackReq = asObjectSchema(
+      channels["version:snapshot:rollback"]?.request,
+    );
+    expect(hasField(rollbackReq, "documentId")).toBe(true);
+    expect(hasField(rollbackReq, "versionId")).toBe(true);
 
-  const switchReq = asObjectSchema(channels["version:branch:switch"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(switchReq.fields, "documentId"),
-    true,
-    "version:branch:switch request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(switchReq.fields, "name"),
-    true,
-    "version:branch:switch request should include name",
-  );
+    const rollbackRes = asObjectSchema(
+      channels["version:snapshot:rollback"]?.response,
+    );
+    expect(hasField(rollbackRes, "restored")).toBe(true);
+  });
 
-  const mergeReq = asObjectSchema(channels["version:branch:merge"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(mergeReq.fields, "documentId"),
-    true,
-    "version:branch:merge request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(mergeReq.fields, "sourceBranchName"),
-    true,
-    "version:branch:merge request should include sourceBranchName",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(mergeReq.fields, "targetBranchName"),
-    true,
-    "version:branch:merge request should include targetBranchName",
-  );
+  it("should expose snapshot create and wordCount fields in snapshot payloads", () => {
+    const createReq = asObjectSchema(
+      channels["version:snapshot:create"]?.request,
+    );
+    expect(hasField(createReq, "documentId")).toBe(true);
+    expect(hasField(createReq, "contentJson")).toBe(true);
+    expect(hasField(createReq, "actor")).toBe(true);
+    expect(hasField(createReq, "reason")).toBe(true);
 
-  const resolveReq = asObjectSchema(
-    channels["version:conflict:resolve"]?.request,
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(resolveReq.fields, "documentId"),
-    true,
-    "version:conflict:resolve request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(resolveReq.fields, "mergeSessionId"),
-    true,
-    "version:conflict:resolve request should include mergeSessionId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(resolveReq.fields, "resolutions"),
-    true,
-    "version:conflict:resolve request should include resolutions",
-  );
-}
+    const createRes = asObjectSchema(
+      channels["version:snapshot:create"]?.response,
+    );
+    expect(hasField(createRes, "compaction")).toBe(true);
 
-/**
- * P2 contract: version:snapshot:diff and version:snapshot:rollback schemas must exist.
- */
-{
-  const channels = ipcContract.channels as unknown as Record<
-    string,
-    { request: unknown; response: unknown }
-  >;
+    const saveRes = asObjectSchema(channels["file:document:save"]?.response);
+    expect(hasField(saveRes, "compaction")).toBe(true);
 
-  const diffReq = asObjectSchema(channels["version:snapshot:diff"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(diffReq.fields, "documentId"),
-    true,
-    "version:snapshot:diff request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(diffReq.fields, "baseVersionId"),
-    true,
-    "version:snapshot:diff request should include baseVersionId",
-  );
+    const listRes = asObjectSchema(channels["version:snapshot:list"]?.response);
+    const listItems = listRes.fields.items as {
+      kind: "array";
+      element: unknown;
+    };
+    expect(listItems.kind).toBe("array");
+    const listItem = asObjectSchema(listItems.element);
+    expect(hasField(listItem, "wordCount")).toBe(true);
 
-  const diffRes = asObjectSchema(channels["version:snapshot:diff"]?.response);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(diffRes.fields, "diffText"),
-    true,
-    "version:snapshot:diff response should include diffText",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(diffRes.fields, "hasDifferences"),
-    true,
-    "version:snapshot:diff response should include hasDifferences",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(diffRes.fields, "stats"),
-    true,
-    "version:snapshot:diff response should include stats",
-  );
+    const readRes = asObjectSchema(channels["version:snapshot:read"]?.response);
+    expect(hasField(readRes, "wordCount")).toBe(true);
+  });
 
-  const rollbackReq = asObjectSchema(
-    channels["version:snapshot:rollback"]?.request,
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(rollbackReq.fields, "documentId"),
-    true,
-    "version:snapshot:rollback request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(rollbackReq.fields, "versionId"),
-    true,
-    "version:snapshot:rollback request should include versionId",
-  );
+  it("should include document type and status fields in create and list contracts", () => {
+    const createReq = asObjectSchema(channels["file:document:create"]?.request);
+    expect(hasField(createReq, "type")).toBe(true);
 
-  const rollbackRes = asObjectSchema(
-    channels["version:snapshot:rollback"]?.response,
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(rollbackRes.fields, "restored"),
-    true,
-    "version:snapshot:rollback response should include restored",
-  );
-}
-
-/**
- * Snapshot contract: must expose create channel + wordCount in list/read payloads.
- */
-{
-  const channels = ipcContract.channels as unknown as Record<
-    string,
-    { request: unknown; response: unknown }
-  >;
-
-  const createReq = asObjectSchema(
-    channels["version:snapshot:create"]?.request,
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "documentId"),
-    true,
-    "version:snapshot:create request should include documentId",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "contentJson"),
-    true,
-    "version:snapshot:create request should include contentJson",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "actor"),
-    true,
-    "version:snapshot:create request should include actor",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "reason"),
-    true,
-    "version:snapshot:create request should include reason",
-  );
-
-  const createRes = asObjectSchema(
-    channels["version:snapshot:create"]?.response,
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createRes.fields, "compaction"),
-    true,
-    "version:snapshot:create response should include optional compaction event",
-  );
-
-  const saveRes = asObjectSchema(channels["file:document:save"]?.response);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(saveRes.fields, "compaction"),
-    true,
-    "file:document:save response should include optional compaction event",
-  );
-
-  const listRes = asObjectSchema(channels["version:snapshot:list"]?.response);
-  const listItems = listRes.fields.items as { kind: "array"; element: unknown };
-  assert.equal(listItems.kind, "array");
-  const listItem = asObjectSchema(listItems.element);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(listItem.fields, "wordCount"),
-    true,
-    "version list item should include wordCount",
-  );
-
-  const readRes = asObjectSchema(channels["version:snapshot:read"]?.response);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(readRes.fields, "wordCount"),
-    true,
-    "version read response should include wordCount",
-  );
-}
-
-/**
- * S1/S3: create/list/read contract includes document type + status fields.
- */
-{
-  const channels = ipcContract.channels as unknown as Record<
-    string,
-    { request: unknown; response: unknown }
-  >;
-
-  const createReq = asObjectSchema(channels["file:document:create"]?.request);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(createReq.fields, "type"),
-    true,
-    "create request should accept optional type",
-  );
-
-  const listRes = asObjectSchema(channels["file:document:list"]?.response);
-  const itemsSchema = listRes.fields.items as {
-    kind: "array";
-    element: unknown;
-  };
-  assert.equal(itemsSchema.kind, "array");
-  const itemObject = asObjectSchema(itemsSchema.element);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(itemObject.fields, "type"),
-    true,
-    "list item should include type",
-  );
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(itemObject.fields, "status"),
-    true,
-    "list item should include status",
-  );
-}
-
-console.log("document-ipc-contract.test.ts: all assertions passed");
+    const listRes = asObjectSchema(channels["file:document:list"]?.response);
+    const itemsSchema = listRes.fields.items as {
+      kind: "array";
+      element: unknown;
+    };
+    expect(itemsSchema.kind).toBe("array");
+    const itemObject = asObjectSchema(itemsSchema.element);
+    expect(hasField(itemObject, "type")).toBe(true);
+    expect(hasField(itemObject, "status")).toBe(true);
+  });
+});

--- a/apps/desktop/tests/unit/projectService.ai-assist.test.ts
+++ b/apps/desktop/tests/unit/projectService.ai-assist.test.ts
@@ -1,57 +1,115 @@
-import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-import { createProjectService } from "../../main/src/services/projects/projectService";
+import {
+  createProjectService,
+  type ProjectService,
+} from "../../main/src/services/projects/projectService";
 
 import {
   createNoopLogger,
   createProjectTestDb,
 } from "./projectService.test-helpers";
 
-/**
- * PM1-S2: should build project draft from ai-service mock response
- */
-async function main(): Promise<void> {
+async function createDraftService(): Promise<{
+  userDataDir: string;
+  db: ReturnType<typeof createProjectTestDb>;
+  service: Pick<ProjectService, "createAiAssistDraft">;
+}> {
   const userDataDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "creonow-pm1-ai-"),
   );
   const db = createProjectTestDb();
-  const svc = createProjectService({
+  const service = createProjectService({
     db,
     userDataDir,
     logger: createNoopLogger(),
-  }) as unknown as {
-    createAiAssistDraft: (args: { prompt: string }) => {
-      ok: boolean;
-      data?: {
-        name: string;
-        type: "novel" | "screenplay" | "media";
-        chapterOutlines: string[];
-        characters: string[];
-      };
-    };
-  };
-
-  const result = svc.createAiAssistDraft({
-    prompt: "帮我创建一部校园推理小说，主角是高中女生侦探",
   });
 
-  assert.equal(result.ok, true);
-  if (!result.ok || !result.data) {
-    throw new Error("expected ai assist mock draft");
-  }
-
-  assert.equal(result.data.type, "novel");
-  assert.equal(result.data.chapterOutlines.length, 5);
-  assert.equal(result.data.characters.length, 3);
-
-  db.close();
-  await fs.rm(userDataDir, { recursive: true, force: true });
+  return {
+    userDataDir,
+    db,
+    service: { createAiAssistDraft: service.createAiAssistDraft },
+  };
 }
 
-void main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
+async function cleanupDraftService(args: {
+  userDataDir: string;
+  db: ReturnType<typeof createProjectTestDb>;
+}): Promise<void> {
+  args.db.close();
+  await fs.rm(args.userDataDir, { recursive: true, force: true });
+}
+
+describe("projectService AI assist draft", () => {
+  it("should build a novel draft from a novel prompt", async () => {
+    const ctx = await createDraftService();
+
+    try {
+      const result = ctx.service.createAiAssistDraft({
+        prompt: "帮我创建一部校园推理小说，主角是高中女生侦探",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error("expected AI assist draft to succeed");
+      }
+
+      expect(result.data).toMatchObject({
+        name: "AI 辅助项目",
+        type: "novel",
+        description: "帮我创建一部校园推理小说，主角是高中女生侦探",
+      });
+      expect(result.data.chapterOutlines).toHaveLength(5);
+      expect(result.data.characters).toHaveLength(3);
+    } finally {
+      await cleanupDraftService(ctx);
+    }
+  });
+
+  it("should classify screenplay prompts as screenplay drafts", async () => {
+    const ctx = await createDraftService();
+
+    try {
+      const result = ctx.service.createAiAssistDraft({
+        prompt: "请帮我起草一个悬疑剧本，包含三幕结构",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error("expected screenplay prompt to succeed");
+      }
+
+      expect(result.data.type).toBe("screenplay");
+      expect(result.data.description).toBe(
+        "请帮我起草一个悬疑剧本，包含三幕结构",
+      );
+    } finally {
+      await cleanupDraftService(ctx);
+    }
+  });
+
+  it("should reject blank prompts", async () => {
+    const ctx = await createDraftService();
+
+    try {
+      const result = ctx.service.createAiAssistDraft({
+        prompt: "   ",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected blank prompt to be rejected");
+      }
+
+      expect(result.error).toMatchObject({
+        code: "INVALID_ARGUMENT",
+        message: "prompt is required",
+      });
+    } finally {
+      await cleanupDraftService(ctx);
+    }
+  });
 });

--- a/openspec/changes/EXECUTION_ORDER.md
+++ b/openspec/changes/EXECUTION_ORDER.md
@@ -1,12 +1,12 @@
 # Active Changes Execution Order
 
-更新时间：2026-03-06 23:30
+更新时间：2026-03-07 12:59
 
 适用范围：`openspec/changes/` 下所有非 `archive/`、非 `_template/` 的活跃 change。
 
 ## 执行策略
 
-- 当前活跃 change 数量为 **5**。
+- 当前活跃 change 数量为 **6**。
 - 执行模式：并行推进（互不依赖的变更可并行进入 Red）。
 - 规则：新 change 启动前，需先在本文件登记顺序与依赖，再进入 Red。
 
@@ -17,14 +17,16 @@
 3. `a0-05-skill-router-negation-guard`
 4. `a0-10-search-mvp`
 5. `a0-12-inline-ai-baseline`
+6. `testing-governance-foundation`
 
-## 本次同步说明（Phase 0 全量登记）
+## 本次同步说明
 
-- `a0-01-zen-mode-editable`：对应 Issue #986，禅模式行为变更。
-- `a0-04-export-honest-grading`：对应 Issue #1002，导出 spec 修正。
-- `a0-05-skill-router-negation-guard`：对应 Issue #987，Skill Router 否定守卫。
-- `a0-10-search-mvp`：对应 Issue #1003，搜索快捷键与发现性。
-- `a0-12-inline-ai-baseline`：对应 Issue #1004，Inline AI 从 0 到 1。
+- 既有 Phase 0 五个 active changes 继续保持原顺序与依赖关系。
+- 新增活跃 change：`testing-governance-foundation`。
+- 该 change 的前两阶段已通过独立 PR 落地：
+  - `#1017 / PR #1018`：testing SSOT 与入口文档收口
+  - `#1019 / PR #1020`：CI / preflight / gate 对齐
+- 当前阶段通过三类测试迁移样板与 change 骨架，把 testing governance 从“已落地规则”推进到“可复用样板 + 活跃 change 跟踪”。
 
 ## 依赖说明
 
@@ -33,6 +35,7 @@
 - `a0-05-skill-router-negation-guard`：无上游依赖，可并行。
 - `a0-10-search-mvp`：无上游依赖，可并行。
 - `a0-12-inline-ai-baseline`：依赖 `a0-01-zen-mode-editable` 完成后启动。
+- `testing-governance-foundation`：无产品行为上的上游依赖；作为治理 change，可与现有 Phase 0 active changes 并行推进，但不应覆盖它们的执行顺序声明。
 
 ## 依赖拓扑
 
@@ -41,4 +44,5 @@ a0-01-zen-mode-editable ──→ a0-12-inline-ai-baseline
 a0-04-export-honest-grading
 a0-05-skill-router-negation-guard
 a0-10-search-mvp
+testing-governance-foundation
 ```

--- a/openspec/changes/testing-governance-foundation/proposal.md
+++ b/openspec/changes/testing-governance-foundation/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: testing-governance-foundation
+
+更新时间：2026-03-07 12:59
+
+## Why
+
+当前仓库已经通过两条已合并 PR 完成了 testing governance 的前两段收口：
+
+- `#1017 / PR #1018`：建立 `docs/references/testing/` 作为测试规范主源（SSOT），并统一入口文档回指；
+- `#1019 / PR #1020`：对齐 CI / preflight / gate 的真实执行策略。
+
+但 testing governance 仍缺两样关键东西：
+
+1. 缺少“历史弱测试如何迁”的可复用样板；
+2. 缺少一个在 `openspec/changes/` 中正式登记的活跃治理 change，来承接后续迁移与第二阶段路线图。
+
+## What Changes
+
+本 change 在当前阶段只完成以下收口：
+
+1. 迁入三类弱测试迁移样板：
+   - 前端交互测试样板（`OnboardingPage.test.tsx`）
+   - IPC / contract 测试样板（`document-ipc-contract.test.ts`）
+   - 服务层脚本式测试迁移样板（`projectService.ai-assist.test.ts`）
+2. 在 `openspec/changes/testing-governance-foundation/` 下建立 proposal / tasks 骨架。
+3. 在 `openspec/changes/EXECUTION_ORDER.md` 中登记该活跃治理 change，并明确其与现有 Phase 0 active changes 并行存在。
+4. 将后续 reviewer 脚本化、spec-scenario-test 映射、更多历史弱测试迁移保留为本 change 的后续阶段，而不在本 PR 中一口吃掉。
+
+## Out of Scope
+
+以下事项不属于本 change 当前阶段的交付范围：
+
+- `docs/references/testing/` 主源目录与入口文档（已由 `#1017 / PR #1018` 收口）。
+- `.github/workflows/ci.yml`、`scripts/agent_pr_preflight.py`、PR 模板与时间戳治理对齐（已由 `#1019 / PR #1020` 收口）。
+- 其他历史弱测试迁移样板，不在本次列举的三类样板之内。
+- 立即上锁第二阶段门禁（如 backend coverage 阈值、spec-scenario-test 映射 gate、reviewer wrapper）。
+
+## Acceptance
+
+- 三个测试样板已迁入 `main`，并以当前测试框架运行通过。
+- `openspec/changes/testing-governance-foundation/` 已建立，文义与已合并的 #1017 / #1019 不冲突。
+- `openspec/changes/EXECUTION_ORDER.md` 已登记该活跃治理 change，且不覆盖现有 Phase 0 active changes。
+- 后续阶段的治理动作已被明确记录，但未被伪装成“当前已完成”。

--- a/openspec/changes/testing-governance-foundation/tasks.md
+++ b/openspec/changes/testing-governance-foundation/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: testing-governance-foundation
+
+更新时间：2026-03-07 12:59
+
+## 1. 已交付的前置阶段（已合并）
+
+- [x] 1.1 建立 `docs/references/testing/` 作为测试规范主源（`#1017 / PR #1018`）。
+- [x] 1.2 统一 `AGENTS.md`、`CLAUDE.md`、`docs/delivery-skill.md`、`openspec/project.md` 等入口回指 testing SSOT（`#1017 / PR #1018`）。
+- [x] 1.3 对齐 CI / preflight / gate 的真实执行策略（`#1019 / PR #1020`）。
+
+## 2. 当前阶段：迁移样板与活跃 change 登记
+
+- [x] 2.1 迁入前端交互测试样板：`apps/desktop/renderer/src/features/onboarding/OnboardingPage.test.tsx`。
+- [x] 2.2 迁入 IPC / contract 测试样板：`apps/desktop/tests/unit/document-ipc-contract.test.ts`。
+- [x] 2.3 迁入服务层脚本式测试迁移样板：`apps/desktop/tests/unit/projectService.ai-assist.test.ts`。
+- [x] 2.4 建立 `openspec/changes/testing-governance-foundation/` 的 proposal / tasks 骨架。
+- [x] 2.5 在 `openspec/changes/EXECUTION_ORDER.md` 中登记该活跃治理 change。
+
+## 3. 后续阶段（留待后续 PR）
+
+- [ ] 3.1 将迁移前后对比补入 `docs/references/testing/08-migration-and-review-playbook.md` 的正式样板章节。
+- [ ] 3.2 评估 reviewer wrapper / 审计脚本化方案。
+- [ ] 3.3 评估 spec-scenario-test 映射门禁的试点落点。


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题
- 迁入三类弱测试迁移样板：前端交互测试、IPC/contract 测试、服务层脚本式测试迁移样板
- 新增 `openspec/changes/testing-governance-foundation/` 的 `proposal.md` 与 `tasks.md`
- 更新 `openspec/changes/EXECUTION_ORDER.md`，登记 `testing-governance-foundation` 活跃 change，并与已合入的 #1017 / #1019 两个阶段保持一致

## 关联 Issue
- Closes #1021

## 用户影响
- 仓库中不再只有 testing SSOT 规则与 CI/gate 约束，还多了三类可复用的“弱测试迁移样板”
- OpenSpec 层也有了正式登记的 `testing-governance-foundation` 活跃 change，可承接后续迁移与第二阶段路线图

## 不修最坏后果
- testing governance 只停留在“规则已经写下”，却没有足够可复用的迁移样板，后续整改容易继续停在抽象层
- 若不登记活跃 change，后续 testing governance 的剩余事项会重新散落在仓库各处，缺少主线跟踪

## 验证证据
- [x] `git diff --check`
- [x] `python3 scripts/check_doc_timestamps.py --files openspec/changes/EXECUTION_ORDER.md openspec/changes/testing-governance-foundation/proposal.md openspec/changes/testing-governance-foundation/tasks.md`
- [x] `pnpm -C apps/desktop test:run renderer/src/features/onboarding/OnboardingPage.test.tsx`
- [x] `pnpm test:unit`
- [x] `pnpm typecheck`（在控制面仓库 `/home/leeky/work/CreoNow` 执行）
- 其他补充验证：`pnpm test:unit` 的输出中已包含 `tests/unit/document-ipc-contract.test.ts` 与 `tests/unit/projectService.ai-assist.test.ts` 通过记录

## 回滚点
- 回滚 commit/分支：`67f41814` / `task/1021-testing-sample-migrations`
- 回滚后需要恢复的数据或配置：无

## 审计门禁
- [ ] 指定审计 Agent 已发布 `FINAL-VERDICT` 评论
- [ ] `FINAL-VERDICT` 的最终判定为 `ACCEPT`

## 说明
- 本 PR 只收口“弱测试迁移样板 + testing-governance 活跃 change 登记”这一层；不重新改动已在 #1018 / #1020 收口的 testing SSOT 与 CI/preflight/gate 文件
- `testing-governance-foundation` change 在当前阶段只登记样板迁移与后续阶段骨架，不把尚未落地的第二阶段门禁伪装成已完成事实