### PR TITLE
feat(autosave): A0-02 自动保存失败可见化

### DIFF
--- a/apps/desktop/renderer/src/components/layout/SaveIndicator.tsx
+++ b/apps/desktop/renderer/src/components/layout/SaveIndicator.tsx
@@ -3,20 +3,57 @@ import { useTranslation } from "react-i18next";
 import type { AutosaveStatus } from "../../stores/editorStore";
 import "../../i18n";
 
-function getSaveLabel(
-  status: AutosaveStatus,
-  t: (key: string) => string,
-): string {
-  if (status === "saving") {
-    return t("workbench.saveIndicator.saving");
-  }
-  if (status === "saved") {
-    return t("workbench.saveIndicator.saved");
-  }
-  if (status === "error") {
-    return t("workbench.saveIndicator.error");
-  }
-  return "";
+/**
+ * Spinning icon for "saving" state.
+ */
+function SavingSpinner(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="inline-block w-3 h-3 animate-spin"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeDasharray="28"
+        strokeDashoffset="8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Error icon for "error" state.
+ */
+function ErrorIcon(): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      className="inline-block w-3 h-3"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="2" />
+      <line
+        x1="8"
+        y1="4"
+        x2="8"
+        y2="9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <circle cx="8" cy="12" r="1" fill="currentColor" />
+    </svg>
+  );
 }
 
 /**
@@ -47,25 +84,67 @@ export function SaveIndicator(props: {
   }, [props.autosaveStatus]);
 
   const isError = displayStatus === "error";
-  const label = getSaveLabel(displayStatus, t);
+  const isSaving = displayStatus === "saving";
+  const isSaved = displayStatus === "saved";
+
+  if (displayStatus === "idle") {
+    return (
+      <span
+        data-testid="editor-autosave-status"
+        role="status"
+        aria-live="polite"
+        data-status="idle"
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <span
+        data-testid="editor-autosave-status"
+        role="status"
+        aria-live="polite"
+        data-status="error"
+      >
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={t("workbench.autosave.a11y.retryLabel")}
+          onClick={() => props.onRetry()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              props.onRetry();
+            }
+          }}
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--radius-sm)] text-[var(--color-error)] bg-[var(--color-error-subtle)] cursor-pointer"
+        >
+          <ErrorIcon />
+          {t("workbench.autosave.status.error")}
+        </span>
+      </span>
+    );
+  }
 
   return (
     <span
       data-testid="editor-autosave-status"
+      role="status"
       aria-live="polite"
       data-status={displayStatus}
-      onClick={() => {
-        if (isError) {
-          props.onRetry();
-        }
-      }}
       className={
-        isError
-          ? "text-[var(--color-error)] cursor-pointer underline"
-          : "text-[var(--color-fg-muted)] cursor-default"
+        isSaved
+          ? "text-[var(--color-success)]"
+          : "text-[var(--color-fg-muted)]"
       }
     >
-      {label}
+      {isSaving && (
+        <span className="inline-flex items-center gap-1">
+          <SavingSpinner />
+          {t("workbench.autosave.status.saving")}
+        </span>
+      )}
+      {isSaved && t("workbench.autosave.status.saved")}
     </span>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/StatusBar.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { StatusBar } from "./StatusBar";
+import { SaveIndicator } from "./SaveIndicator";
 import {
   ProjectStoreProvider,
   createProjectStore,
@@ -140,8 +141,96 @@ describe("StatusBar", () => {
 
     const indicator = screen.getByTestId("editor-autosave-status");
     expect(indicator).toHaveTextContent("Save failed");
-    fireEvent.click(indicator);
+    const retryButton = screen.getByRole("button", { name: "Retry save" });
+    fireEvent.click(retryButton);
 
     expect(retryLastAutosave).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SaveIndicator 四态映射 (AC-1, AC-7, AC-10)", () => {
+  it("idle 状态下不渲染可见文本", () => {
+    render(<SaveIndicator autosaveStatus="idle" onRetry={vi.fn()} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveTextContent("");
+    expect(indicator).toHaveAttribute("data-status", "idle");
+  });
+
+  it("saving 状态下渲染保存中文案和旋转图标", () => {
+    render(<SaveIndicator autosaveStatus="saving" onRetry={vi.fn()} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveTextContent("Saving...");
+    expect(indicator).toHaveAttribute("data-status", "saving");
+    // Spinner should be aria-hidden
+    const spinner = indicator.querySelector("svg[aria-hidden='true']");
+    expect(spinner).not.toBeNull();
+  });
+
+  it("saved 状态下渲染成功文案", () => {
+    render(<SaveIndicator autosaveStatus="saved" onRetry={vi.fn()} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveTextContent("Saved");
+    expect(indicator).toHaveAttribute("data-status", "saved");
+  });
+
+  it("saved 状态 2 秒后切换回 idle", () => {
+    vi.useFakeTimers();
+    render(
+      <SaveIndicator autosaveStatus="saved" onRetry={vi.fn()} />,
+    );
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveAttribute("data-status", "saved");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByTestId("editor-autosave-status")).toHaveAttribute(
+      "data-status",
+      "idle",
+    );
+    expect(screen.getByTestId("editor-autosave-status")).toHaveTextContent("");
+  });
+
+  it("error 状态下渲染错误指示器，可点击触发重试", () => {
+    const onRetry = vi.fn();
+    render(<SaveIndicator autosaveStatus="error" onRetry={onRetry} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveTextContent("Save failed");
+    expect(indicator).toHaveAttribute("data-status", "error");
+
+    const retryButton = screen.getByRole("button", { name: "Retry save" });
+    fireEvent.click(retryButton);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("error 重试区域支持键盘 Enter 触发", () => {
+    const onRetry = vi.fn();
+    render(<SaveIndicator autosaveStatus="error" onRetry={onRetry} />);
+    const retryButton = screen.getByRole("button", { name: "Retry save" });
+    fireEvent.keyDown(retryButton, { key: "Enter" });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SaveIndicator 无障碍 (AC-8)", () => {
+  it("保存指示区域具有 role=status 和 aria-live=polite", () => {
+    render(<SaveIndicator autosaveStatus="idle" onRetry={vi.fn()} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveAttribute("role", "status");
+    expect(indicator).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("error 态重试具有 role=button 和 aria-label", () => {
+    render(<SaveIndicator autosaveStatus="error" onRetry={vi.fn()} />);
+    const retryButton = screen.getByRole("button", { name: "Retry save" });
+    expect(retryButton).toHaveAttribute("aria-label", "Retry save");
+  });
+
+  it("saving 态旋转图标具有 aria-hidden=true", () => {
+    render(<SaveIndicator autosaveStatus="saving" onRetry={vi.fn()} />);
+    const indicator = screen.getByTestId("editor-autosave-status");
+    const svg = indicator.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
   });
 });

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -6,7 +6,7 @@ import { useProjectStore } from "../../stores/projectStore";
 import { useFileStore } from "../../stores/fileStore";
 import { SaveIndicator } from "./SaveIndicator";
 import { useToast, Toast, ToastProvider, ToastViewport } from "../primitives/Toast";
-import { useAutosaveToast } from "../../features/editor/useAutosaveToast";
+import { useAutosaveToast, useFlushErrorToast } from "../../features/editor/useAutosaveToast";
 import "../../i18n";
 
 function formatCurrentTime(value: Date): string {
@@ -36,6 +36,7 @@ export function StatusBar(): JSX.Element {
   const autosaveStatus = useEditorStore((s) => s.autosaveStatus);
   const retryLastAutosave = useEditorStore((s) => s.retryLastAutosave);
   const capacityWarning = useEditorStore((s) => s.capacityWarning);
+  const flushError = useEditorStore((s) => s.flushError);
 
   const { toast, showToast, setOpen } = useToast();
 
@@ -44,6 +45,11 @@ export function StatusBar(): JSX.Element {
     documentId: documentId ?? currentDocumentId ?? null,
     showToast,
     retryLastAutosave,
+  });
+
+  useFlushErrorToast({
+    flushError,
+    showToast,
   });
 
   const [currentTime, setCurrentTime] = React.useState(() =>

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -5,6 +5,8 @@ import { useEditorStore } from "../../stores/editorStore";
 import { useProjectStore } from "../../stores/projectStore";
 import { useFileStore } from "../../stores/fileStore";
 import { SaveIndicator } from "./SaveIndicator";
+import { useToast, Toast, ToastProvider, ToastViewport } from "../primitives/Toast";
+import { useAutosaveToast } from "../../features/editor/useAutosaveToast";
 import "../../i18n";
 
 function formatCurrentTime(value: Date): string {
@@ -34,6 +36,15 @@ export function StatusBar(): JSX.Element {
   const autosaveStatus = useEditorStore((s) => s.autosaveStatus);
   const retryLastAutosave = useEditorStore((s) => s.retryLastAutosave);
   const capacityWarning = useEditorStore((s) => s.capacityWarning);
+
+  const { toast, showToast, setOpen } = useToast();
+
+  useAutosaveToast({
+    autosaveStatus,
+    documentId: documentId ?? currentDocumentId ?? null,
+    showToast,
+    retryLastAutosave,
+  });
 
   const [currentTime, setCurrentTime] = React.useState(() =>
     formatCurrentTime(new Date()),
@@ -76,40 +87,51 @@ export function StatusBar(): JSX.Element {
   );
 
   return (
-    <div
-      data-testid="layout-statusbar"
-      className="shrink-0 flex items-center justify-between gap-3 px-3 text-[11px] font-[var(--font-family-ui)] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator-bold)]"
-      style={{ height: LAYOUT_DEFAULTS.statusBarHeight }}
-    >
-      <div className="min-w-0 flex items-center gap-2">
-        <span data-testid="status-project-name" className="truncate">
-          {projectName}
-        </span>
-        <span aria-hidden="true">/</span>
-        <span data-testid="status-document-name" className="truncate">
-          {documentName}
-        </span>
-      </div>
-
-      <div className="ml-auto flex items-center gap-3">
-        <span data-testid="status-word-count">{wordCountText}</span>
-        <SaveIndicator
-          autosaveStatus={autosaveStatus}
-          onRetry={() => {
-            void retryLastAutosave();
-          }}
-        />
-        <span data-testid="status-current-time">{currentTime}</span>
-        {capacityWarning ? (
-          <span
-            data-testid="editor-capacity-warning"
-            className="text-[var(--color-warning)]"
-            role="status"
-          >
-            {capacityWarning}
+    <ToastProvider>
+      <div
+        data-testid="layout-statusbar"
+        className="shrink-0 flex items-center justify-between gap-3 px-3 text-[11px] font-[var(--font-family-ui)] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator-bold)]"
+        style={{ height: LAYOUT_DEFAULTS.statusBarHeight }}
+      >
+        <div className="min-w-0 flex items-center gap-2">
+          <span data-testid="status-project-name" className="truncate">
+            {projectName}
           </span>
-        ) : null}
+          <span aria-hidden="true">/</span>
+          <span data-testid="status-document-name" className="truncate">
+            {documentName}
+          </span>
+        </div>
+
+        <div className="ml-auto flex items-center gap-3">
+          <span data-testid="status-word-count">{wordCountText}</span>
+          <SaveIndicator
+            autosaveStatus={autosaveStatus}
+            onRetry={() => {
+              void retryLastAutosave();
+            }}
+          />
+          <span data-testid="status-current-time">{currentTime}</span>
+          {capacityWarning ? (
+            <span
+              data-testid="editor-capacity-warning"
+              className="text-[var(--color-warning)]"
+              role="status"
+            >
+              {capacityWarning}
+            </span>
+          ) : null}
+        </div>
       </div>
-    </div>
+      <Toast
+        title={toast.title}
+        description={toast.description}
+        variant={toast.variant}
+        action={toast.action}
+        open={toast.open}
+        onOpenChange={setOpen}
+      />
+      <ToastViewport />
+    </ToastProvider>
   );
 }

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -96,6 +96,9 @@ export function StatusBar(): JSX.Element {
     <ToastProvider>
       <div
         data-testid="layout-statusbar"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
         className="shrink-0 flex items-center justify-between gap-3 px-3 text-[11px] font-[var(--font-family-ui)] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator-bold)]"
         style={{ height: LAYOUT_DEFAULTS.statusBarHeight }}
       >

--- a/apps/desktop/renderer/src/features/__tests__/i18n-text-extract.test.tsx
+++ b/apps/desktop/renderer/src/features/__tests__/i18n-text-extract.test.tsx
@@ -54,13 +54,13 @@ describe("S3-I18N-EXTRACT-S1: hardcoded chinese literals are extracted to locale
     expect(saveIndicatorSource).not.toContain("已保存");
     expect(saveIndicatorSource).not.toContain("保存失败");
     expect(saveIndicatorSource).toMatch(
-      /t\(["']workbench\.saveIndicator\.saving["']\)/,
+      /t\(["']workbench\.autosave\.status\.saving["']\)/,
     );
     expect(saveIndicatorSource).toMatch(
-      /t\(["']workbench\.saveIndicator\.saved["']\)/,
+      /t\(["']workbench\.autosave\.status\.saved["']\)/,
     );
     expect(saveIndicatorSource).toMatch(
-      /t\(["']workbench\.saveIndicator\.error["']\)/,
+      /t\(["']workbench\.autosave\.status\.error["']\)/,
     );
 
     expect(appShellSource).not.toContain('group: "命令"');

--- a/apps/desktop/renderer/src/features/editor/useAutosave.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosave.ts
@@ -18,6 +18,7 @@ export function useAutosave(args: {
 }): void {
   const save = useEditorStore((s) => s.save);
   const setAutosaveStatus = useEditorStore((s) => s.setAutosaveStatus);
+  const setFlushError = useEditorStore((s) => s.setFlushError);
 
   const timerRef = React.useRef<number | null>(null);
   const lastQueuedJsonRef = React.useRef<string | null>(null);
@@ -71,7 +72,7 @@ export function useAutosave(args: {
             actor: "auto",
             reason: "autosave",
           }).catch(() => {
-            // Error state is handled inside editorStore.save/saveQueue
+            setFlushError({ documentId: args.documentId });
           });
         }
       }
@@ -85,5 +86,6 @@ export function useAutosave(args: {
     args.suppressRef,
     save,
     setAutosaveStatus,
+    setFlushError,
   ]);
 }

--- a/apps/desktop/renderer/src/features/editor/useAutosave.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosave.ts
@@ -64,12 +64,14 @@ export function useAutosave(args: {
         timerRef.current = null;
         const queued = lastQueuedJsonRef.current;
         if (queued && queued.length > 0) {
-          void save({
+          save({
             projectId: args.projectId,
             documentId: args.documentId,
             contentJson: queued,
             actor: "auto",
             reason: "autosave",
+          }).catch(() => {
+            // Error state is handled inside editorStore.save/saveQueue
           });
         }
       }

--- a/apps/desktop/renderer/src/features/editor/useAutosaveToast.test.tsx
+++ b/apps/desktop/renderer/src/features/editor/useAutosaveToast.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+
+import { useAutosaveToast } from "./useAutosaveToast";
+import type { AutosaveStatus } from "../../stores/editorStore";
+import type { ToastState } from "../../components/primitives/Toast";
+
+function ToastHarness(props: {
+  autosaveStatus: AutosaveStatus;
+  documentId: string | null;
+  showToast: (toast: Omit<ToastState, "open">) => void;
+  retryLastAutosave: () => Promise<void>;
+}): JSX.Element {
+  useAutosaveToast(props);
+  return <div data-testid="toast-harness" />;
+}
+
+describe("useAutosaveToast — Toast 触发 (AC-2, AC-4)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("autosaveStatus 从 saving 变为 error 时触发 error Toast", () => {
+    const showToast = vi.fn();
+    const retryLastAutosave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Auto-save failed",
+        variant: "error",
+        action: expect.objectContaining({
+          label: "Retry",
+        }),
+      }),
+    );
+  });
+
+  it("error Toast 的 action 按钮调用 retryLastAutosave", () => {
+    const showToast = vi.fn();
+    const retryLastAutosave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    const callArg = showToast.mock.calls[0][0] as Omit<ToastState, "open"> & {
+      action?: { onClick: () => void };
+    };
+    callArg.action?.onClick();
+    expect(retryLastAutosave).toHaveBeenCalledTimes(1);
+  });
+
+  it("重试成功后触发 success Toast", () => {
+    const showToast = vi.fn();
+    const retryLastAutosave = vi.fn().mockResolvedValue(undefined);
+
+    // Start at saving
+    const { rerender } = render(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // Error
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+    expect(showToast).toHaveBeenCalledTimes(1);
+
+    // Retrying (saving again)
+    rerender(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // Retry succeeds
+    rerender(
+      <ToastHarness
+        autosaveStatus="saved"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    expect(showToast).toHaveBeenCalledTimes(2);
+    expect(showToast).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: "Save recovered",
+        variant: "success",
+      }),
+    );
+  });
+});
+
+describe("useAutosaveToast — 连续失败去重 (AC-5)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("同一 documentId 的连续两次 error 仅触发一次 Toast", () => {
+    const showToast = vi.fn();
+    const retryLastAutosave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // First error
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+    expect(showToast).toHaveBeenCalledTimes(1);
+
+    // Back to saving then error again (same doc)
+    rerender(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // Still only 1 toast
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("切换到新 documentId 后再次失败触发新的 Toast", () => {
+    const showToast = vi.fn();
+    const retryLastAutosave = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // First doc error
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-1"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+    expect(showToast).toHaveBeenCalledTimes(1);
+
+    // Switch to new doc
+    rerender(
+      <ToastHarness
+        autosaveStatus="saving"
+        documentId="doc-2"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    // New doc error
+    rerender(
+      <ToastHarness
+        autosaveStatus="error"
+        documentId="doc-2"
+        showToast={showToast}
+        retryLastAutosave={retryLastAutosave}
+      />,
+    );
+
+    expect(showToast).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/renderer/src/features/editor/useAutosaveToast.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosaveToast.ts
@@ -16,48 +16,54 @@ export function useAutosaveToast(args: {
   retryLastAutosave: () => Promise<void>;
 }): void {
   const { t } = useTranslation();
+  const {
+    autosaveStatus,
+    documentId,
+    showToast,
+    retryLastAutosave,
+  } = args;
   const prevStatusRef = React.useRef<AutosaveStatus>(args.autosaveStatus);
   const toastedDocRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     const prev = prevStatusRef.current;
-    prevStatusRef.current = args.autosaveStatus;
+    prevStatusRef.current = autosaveStatus;
 
-    if (args.autosaveStatus === "error" && prev !== "error") {
+    if (autosaveStatus === "error" && prev !== "error") {
       // Dedup: don't re-toast the same document
-      if (args.documentId && args.documentId === toastedDocRef.current) {
+      if (documentId && documentId === toastedDocRef.current) {
         return;
       }
-      toastedDocRef.current = args.documentId;
-      args.showToast({
+      toastedDocRef.current = documentId;
+      showToast({
         title: t("workbench.autosave.toast.error.title"),
         description: t("workbench.autosave.toast.error.description"),
         variant: "error",
         action: {
           label: t("workbench.autosave.toast.error.retry"),
           onClick: () => {
-            void args.retryLastAutosave();
+            void retryLastAutosave();
           },
         },
       });
     }
 
-    if (args.autosaveStatus === "saved" && prev === "saving") {
+    if (autosaveStatus === "saved" && prev === "saving") {
       // If we previously had a toast for this doc and it just recovered, notify
-      if (toastedDocRef.current === args.documentId && args.documentId) {
+      if (toastedDocRef.current === documentId && documentId) {
         toastedDocRef.current = null;
-        args.showToast({
+        showToast({
           title: t("workbench.autosave.toast.retrySuccess.title"),
           variant: "success",
         });
       }
     }
-  }, [args.autosaveStatus, args.documentId, args.showToast, args.retryLastAutosave, t]);
+  }, [autosaveStatus, documentId, showToast, retryLastAutosave, t]);
 
   // Reset dedup tracking when document changes
   React.useEffect(() => {
     toastedDocRef.current = null;
-  }, [args.documentId]);
+  }, [documentId]);
 }
 
 /**
@@ -68,14 +74,15 @@ export function useFlushErrorToast(args: {
   showToast: (toast: Omit<ToastState, "open">) => void;
 }): void {
   const { t } = useTranslation();
+  const { flushError, showToast } = args;
 
   React.useEffect(() => {
-    if (args.flushError) {
-      args.showToast({
+    if (flushError) {
+      showToast({
         title: t("workbench.autosave.toast.flushError.title"),
         description: t("workbench.autosave.toast.flushError.description"),
         variant: "warning",
       });
     }
-  }, [args.flushError, args.showToast, t]);
+  }, [flushError, showToast, t]);
 }

--- a/apps/desktop/renderer/src/features/editor/useAutosaveToast.ts
+++ b/apps/desktop/renderer/src/features/editor/useAutosaveToast.ts
@@ -1,0 +1,81 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { AutosaveStatus } from "../../stores/editorStore";
+import type { ToastState } from "../../components/primitives/Toast";
+
+/**
+ * Hook that watches autosave status and triggers Toast notifications.
+ *
+ * Why: autosave failures must be visible to users so they can act on them.
+ * Dedup logic prevents toast spam for repeated failures on the same document.
+ */
+export function useAutosaveToast(args: {
+  autosaveStatus: AutosaveStatus;
+  documentId: string | null;
+  showToast: (toast: Omit<ToastState, "open">) => void;
+  retryLastAutosave: () => Promise<void>;
+}): void {
+  const { t } = useTranslation();
+  const prevStatusRef = React.useRef<AutosaveStatus>(args.autosaveStatus);
+  const toastedDocRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = args.autosaveStatus;
+
+    if (args.autosaveStatus === "error" && prev !== "error") {
+      // Dedup: don't re-toast the same document
+      if (args.documentId && args.documentId === toastedDocRef.current) {
+        return;
+      }
+      toastedDocRef.current = args.documentId;
+      args.showToast({
+        title: t("workbench.autosave.toast.error.title"),
+        description: t("workbench.autosave.toast.error.description"),
+        variant: "error",
+        action: {
+          label: t("workbench.autosave.toast.error.retry"),
+          onClick: () => {
+            void args.retryLastAutosave();
+          },
+        },
+      });
+    }
+
+    if (args.autosaveStatus === "saved" && prev === "saving") {
+      // If we previously had a toast for this doc and it just recovered, notify
+      if (toastedDocRef.current === args.documentId && args.documentId) {
+        toastedDocRef.current = null;
+        args.showToast({
+          title: t("workbench.autosave.toast.retrySuccess.title"),
+          variant: "success",
+        });
+      }
+    }
+  }, [args.autosaveStatus, args.documentId, args.showToast, args.retryLastAutosave, t]);
+
+  // Reset dedup tracking when document changes
+  React.useEffect(() => {
+    toastedDocRef.current = null;
+  }, [args.documentId]);
+}
+
+/**
+ * Hook to handle flush-save failure toast (warning on document switch).
+ */
+export function useFlushErrorToast(args: {
+  flushError: { documentId: string } | null;
+  showToast: (toast: Omit<ToastState, "open">) => void;
+}): void {
+  const { t } = useTranslation();
+
+  React.useEffect(() => {
+    if (args.flushError) {
+      args.showToast({
+        title: t("workbench.autosave.toast.flushError.title"),
+        description: t("workbench.autosave.toast.flushError.description"),
+        variant: "warning",
+      });
+    }
+  }, [args.flushError, args.showToast, t]);
+}

--- a/apps/desktop/renderer/src/i18n/autosave-i18n-keys.test.ts
+++ b/apps/desktop/renderer/src/i18n/autosave-i18n-keys.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const AUTOSAVE_KEYS = [
+  "workbench.autosave.status.saving",
+  "workbench.autosave.status.saved",
+  "workbench.autosave.status.error",
+  "workbench.autosave.toast.error.title",
+  "workbench.autosave.toast.error.description",
+  "workbench.autosave.toast.error.retry",
+  "workbench.autosave.toast.retrySuccess.title",
+  "workbench.autosave.toast.flushError.title",
+  "workbench.autosave.toast.flushError.description",
+  "workbench.autosave.a11y.retryLabel",
+] as const;
+
+function loadLocale(locale: string): Record<string, unknown> {
+  const filePath = path.resolve(
+    __dirname,
+    "locales",
+    `${locale}.json`,
+  );
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function getNestedValue(
+  obj: Record<string, unknown>,
+  keyPath: string,
+): unknown {
+  const parts = keyPath.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+describe("autosave i18n key 完整性 (AC-9)", () => {
+  const enData = loadLocale("en");
+  const zhData = loadLocale("zh-CN");
+
+  it.each(AUTOSAVE_KEYS)("en.json 包含 key: %s", (key) => {
+    const value = getNestedValue(enData, key);
+    expect(value).toBeDefined();
+    expect(typeof value).toBe("string");
+    expect((value as string).length).toBeGreaterThan(0);
+  });
+
+  it.each(AUTOSAVE_KEYS)("zh-CN.json 包含 key: %s", (key) => {
+    const value = getNestedValue(zhData, key);
+    expect(value).toBeDefined();
+    expect(typeof value).toBe("string");
+    expect((value as string).length).toBeGreaterThan(0);
+  });
+
+  it("中英文 autosave key 数量一致", () => {
+    const enAutosave = getNestedValue(enData, "workbench.autosave") as Record<
+      string,
+      unknown
+    >;
+    const zhAutosave = getNestedValue(zhData, "workbench.autosave") as Record<
+      string,
+      unknown
+    >;
+    expect(enAutosave).toBeDefined();
+    expect(zhAutosave).toBeDefined();
+    expect(JSON.stringify(Object.keys(enAutosave).sort())).toEqual(
+      JSON.stringify(Object.keys(zhAutosave).sort()),
+    );
+  });
+});

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -39,6 +39,30 @@
       "saved": "Saved",
       "error": "Save failed"
     },
+    "autosave": {
+      "status": {
+        "saving": "Saving...",
+        "saved": "Saved",
+        "error": "Save failed"
+      },
+      "toast": {
+        "error": {
+          "title": "Auto-save failed",
+          "description": "Your changes could not be saved automatically. Please retry or save manually.",
+          "retry": "Retry"
+        },
+        "retrySuccess": {
+          "title": "Save recovered"
+        },
+        "flushError": {
+          "title": "Previous document save failed",
+          "description": "Changes to the previous document may not have been saved."
+        }
+      },
+      "a11y": {
+        "retryLabel": "Retry save"
+      }
+    },
     "infoPanel": {
       "openVersionHistory": "View Version History"
     },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -39,6 +39,30 @@
       "saved": "已保存",
       "error": "保存失败"
     },
+    "autosave": {
+      "status": {
+        "saving": "保存中...",
+        "saved": "已保存",
+        "error": "保存失败"
+      },
+      "toast": {
+        "error": {
+          "title": "自动保存失败",
+          "description": "您的更改未能自动保存，请重试或手动保存。",
+          "retry": "重试"
+        },
+        "retrySuccess": {
+          "title": "保存已恢复"
+        },
+        "flushError": {
+          "title": "上一篇文档保存失败",
+          "description": "上一篇文档的更改可能未被保存。"
+        }
+      },
+      "a11y": {
+        "retryLabel": "重试保存"
+      }
+    },
     "infoPanel": {
       "openVersionHistory": "查看版本历史"
     },

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -55,6 +55,7 @@ export type EditorState = {
   capacityWarning: string | null;
   autosaveStatus: AutosaveStatus;
   autosaveError: IpcError | null;
+  flushError: { documentId: string } | null;
   entityCompletionSession: EntityCompletionSession;
   /** Whether compare mode is active (showing DiffView instead of Editor) */
   compareMode: boolean;
@@ -88,6 +89,7 @@ export type EditorActions = {
     projectId: string;
   }) => Promise<IpcInvokeResult<"knowledge:entity:list">>;
   clearAutosaveError: () => void;
+  setFlushError: (error: { documentId: string } | null) => void;
   downgradeFinalStatusForEdit: (args: {
     projectId: string;
     documentId: string;
@@ -228,11 +230,13 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
       capacityWarning: null,
       autosaveStatus: "idle",
       autosaveError: null,
+      flushError: null,
       entityCompletionSession: createInitialEntityCompletionSession(),
       compareMode: false,
       compareVersionId: null,
 
       setAutosaveStatus: (status) => set({ autosaveStatus: status }),
+      setFlushError: (error) => set({ flushError: error }),
       setDocumentCharacterCount: (count) =>
         set({ documentCharacterCount: count }),
       setCapacityWarning: (warning) => set({ capacityWarning: warning }),


### PR DESCRIPTION
## Summary

自动保存失败不再静默——用户可看到错误状态并手动重试。

Closes #992

## Changes

### SaveIndicator 四态指示（AC-1, AC-7, AC-10）
- idle: 不渲染可见内容
- saving: 旋转图标 + "保存中..." 文案
- saved: 成功文案（`--color-success`），2s 后自动回到 idle
- error: 红色错误指示器（`--color-error` + `--color-error-subtle` 背景），含错误图标

### 重试交互（AC-3, AC-4）
- StatusBar error 指示器可**点击**或**键盘Enter**触发 `retryLastAutosave()`
- Toast 中的 Retry action 按钮同样调用 `retryLastAutosave()`

### Error Toast（AC-2）
- autosave 失败时触发 error variant Toast，含 title/description/retry action
- 持续时间使用 error 默认值

### 去重逻辑（AC-5）
- 同一 `documentId` 连续失败不重复触发 Toast
- 切换到新文档后失败可正常触发

### 无障碍（AC-8）
- 保存指示区域具有 `role="status"` + `aria-live="polite"`
- error 态重试具有 `role="button"` + `aria-label`
- 旋转图标 `aria-hidden="true"`

### i18n（AC-9）
- zh-CN/en 均新增 `autosave.status/toast/a11y` 全部 key

### useAutosave cleanup 改进
- cleanup flush save 错误不再静默吞没（`.catch()` 替代 `void`）

## Verification

```bash
pnpm -C apps/desktop vitest run SaveIndicator StatusBar autosave-i18n-keys useAutosaveToast useAutosave
# 5 test files, 42 tests, all passed
pnpm typecheck  # 0 errors
pnpm lint       # 0 errors
```

## Rollback

Revert this single commit.

## Audit Gate

等待审计 Agent 发布 FINAL-VERDICT。