### PR TITLE
feat(settings): A0-14 Settings General 持久化 — PreferenceStore 收口

### DIFF
--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "./components/layout/AppShell";
 import { OnboardingPage } from "./features/onboarding";
 import { invoke } from "./lib/ipcClient";
 import { createPreferenceStore } from "./lib/preferences";
+import { PreferenceProvider } from "./lib/PreferenceContext";
 import { createAiStore, AiStoreProvider } from "./stores/aiStore";
 import { createEditorStore, EditorStoreProvider } from "./stores/editorStore";
 import { createFileStore, FileStoreProvider } from "./stores/fileStore";
@@ -143,6 +144,7 @@ export function App(): JSX.Element {
   }, []);
 
   return (
+    <PreferenceProvider value={preferences}>
     <ThemeStoreProvider store={themeStore}>
       <OnboardingStoreProvider store={onboardingStore}>
         <AiStoreProvider store={aiStore}>
@@ -171,5 +173,6 @@ export function App(): JSX.Element {
         </AiStoreProvider>
       </OnboardingStoreProvider>
     </ThemeStoreProvider>
+    </PreferenceProvider>
   );
 }

--- a/apps/desktop/renderer/src/__integration__/dashboard-editor-flow.test.tsx
+++ b/apps/desktop/renderer/src/__integration__/dashboard-editor-flow.test.tsx
@@ -26,6 +26,7 @@ import {
   VersionStoreProvider,
   createVersionStore,
 } from "../stores/versionStore";
+import { PreferenceProvider } from "../lib/PreferenceContext";
 
 // =============================================================================
 // Test Fixtures
@@ -209,27 +210,29 @@ function IntegrationTestWrapper({
   const themeStore = React.useMemo(() => createThemeStore(mockPreferences), []);
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <ThemeStoreProvider store={themeStore}>
-              <AiStoreProvider store={aiStore}>
-                <MemoryStoreProvider store={memoryStore}>
-                  <SearchStoreProvider store={searchStore}>
-                    <KgStoreProvider store={kgStore}>
-                      <VersionStoreProvider store={versionStore}>
-                        {children}
-                      </VersionStoreProvider>
-                    </KgStoreProvider>
-                  </SearchStoreProvider>
-                </MemoryStoreProvider>
-              </AiStoreProvider>
-            </ThemeStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <ThemeStoreProvider store={themeStore}>
+                <AiStoreProvider store={aiStore}>
+                  <MemoryStoreProvider store={memoryStore}>
+                    <SearchStoreProvider store={searchStore}>
+                      <KgStoreProvider store={kgStore}>
+                        <VersionStoreProvider store={versionStore}>
+                          {children}
+                        </VersionStoreProvider>
+                      </KgStoreProvider>
+                    </SearchStoreProvider>
+                  </MemoryStoreProvider>
+                </AiStoreProvider>
+              </ThemeStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/components/layout/AppShell.ai-toggle.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.ai-toggle.test.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../stores/searchStore";
 import { KgStoreProvider, createKgStore } from "../../stores/kgStore";
 import { ThemeStoreProvider, createThemeStore } from "../../stores/themeStore";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 const mockPreferences = {
   get: <T,>(): T | null => null,
@@ -108,27 +109,29 @@ function TestWrapper({
   const themeStore = React.useMemo(() => createThemeStore(mockPreferences), []);
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <VersionStoreProvider store={versionStore}>
-              <ThemeStoreProvider store={themeStore}>
-                <AiStoreProvider store={aiStore}>
-                  <MemoryStoreProvider store={memoryStore}>
-                    <SearchStoreProvider store={searchStore}>
-                      <KgStoreProvider store={kgStore}>
-                        {children}
-                      </KgStoreProvider>
-                    </SearchStoreProvider>
-                  </MemoryStoreProvider>
-                </AiStoreProvider>
-              </ThemeStoreProvider>
-            </VersionStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <VersionStoreProvider store={versionStore}>
+                <ThemeStoreProvider store={themeStore}>
+                  <AiStoreProvider store={aiStore}>
+                    <MemoryStoreProvider store={memoryStore}>
+                      <SearchStoreProvider store={searchStore}>
+                        <KgStoreProvider store={kgStore}>
+                          {children}
+                        </KgStoreProvider>
+                      </SearchStoreProvider>
+                    </MemoryStoreProvider>
+                  </AiStoreProvider>
+                </ThemeStoreProvider>
+              </VersionStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.test.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../stores/searchStore";
 import { KgStoreProvider, createKgStore } from "../../stores/kgStore";
 import { ThemeStoreProvider, createThemeStore } from "../../stores/themeStore";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 /**
  * Mock preferences for testing.
@@ -127,27 +128,29 @@ function AppShellTestWrapper({
   const themeStore = React.useMemo(() => createThemeStore(mockPreferences), []);
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <VersionStoreProvider store={versionStore}>
-              <ThemeStoreProvider store={themeStore}>
-                <AiStoreProvider store={aiStore}>
-                  <MemoryStoreProvider store={memoryStore}>
-                    <SearchStoreProvider store={searchStore}>
-                      <KgStoreProvider store={kgStore}>
-                        {children}
-                      </KgStoreProvider>
-                    </SearchStoreProvider>
-                  </MemoryStoreProvider>
-                </AiStoreProvider>
-              </ThemeStoreProvider>
-            </VersionStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <VersionStoreProvider store={versionStore}>
+                <ThemeStoreProvider store={themeStore}>
+                  <AiStoreProvider store={aiStore}>
+                    <MemoryStoreProvider store={memoryStore}>
+                      <SearchStoreProvider store={searchStore}>
+                        <KgStoreProvider store={kgStore}>
+                          {children}
+                        </KgStoreProvider>
+                      </SearchStoreProvider>
+                    </MemoryStoreProvider>
+                  </AiStoreProvider>
+                </ThemeStoreProvider>
+              </VersionStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/components/layout/IconBar.dialog-migration.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/IconBar.dialog-migration.test.tsx
@@ -15,6 +15,7 @@ import { MemoryStoreProvider, createMemoryStore } from "../../stores/memoryStore
 import { SearchStoreProvider, createSearchStore } from "../../stores/searchStore";
 import { KgStoreProvider, createKgStore } from "../../stores/kgStore";
 import { ThemeStoreProvider, createThemeStore } from "../../stores/themeStore";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 const mockPreferences = {
   get: <T,>(): T | null => null,
@@ -99,27 +100,29 @@ function AppShellTestWrapper(props: { children: React.ReactNode }): JSX.Element 
   const themeStore = React.useMemo(() => createThemeStore(mockPreferences), []);
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <VersionStoreProvider store={versionStore}>
-              <ThemeStoreProvider store={themeStore}>
-                <AiStoreProvider store={aiStore}>
-                  <MemoryStoreProvider store={memoryStore}>
-                    <SearchStoreProvider store={searchStore}>
-                      <KgStoreProvider store={kgStore}>
-                        {props.children}
-                      </KgStoreProvider>
-                    </SearchStoreProvider>
-                  </MemoryStoreProvider>
-                </AiStoreProvider>
-              </ThemeStoreProvider>
-            </VersionStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <VersionStoreProvider store={versionStore}>
+                <ThemeStoreProvider store={themeStore}>
+                  <AiStoreProvider store={aiStore}>
+                    <MemoryStoreProvider store={memoryStore}>
+                      <SearchStoreProvider store={searchStore}>
+                        <KgStoreProvider store={kgStore}>
+                          {props.children}
+                        </KgStoreProvider>
+                      </SearchStoreProvider>
+                    </MemoryStoreProvider>
+                  </AiStoreProvider>
+                </ThemeStoreProvider>
+              </VersionStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/components/layout/Layout.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/Layout.test.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../stores/searchStore";
 import { KgStoreProvider, createKgStore } from "../../stores/kgStore";
 import { ThemeStoreProvider, createThemeStore } from "../../stores/themeStore";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 /**
  * Mock preferences for testing.
@@ -94,23 +95,25 @@ function LayoutTestWrapper({
   const themeStore = React.useMemo(() => createThemeStore(mockPreferences), []);
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <ThemeStoreProvider store={themeStore}>
-              <AiStoreProvider store={aiStore}>
-                <MemoryStoreProvider store={memoryStore}>
-                  <SearchStoreProvider store={searchStore}>
-                    <KgStoreProvider store={kgStore}>{children}</KgStoreProvider>
-                  </SearchStoreProvider>
-                </MemoryStoreProvider>
-              </AiStoreProvider>
-            </ThemeStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <ThemeStoreProvider store={themeStore}>
+                <AiStoreProvider store={aiStore}>
+                  <MemoryStoreProvider store={memoryStore}>
+                    <SearchStoreProvider store={searchStore}>
+                      <KgStoreProvider store={kgStore}>{children}</KgStoreProvider>
+                    </SearchStoreProvider>
+                  </MemoryStoreProvider>
+                </AiStoreProvider>
+              </ThemeStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/components/layout/test-utils.tsx
+++ b/apps/desktop/renderer/src/components/layout/test-utils.tsx
@@ -23,6 +23,7 @@ import {
   createSearchStore,
 } from "../../stores/searchStore";
 import { KgStoreProvider, createKgStore } from "../../stores/kgStore";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 /**
  * Mock preferences for testing layout components.
@@ -141,25 +142,27 @@ export function LayoutTestWrapper({
   );
 
   return (
-    <LayoutStoreProvider store={layoutStore}>
-      <ProjectStoreProvider store={projectStore}>
-        <FileStoreProvider store={fileStore}>
-          <EditorStoreProvider store={editorStore}>
-            <ThemeStoreProvider store={themeStore}>
-              <AiStoreProvider store={aiStore}>
-                <MemoryStoreProvider store={memoryStore}>
-                  <SearchStoreProvider store={searchStore}>
-                    <KgStoreProvider store={kgStore}>
-                      {children}
-                    </KgStoreProvider>
-                  </SearchStoreProvider>
-                </MemoryStoreProvider>
-              </AiStoreProvider>
-            </ThemeStoreProvider>
-          </EditorStoreProvider>
-        </FileStoreProvider>
-      </ProjectStoreProvider>
-    </LayoutStoreProvider>
+    <PreferenceProvider value={mockPreferences}>
+      <LayoutStoreProvider store={layoutStore}>
+        <ProjectStoreProvider store={projectStore}>
+          <FileStoreProvider store={fileStore}>
+            <EditorStoreProvider store={editorStore}>
+              <ThemeStoreProvider store={themeStore}>
+                <AiStoreProvider store={aiStore}>
+                  <MemoryStoreProvider store={memoryStore}>
+                    <SearchStoreProvider store={searchStore}>
+                      <KgStoreProvider store={kgStore}>
+                        {children}
+                      </KgStoreProvider>
+                    </SearchStoreProvider>
+                  </MemoryStoreProvider>
+                </AiStoreProvider>
+              </ThemeStoreProvider>
+            </EditorStoreProvider>
+          </FileStoreProvider>
+        </ProjectStoreProvider>
+      </LayoutStoreProvider>
+    </PreferenceProvider>
   );
 }
 

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { createPreferenceStore } from "../../lib/preferences";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 import { createThemeStore, ThemeStoreProvider } from "../../stores/themeStore";
 import { SettingsDialog } from "./SettingsDialog";
 
@@ -52,6 +53,7 @@ const meta: Meta<typeof SettingsDialog> = {
   decorators: [
     (Story) => {
       return (
+        <PreferenceProvider value={preferences}>
         <ThemeStoreProvider store={themeStore}>
           <div
             className="w-full h-screen bg-[var(--color-bg-base)]"
@@ -60,6 +62,7 @@ const meta: Meta<typeof SettingsDialog> = {
             <Story />
           </div>
         </ThemeStoreProvider>
+        </PreferenceProvider>
       );
     },
   ],

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
@@ -4,6 +4,50 @@ import userEvent from "@testing-library/user-event";
 
 import { SettingsDialog } from "./SettingsDialog";
 
+vi.mock("../../lib/PreferenceContext", () => ({
+  usePreferenceStore: () => ({
+    get: () => null,
+    set: () => {},
+    remove: () => {},
+    clear: () => {},
+  }),
+}));
+
+vi.mock("./settingsGeneralPersistence", () => ({
+  loadGeneralSettings: () => ({
+    focusMode: true,
+    typewriterScroll: false,
+    smartPunctuation: true,
+    localAutoSave: true,
+    backupInterval: "5min",
+    defaultTypography: "inter",
+    interfaceScale: 100,
+  }),
+  saveGeneralSettings: () => {},
+}));
+
+vi.mock("../../lib/PreferenceContext", () => ({
+  usePreferenceStore: () => ({
+    get: () => null,
+    set: () => {},
+    remove: () => {},
+    clear: () => {},
+  }),
+}));
+
+vi.mock("./settingsGeneralPersistence", () => ({
+  loadGeneralSettings: () => ({
+    focusMode: true,
+    typewriterScroll: false,
+    smartPunctuation: true,
+    localAutoSave: true,
+    backupInterval: "5min",
+    defaultTypography: "inter",
+    interfaceScale: 100,
+  }),
+  saveGeneralSettings: () => {},
+}));
+
 vi.mock("./SettingsGeneral", () => ({
   SettingsGeneral: () => <div data-testid="mock-general-section">General</div>,
   defaultGeneralSettings: {

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -9,9 +9,10 @@ import { AiSettingsSection } from "../settings/AiSettingsSection";
 import { JudgeSection } from "../settings/JudgeSection";
 import {
   SettingsGeneral,
-  defaultGeneralSettings,
   type GeneralSettings,
 } from "./SettingsGeneral";
+import { usePreferenceStore } from "../../lib/PreferenceContext";
+import { loadGeneralSettings, saveGeneralSettings } from "./settingsGeneralPersistence";
 import {
   SettingsAccount,
   defaultAccountSettings,
@@ -164,8 +165,17 @@ export function SettingsDialog({
   const { t } = useTranslation();
   const navItems = getNavItems(t);
   const [activeTab, setActiveTab] = React.useState<SettingsTab>(defaultTab);
+  const preferenceStore = usePreferenceStore();
   const [generalSettings, setGeneralSettings] = React.useState<GeneralSettings>(
-    defaultGeneralSettings,
+    () => loadGeneralSettings(preferenceStore),
+  );
+
+  const handleGeneralSettingsChange = React.useCallback(
+    (settings: GeneralSettings) => {
+      setGeneralSettings(settings);
+      saveGeneralSettings(preferenceStore, settings);
+    },
+    [preferenceStore],
   );
   const [accountSettings] = React.useState<AccountSettings>(
     defaultAccountSettings,
@@ -187,7 +197,7 @@ export function SettingsDialog({
             settings={generalSettings}
             showAiMarks={showAiMarks}
             onShowAiMarksChange={setShowAiMarks}
-            onSettingsChange={setGeneralSettings}
+            onSettingsChange={handleGeneralSettingsChange}
           />
         );
       case "appearance":

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.language.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.language.test.tsx
@@ -1,10 +1,9 @@
+import React from "react";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../i18n/languagePreference", () => ({
-  getLanguagePreference: vi.fn(() => "zh-CN"),
-  setLanguagePreference: vi.fn(),
-}));
+import { createPreferenceStore, type PreferenceStore } from "../../lib/preferences";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
 
 vi.mock("../../i18n", () => ({
   i18n: { changeLanguage: vi.fn(() => Promise.resolve()) },
@@ -15,13 +14,38 @@ import {
   defaultGeneralSettings,
 } from "./SettingsGeneral";
 
+function createMockStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() { return store.size; },
+  };
+}
+
+function renderWithPreferences(
+  preferenceStore: PreferenceStore,
+  ui: React.ReactElement,
+) {
+  return render(
+    <PreferenceProvider value={preferenceStore}>{ui}</PreferenceProvider>,
+  );
+}
+
 describe("SettingsGeneral language selector", () => {
+  let preferenceStore: PreferenceStore;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    preferenceStore = createPreferenceStore(createMockStorage());
   });
 
   it("renders a Language section heading", () => {
-    render(
+    renderWithPreferences(
+      preferenceStore,
       <SettingsGeneral
         settings={defaultGeneralSettings}
         showAiMarks={false}
@@ -34,7 +58,8 @@ describe("SettingsGeneral language selector", () => {
   });
 
   it("renders a Display Language label", () => {
-    render(
+    renderWithPreferences(
+      preferenceStore,
       <SettingsGeneral
         settings={defaultGeneralSettings}
         showAiMarks={false}
@@ -46,8 +71,9 @@ describe("SettingsGeneral language selector", () => {
     expect(screen.getByText("Display Language")).toBeInTheDocument();
   });
 
-  it("shows current language preference as default", () => {
-    render(
+  it("shows default language when no preference stored", () => {
+    renderWithPreferences(
+      preferenceStore,
       <SettingsGeneral
         settings={defaultGeneralSettings}
         showAiMarks={false}
@@ -56,8 +82,7 @@ describe("SettingsGeneral language selector", () => {
       />,
     );
 
-    // getLanguagePreference mock returns "zh-CN", so the Select should
-    // display the matching label from languageOptions.
+    // Default is zh-CN, so it should render the Chinese label
     expect(screen.getByText("Chinese (Simplified)")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -6,10 +6,7 @@ import { Slider } from "../../components/primitives/Slider";
 import { Select } from "../../components/primitives";
 import { FormField } from "../../components/composites/FormField";
 import { i18n } from "../../i18n";
-import {
-  getLanguagePreference,
-  setLanguagePreference,
-} from "../../i18n/languagePreference";
+import { usePreferenceStore } from "../../lib/PreferenceContext";
 
 /**
  * Settings state for General page
@@ -97,15 +94,17 @@ export function SettingsGeneral({
     { value: "en", label: "English" },
   ], [t]);
 
+  const preferenceStore = usePreferenceStore();
+
   const [currentLanguage, setCurrentLanguage] = React.useState(
-    () => getLanguagePreference(),
+    () => preferenceStore.get<string>("creonow.settings.language") ?? "zh-CN",
   );
 
   const handleLanguageChange = React.useCallback((value: string) => {
     setCurrentLanguage(value);
-    setLanguagePreference(value);
+    preferenceStore.set("creonow.settings.language", value);
     void i18n.changeLanguage(value);
-  }, []);
+  }, [preferenceStore]);
 
   const updateSetting = <K extends keyof GeneralSettings>(
     key: K,

--- a/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.test.tsx
@@ -1,0 +1,230 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+  createPreferenceStore,
+  type PreferenceStore,
+} from "../../lib/preferences";
+import { PreferenceProvider } from "../../lib/PreferenceContext";
+import {
+  loadGeneralSettings,
+  saveGeneralSetting,
+} from "./settingsGeneralPersistence";
+import {
+  SettingsGeneral,
+  defaultGeneralSettings,
+} from "./SettingsGeneral";
+
+vi.mock("../../i18n", () => ({
+  i18n: { changeLanguage: vi.fn(() => Promise.resolve()) },
+}));
+
+function createMockStorage(initial?: Record<string, string>): Storage {
+  const store = new Map<string, string>(
+    initial ? Object.entries(initial) : [],
+  );
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function renderWithPreferences(
+  preferenceStore: PreferenceStore,
+  ui: React.ReactElement,
+) {
+  return render(
+    <PreferenceProvider value={preferenceStore}>{ui}</PreferenceProvider>,
+  );
+}
+
+describe("loadGeneralSettings", () => {
+  it("returns default values when store is empty", () => {
+    const store = createPreferenceStore(createMockStorage());
+    const settings = loadGeneralSettings(store);
+    expect(settings).toEqual(defaultGeneralSettings);
+  });
+
+  it("merges stored values with defaults", () => {
+    const store = createPreferenceStore(createMockStorage());
+    store.set("creonow.settings.focusMode", false);
+    store.set("creonow.settings.backupInterval", "1hour");
+
+    const settings = loadGeneralSettings(store);
+    expect(settings.focusMode).toBe(false);
+    expect(settings.backupInterval).toBe("1hour");
+    // Others remain default
+    expect(settings.typewriterScroll).toBe(false);
+    expect(settings.smartPunctuation).toBe(true);
+  });
+});
+
+describe("saveGeneralSetting", () => {
+  it("persists a single setting to the store", () => {
+    const store = createPreferenceStore(createMockStorage());
+    saveGeneralSetting(store, "interfaceScale", 120);
+    expect(store.get("creonow.settings.interfaceScale")).toBe(120);
+  });
+});
+
+describe("SettingsGeneral persistence integration", () => {
+  let preferenceStore: PreferenceStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    preferenceStore = createPreferenceStore(createMockStorage());
+  });
+
+  it("AC-3: shows default values when no preferences exist", () => {
+    renderWithPreferences(
+      preferenceStore,
+      <SettingsGeneral
+        settings={defaultGeneralSettings}
+        showAiMarks={false}
+        onShowAiMarksChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    // Default language is zh-CN
+    expect(screen.getByText("Chinese (Simplified)")).toBeInTheDocument();
+  });
+
+  it("AC-4: onSettingsChange propagates toggle interactions", async () => {
+    const user = userEvent.setup();
+    const onSettingsChange = vi.fn();
+
+    renderWithPreferences(
+      preferenceStore,
+      <SettingsGeneral
+        settings={defaultGeneralSettings}
+        showAiMarks={false}
+        onShowAiMarksChange={vi.fn()}
+        onSettingsChange={onSettingsChange}
+      />,
+    );
+
+    // Smart Punctuation toggle — default is on, click should turn off
+    const toggles = screen.getAllByRole("switch");
+    // Find the Smart Punctuation toggle (3rd writing toggle)
+    const smartPuncToggle = toggles[2];
+    await user.click(smartPuncToggle);
+
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ smartPunctuation: false }),
+    );
+  });
+
+  it("AC-5: loads persisted values when preStore has data", () => {
+    preferenceStore.set("creonow.settings.focusMode", false);
+    preferenceStore.set("creonow.settings.backupInterval", "1hour");
+
+    const loaded = loadGeneralSettings(preferenceStore);
+    expect(loaded.focusMode).toBe(false);
+    expect(loaded.backupInterval).toBe("1hour");
+    // re-opening should retain
+    const loaded2 = loadGeneralSettings(preferenceStore);
+    expect(loaded2.focusMode).toBe(false);
+  });
+
+  it("AC-6: persists language change via PreferenceStore", async () => {
+    // Radix Select uses pointer-events:none in jsdom, so disable the check
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+    renderWithPreferences(
+      preferenceStore,
+      <SettingsGeneral
+        settings={defaultGeneralSettings}
+        showAiMarks={false}
+        onShowAiMarksChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    // Open language selector and choose English
+    const trigger = screen.getByText("Chinese (Simplified)");
+    await user.click(trigger);
+
+    const englishOption = await screen.findByText("English");
+    await user.click(englishOption);
+
+    expect(preferenceStore.get("creonow.settings.language")).toBe("en");
+  });
+
+  it("AC-6: loads persisted language preference", () => {
+    preferenceStore.set("creonow.settings.language", "en");
+
+    renderWithPreferences(
+      preferenceStore,
+      <SettingsGeneral
+        settings={defaultGeneralSettings}
+        showAiMarks={false}
+        onShowAiMarksChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("English")).toBeInTheDocument();
+  });
+
+  it("AC-7: falls back to default on corrupted value in storage", () => {
+    // Write corrupted JSON directly to the mock storage backing the store
+    const storage = createMockStorage({
+      "creonow.version": "1",
+      "creonow.settings.interfaceScale": "not-valid-json{{{",
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createPreferenceStore(storage);
+    const settings = loadGeneralSettings(store);
+
+    // Should fall back to default
+    expect(settings.interfaceScale).toBe(100);
+    errorSpy.mockRestore();
+  });
+
+  it("AC-7: does not throw on corrupted value", () => {
+    const storage = createMockStorage({
+      "creonow.version": "1",
+      "creonow.settings.focusMode": "broken!!!",
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createPreferenceStore(storage);
+
+    expect(() => loadGeneralSettings(store)).not.toThrow();
+    errorSpy.mockRestore();
+  });
+
+  it("AC-8: SettingsDialog.tsx has no direct localStorage calls", () => {
+    const dialogSrc = fs.readFileSync(
+      path.resolve(__dirname, "./SettingsDialog.tsx"),
+      "utf-8",
+    );
+    expect(dialogSrc).not.toContain("localStorage.getItem");
+    expect(dialogSrc).not.toContain("localStorage.setItem");
+  });
+
+  it("AC-8: SettingsGeneral.tsx has no direct localStorage calls", () => {
+    const generalSrc = fs.readFileSync(
+      path.resolve(__dirname, "./SettingsGeneral.tsx"),
+      "utf-8",
+    );
+    expect(generalSrc).not.toContain("localStorage.getItem");
+    expect(generalSrc).not.toContain("localStorage.setItem");
+  });
+});

--- a/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.ts
+++ b/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.ts
@@ -1,0 +1,61 @@
+import type { PreferenceStore, PreferenceKey } from "../../lib/preferences";
+import { defaultGeneralSettings, type GeneralSettings } from "./SettingsGeneral";
+
+/**
+ * Maps GeneralSettings keys to PreferenceKey strings.
+ */
+const SETTINGS_KEY_MAP: Record<keyof GeneralSettings, PreferenceKey> = {
+  focusMode: "creonow.settings.focusMode",
+  typewriterScroll: "creonow.settings.typewriterScroll",
+  smartPunctuation: "creonow.settings.smartPunctuation",
+  localAutoSave: "creonow.settings.localAutoSave",
+  backupInterval: "creonow.settings.backupInterval",
+  defaultTypography: "creonow.settings.defaultTypography",
+  interfaceScale: "creonow.settings.interfaceScale",
+};
+
+/**
+ * Load all General settings from PreferenceStore, falling back to defaults.
+ */
+export function loadGeneralSettings(store: PreferenceStore): GeneralSettings {
+  const result = { ...defaultGeneralSettings };
+
+  for (const [field, prefKey] of Object.entries(SETTINGS_KEY_MAP) as Array<
+    [keyof GeneralSettings, PreferenceKey]
+  >) {
+    const stored = store.get(prefKey);
+    if (stored !== null) {
+      (result as Record<string, unknown>)[field] = stored;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Save a single General setting to PreferenceStore.
+ */
+export function saveGeneralSetting<K extends keyof GeneralSettings>(
+  store: PreferenceStore,
+  key: K,
+  value: GeneralSettings[K],
+): void {
+  const prefKey = SETTINGS_KEY_MAP[key];
+  if (prefKey) {
+    store.set(prefKey, value);
+  }
+}
+
+/**
+ * Save all General settings to PreferenceStore.
+ */
+export function saveGeneralSettings(
+  store: PreferenceStore,
+  settings: GeneralSettings,
+): void {
+  for (const [field, prefKey] of Object.entries(SETTINGS_KEY_MAP) as Array<
+    [keyof GeneralSettings, PreferenceKey]
+  >) {
+    store.set(prefKey, settings[field]);
+  }
+}

--- a/apps/desktop/renderer/src/i18n/__tests__/languagePreference.test.ts
+++ b/apps/desktop/renderer/src/i18n/__tests__/languagePreference.test.ts
@@ -26,7 +26,7 @@ describe("languagePreference", () => {
   });
 
   it("reads language from localStorage", () => {
-    mockStorage["creonow-language"] = "en";
+    mockStorage["creonow.settings.language"] = JSON.stringify("en");
     expect(getLanguagePreference()).toBe("en");
   });
 
@@ -35,7 +35,7 @@ describe("languagePreference", () => {
   });
 
   it("falls back to zh-CN for unsupported values", () => {
-    mockStorage["creonow-language"] = "fr";
+    mockStorage["creonow.settings.language"] = JSON.stringify("fr");
     expect(getLanguagePreference()).toBe("zh-CN");
   });
 
@@ -52,8 +52,8 @@ describe("languagePreference", () => {
   it("persists language to localStorage", () => {
     setLanguagePreference("en");
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      "creonow-language",
-      "en",
+      "creonow.settings.language",
+      JSON.stringify("en"),
     );
   });
 

--- a/apps/desktop/renderer/src/i18n/languagePreference.ts
+++ b/apps/desktop/renderer/src/i18n/languagePreference.ts
@@ -1,13 +1,12 @@
 /**
  * Language preference persistence — localStorage-only, no i18n dependency.
  *
- * Reading and writing are intentionally decoupled from the i18n instance
- * to avoid circular imports (index.ts → languagePreference → index.ts).
- * Callers that need to hot-switch the UI language should also call
- * `i18n.changeLanguage(lng)` after `setLanguagePreference(lng)`.
+ * Reads/writes the unified PreferenceStore key `creonow.settings.language`
+ * so that i18n init, onboarding, and Settings General all share one source.
+ * Values are JSON-serialized to match PreferenceStore conventions.
  */
 
-const STORAGE_KEY = "creonow-language";
+const STORAGE_KEY = "creonow.settings.language";
 const DEFAULT_LANGUAGE = "zh-CN";
 
 /**
@@ -17,9 +16,13 @@ const DEFAULT_LANGUAGE = "zh-CN";
  */
 export function getLanguagePreference(): string {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "en" || stored === "zh-CN") {
-      return stored;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) {
+      return DEFAULT_LANGUAGE;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === "en" || parsed === "zh-CN") {
+      return parsed;
     }
     return DEFAULT_LANGUAGE;
   } catch {
@@ -33,7 +36,7 @@ export function getLanguagePreference(): string {
  */
 export function setLanguagePreference(lng: string): void {
   try {
-    localStorage.setItem(STORAGE_KEY, lng);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(lng));
   } catch {
     // localStorage may be unavailable in some environments
   }

--- a/apps/desktop/renderer/src/lib/PreferenceContext.ts
+++ b/apps/desktop/renderer/src/lib/PreferenceContext.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+import type { PreferenceStore } from "./preferences";
+
+const PreferenceContext = React.createContext<PreferenceStore | null>(null);
+
+export const PreferenceProvider = PreferenceContext.Provider;
+
+export function usePreferenceStore(): PreferenceStore {
+  const store = React.useContext(PreferenceContext);
+  if (!store) {
+    throw new Error("usePreferenceStore must be used within a PreferenceProvider");
+  }
+  return store;
+}

--- a/apps/desktop/renderer/src/lib/preferences.test.ts
+++ b/apps/desktop/renderer/src/lib/preferences.test.ts
@@ -62,3 +62,32 @@ describe("createPreferenceStore", () => {
     errorSpy.mockRestore();
   });
 });
+
+describe("PreferenceKey settings extension", () => {
+  it("isCreonowKey recognizes creonow.settings.focusMode", () => {
+    const store = createPreferenceStore(createMockStorage());
+    store.set("creonow.settings.focusMode", false);
+    expect(store.get("creonow.settings.focusMode")).toBe(false);
+  });
+
+  it("isCreonowKey recognizes creonow.settings.typewriterScroll", () => {
+    const store = createPreferenceStore(createMockStorage());
+    store.set("creonow.settings.typewriterScroll", true);
+    expect(store.get("creonow.settings.typewriterScroll")).toBe(true);
+  });
+
+  it("isCreonowKey recognizes creonow.settings.language", () => {
+    const store = createPreferenceStore(createMockStorage());
+    store.set("creonow.settings.language", "en");
+    expect(store.get("creonow.settings.language")).toBe("en");
+  });
+
+  it("clear() removes creonow.settings.* keys", () => {
+    const store = createPreferenceStore(createMockStorage());
+    store.set("creonow.settings.focusMode", true);
+    store.set("creonow.settings.backupInterval", "1hour");
+    store.clear();
+    expect(store.get("creonow.settings.focusMode")).toBeNull();
+    expect(store.get("creonow.settings.backupInterval")).toBeNull();
+  });
+});

--- a/apps/desktop/renderer/src/lib/preferences.ts
+++ b/apps/desktop/renderer/src/lib/preferences.ts
@@ -16,6 +16,15 @@ export type PreferenceKey =
   | `${typeof APP_ID}.theme.${"mode"}`
   | `${typeof APP_ID}.editor.${"showAiMarks"}`
   | `${typeof APP_ID}.onboarding.${"completed"}`
+  | `${typeof APP_ID}.settings.${
+      | "focusMode"
+      | "typewriterScroll"
+      | "smartPunctuation"
+      | "localAutoSave"
+      | "backupInterval"
+      | "defaultTypography"
+      | "interfaceScale"
+      | "language"}`
   | `${typeof APP_ID}.version`;
 
 export interface PreferenceStore {
@@ -47,7 +56,9 @@ function isCreonowKey(key: string): key is PreferenceKey {
     key.startsWith(`${APP_ID}.layout.`) ||
     key.startsWith(`${APP_ID}.theme.`) ||
     key.startsWith(`${APP_ID}.editor.`) ||
-    key.startsWith(`${APP_ID}.onboarding.`)
+    key.startsWith(`${APP_ID}.onboarding.`) ||
+    key.startsWith(`${APP_ID}.settings.`) ||
+    key.startsWith(`${APP_ID}.settings.`)
   );
 }
 

--- a/apps/desktop/renderer/src/lib/preferences.ts
+++ b/apps/desktop/renderer/src/lib/preferences.ts
@@ -57,7 +57,6 @@ function isCreonowKey(key: string): key is PreferenceKey {
     key.startsWith(`${APP_ID}.theme.`) ||
     key.startsWith(`${APP_ID}.editor.`) ||
     key.startsWith(`${APP_ID}.onboarding.`) ||
-    key.startsWith(`${APP_ID}.settings.`) ||
     key.startsWith(`${APP_ID}.settings.`)
   );
 }


### PR DESCRIPTION
## Summary

Settings General 页面的全部设置项（Focus Mode, 打字机滚动, 智能标点, 本地自动保存, 备份间隔, 默认字体, 界面缩放, 语言）从 `useState` 改为通过 `PreferenceStore` 持久化，关闭对话框后再打开依然保留用户上次的修改。

## Changes

### Core
- **`preferences.ts`**: `PreferenceKey` 联合类型新增 `creonow.settings.*` 8 个 key；`isCreonowKey()` 新增 `creonow.settings.` 前缀分支
- **`PreferenceContext.ts`** (新): React Context + `usePreferenceStore()` hook，为所有子树提供 `PreferenceStore` 实例
- **`settingsGeneralPersistence.ts`** (新): `loadGeneralSettings()` / `saveGeneralSettings()` / `saveGeneralSetting()` 读写辅助函数
- **`SettingsDialog.tsx`**: 初始化时从 `PreferenceStore` 读取；变更时写入 store
- **`SettingsGeneral.tsx`**: 语言持久化从裸 `localStorage` 收口到 `PreferenceStore`
- **`App.tsx`**: Provider 树顶层包裹 `PreferenceProvider`

### Tests (29 pass / 5 files)
- `preferences.test.ts`: AC-1/AC-2 — `isCreonowKey` + 存取 + `clear()` 4 cases
- `settingsGeneralPersistence.test.tsx`: AC-3~AC-8 — 默认值、持久化写入、重启恢复、语言持久化、损坏容错、无直接 localStorage 调用 12 cases
- `SettingsGeneral.language.test.tsx`: 3 cases 重构为 PreferenceProvider 注入
- `SettingsDialog.test.tsx`: 6 cases 新增 mock 适配
- `SettingsAccount.test.tsx`: 2 cases 回归通过

## Verification
```
pnpm -C apps/desktop vitest run preferences.test settings-dialog  # 29 passed
npx tsc --noEmit                                                   # 0 errors
```

## Checklist
- [x] AC-1 PreferenceKey 扩展
- [x] AC-2 isCreonowKey 守卫
- [x] AC-3 首次启动默认值
- [x] AC-4 修改即时持久化
- [x] AC-5 恢复持久化偏好
- [x] AC-6 语言持久化统一
- [x] AC-7 损坏值容错
- [x] AC-8 无直接 localStorage 调用

Closes #994