### PR TITLE
feat(a0-15): 收口所有假功能占位 UI

### DIFF
--- a/apps/desktop/renderer/src/features/ai/ChatHistory.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/ChatHistory.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ChatHistory } from "./ChatHistory";
+
+describe("ChatHistory placeholder UI closure", () => {
+  it("Scenario: ChatHistory 空态展示 Coming Soon 文案", () => {
+    const onSelectChat = vi.fn();
+
+    render(
+      <ChatHistory open onOpenChange={vi.fn()} onSelectChat={onSelectChat} />,
+    );
+
+    expect(screen.getByText("Coming Soon")).toBeInTheDocument();
+  });
+
+  it("Scenario: ChatHistory onSelectChat 不会被调用（无可点击条目）", async () => {
+    const user = userEvent.setup();
+    const onSelectChat = vi.fn();
+
+    render(
+      <ChatHistory open onOpenChange={vi.fn()} onSelectChat={onSelectChat} />,
+    );
+
+    // Click inside the dialog area — should not trigger onSelectChat
+    const dialog = screen.getByRole("dialog");
+    await user.click(dialog);
+
+    expect(onSelectChat).not.toHaveBeenCalled();
+  });
+
+  it("Scenario: ChatHistory 关闭时不渲染", () => {
+    render(
+      <ChatHistory
+        open={false}
+        onOpenChange={vi.fn()}
+        onSelectChat={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/ai/ChatHistory.tsx
+++ b/apps/desktop/renderer/src/features/ai/ChatHistory.tsx
@@ -16,6 +16,7 @@ type ChatHistoryProps = {
  */
 export function ChatHistory(props: ChatHistoryProps): JSX.Element | null {
   const { t } = useTranslation();
+  void props.onSelectChat; // Reserved for future use — chat persistence not yet available
 
   if (!props.open) {
     return null;
@@ -56,6 +57,9 @@ export function ChatHistory(props: ChatHistoryProps): JSX.Element | null {
           </Text>
           <Text size="tiny" color="muted" className="mt-1 block">
             {t('ai.chatHistory.emptyDescription')}
+          </Text>
+          <Text size="tiny" color="muted" className="mt-2 block" aria-label={t('common.comingSoon')}>
+            {t('common.comingSoon')}
           </Text>
         </div>
       </div>

--- a/apps/desktop/renderer/src/features/search/SearchPanel.placeholder-ui.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.placeholder-ui.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SearchPanel, type SearchResultItem } from "./SearchPanel";
+
+vi.mock("../../stores/searchStore", () => ({
+  useSearchStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      query: "",
+      items: [],
+      status: "idle" as const,
+      indexState: "ready" as const,
+      total: 0,
+      hasMore: false,
+      lastError: null,
+      setQuery: vi.fn(),
+      runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+      clearResults: vi.fn(),
+      clearError: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("../../stores/fileStore", () => ({
+  useFileStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      setCurrent: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    return selector(state);
+  }),
+}));
+
+const mockResults: SearchResultItem[] = Array.from({ length: 8 }, (_, i) => ({
+  id: `doc-${i}`,
+  documentId: `doc-${i}`,
+  type: "document" as const,
+  title: `Document ${i}`,
+  snippet: `Snippet for document ${i}`,
+}));
+
+describe("SearchPanel placeholder UI closure", () => {
+  it("Scenario: Search 面板隐藏 View More 链接", () => {
+    render(
+      <SearchPanel
+        projectId="p1"
+        open
+        mockResults={mockResults}
+        mockQuery="test"
+        mockStatus="idle"
+        mockIndexState="ready"
+      />,
+    );
+
+    expect(screen.queryByText(/view more/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/View More/)).not.toBeInTheDocument();
+  });
+
+  it("Scenario: Search 面板隐藏 Search All Projects 链接", () => {
+    render(
+      <SearchPanel
+        projectId="p1"
+        open
+        mockResults={[]}
+        mockQuery="nonexistent"
+        mockStatus="idle"
+        mockIndexState="ready"
+      />,
+    );
+
+    expect(
+      screen.queryByText(/search.+all.+projects/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Search in all projects"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Scenario: 搜索结果列表正常渲染", () => {
+    render(
+      <SearchPanel
+        projectId="p1"
+        open
+        mockResults={mockResults.slice(0, 3)}
+        mockQuery="test"
+        mockStatus="idle"
+        mockIndexState="ready"
+      />,
+    );
+
+    expect(screen.getByTestId("search-result-item-doc-0")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-item-doc-1")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-item-doc-2")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -10,7 +10,7 @@ import { Toggle } from "../../components/primitives/Toggle";
 import { useFileStore } from "../../stores/fileStore";
 import { useSearchStore, type SearchStatus } from "../../stores/searchStore";
 
-import { ArrowRight, ChevronDown, ChevronUp, CornerDownLeft, FileText, Folder, Frown, Globe, Lightbulb, RefreshCw, Search, Share2, Sparkles, TriangleAlert, X } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp, CornerDownLeft, FileText, Folder, Frown, Lightbulb, RefreshCw, Search, Share2, Sparkles, TriangleAlert, X } from "lucide-react";
 /**
  * Search category filter options.
  */
@@ -437,13 +437,7 @@ function SearchResultsArea(props: {
             {t("search.suggestionsText")}
           </p>
         </div>
-        <Button
-          variant="primary"
-          className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
-        >
-          <Globe className="w-4 h-4" size={16} strokeWidth={1.5} />
-          {t("search.searchAllProjects")}
-        </Button>
+        {/* placeholder: hidden in v0.1, restore when search expansion is implemented */}
         <Button
           variant="ghost"
           onClick={props.onClearQuery}
@@ -515,16 +509,7 @@ function SearchResultsArea(props: {
           </ResultGroup>
         )}
 
-      {props.totalResults > 5 && (
-        <div className="p-2 text-center border-t border-[var(--color-separator)] mt-2">
-          <Button
-            variant="ghost"
-            className="!text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-info)] !py-2 w-full !h-auto"
-          >
-            {t("search.results.viewMore", { count: props.totalResults - 5 })}
-          </Button>
-        </div>
-      )}
+      {/* placeholder: hidden in v0.1, restore when search expansion is implemented */}
     </>
   );
 }

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.test.tsx
@@ -16,12 +16,18 @@ const freePlanAccount: AccountSettings = {
   plan: "free",
 };
 
+const proPlanAccount: AccountSettings = {
+  name: "Test User",
+  email: "test@example.com",
+  plan: "pro",
+};
+
 describe("SettingsAccount", () => {
   beforeEach(() => {
     invokeMock.mockReset();
   });
 
-  it("Scenario: Account入口以禁用态展示并带“Coming Soon”提示", () => {
+  it("Scenario: Account入口以禁用态展示并带Coming Soon提示", () => {
     render(<SettingsAccount account={freePlanAccount} />);
 
     expect(
@@ -30,7 +36,30 @@ describe("SettingsAccount", () => {
     expect(
       screen.getByRole("button", { name: "Delete Account" }),
     ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Edit Profile" }),
+    ).toBeDisabled();
     expect(screen.getAllByText("Coming Soon")).toHaveLength(2);
+  });
+
+  it("Scenario: 所有 disabled 按钮设置 aria-disabled", () => {
+    render(<SettingsAccount account={freePlanAccount} />);
+
+    const upgradeBtn = screen.getByRole("button", { name: "Upgrade to Pro" });
+    const deleteBtn = screen.getByRole("button", { name: "Delete Account" });
+    const editProfileBtn = screen.getByRole("button", { name: "Edit Profile" });
+
+    expect(upgradeBtn).toHaveAttribute("aria-disabled", "true");
+    expect(deleteBtn).toHaveAttribute("aria-disabled", "true");
+    expect(editProfileBtn).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("Scenario: Pro plan Manage Subscription 按钮也 disabled + aria-disabled", () => {
+    render(<SettingsAccount account={proPlanAccount} />);
+
+    const manageBtn = screen.getByRole("button", { name: "Manage Subscription" });
+    expect(manageBtn).toBeDisabled();
+    expect(manageBtn).toHaveAttribute("aria-disabled", "true");
   });
 
   it("Scenario: 禁用态入口点击不触发业务回调且不发起 IPC", async () => {

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Avatar, Button, Text } from "../../components/primitives";
+import { Tooltip } from "../../components/primitives/Tooltip";
 
 /**
  * Subscription plan types
@@ -129,9 +130,11 @@ export function SettingsAccount({
               {account.email}
             </Text>
           </div>
-          <Button variant="secondary" size="sm" className="ml-auto">
-            {t('settingsDialog.account.editProfile')}
-          </Button>
+          <Tooltip content={t('settingsDialog.account.comingSoonTooltip')}>
+            <Button variant="secondary" size="sm" className="ml-auto" disabled aria-disabled="true">
+              {t('settingsDialog.account.editProfile')}
+            </Button>
+          </Tooltip>
         </div>
       </div>
 
@@ -161,14 +164,18 @@ export function SettingsAccount({
 
           <div className="flex gap-3">
             {account.plan === "free" && (
-              <Button variant="primary" size="sm" onClick={onUpgrade} disabled>
-                {t('settingsDialog.account.upgradeToPro')}
-              </Button>
+              <Tooltip content={t('settingsDialog.account.comingSoonTooltip')}>
+                <Button variant="primary" size="sm" onClick={onUpgrade} disabled aria-disabled="true">
+                  {t('settingsDialog.account.upgradeToPro')}
+                </Button>
+              </Tooltip>
             )}
             {account.plan !== "free" && (
-              <Button variant="secondary" size="sm" disabled>
-                {t('settingsDialog.account.manageSubscription')}
-              </Button>
+              <Tooltip content={t('settingsDialog.account.comingSoonTooltip')}>
+                <Button variant="secondary" size="sm" disabled aria-disabled="true">
+                  {t('settingsDialog.account.manageSubscription')}
+                </Button>
+              </Tooltip>
             )}
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
@@ -193,14 +200,17 @@ export function SettingsAccount({
                 {t('settingsDialog.account.deleteAccountDescription')}
               </Text>
             </div>
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={onDeleteAccount}
-              disabled
-            >
-              {t('settingsDialog.account.deleteAccount')}
-            </Button>
+            <Tooltip content={t('settingsDialog.account.comingSoonTooltip')}>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={onDeleteAccount}
+                disabled
+                aria-disabled="true"
+              >
+                {t('settingsDialog.account.deleteAccount')}
+              </Button>
+            </Tooltip>
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
             {t('settingsDialog.account.comingSoon')}

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.test.tsx
@@ -11,7 +11,6 @@ vi.mock("./SettingsGeneral", () => ({
     typewriterScroll: false,
     smartPunctuation: true,
     localAutoSave: true,
-    backupInterval: "5min",
     defaultTypography: "inter",
     interfaceScale: 100,
   },

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -19,7 +19,6 @@ export interface GeneralSettings {
   typewriterScroll: boolean;
   smartPunctuation: boolean;
   localAutoSave: boolean;
-  backupInterval: string;
   defaultTypography: string;
   interfaceScale: number;
 }
@@ -59,15 +58,6 @@ const dividerStyles = [
   "bg-[var(--color-separator)]",
   "my-12",
 ].join(" ");
-
-/**
- * Backup interval options
- */
-const backupIntervalOptions = [
-  { value: "5min", label: "Every 5 minutes" },
-  { value: "15min", label: "Every 15 minutes" },
-  { value: "1hour", label: "Every hour" },
-];
 
 /**
  * Typography options
@@ -186,15 +176,6 @@ export function SettingsGeneral({
               updateSetting("localAutoSave", checked)
             }
           />
-
-          <FormField label={t('settings.general.backupInterval')} htmlFor="backup-interval" help={t('settings.general.backupIntervalHelp')} className="mt-2">
-            <Select
-              options={backupIntervalOptions}
-              value={settings.backupInterval}
-              onValueChange={(value) => updateSetting("backupInterval", value)}
-              fullWidth
-            />
-          </FormField>
         </div>
       </div>
 
@@ -249,7 +230,6 @@ export const defaultGeneralSettings: GeneralSettings = {
   typewriterScroll: false,
   smartPunctuation: true,
   localAutoSave: true,
-  backupInterval: "5min",
   defaultTypography: "inter",
   interfaceScale: 100,
 };

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.restore.test.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.restore.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  VersionHistoryPanel,
+  type TimeGroup,
+} from "./VersionHistoryPanel";
+
+const timeGroups: TimeGroup[] = [
+  {
+    label: "Earlier Today",
+    versions: [
+      {
+        id: "v-1",
+        timestamp: "10:42 AM",
+        authorType: "user",
+        authorName: "You",
+        description: "Test change",
+        wordChange: { type: "added", count: 10 },
+      },
+    ],
+  },
+];
+
+describe("VersionHistoryPanel Restore 按钮 placeholder UI closure", () => {
+  it("Scenario: 选中版本卡片的 Restore 按钮处于 disabled 状态", async () => {
+    const user = userEvent.setup();
+    const onRestore = vi.fn();
+
+    render(
+      <VersionHistoryPanel
+        timeGroups={timeGroups}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onRestore={onRestore}
+      />,
+    );
+
+    // Click the version card to select it
+    const card = screen.getByTestId("version-card-v-1");
+    await user.click(card);
+
+    // Re-render with selected
+    const { unmount } = render(
+      <VersionHistoryPanel
+        timeGroups={timeGroups}
+        selectedId="v-1"
+        onSelect={vi.fn()}
+        onRestore={onRestore}
+      />,
+    );
+
+    // The Restore button in the selected card should be disabled
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    const disabledRestores = restoreButtons.filter(
+      (btn) => btn.hasAttribute("disabled") || btn.getAttribute("aria-disabled") === "true",
+    );
+    expect(disabledRestores.length).toBeGreaterThanOrEqual(1);
+
+    unmount();
+  });
+
+  it("Scenario: Restore 按钮设置 aria-disabled", () => {
+    render(
+      <VersionHistoryPanel
+        timeGroups={timeGroups}
+        selectedId="v-1"
+        onRestore={vi.fn()}
+      />,
+    );
+
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    const ariaDisabled = restoreButtons.filter(
+      (btn) => btn.getAttribute("aria-disabled") === "true",
+    );
+    expect(ariaDisabled.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Scenario: 点击 disabled Restore 按钮不触发 onRestore 回调", async () => {
+    const user = userEvent.setup();
+    const onRestore = vi.fn();
+
+    render(
+      <VersionHistoryPanel
+        timeGroups={timeGroups}
+        selectedId="v-1"
+        onRestore={onRestore}
+      />,
+    );
+
+    const restoreButtons = screen.getAllByRole("button", { name: /restore/i });
+    for (const btn of restoreButtons) {
+      await user.click(btn);
+    }
+
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.test.tsx
@@ -194,7 +194,7 @@ describe("VersionHistoryPanel", () => {
     expect(previewButtons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("calls onRestore when clicking Restore button", () => {
+  it("Restore button is disabled (Coming Soon)", () => {
     const onRestore = vi.fn();
     render(
       <VersionHistoryPanel
@@ -205,12 +205,14 @@ describe("VersionHistoryPanel", () => {
       />,
     );
 
-    // Get the button with text "Restore" (not just title)
     const restoreButtons = screen.getAllByRole("button", { name: /Restore/i });
-    // Click the first one which should be the explicit button in the selected card
+    // All Restore buttons should be disabled
+    for (const btn of restoreButtons) {
+      expect(btn).toBeDisabled();
+    }
+    // Click should not trigger onRestore
     fireEvent.click(restoreButtons[0]);
-
-    expect(onRestore).toHaveBeenCalledWith("v-1042");
+    expect(onRestore).not.toHaveBeenCalled();
   });
 
   it("calls onCompare when clicking Compare button", () => {

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -339,7 +339,7 @@ function WordChangeBadge({ change }: { change: WordChange }) {
  */
 function HoverActions({
   versionId,
-  onRestore,
+  onRestore: _onRestore,
   onCompare,
   onPreview,
 }: {
@@ -348,6 +348,8 @@ function HoverActions({
   onCompare?: (id: string) => void;
   onPreview?: (id: string) => void;
 }) {
+  const { t } = useTranslation();
+  void _onRestore; // Reserved for future use
   return (
     <div
       className={[
@@ -369,11 +371,12 @@ function HoverActions({
         "duration-[var(--duration-fast)]",
       ].join(" ")}
     >
-      <Tooltip content="Restore">
+      <Tooltip content={t('versionHistory.panel.restoreComingSoon')}>
         <button
           type="button"
-          onClick={() => onRestore?.(versionId)}
-          className="focus-ring p-1.5 rounded-md hover:bg-[var(--color-bg-overlay)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+          disabled
+          aria-disabled="true"
+          className="focus-ring p-1.5 rounded-md text-[var(--color-fg-muted)] opacity-50 cursor-not-allowed"
         >
           <RestoreIcon />
         </button>
@@ -465,14 +468,17 @@ function VersionCard({
 
         {/* Action buttons */}
         <div className="grid grid-cols-3 gap-2 mt-3">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => onRestore?.(version.id)}
-            className="!h-7 !text-[10px] !px-0 !bg-[var(--color-bg-active)] hover:!bg-[var(--color-bg-selected)]"
-          >
-            {t("versionHistory.panel.restore")}
-          </Button>
+          <Tooltip content={t('versionHistory.panel.restoreComingSoon')}>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled
+              aria-disabled="true"
+              className="!h-7 !text-[10px] !px-0 !bg-[var(--color-bg-active)]"
+            >
+              {t("versionHistory.panel.restore")}
+            </Button>
+          </Tooltip>
           <Button
             variant="secondary"
             size="sm"

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -792,7 +792,8 @@
       "autoSaveOn": "Auto-save on (last saved {{time}})",
       "autoSaveOff": "Auto-save off",
       "configureAutoSave": "Configure auto-save settings",
-      "wordsChanged": "{{value}} words changed"
+      "wordsChanged": "{{value}} words changed",
+      "restoreComingSoon": "Version restore is in development"
     },
     "preview": {
       "actorUser": "User",
@@ -868,7 +869,8 @@
       "manageSubscription": "Manage Subscription",
       "dangerZone": "Danger Zone",
       "deleteAccount": "Delete Account",
-      "deleteAccountDescription": "Permanently delete your account and all associated data."
+      "deleteAccountDescription": "Permanently delete your account and all associated data.",
+      "comingSoonTooltip": "Account features are in development"
     },
     "general": {
       "zhCN": "Chinese (Simplified)",
@@ -879,7 +881,7 @@
       "writingExperience": "Writing Experience",
       "dataAndStorage": "Data & Storage",
       "editorDefaults": "Editor Defaults",
-      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra \u201c{{marker}}\u201d marker."
+      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra “{{marker}}” marker."
     },
     "appearance": {
       "colorWhite": "White",
@@ -1337,5 +1339,9 @@
     "spinner": {
       "loading": "Loading"
     }
+  },
+  "common": {
+    "comingSoon": "Coming Soon",
+    "featureInDevelopment": "This feature is in development"
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -792,7 +792,8 @@
       "autoSaveOn": "自动保存已开启（上次保存于 {{time}}）",
       "autoSaveOff": "自动保存已关闭",
       "configureAutoSave": "配置自动保存设置",
-      "wordsChanged": "{{value}} 词已变更"
+      "wordsChanged": "{{value}} 词已变更",
+      "restoreComingSoon": "版本恢复功能正在开发中"
     },
     "preview": {
       "actorUser": "用户",
@@ -868,7 +869,8 @@
       "manageSubscription": "管理订阅",
       "dangerZone": "危险操作",
       "deleteAccount": "删除账户",
-      "deleteAccountDescription": "永久删除你的账户及所有关联数据。"
+      "deleteAccountDescription": "永久删除你的账户及所有关联数据。",
+      "comingSoonTooltip": "账户功能正在开发中"
     },
     "general": {
       "zhCN": "中文 (简体)",
@@ -879,7 +881,7 @@
       "writingExperience": "写作体验",
       "dataAndStorage": "数据与存储",
       "editorDefaults": "编辑器默认值",
-      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的\u201c{{marker}}\u201d标记。"
+      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的“{{marker}}”标记。"
     },
     "appearance": {
       "colorWhite": "白色",
@@ -1337,5 +1339,9 @@
     "spinner": {
       "loading": "加载中"
     }
+  },
+  "common": {
+    "comingSoon": "即将推出",
+    "featureInDevelopment": "此功能正在开发中"
   }
 }

--- a/apps/desktop/renderer/src/i18n/placeholder-ui-keys.test.ts
+++ b/apps/desktop/renderer/src/i18n/placeholder-ui-keys.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import enJson from "./locales/en.json";
+import zhCNJson from "./locales/zh-CN.json";
+
+const REQUIRED_KEYS: [string, string, ...string[]][] = [
+  ["common", "comingSoon"],
+  ["common", "featureInDevelopment"],
+  ["settingsDialog", "account", "comingSoonTooltip"],
+  ["versionHistory", "panel", "restoreComingSoon"],
+];
+
+function getNestedValue(
+  obj: Record<string, unknown>,
+  path: readonly string[],
+): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+describe("A0-15 placeholder UI i18n keys", () => {
+  it.each(REQUIRED_KEYS)(
+    "en.json contains key %s.%s",
+    (...path: string[]) => {
+      const value = getNestedValue(
+        enJson as unknown as Record<string, unknown>,
+        path,
+      );
+      expect(value).toBeDefined();
+      expect(typeof value).toBe("string");
+      expect((value as string).length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(REQUIRED_KEYS)(
+    "zh-CN.json contains key %s.%s",
+    (...path: string[]) => {
+      const value = getNestedValue(
+        zhCNJson as unknown as Record<string, unknown>,
+        path,
+      );
+      expect(value).toBeDefined();
+      expect(typeof value).toBe("string");
+      expect((value as string).length).toBeGreaterThan(0);
+    },
+  );
+
+  it("en.json and zh-CN.json have the same number of required keys", () => {
+    const enCount = REQUIRED_KEYS.filter(
+      (path) =>
+        getNestedValue(enJson as unknown as Record<string, unknown>, path) !==
+        undefined,
+    ).length;
+    const zhCount = REQUIRED_KEYS.filter(
+      (path) =>
+        getNestedValue(
+          zhCNJson as unknown as Record<string, unknown>,
+          path,
+        ) !== undefined,
+    ).length;
+    expect(enCount).toBe(zhCount);
+    expect(enCount).toBe(REQUIRED_KEYS.length);
+  });
+});


### PR DESCRIPTION
## 概要

收口所有假功能占位 UI，为 v0.1 发布做能力诚实分级。

## 变更内容

### Settings Account (AC-1, AC-9)
- 所有按钮（Edit Profile / Upgrade / Manage / Delete）标为 `disabled` + Coming Soon Tooltip
- 添加 `aria-disabled="true"`

### Search Panel (AC-2, AC-3)
- 移除 "View More" 链接（totalResults > 5 时不再渲染）
- 移除 "Search All Projects" 按钮（无结果态）
- 搜索结果列表正常渲染不受影响

### ChatHistory (AC-4)
- 空态增加 Coming Soon 文案
- `onSelectChat` 标为 reserved（无可点击条目）

### Version History Restore (AC-5, AC-9)
- HoverActions 中 Restore 按钮 `disabled` + `aria-disabled="true"` + Coming Soon Tooltip
- 选中卡片中 Restore 按钮同样 disabled

### SettingsGeneral（A0-08 S1 决策）
- 移除备份间隔 Select 和 `backupIntervalOptions` 假数据
- 从 `GeneralSettings` interface 移除 `backupInterval` 字段

### i18n (AC-6, AC-7, AC-8)
- `common.comingSoon` / `common.featureInDevelopment`（中英双语）
- `settingsDialog.account.comingSoonTooltip`
- `versionHistory.panel.restoreComingSoon`
- 所有文案通过 `t()` 获取，无裸字符串字面量

## 测试

| 测试文件 | 数量 |
|---------|------|
| SettingsAccount.test.tsx | 4 tests |
| SearchPanel.placeholder-ui.test.tsx | 3 tests |
| ChatHistory.test.tsx | 3 tests |
| VersionHistoryPanel.restore.test.tsx | 3 tests |
| placeholder-ui-keys.test.ts | 9 tests |
| VersionHistoryPanel.test.tsx (updated) | 23 tests |
| SettingsDialog.test.tsx (updated) | - |

**全部 94 tests pass，0 errors，typecheck clean，lint 0 errors。**

## 验收标准对照

- [x] AC-1: Settings Account disabled buttons + tooltip
- [x] AC-2: View More 不渲染
- [x] AC-3: Search All Projects 不渲染
- [x] AC-4: ChatHistory 不可点击 + Coming Soon
- [x] AC-5: Restore 按钮 disabled + tooltip
- [x] AC-6: i18n keys 中英齐全
- [x] AC-7: 文案通过 t() 获取
- [x] AC-8: 无裸字符串字面量
- [x] AC-9: aria-disabled + tooltip

## 回滚点

所有变更可原子回滚，不影响核心编辑器功能。

Closes #995