### PR TITLE
feat(skill-router): A0-05 否定语境守卫 — isNegated + 双重否定 + 集成测试

### DIFF
--- a/apps/desktop/main/src/services/skills/__tests__/skillRouter.negation.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skillRouter.negation.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+
+import { inferSkillFromInput, isNegated } from "../skillRouter";
+
+// ---------------------------------------------------------------------------
+// Task 1.1: 中文否定
+// ---------------------------------------------------------------------------
+describe("isNegated — 中文否定词", () => {
+  it("不要 + 续写 → 被否定", () => {
+    const input = "不要续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("别 + 扩写 → 被否定", () => {
+    const input = "别帮我扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(true);
+  });
+
+  it("不想 + 翻译 → 被否定", () => {
+    const input = "不想让你翻译";
+    expect(isNegated(input, input.indexOf("翻译"), "翻译")).toBe(true);
+  });
+
+  it("不用 + 总结 → 被否定", () => {
+    const input = "不用总结了";
+    expect(isNegated(input, input.indexOf("总结"), "总结")).toBe(true);
+  });
+
+  it("不需要 + 续写 → 被否定", () => {
+    const input = "不需要续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("停止 + 续写 → 被否定", () => {
+    const input = "停止续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("禁止 + 扩写 → 被否定", () => {
+    const input = "禁止扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.2: 英文否定
+// ---------------------------------------------------------------------------
+describe("isNegated — 英文否定词", () => {
+  it("don't + continue writing → negated", () => {
+    const input = "don't continue writing";
+    expect(isNegated(input, input.indexOf("continue writing"), "continue writing")).toBe(true);
+  });
+
+  it("do not + expand → negated", () => {
+    const input = "do not expand this";
+    expect(isNegated(input, input.indexOf("expand"), "expand")).toBe(true);
+  });
+
+  it("stop + summarize → negated", () => {
+    const input = "stop summarize";
+    expect(isNegated(input, input.indexOf("summarize"), "summarize")).toBe(true);
+  });
+
+  it("never + translate → negated", () => {
+    const input = "never translate this";
+    expect(isNegated(input, input.indexOf("translate"), "translate")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.3: 双重否定 → 恢复正向
+// ---------------------------------------------------------------------------
+describe("isNegated — 双重否定恢复正向", () => {
+  it("不是不想续写 → 非否定", () => {
+    const input = "不是不想续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(false);
+  });
+
+  it("并非不要扩写 → 非否定", () => {
+    const input = "并非不要扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(false);
+  });
+
+  it("不是不想续写 → 路由到 builtin:continue", () => {
+    expect(
+      inferSkillFromInput({
+        input: "不是不想续写，请帮我续写后面的内容",
+        hasSelection: false,
+      }),
+    ).toBe("builtin:continue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.4: 正向回归（否定守卫不影响正向匹配）
+// ---------------------------------------------------------------------------
+describe("否定守卫不影响正向匹配", () => {
+  it("帮我续写这个段落 → builtin:continue", () => {
+    expect(
+      inferSkillFromInput({ input: "帮我续写这个段落", hasSelection: false }),
+    ).toBe("builtin:continue");
+  });
+
+  it("头脑风暴一下 → builtin:brainstorm", () => {
+    expect(
+      inferSkillFromInput({ input: "头脑风暴一下", hasSelection: false }),
+    ).toBe("builtin:brainstorm");
+  });
+
+  it("请写下去 → builtin:continue", () => {
+    expect(
+      inferSkillFromInput({ input: "请写下去", hasSelection: false }),
+    ).toBe("builtin:continue");
+  });
+
+  it("空输入 + 有选区 → builtin:polish", () => {
+    expect(
+      inferSkillFromInput({ input: "", hasSelection: true }),
+    ).toBe("builtin:polish");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.5: 否定词距离超出检测窗口 → 不拦截
+// ---------------------------------------------------------------------------
+describe("否定检测窗口边界", () => {
+  it("否定词距离关键词过远时不触发守卫", () => {
+    expect(
+      inferSkillFromInput({
+        input: "我不喜欢上次的结果，这次请帮我续写得更好一些",
+        hasSelection: false,
+      }),
+    ).toBe("builtin:continue");
+  });
+
+  it("前面不好，续写 → 非否定（不好 不在否定词表中）", () => {
+    const input = "前面不好，续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.6: inferSkillFromInput 集成测试——否定场景
+// ---------------------------------------------------------------------------
+describe("inferSkillFromInput — 否定场景路由到 builtin:chat", () => {
+  it("不要续写 → builtin:chat", () => {
+    expect(
+      inferSkillFromInput({ input: "不要续写，我想自己写", hasSelection: false }),
+    ).toBe("builtin:chat");
+  });
+
+  it("别帮我扩写 + 有选区 → builtin:chat", () => {
+    expect(
+      inferSkillFromInput({ input: "别帮我扩写这段", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+
+  it("don't continue writing → builtin:chat", () => {
+    expect(
+      inferSkillFromInput({
+        input: "don't continue writing this",
+        hasSelection: false,
+      }),
+    ).toBe("builtin:chat");
+  });
+
+  it("不用改写 + 有选区 → builtin:chat（REWRITE_KEYWORDS 路径）", () => {
+    expect(
+      inferSkillFromInput({ input: "不用改写", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+
+  it("不用改 + 有选区 → builtin:chat（短改写 + 否定）", () => {
+    expect(
+      inferSkillFromInput({ input: "不用改", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+});
+
+describe("inferSkillFromInput — explicitSkillId 不受否定守卫影响", () => {
+  it("否定输入 + explicitSkillId → 走显式技能", () => {
+    expect(
+      inferSkillFromInput({
+        input: "不要续写",
+        hasSelection: false,
+        explicitSkillId: "builtin:continue",
+      }),
+    ).toBe("builtin:continue");
+  });
+});

--- a/apps/desktop/main/src/services/skills/skillRouter.ts
+++ b/apps/desktop/main/src/services/skills/skillRouter.ts
@@ -16,6 +16,56 @@ type InferSkillArgs = {
   explicitSkillId?: string;
 };
 
+// ---------------------------------------------------------------------------
+// 否定语境守卫 (Negation Guard)
+// ---------------------------------------------------------------------------
+
+const CN_NEGATION_WORDS: readonly string[] = [
+  "不要", "别", "不想", "不用", "不需要", "停止", "取消", "禁止", "不必", "无需",
+];
+
+const EN_NEGATION_WORDS: readonly string[] = [
+  "don't", "do not", "stop", "never", "cancel", "no more",
+];
+
+const CN_DOUBLE_NEGATION: readonly string[] = [
+  "不是不想", "不是不要", "并非不要", "并非不想",
+];
+
+const NEGATION_WINDOW = 12;
+
+export function isNegated(input: string, keywordIndex: number, _keyword: string): boolean {
+  const windowStart = Math.max(0, keywordIndex - NEGATION_WINDOW);
+  const window = input.substring(windowStart, keywordIndex);
+
+  for (const dn of CN_DOUBLE_NEGATION) {
+    if (window.includes(dn)) {
+      return false;
+    }
+  }
+
+  for (const neg of CN_NEGATION_WORDS) {
+    if (window.includes(neg)) {
+      return true;
+    }
+  }
+
+  const windowLower = window.toLowerCase();
+  for (const neg of EN_NEGATION_WORDS) {
+    if (windowLower.includes(neg)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function matchesKeyword(input: string, keyword: string): boolean {
+  const idx = input.indexOf(keyword);
+  if (idx === -1) return false;
+  return !isNegated(input, idx, keyword);
+}
+
 const KEYWORD_RULES: ReadonlyArray<{
   keywords: readonly string[];
   skillId: string;
@@ -68,7 +118,7 @@ export function inferSkillFromInput(args: InferSkillArgs): string {
       return "builtin:polish";
     }
 
-    const isRewriteIntent = REWRITE_KEYWORDS.some((kw) => input.includes(kw));
+    const isRewriteIntent = REWRITE_KEYWORDS.some((kw) => matchesKeyword(input, kw));
     if (isRewriteIntent && input.length < 20) {
       return "builtin:rewrite";
     }
@@ -76,7 +126,7 @@ export function inferSkillFromInput(args: InferSkillArgs): string {
 
   // 3. Keyword matching
   for (const rule of KEYWORD_RULES) {
-    if (rule.keywords.some((kw) => input.includes(kw))) {
+    if (rule.keywords.some((kw) => matchesKeyword(input, kw))) {
       return rule.skillId;
     }
   }


### PR DESCRIPTION
## Summary

Skill Router 新增否定语境检测守卫，当用户说「不要续写」「别扩写」「don't continue writing」时，路由到 `builtin:chat` 而非执行对应技能。

## Changes

### `apps/desktop/main/src/services/skills/skillRouter.ts`
- 新增 `isNegated()` 辅助函数：在关键词前方 12 字符窗口内检测中/英否定词
- 新增 `matchesKeyword()`：统一「包含关键词 + 未被否定」判断
- 中文否定词：不要/别/不想/不用/不需要/停止/取消/禁止/不必/无需
- 英文否定词：don't/do not/stop/never/cancel/no more
- 双重否定前缀（不是不想/并非不要 等）恢复正向匹配
- KEYWORD_RULES 和 REWRITE_KEYWORDS 两条路径均受否定守卫保护
- `explicitSkillId` 路径不受影响

### `apps/desktop/main/src/services/skills/__tests__/skillRouter.negation.test.ts`（新建）
- 26 项 vitest 测试全通过，覆盖：中文否定 / 英文否定 / 双重否定 / 正向回归 / 窗口边界 / 集成路由 / 显式覆盖

## Verification

```bash
pnpm -C apps/desktop vitest run --config vitest.config.core.ts main/src/services/skills/__tests__/skillRouter.negation.test.ts
# 26 passed

npx tsx apps/desktop/main/src/services/skills/__tests__/skillRouter.test.ts
# regression: no assertion errors
```

## Rollback

Revert commit `4966b311`。仅涉及 2 个文件（1 新建 + 1 修改），不影响其他模块。

## Audit Gate

- [ ] 审计 Agent 发布 `FINAL-VERDICT: ACCEPT` 后方可开启 auto-merge

Closes #987