### PR TITLE
feat(search): A0-10 基础全文搜索入口 — 快捷键/键盘导航/Escape/a11y/i18n

### DIFF
--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -906,6 +906,7 @@ export function AppShell(): JSX.Element {
           if (!ctrl.currentProjectId) return;
           void ctrl.createDocument({ projectId: ctrl.currentProjectId });
         }}
+        onOpenGlobalSearch={() => ctrl.setSpotlightOpen(true)}
       />
 
       <PanelOrchestrator>

--- a/apps/desktop/renderer/src/components/layout/NavigationController.tsx
+++ b/apps/desktop/renderer/src/components/layout/NavigationController.tsx
@@ -14,6 +14,7 @@ type NavigationControllerProps = {
   onOpenSettings: () => void;
   onOpenCreateProject: () => void;
   onCreateDocument: () => void;
+  onOpenGlobalSearch: () => void;
 };
 
 /**
@@ -33,6 +34,7 @@ export function NavigationController({
   onOpenSettings,
   onOpenCreateProject,
   onCreateDocument,
+  onOpenGlobalSearch,
 }: NavigationControllerProps): null {
   const debouncedToggleSidebar = useDebouncedCallback(
     onToggleSidebar,
@@ -146,6 +148,19 @@ export function NavigationController({
     }, [zenMode, canCreateDocument, onCreateDocument]),
     "global",
     10,
+  );
+
+  // Cmd/Ctrl+Shift+F: Open Global Search
+  useHotkey(
+    "nav:global-search",
+    { key: "F", modKey: true, shiftKey: true },
+    React.useCallback(() => {
+      if (!zenMode) {
+        onOpenGlobalSearch();
+      }
+    }, [zenMode, onOpenGlobalSearch]),
+    "global",
+    15,
   );
 
   return null;

--- a/apps/desktop/renderer/src/components/layout/__tests__/navigation-controller.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/__tests__/navigation-controller.test.tsx
@@ -22,6 +22,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     const onOpenSettings = vi.fn();
     const onOpenCreateProject = vi.fn();
     const onCreateDocument = vi.fn();
+    const onOpenGlobalSearch = vi.fn();
 
     render(
       <NavigationController
@@ -35,6 +36,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
         onOpenSettings={onOpenSettings}
         onOpenCreateProject={onOpenCreateProject}
         onCreateDocument={onCreateDocument}
+        onOpenGlobalSearch={onOpenGlobalSearch}
       />,
     );
 
@@ -70,6 +72,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     const onOpenSettings = vi.fn();
     const onOpenCreateProject = vi.fn();
     const onCreateDocument = vi.fn();
+    const onOpenGlobalSearch = vi.fn();
 
     render(
       <NavigationController
@@ -83,6 +86,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
         onOpenSettings={onOpenSettings}
         onOpenCreateProject={onOpenCreateProject}
         onCreateDocument={onCreateDocument}
+        onOpenGlobalSearch={onOpenGlobalSearch}
       />,
     );
 

--- a/apps/desktop/renderer/src/config/shortcuts.test.ts
+++ b/apps/desktop/renderer/src/config/shortcuts.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  LAYOUT_SHORTCUTS,
+  EDITOR_SHORTCUTS,
+  getAllShortcuts,
+  getShortcutDisplay,
+  isMac,
+} from "./shortcuts";
+
+describe("shortcuts — globalSearch", () => {
+  it("LAYOUT_SHORTCUTS.globalSearch 存在且 keys 为 mod+Shift+F", () => {
+    expect(LAYOUT_SHORTCUTS.globalSearch).toBeDefined();
+    expect(LAYOUT_SHORTCUTS.globalSearch.id).toBe("globalSearch");
+    expect(LAYOUT_SHORTCUTS.globalSearch.keys).toBe("mod+Shift+F");
+  });
+
+  it("getAllShortcuts() 返回包含 id 为 globalSearch 的条目", () => {
+    const all = getAllShortcuts();
+    const match = all.find((s) => s.id === "globalSearch");
+    expect(match).toBeDefined();
+    expect(match!.keys).toBe("mod+Shift+F");
+  });
+
+  it("getShortcutDisplay('globalSearch') 返回非空字符串", () => {
+    const display = getShortcutDisplay("globalSearch");
+    expect(display).toBeTruthy();
+    expect(display.length).toBeGreaterThan(0);
+  });
+
+  it("Mac 下 display() 返回 ⌘⇧F", () => {
+    // Mock navigator.platform
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    // Re-evaluate: since isMac() checks at call time, the display function re-reads
+    expect(LAYOUT_SHORTCUTS.globalSearch.display()).toBe("⌘⇧F");
+    vi.unstubAllGlobals();
+  });
+
+  it("非 Mac 下 display() 返回 Ctrl+Shift+F", () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    expect(LAYOUT_SHORTCUTS.globalSearch.display()).toBe("Ctrl+Shift+F");
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/desktop/renderer/src/config/shortcuts.test.ts
+++ b/apps/desktop/renderer/src/config/shortcuts.test.ts
@@ -1,11 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import {
   LAYOUT_SHORTCUTS,
-  EDITOR_SHORTCUTS,
   getAllShortcuts,
   getShortcutDisplay,
-  isMac,
 } from "./shortcuts";
 
 describe("shortcuts — globalSearch", () => {

--- a/apps/desktop/renderer/src/config/shortcuts.ts
+++ b/apps/desktop/renderer/src/config/shortcuts.ts
@@ -124,6 +124,7 @@ export const LAYOUT_SHORTCUTS = {
   commandPalette: defineShortcut("commandPalette", "Command Palette", "mod+P"),
   toggleSidebar: defineShortcut("toggleSidebar", "Toggle Sidebar", "mod+\\"),
   togglePanel: defineShortcut("togglePanel", "Toggle Panel", "mod+L"),
+  globalSearch: defineShortcut("globalSearch", "Global Search", "mod+Shift+F"),
 } as const;
 
 // =============================================================================

--- a/apps/desktop/renderer/src/features/search/SearchPanel.a0-10.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.a0-10.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchPanel } from "./SearchPanel";
+
+const mockSetQuery = vi.fn();
+
+vi.mock("../../stores/searchStore", () => ({
+  useSearchStore: vi.fn((selector) => {
+    const state = {
+      query: "",
+      items: [],
+      status: "idle" as const,
+      indexState: "ready" as const,
+      total: 0,
+      hasMore: false,
+      lastError: null,
+      setQuery: mockSetQuery,
+      runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+      clearResults: vi.fn(),
+      clearError: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("../../stores/fileStore", () => ({
+  useFileStore: vi.fn((selector) => {
+    const state = { setCurrent: vi.fn().mockResolvedValue({ ok: true }) };
+    return selector(state);
+  }),
+}));
+
+describe("SearchPanel — A0-10 基础全文搜索入口", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // AC-2: 打开后搜索输入框自动获得焦点
+  // ===========================================================================
+  describe("自动聚焦 (AC-2)", () => {
+    it("打开 SearchPanel 后，搜索输入框获得焦点", () => {
+      render(<SearchPanel projectId="test-project" open={true} />);
+      const input = screen.getByTestId("search-input");
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  // ===========================================================================
+  // AC-10: Escape 键退出搜索
+  // ===========================================================================
+  describe("Escape 行为 (AC-10)", () => {
+    it("搜索输入框为空时按 Escape 关闭 SearchPanel", () => {
+      const onClose = vi.fn();
+      render(
+        <SearchPanel projectId="test-project" open={true} onClose={onClose} />,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("搜索输入框有文本时按 Escape 清空文本，不关闭面板", () => {
+      const onClose = vi.fn();
+      render(
+        <SearchPanel
+          projectId="test-project"
+          open={true}
+          onClose={onClose}
+          mockQuery="test query"
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(mockSetQuery).toHaveBeenCalledWith("");
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // AC-11: 无障碍属性
+  // ===========================================================================
+  describe("无障碍属性 (AC-11)", () => {
+    it("搜索输入框具有 role='searchbox'", () => {
+      render(<SearchPanel projectId="test-project" open={true} />);
+      const input = screen.getByRole("searchbox");
+      expect(input).toBeInTheDocument();
+    });
+
+    it("搜索输入框具有非空 aria-label", () => {
+      render(<SearchPanel projectId="test-project" open={true} />);
+      const input = screen.getByRole("searchbox");
+      expect(input.getAttribute("aria-label")).toBeTruthy();
+    });
+  });
+
+  // ===========================================================================
+  // AC-8: 搜索无结果展示
+  // ===========================================================================
+  describe("无结果状态 (AC-8)", () => {
+    it("搜索有查询但无结果时渲染无结果提示", () => {
+      render(
+        <SearchPanel
+          projectId="test-project"
+          open={true}
+          mockQuery="nonexistent"
+          mockResults={[]}
+          mockStatus="idle"
+        />,
+      );
+      // 应该渲染无结果提示
+      expect(screen.getByText("No matching results")).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // AC-9: 键盘导航 — Arrow Down/Up 和 Enter
+  // ===========================================================================
+  describe("键盘导航 (AC-9)", () => {
+    const mockResults = [
+      {
+        id: "doc1",
+        documentId: "doc1",
+        type: "document" as const,
+        title: "First Document",
+        snippet: "some text",
+      },
+      {
+        id: "doc2",
+        documentId: "doc2",
+        type: "document" as const,
+        title: "Second Document",
+        snippet: "other text",
+      },
+      {
+        id: "doc3",
+        documentId: "doc3",
+        type: "document" as const,
+        title: "Third Document",
+        snippet: "more text",
+      },
+    ];
+
+    it("初始态第一项被选中（aria-selected='true'），按 Arrow Down 后第二项被选中", () => {
+      render(
+        <SearchPanel
+          projectId="test-project"
+          open={true}
+          mockQuery="test"
+          mockResults={mockResults}
+          mockStatus="idle"
+        />,
+      );
+      // 初始状态第一项已选中
+      const firstItem = screen.getByTestId("search-result-item-doc1");
+      expect(firstItem.closest("[aria-selected='true']")).toBeTruthy();
+
+      // Arrow Down → 第二项选中
+      fireEvent.keyDown(document, { key: "ArrowDown" });
+      const secondItem = screen.getByTestId("search-result-item-doc2");
+      expect(secondItem.closest("[aria-selected='true']")).toBeTruthy();
+      // 第一项不再选中
+      expect(firstItem.closest("[aria-selected='true']")).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -147,6 +147,7 @@ function DocumentResultItem(props: {
       interactive
       onClick={onClick}
       data-testid={`search-result-item-${item.documentId ?? item.id}`}
+      aria-selected={isActive}
       className={`group w-full text-left mx-2 !p-2 !h-auto !rounded-lg !items-start !gap-3 relative ${
         isActive
           ? "!bg-[var(--color-separator)] border border-[var(--color-separator)]"
@@ -424,7 +425,7 @@ function SearchResultsArea(props: {
       <div className="flex flex-col items-center justify-center py-16 px-8">
         <Frown className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4" size={24} strokeWidth={1.5} />
         <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
-          {t("search.noResults")}
+          {t("search.noResults.title")}
         </p>
         <p className="text-xs text-[var(--color-fg-muted)] text-center">
           {t("search.noResultsQuery", { query: props.effectiveQuery })}
@@ -465,7 +466,7 @@ function SearchResultsArea(props: {
                 key={item.id}
                 item={item}
                 query={props.effectiveQuery}
-                isActive={index === 0 && props.activeIndex === 0}
+                isActive={index === props.activeIndex}
                 isFlashing={
                   props.flashKey?.startsWith(
                     `${item.documentId ?? item.id}:${item.anchor?.start ?? 0}:${item.anchor?.end ?? 0}:`,
@@ -623,10 +624,15 @@ export function SearchPanel(props: {
     "search:close",
     { key: "Escape" },
     React.useCallback(() => {
+      // AC-10: Escape clears text first; if already empty, closes panel
+      if (effectiveQuery.trim().length > 0) {
+        setQuery("");
+        return;
+      }
       if (onClose) {
         onClose();
       }
-    }, [onClose]),
+    }, [onClose, effectiveQuery, setQuery]),
     "global",
     25,
     open,
@@ -657,6 +663,19 @@ export function SearchPanel(props: {
     "global",
     25,
     open,
+  );
+
+  useHotkey(
+    "search:nav-enter",
+    { key: "Enter" },
+    React.useCallback(() => {
+      if (items.length > 0 && activeIndex >= 0 && activeIndex < items.length) {
+        handleItemClick(items[activeIndex].id);
+      }
+    }, [items, activeIndex]),
+    "global",
+    25,
+    open && items.length > 0,
   );
 
   function handleInputKeyDown(e: React.KeyboardEvent): void {
@@ -718,6 +737,8 @@ export function SearchPanel(props: {
             <Input
               ref={inputRef}
               data-testid="search-input"
+              role="searchbox"
+              aria-label={t("search.input.ariaLabel")}
               type="text"
               value={effectiveQuery}
               onChange={(e) => setQuery(e.target.value)}

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -530,6 +530,56 @@ function SearchResultsArea(props: {
   );
 }
 
+function SearchFooter(props: {
+  hasResults: boolean;
+  totalResults: number;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}): JSX.Element {
+  return (
+    <div
+      className="border-t border-[var(--color-separator)] px-4 py-3 flex items-center justify-between shrink-0 bg-[var(--color-bg-raised)]"
+    >
+      <div className="flex items-center gap-4">
+        {props.hasResults && (
+          <>
+            <span className="text-xs text-[var(--color-fg-muted)] font-medium">
+              {props.t("search.results.result", { count: props.totalResults })}
+            </span>
+            <div className="h-3 w-px bg-[var(--color-bg-overlay)]" />
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              {props.t("search.results.searchTime", { time: "0.04s" })}
+            </span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <KeyHint
+          icon={
+            <span className="flex gap-0.5">
+              <ChevronUp className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
+            </span>
+          }
+          label=""
+        />
+        <KeyHint
+          icon={
+            <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
+          }
+          label={props.t("search.footer.toNavigate")}
+        />
+        <KeyHint
+          icon={
+            <CornerDownLeft className="w-3 h-3" size={16} strokeWidth={1.5} />
+          }
+          label={props.t("search.footer.toOpen")}
+        />
+        <KeyHint text="esc" label={props.t("search.footer.toClose")} />
+      </div>
+    </div>
+  );
+}
+
 
 /**
  * SearchPanel provides a modal search interface across documents, memories, and knowledge.
@@ -612,6 +662,37 @@ export function SearchPanel(props: {
   const hasQuery = effectiveQuery.trim().length > 0;
   const hasError = effectiveStatus === "error" && lastError !== null;
 
+  function handleInputKeyDown(e: React.KeyboardEvent): void {
+    if (e.key === "Enter") {
+      void runFulltext({ projectId, limit: 20 });
+    }
+  }
+
+  const handleItemClick = React.useCallback((documentId: string): void => {
+    const result = items.find((item) => item.id === documentId);
+    if (!result || result.type !== "document") {
+      onClose?.();
+      return;
+    }
+
+    const targetDocumentId = result.documentId ?? result.id;
+    void navigateSearchResult({
+      projectId,
+      result: {
+        documentId: targetDocumentId,
+        anchor: result.anchor,
+      },
+      setCurrent,
+      setFlashKey,
+      onClose,
+    });
+  }, [items, onClose, projectId, setCurrent, setFlashKey]);
+
+  function handleRetrySearch(): void {
+    clearError();
+    void runFulltext({ projectId, limit: 20 });
+  }
+
   // Auto-focus input when opened
   React.useEffect(() => {
     if (open) {
@@ -672,42 +753,11 @@ export function SearchPanel(props: {
       if (items.length > 0 && activeIndex >= 0 && activeIndex < items.length) {
         handleItemClick(items[activeIndex].id);
       }
-    }, [items, activeIndex]),
+    }, [items, activeIndex, handleItemClick]),
     "global",
     25,
     open && items.length > 0,
   );
-
-  function handleInputKeyDown(e: React.KeyboardEvent): void {
-    if (e.key === "Enter") {
-      void runFulltext({ projectId, limit: 20 });
-    }
-  }
-
-  function handleItemClick(documentId: string): void {
-    const result = items.find((item) => item.id === documentId);
-    if (!result || result.type !== "document") {
-      onClose?.();
-      return;
-    }
-
-    const targetDocumentId = result.documentId ?? result.id;
-    void navigateSearchResult({
-      projectId,
-      result: {
-        documentId: targetDocumentId,
-        anchor: result.anchor,
-      },
-      setCurrent,
-      setFlashKey,
-      onClose,
-    });
-  }
-
-  function handleRetrySearch(): void {
-    clearError();
-    void runFulltext({ projectId, limit: 20 });
-  }
 
   if (!open) return null;
 
@@ -850,50 +900,9 @@ export function SearchPanel(props: {
 
         </div>
 
-        {/* Footer */}
-        <div
-          className="border-t border-[var(--color-separator)] px-4 py-3 flex items-center justify-between shrink-0 bg-[var(--color-bg-raised)]"
-        >
-          <div className="flex items-center gap-4">
-            {hasResults && (
-              <>
-                <span className="text-xs text-[var(--color-fg-muted)] font-medium">
-                  {t("search.results.result", { count: totalResults })}
-                </span>
-                <div className="h-3 w-px bg-[var(--color-bg-overlay)]" />
-                <span className="text-[10px] text-[var(--color-fg-placeholder)]">
-                  {t("search.results.searchTime", { time: "0.04s" })}
-                </span>
-              </>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            <KeyHint
-              icon={
-                <span className="flex gap-0.5">
-                  <ChevronUp className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
-                </span>
-              }
-              label=""
-            />
-            <KeyHint
-              icon={
-                <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
-              }
-              label={t("search.footer.toNavigate")}
-            />
-            <KeyHint
-              icon={
-                <CornerDownLeft className="w-3 h-3" size={16} strokeWidth={1.5} />
-              }
-              label={t("search.footer.toOpen")}
-            />
-            <KeyHint text="esc" label={t("search.footer.toClose")} />
-          </div>
+          <SearchFooter hasResults={hasResults} totalResults={totalResults} t={t} />
         </div>
-      </div>
 
-    </div>
-  );
-}
+      </div>
+    );
+  }

--- a/apps/desktop/renderer/src/features/search/search-i18n-keys.test.ts
+++ b/apps/desktop/renderer/src/features/search/search-i18n-keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const LOCALES_DIR = path.resolve(
+  __dirname,
+  "../../i18n/locales",
+);
+
+const REQUIRED_KEYS = [
+  "search.input.placeholder",
+  "search.input.ariaLabel",
+  "search.noResults.title",
+  "search.resultCount",
+  "search.shortcut.label",
+];
+
+function getNestedValue(obj: Record<string, unknown>, keyPath: string): unknown {
+  const parts = keyPath.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+describe("search i18n key 覆盖验证 (AC-14)", () => {
+  const zhRaw = fs.readFileSync(path.join(LOCALES_DIR, "zh-CN.json"), "utf-8");
+  const enRaw = fs.readFileSync(path.join(LOCALES_DIR, "en.json"), "utf-8");
+  const zh = JSON.parse(zhRaw) as Record<string, unknown>;
+  const en = JSON.parse(enRaw) as Record<string, unknown>;
+
+  for (const key of REQUIRED_KEYS) {
+    it(`zh-CN.json 包含 ${key}`, () => {
+      expect(getNestedValue(zh, key)).toBeDefined();
+      expect(typeof getNestedValue(zh, key)).toBe("string");
+    });
+
+    it(`en.json 包含 ${key}`, () => {
+      expect(getNestedValue(en, key)).toBeDefined();
+      expect(typeof getNestedValue(en, key)).toBe("string");
+    });
+  }
+});

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -229,12 +229,23 @@
   },
   "search": {
     "placeholder": "Search documents, memories, knowledge...",
+    "input": {
+      "placeholder": "Search documents, memories, knowledge...",
+      "ariaLabel": "Global search"
+    },
+    "noResults": {
+      "title": "No matching results",
+      "suggestion": "Try checking your spelling or using different keywords"
+    },
+    "resultCount": "{{count}} result(s)",
+    "shortcut": {
+      "label": "Global Search"
+    },
     "emptyStateHint": "Enter a search term to find documents",
     "rebuildingIndex": "Rebuilding index, please try again later",
     "rebuildingQuery": "Query: \"{{query}}\"",
     "errorTitle": "Search failed, please retry",
     "retrySearch": "Retry Search",
-    "noResults": "No matching results",
     "noResultsQuery": "Query: \"{{query}}\"",
     "suggestionsTitle": "Suggestions",
     "suggestionsText": "Try checking your spelling or using different keywords",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -229,12 +229,23 @@
   },
   "search": {
     "placeholder": "搜索文档、记忆、知识...",
+    "input": {
+      "placeholder": "搜索文档、记忆、知识...",
+      "ariaLabel": "全局搜索"
+    },
+    "noResults": {
+      "title": "未找到匹配结果",
+      "suggestion": "建议检查拼写或使用不同关键词"
+    },
+    "resultCount": "{{count}} 个结果",
+    "shortcut": {
+      "label": "全局搜索"
+    },
     "emptyStateHint": "输入搜索词查找文档",
     "rebuildingIndex": "正在重建索引，请稍后重试",
     "rebuildingQuery": "查询词：\"{{query}}\"",
     "errorTitle": "搜索失败，请重试",
     "retrySearch": "重试搜索",
-    "noResults": "未找到匹配结果",
     "noResultsQuery": "查询词：\"{{query}}\"",
     "suggestionsTitle": "建议",
     "suggestionsText": "建议检查拼写或使用不同关键词",

--- a/apps/desktop/renderer/src/surfaces/surfaceRegistry.test.ts
+++ b/apps/desktop/renderer/src/surfaces/surfaceRegistry.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+
+import { getSurfaceById } from "./surfaceRegistry";
+
+describe("surfaceRegistry — searchPanel shortcut 入口", () => {
+  it("getSurfaceById('searchPanel') 的 entryPoints 中包含 type: 'shortcut' 的条目", () => {
+    const surface = getSurfaceById("searchPanel");
+    expect(surface).toBeDefined();
+    const shortcutEntry = surface!.entryPoints.find((ep) => ep.type === "shortcut");
+    expect(shortcutEntry).toBeDefined();
+  });
+
+  it("shortcut 入口的 description 包含 Cmd/Ctrl+Shift+F", () => {
+    const surface = getSurfaceById("searchPanel");
+    const shortcutEntry = surface!.entryPoints.find((ep) => ep.type === "shortcut");
+    expect(shortcutEntry!.description).toContain("Cmd/Ctrl+Shift+F");
+  });
+});

--- a/apps/desktop/renderer/src/surfaces/surfaceRegistry.ts
+++ b/apps/desktop/renderer/src/surfaces/surfaceRegistry.ts
@@ -509,7 +509,10 @@ export const surfaceRegistry: SurfaceRegistryItem[] = [
   {
     id: "searchPanel",
     kind: "leftPanel",
-    entryPoints: [{ type: "iconBar", description: "Search icon" }],
+    entryPoints: [
+      { type: "iconBar", description: "Search icon" },
+      { type: "shortcut", description: "Cmd/Ctrl+Shift+F" },
+    ],
     testId: "search-panel",
     storybookTitle: "Features/SearchPanel",
   },


### PR DESCRIPTION
## 概述
Closes #1003

实现 A0-10 基础全文搜索入口功能。

## 变更内容

### 1. 快捷键注册 (AC-12)
- `LAYOUT_SHORTCUTS` 新增 `globalSearch: mod+Shift+F`

### 2. Surface 入口注册 (AC-13)
- `surfaceRegistry.ts` 的 `searchPanel` 新增 `{ type: 'shortcut', description: 'Cmd/Ctrl+Shift+F' }`

### 3. SearchPanel 增强 (AC-2/8/9/10/11)
- `role="searchbox"` + `aria-label` (AC-11)
- Escape 分级行为: 有文本清空，无文本关闭面板 (AC-10)
- 键盘导航 `aria-selected` + Enter 激活 (AC-9)
- 打开时自动 focus (AC-2)
- 无结果态显示 i18n 化提示 (AC-8)

### 4. i18n (AC-14)
- 新增 `search.input.placeholder`, `search.input.ariaLabel`, `search.noResults.title`, `search.resultCount`, `search.shortcut.label`
- 修复 `noResults` 重复 key 冲突（合并为嵌套结构）

## 测试 (24 tests, 4 files)
| 文件 | 测试数 | 覆盖 |
|------|--------|------|
| shortcuts.test.ts | 5 | AC-12 |
| surfaceRegistry.test.ts | 2 | AC-13 |
| SearchPanel.a0-10.test.tsx | 7 | AC-2/8/9/10/11 |
| search-i18n-keys.test.ts | 10 | AC-14 |

全部 59 tests / 17 files 通过，无回归。

## 回滚点
还原此 PR 的 commit 即可。

## 审计门禁
auto-merge 已关闭，等待审计 Agent FINAL-VERDICT。