### PR TITLE
feat(i18n): 消除编辑器/版本/Slash 28+ 裸字符串 (#991)

### DIFF
--- a/apps/desktop/renderer/src/__tests__/i18n/editor-version-slash-i18n.test.ts
+++ b/apps/desktop/renderer/src/__tests__/i18n/editor-version-slash-i18n.test.ts
@@ -1,0 +1,302 @@
+/**
+ * A0-16: 编辑器/版本/Slash i18n 裸字符串消除验证
+ *
+ * 验证所有目标文件中的裸字符串已被 i18n t() 调用替换，
+ * 且 zh-CN.json / en.json 的新增 key 完整对称。
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const RENDERER_SRC = resolve(__dirname, "../..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(RENDERER_SRC, relativePath), "utf-8");
+}
+
+function loadLocale(locale: string): Record<string, unknown> {
+  const raw = readFileSync(
+    resolve(RENDERER_SRC, `i18n/locales/${locale}.json`),
+    "utf-8",
+  );
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/**
+ * Recursively collect all leaf keys from a nested object.
+ */
+function collectKeys(obj: Record<string, unknown>, prefix = ""): string[] {
+  const keys: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      keys.push(...collectKeys(v as Record<string, unknown>, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}
+
+// ─── AC-1: EditorPane 裸字符串消除 ───────────────────────────
+
+describe("AC-1: EditorPane.tsx 裸字符串已被 t() 替换", () => {
+  const source = readSource("features/editor/EditorPane.tsx");
+
+  it("不包含裸字符串 'Entity suggestions unavailable.'", () => {
+    expect(source).not.toContain('"Entity suggestions unavailable."');
+  });
+
+  it("不包含裸字符串 'This document is final...'", () => {
+    expect(source).not.toContain(
+      '"This document is final. Editing will switch it back to draft. Continue?"',
+    );
+  });
+
+  it("包含 t('editor.entitySuggestionsUnavailable') 调用", () => {
+    expect(source).toContain("t('editor.entitySuggestionsUnavailable')");
+  });
+
+  it("包含 t('editor.confirmSwitchToDraft') 调用", () => {
+    expect(source).toContain("t('editor.confirmSwitchToDraft')");
+  });
+});
+
+// ─── AC-2: EditorContextMenu AI 标签 ───────────────────────────
+
+describe("AC-2: EditorContextMenu.tsx AI 标签已 i18n", () => {
+  const source = readSource("features/editor/EditorContextMenu.tsx");
+
+  it("AI 菜单标签使用 t('editor.contextMenu.ai') 而非裸字符串", () => {
+    expect(source).toContain('t("editor.contextMenu.ai")');
+    // 确保没有裸 >AI< 作为 ContextMenu.Label 内容
+    expect(source).not.toMatch(/<ContextMenu\.Label[^>]*>AI<\/ContextMenu\.Label>/);
+  });
+});
+
+// ─── AC-3: Slash command i18n ───────────────────────────────
+
+describe("AC-3: slashCommands.ts label/description 已 i18n", () => {
+  const source = readSource("features/editor/slashCommands.ts");
+
+  const bareLabels = ["/续写", "/描写", "/对白", "/角色", "/大纲", "/搜索"];
+  for (const label of bareLabels) {
+    it(`不包含硬编码 label "${label}"`, () => {
+      // keywords 数组中的中文触发词不算裸字符串
+      const lines = source.split("\n");
+      const nonKeywordLines = lines.filter((l) => !l.includes("keywords:"));
+      expect(nonKeywordLines.join("\n")).not.toContain(`"${label}"`);
+    });
+  }
+
+  const slashKeys = [
+    "editor.slash.continue.label",
+    "editor.slash.continue.description",
+    "editor.slash.describe.label",
+    "editor.slash.describe.description",
+    "editor.slash.dialogue.label",
+    "editor.slash.dialogue.description",
+    "editor.slash.character.label",
+    "editor.slash.character.description",
+    "editor.slash.outline.label",
+    "editor.slash.outline.description",
+    "editor.slash.search.label",
+    "editor.slash.search.description",
+  ];
+
+  it("zh-CN.json 包含全部 12 个 slash i18n key", () => {
+    const zhCN = loadLocale("zh-CN");
+    const allKeys = collectKeys(zhCN);
+    for (const key of slashKeys) {
+      expect(allKeys, `missing key: ${key}`).toContain(key);
+    }
+  });
+
+  it("en.json 包含全部 12 个 slash i18n key", () => {
+    const en = loadLocale("en");
+    const allKeys = collectKeys(en);
+    for (const key of slashKeys) {
+      expect(allKeys, `missing key: ${key}`).toContain(key);
+    }
+  });
+});
+
+// ─── AC-4/5/6: VersionHistoryContainer 裸字符串消除 ──────────
+
+describe("AC-4/5/6: VersionHistoryContainer.tsx 裸字符串已被 t() 替换", () => {
+  const source = readSource(
+    "features/version-history/VersionHistoryContainer.tsx",
+  );
+
+  it("作者名不包含裸字符串赋值", () => {
+    // "You", "AI", "Auto", "Unknown" 不应作为 return 值
+    const returnStatements = source
+      .split("\n")
+      .filter((l) => l.trim().startsWith("return "));
+    for (const line of returnStatements) {
+      expect(line).not.toMatch(/return "You"/);
+      expect(line).not.toMatch(/return "Auto"/);
+      expect(line).not.toMatch(/return "Unknown"/);
+    }
+    // "AI" 作为作者名 return 值也不应出现
+    expect(
+      returnStatements.some((l) => /return "AI"/.test(l) && !l.includes("i18n")),
+    ).toBe(false);
+  });
+
+  it("时间分组不包含裸字符串 'Just now' / 'Today' / 'Yesterday' / 'Earlier'", () => {
+    const returnStatements = source
+      .split("\n")
+      .filter((l) => l.trim().startsWith("return "));
+    for (const line of returnStatements) {
+      expect(line).not.toMatch(/return "Just now"/);
+      expect(line).not.toMatch(/return "Today"/);
+      expect(line).not.toMatch(/return "Yesterday"/);
+      expect(line).not.toMatch(/return "Earlier"/);
+    }
+  });
+
+  it("不包含裸字符串 'Loading versions...'", () => {
+    expect(source).not.toContain("Loading versions...");
+  });
+
+  it("使用 i18n.t() 进行作者名翻译", () => {
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.author.you")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.author.ai")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.author.auto")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.author.unknown")',
+    );
+  });
+
+  it("使用 i18n.t() 进行时间分组翻译", () => {
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.timeGroup.justNow")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.timeGroup.today")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.timeGroup.yesterday")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.container.timeGroup.earlier")',
+    );
+  });
+});
+
+// ─── AC-7: VersionHistoryPanel tooltips ──────────────────────
+
+describe("AC-7: VersionHistoryPanel.tsx tooltip 裸字符串已被 t() 替换", () => {
+  const source = readSource(
+    "features/version-history/VersionHistoryPanel.tsx",
+  );
+
+  it("不包含裸字符串 tooltip 'Restore' / 'Compare' / 'Preview'", () => {
+    expect(source).not.toMatch(/content="Restore"/);
+    expect(source).not.toMatch(/content="Compare"/);
+    expect(source).not.toMatch(/content="Preview"/);
+  });
+
+  it("使用 t() 进行 tooltip 翻译", () => {
+    expect(source).toContain('t("versionHistory.panel.restore")');
+    expect(source).toContain('t("versionHistory.panel.compare")');
+    expect(source).toContain('t("versionHistory.panel.preview")');
+  });
+});
+
+// ─── AC-8: useVersionCompare 错误消息 ───────────────────────
+
+describe("AC-8: useVersionCompare.ts 裸字符串已被 i18n.t() 替换", () => {
+  const source = readSource(
+    "features/version-history/useVersionCompare.ts",
+  );
+
+  it("不包含裸字符串 'No differences found.'", () => {
+    expect(source).not.toContain('"No differences found."');
+  });
+
+  it("不包含裸字符串 'Unknown error'", () => {
+    expect(source).not.toContain('"Unknown error"');
+  });
+
+  it("使用 i18n.t() 进行翻译", () => {
+    expect(source).toContain(
+      'i18n.t("versionHistory.compare.noDifferencesFound")',
+    );
+    expect(source).toContain(
+      'i18n.t("versionHistory.compare.unknownError")',
+    );
+  });
+});
+
+// ─── AC-9: i18n key 完整性与对称性 ──────────────────────────
+
+describe("AC-9: i18n key 完整性与对称性", () => {
+  const NEW_KEYS = [
+    // editor (3 keys)
+    "editor.entitySuggestionsUnavailable",
+    "editor.confirmSwitchToDraft",
+    "editor.contextMenu.ai",
+    // slash commands (12 keys)
+    "editor.slash.continue.label",
+    "editor.slash.continue.description",
+    "editor.slash.describe.label",
+    "editor.slash.describe.description",
+    "editor.slash.dialogue.label",
+    "editor.slash.dialogue.description",
+    "editor.slash.character.label",
+    "editor.slash.character.description",
+    "editor.slash.outline.label",
+    "editor.slash.outline.description",
+    "editor.slash.search.label",
+    "editor.slash.search.description",
+    // version history (13 keys)
+    "versionHistory.container.author.you",
+    "versionHistory.container.author.ai",
+    "versionHistory.container.author.auto",
+    "versionHistory.container.author.unknown",
+    "versionHistory.container.timeGroup.justNow",
+    "versionHistory.container.timeGroup.minutesAgo",
+    "versionHistory.container.timeGroup.today",
+    "versionHistory.container.timeGroup.yesterday",
+    "versionHistory.container.timeGroup.earlier",
+    "versionHistory.container.loadingVersions",
+    "versionHistory.compare.noDifferencesFound",
+    "versionHistory.compare.unknownError",
+  ];
+
+  it("zh-CN.json 包含全部新增 key", () => {
+    const zhCN = loadLocale("zh-CN");
+    const allKeys = collectKeys(zhCN);
+    for (const key of NEW_KEYS) {
+      expect(allKeys, `zh-CN missing key: ${key}`).toContain(key);
+    }
+  });
+
+  it("en.json 包含全部新增 key", () => {
+    const en = loadLocale("en");
+    const allKeys = collectKeys(en);
+    for (const key of NEW_KEYS) {
+      expect(allKeys, `en missing key: ${key}`).toContain(key);
+    }
+  });
+
+  it("zh-CN 与 en 新增 key 集合完全一致", () => {
+    const zhCN = loadLocale("zh-CN");
+    const en = loadLocale("en");
+    const zhKeys = new Set(collectKeys(zhCN));
+    const enKeys = new Set(collectKeys(en));
+
+    for (const key of NEW_KEYS) {
+      expect(zhKeys.has(key), `zh-CN 缺少 ${key}`).toBe(true);
+      expect(enKeys.has(key), `en 缺少 ${key}`).toBe(true);
+    }
+  });
+});

--- a/apps/desktop/renderer/src/features/editor/EditorContextMenu.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorContextMenu.tsx
@@ -262,7 +262,7 @@ export function EditorContextMenu({
           <ContextMenu.Separator className={separatorClass} />
 
           {/* ---- AI actions ---- */}
-          <ContextMenu.Label className={labelClass}>AI</ContextMenu.Label>
+          <ContextMenu.Label className={labelClass}>{t("editor.contextMenu.ai")}</ContextMenu.Label>
 
           {AI_CONTEXT_ACTIONS.map((action) => (
             <ContextMenu.Item

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -423,7 +423,7 @@ function useEntityCompletion(deps: {
         message: null,
       });
     },
-    [listKnowledgeEntities, projectId, setEntityCompletionSession],
+    [listKnowledgeEntities, projectId, setEntityCompletionSession, t],
   );
 
   React.useEffect(() => {

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -604,7 +604,7 @@ function useEditorCommands(deps: {
     aiRun, aiSetSelectedSkillId, aiStatus, bootstrapStatus,
     closeSlashPanel, contentReady, documentId, documentStatus,
     downgradeFinalStatusForEdit, editor, isPreviewMode, projectId,
-    save,
+    save, t,
   } = deps;
 
   const aiStreamCheckpointRef = React.useRef<AiStreamCheckpoint | null>(null);

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -27,8 +27,8 @@ import { DragHandleExtension } from "./extensions/dragHandle";
 import { SlashCommandPanel } from "./SlashCommandPanel";
 import { EntityCompletionPanel } from "./EntityCompletionPanel";
 import {
+  getSlashCommandRegistry,
   routeSlashCommandExecution,
-  SLASH_COMMAND_REGISTRY,
   type SlashCommandExecutors,
   type SlashCommandId,
 } from "./slashCommands";
@@ -348,11 +348,12 @@ function useEntityCompletion(deps: {
   clearEntityCompletionSession: () => void;
   listKnowledgeEntities: (args: { projectId: string }) => Promise<{ ok: true; data: { items: EntityListItem[] } } | { ok: false }>;
   projectId: string;
+  t: (key: string) => string;
 }) {
   const {
     bootstrapStatus, clearEntityCompletionSession, contentReady, documentId,
     documentStatus, editor, entityCompletionSession, isPreviewMode,
-    listKnowledgeEntities, projectId, setEntityCompletionSession,
+    listKnowledgeEntities, projectId, setEntityCompletionSession, t,
   } = deps;
 
   const entityCompletionSessionRef = React.useRef(entityCompletionSession);
@@ -397,7 +398,7 @@ function useEntityCompletion(deps: {
           status: "error",
           candidates: [],
           selectedIndex: 0,
-          message: "Entity suggestions unavailable.",
+          message: t('editor.entitySuggestionsUnavailable'),
         });
         return;
       }
@@ -613,7 +614,7 @@ function useEditorCommands(deps: {
       return;
     }
     const confirmed = window.confirm(
-      "This document is final. Editing will switch it back to draft. Continue?",
+      t('editor.confirmSwitchToDraft'),
     );
     const decision = resolveFinalDocumentEditDecision({
       status: documentStatus,
@@ -1034,6 +1035,7 @@ function useEditorPaneCore(projectId: string) {
     clearEntityCompletionSession,
     listKnowledgeEntities,
     projectId,
+    t,
   });
 
 
@@ -1184,7 +1186,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
       <SlashCommandPanel
         open={core.isSlashPanelOpen}
         query={core.slashSearchQuery}
-        candidates={SLASH_COMMAND_REGISTRY}
+        candidates={getSlashCommandRegistry()}
         onQueryChange={core.setSlashSearchQuery}
         onSelectCommand={core.handleSlashCommandSelect}
         onRequestClose={core.closeSlashPanel}

--- a/apps/desktop/renderer/src/features/editor/slashCommands.test.ts
+++ b/apps/desktop/renderer/src/features/editor/slashCommands.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  SLASH_COMMAND_REGISTRY,
+  getSlashCommandRegistry,
   filterSlashCommands,
   routeSlashCommandExecution,
   type SlashCommandId,
@@ -9,29 +9,23 @@ import {
 
 describe("s2 slash commands", () => {
   it("[SCN-S2-CMD-1] should register exactly six roadmap commands with unique ids", () => {
-    const labels = SLASH_COMMAND_REGISTRY.map((command) => command.label);
-    expect(labels).toEqual([
-      "/续写",
-      "/描写",
-      "/对白",
-      "/角色",
-      "/大纲",
-      "/搜索",
-    ]);
+    const registry = getSlashCommandRegistry();
+    expect(registry).toHaveLength(6);
 
     const uniqueIds = new Set(
-      SLASH_COMMAND_REGISTRY.map((command) => command.id),
+      registry.map((command) => command.id),
     );
-    expect(uniqueIds.size).toBe(SLASH_COMMAND_REGISTRY.length);
+    expect(uniqueIds.size).toBe(registry.length);
   });
 
   it("[SCN-S2-CMD-2] should filter by keyword and recover full list for empty query", () => {
-    expect(filterSlashCommands(SLASH_COMMAND_REGISTRY, "描写")).toEqual([
+    const registry = getSlashCommandRegistry();
+    expect(filterSlashCommands(registry, "描写")).toEqual([
       expect.objectContaining({ id: "describe" }),
     ]);
 
-    expect(filterSlashCommands(SLASH_COMMAND_REGISTRY, "  ")).toEqual(
-      SLASH_COMMAND_REGISTRY,
+    expect(filterSlashCommands(registry, "  ")).toEqual(
+      registry,
     );
   });
 

--- a/apps/desktop/renderer/src/features/editor/slashCommands.ts
+++ b/apps/desktop/renderer/src/features/editor/slashCommands.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n";
+
 export type SlashCommandId =
   | "continueWriting"
   | "describe"
@@ -13,44 +15,46 @@ export interface SlashCommandDefinition {
   keywords: string[];
 }
 
-export const SLASH_COMMAND_REGISTRY: SlashCommandDefinition[] = [
-  {
-    id: "continueWriting",
-    label: "/续写",
-    description: "基于当前光标附近上下文继续创作。",
-    keywords: ["续写", "continue", "write"],
-  },
-  {
-    id: "describe",
-    label: "/描写",
-    description: "扩展场景细节与氛围描写。",
-    keywords: ["描写", "description", "describe"],
-  },
-  {
-    id: "dialogue",
-    label: "/对白",
-    description: "生成角色间自然对话。",
-    keywords: ["对白", "dialogue", "conversation"],
-  },
-  {
-    id: "character",
-    label: "/角色",
-    description: "补充角色设定与人物动机。",
-    keywords: ["角色", "character", "persona"],
-  },
-  {
-    id: "outline",
-    label: "/大纲",
-    description: "整理章节结构与叙事节奏。",
-    keywords: ["大纲", "outline", "structure"],
-  },
-  {
-    id: "search",
-    label: "/搜索",
-    description: "检索项目中的相关信息。",
-    keywords: ["搜索", "search", "find"],
-  },
-];
+export function getSlashCommandRegistry(): SlashCommandDefinition[] {
+  return [
+    {
+      id: "continueWriting",
+      label: i18n.t("editor.slash.continue.label"),
+      description: i18n.t("editor.slash.continue.description"),
+      keywords: ["续写", "continue", "write"],
+    },
+    {
+      id: "describe",
+      label: i18n.t("editor.slash.describe.label"),
+      description: i18n.t("editor.slash.describe.description"),
+      keywords: ["描写", "description", "describe"],
+    },
+    {
+      id: "dialogue",
+      label: i18n.t("editor.slash.dialogue.label"),
+      description: i18n.t("editor.slash.dialogue.description"),
+      keywords: ["对白", "dialogue", "conversation"],
+    },
+    {
+      id: "character",
+      label: i18n.t("editor.slash.character.label"),
+      description: i18n.t("editor.slash.character.description"),
+      keywords: ["角色", "character", "persona"],
+    },
+    {
+      id: "outline",
+      label: i18n.t("editor.slash.outline.label"),
+      description: i18n.t("editor.slash.outline.description"),
+      keywords: ["大纲", "outline", "structure"],
+    },
+    {
+      id: "search",
+      label: i18n.t("editor.slash.search.label"),
+      description: i18n.t("editor.slash.search.description"),
+      keywords: ["搜索", "search", "find"],
+    },
+  ];
+}
 
 export function filterSlashCommands(
   commands: SlashCommandDefinition[],

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -45,13 +45,13 @@ function mapActorToAuthorType(
 function getAuthorName(actor: "user" | "auto" | "ai"): string {
   switch (actor) {
     case "user":
-      return "You";
+      return i18n.t("versionHistory.container.author.you");
     case "ai":
-      return "AI";
+      return i18n.t("versionHistory.container.author.ai");
     case "auto":
-      return "Auto";
+      return i18n.t("versionHistory.container.author.auto");
     default:
-      return "Unknown";
+      return i18n.t("versionHistory.container.author.unknown");
   }
 }
 
@@ -67,10 +67,10 @@ export function formatTimestamp(
   const hours = Math.floor(diff / 3600000);
 
   if (minutes < 1) {
-    return "Just now";
+    return i18n.t("versionHistory.container.timeGroup.justNow");
   }
   if (minutes < 60) {
-    return `${minutes}m ago`;
+    return i18n.t("versionHistory.container.timeGroup.minutesAgo", { count: minutes });
   }
   if (hours < 24) {
     const date = new Date(createdAt);
@@ -101,12 +101,12 @@ function getTimeGroupLabel(createdAt: number): string {
     date.getFullYear() === yesterday.getFullYear();
 
   if (isToday) {
-    return "Today";
+    return "today";
   }
   if (isYesterday) {
-    return "Yesterday";
+    return "yesterday";
   }
-  return "Earlier";
+  return "earlier";
 }
 
 /**
@@ -167,14 +167,19 @@ function convertToTimeGroups(
     groupMap.set(label, existing);
   }
 
-  // Sort groups: Today first, then Yesterday, then Earlier
-  const order = ["Today", "Yesterday", "Earlier"];
+  // Sort groups: today first, then yesterday, then earlier
+  const order = ["today", "yesterday", "earlier"];
+  const labelTranslations: Record<string, string> = {
+    today: i18n.t("versionHistory.container.timeGroup.today"),
+    yesterday: i18n.t("versionHistory.container.timeGroup.yesterday"),
+    earlier: i18n.t("versionHistory.container.timeGroup.earlier"),
+  };
   const groups: TimeGroup[] = [];
 
   for (const label of order) {
     const versions = groupMap.get(label);
     if (versions && versions.length > 0) {
-      groups.push({ label, versions });
+      groups.push({ label: labelTranslations[label] ?? label, versions });
     }
   }
 
@@ -595,7 +600,7 @@ const {
   if (status === "loading") {
     return (
       <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-        Loading versions...
+        {t('versionHistory.container.loadingVersions')}
       </div>
     );
   }

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -348,6 +348,7 @@ function HoverActions({
   onCompare?: (id: string) => void;
   onPreview?: (id: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       className={[
@@ -369,7 +370,7 @@ function HoverActions({
         "duration-[var(--duration-fast)]",
       ].join(" ")}
     >
-      <Tooltip content="Restore">
+      <Tooltip content={t("versionHistory.panel.restore")}>
         <button
           type="button"
           onClick={() => onRestore?.(versionId)}
@@ -378,7 +379,7 @@ function HoverActions({
           <RestoreIcon />
         </button>
       </Tooltip>
-      <Tooltip content="Compare">
+      <Tooltip content={t("versionHistory.panel.compare")}>
         <button
           type="button"
           onClick={() => onCompare?.(versionId)}
@@ -387,7 +388,7 @@ function HoverActions({
           <CompareIcon />
         </button>
       </Tooltip>
-      <Tooltip content="Preview">
+      <Tooltip content={t("versionHistory.panel.preview")}>
         <button
           type="button"
           onClick={() => onPreview?.(versionId)}

--- a/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
+++ b/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
@@ -5,6 +5,7 @@
 import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { invoke } from "../../lib/ipcClient";
+import { i18n } from "../../i18n";
 
 export type CompareState = {
   status: "idle" | "loading" | "ready" | "error";
@@ -69,11 +70,11 @@ export function useVersionCompare() {
 
         setCompareState({
           status: "ready",
-          diffText: res.data.diffText || "No differences found.",
+          diffText: res.data.diffText || i18n.t("versionHistory.compare.noDifferencesFound"),
           aiMarked: res.data.aiMarked,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Unknown error";
+        const message = err instanceof Error ? err.message : i18n.t("versionHistory.compare.unknownError");
         setCompareState({
           status: "error",
           diffText: "",

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -108,6 +108,8 @@
     }
   },
   "editor": {
+    "entitySuggestionsUnavailable": "Entity suggestions unavailable.",
+    "confirmSwitchToDraft": "This document is final. Editing will switch it back to draft. Continue?",
     "contextMenu": {
       "copy": "Copy",
       "paste": "Paste",
@@ -117,6 +119,7 @@
       "bold": "Bold",
       "italic": "Italic",
       "underline": "Underline",
+      "ai": "AI",
       "aiPolish": "Polish",
       "aiRewrite": "Rewrite"
     },
@@ -132,6 +135,32 @@
       "generating": "Generating...",
       "tooltip": "Trigger continue-writing skill",
       "writing": "Writing..."
+    },
+    "slash": {
+      "continue": {
+        "label": "/Continue",
+        "description": "Continue writing based on surrounding context."
+      },
+      "describe": {
+        "label": "/Describe",
+        "description": "Expand scene details and atmosphere."
+      },
+      "dialogue": {
+        "label": "/Dialogue",
+        "description": "Generate natural character dialogue."
+      },
+      "character": {
+        "label": "/Character",
+        "description": "Add character settings and motivations."
+      },
+      "outline": {
+        "label": "/Outline",
+        "description": "Organize chapter structure and narrative pacing."
+      },
+      "search": {
+        "label": "/Search",
+        "description": "Search for relevant information in the project."
+      }
     },
     "pane": {
       "charLimitReached": "Document has reached the 1,000,000 character limit. Consider splitting the document to continue writing.",
@@ -771,7 +800,21 @@
       "useOurs": "ours",
       "useTheirs": "theirs",
       "useManual": "manual",
-      "submitConflictResolution": "Submit Conflict Resolution"
+      "submitConflictResolution": "Submit Conflict Resolution",
+      "author": {
+        "you": "You",
+        "ai": "AI",
+        "auto": "Auto",
+        "unknown": "Unknown"
+      },
+      "timeGroup": {
+        "justNow": "Just now",
+        "minutesAgo": "{{count}}m ago",
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "earlier": "Earlier"
+      },
+      "loadingVersions": "Loading versions..."
     },
     "panel": {
       "closeAriaLabel": "Close version history",
@@ -805,6 +848,10 @@
       "actorLabel": "Actor:",
       "timestampLabel": "Timestamp:",
       "reasonLabel": "Reason:"
+    },
+    "compare": {
+      "noDifferencesFound": "No differences found.",
+      "unknownError": "Unknown error"
     }
   },
   "settings": {

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -108,6 +108,8 @@
     }
   },
   "editor": {
+    "entitySuggestionsUnavailable": "实体建议不可用。",
+    "confirmSwitchToDraft": "此文档已定稿。编辑将使其切回草稿状态。是否继续？",
     "contextMenu": {
       "copy": "复制",
       "paste": "粘贴",
@@ -117,6 +119,7 @@
       "bold": "加粗",
       "italic": "斜体",
       "underline": "下划线",
+      "ai": "AI",
       "aiPolish": "润色",
       "aiRewrite": "改写"
     },
@@ -132,6 +135,32 @@
       "generating": "生成中...",
       "tooltip": "触发续写技能",
       "writing": "续写中..."
+    },
+    "slash": {
+      "continue": {
+        "label": "/续写",
+        "description": "基于当前光标附近上下文继续创作。"
+      },
+      "describe": {
+        "label": "/描写",
+        "description": "扩展场景细节与氛围描写。"
+      },
+      "dialogue": {
+        "label": "/对白",
+        "description": "生成角色间自然对话。"
+      },
+      "character": {
+        "label": "/角色",
+        "description": "补充角色设定与人物动机。"
+      },
+      "outline": {
+        "label": "/大纲",
+        "description": "整理章节结构与叙事节奏。"
+      },
+      "search": {
+        "label": "/搜索",
+        "description": "检索项目中的相关信息。"
+      }
     },
     "pane": {
       "charLimitReached": "文档已达到 1000000 字符上限，建议拆分文档后继续写作。",
@@ -771,7 +800,21 @@
       "useOurs": "我方",
       "useTheirs": "对方",
       "useManual": "手动",
-      "submitConflictResolution": "提交冲突解决"
+      "submitConflictResolution": "提交冲突解决",
+      "author": {
+        "you": "你",
+        "ai": "AI",
+        "auto": "自动",
+        "unknown": "未知"
+      },
+      "timeGroup": {
+        "justNow": "刚刚",
+        "minutesAgo": "{{count}}分钟前",
+        "today": "今天",
+        "yesterday": "昨天",
+        "earlier": "更早"
+      },
+      "loadingVersions": "加载版本中..."
     },
     "panel": {
       "closeAriaLabel": "关闭版本历史",
@@ -805,6 +848,10 @@
       "actorLabel": "操作者：",
       "timestampLabel": "时间戳：",
       "reasonLabel": "原因："
+    },
+    "compare": {
+      "noDifferencesFound": "未发现差异。",
+      "unknownError": "未知错误"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary

消除编辑器、版本历史、Slash 命令模块中 28+ 个裸字符串字面量，全部替换为 i18n `t()` 调用。

Closes #991

## Changes

### 编辑器 (3 裸字符串)
- `EditorPane.tsx`: `"Entity suggestions unavailable."` → `t('editor.entitySuggestionsUnavailable')`
- `EditorPane.tsx`: confirm dialog 文案 → `t('editor.confirmSwitchToDraft')`
- `EditorContextMenu.tsx`: AI 菜单标签 → `t('editor.contextMenu.ai')`

### Slash Commands (12 裸字符串)
- `slashCommands.ts`: 6 组 label + description 全部改为 `i18n.t()`
- 新增 `getSlashCommandRegistry()` 函数，支持 locale 切换时动态翻译

### 版本历史 (13 裸字符串)
- `VersionHistoryContainer.tsx`: 作者名 You/AI/Auto/Unknown → `i18n.t()`
- `VersionHistoryContainer.tsx`: 时间分组 Just now/Today/Yesterday/Earlier → `i18n.t()`
- `VersionHistoryContainer.tsx`: Loading versions... → `t()`
- `VersionHistoryPanel.tsx`: tooltips Restore/Compare/Preview → `t()`
- `useVersionCompare.ts`: No differences found / Unknown error → `i18n.t()`

### i18n Keys
- zh-CN.json: +28 keys
- en.json: +28 keys (完全对称)

## Verification
- 26 个新增 i18n 测试全部通过
- 265 个测试文件 / 1817 个测试全绿，无回归
- JSON 语法验证通过

## Rollback
`git revert <commit-sha>` 即可回退。