### PR TITLE
feat(error-surface): A0-21 — 收口 18+ 错误显示站点至 getUserFacingErrorMessage

### DIFF
--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDialogs.test.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDialogs.test.tsx
@@ -503,9 +503,9 @@ describe("AiErrorCard", () => {
       errorCode: "upstream_error_503",
     };
 
-    render(<AiErrorCard error={error} />);
+    render(<AiErrorCard error={error} errorCodeTestId="ai-error-code-test" />);
 
-    expect(screen.getByText("upstream_error_503")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-error-code-test")).toHaveTextContent("Service is experiencing issues.");
   });
 
   it("displays countdown for rate limit errors", () => {

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AiErrorCardProps, AiErrorType } from "./types";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../../lib/errorMessages";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 
 /**
 
@@ -766,8 +769,8 @@ export function AiErrorCard({
           {/* Error code for service errors */}
 
           {error.errorCode && (
-            <div data-testid={errorCodeTestId} className={errorCodeStyles}>
-              {error.errorCode}
+            <div data-testid={errorCodeTestId} className={errorCodeStyles} role="alert">
+              {getUserFacingErrorMessage({ code: error.errorCode as IpcErrorCode, message: error.description })}
             </div>
           )}
 

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -63,6 +63,8 @@ import {
 import { runFireAndForget } from "../../lib/fireAndForget";
 import { invoke } from "../../lib/ipcClient";
 import { extractZenModeContent, getModKey } from "./appShellLayoutHelpers";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import "../../i18n";
 
 type FileItem = {
@@ -658,7 +660,7 @@ function useAppShellController() {
       onCreateDocument: async () => {
         if (!currentProjectId) throw new Error("No project selected");
         const res = await createDocument({ projectId: currentProjectId });
-        if (!res.ok) throw new Error(`${res.error.code}: ${res.error.message}`);
+        if (!res.ok) throw new Error(getUserFacingErrorMessage(res.error));
       },
     }), [createDocument, currentProjectId]);
 

--- a/apps/desktop/renderer/src/features/ai/AiPanel.error-guide.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.error-guide.test.tsx
@@ -227,7 +227,7 @@ describe("AiPanel error guidance", () => {
     render(<AiPanel />);
 
     expect(await screen.findByTestId("ai-error-code")).toHaveTextContent(
-      "UNKNOWN_ERROR",
+      "Something went wrong",
     );
     expect(screen.queryByTestId("ai-error-guide-db")).not.toBeInTheDocument();
     expect(
@@ -245,7 +245,7 @@ describe("AiPanel error guidance", () => {
     render(<AiPanel />);
 
     expect(await screen.findByTestId("ai-error-code")).toHaveTextContent(
-      "UPSTREAM_ERROR",
+      "Gateway timeout",
     );
     expect(
       screen.queryByTestId("ai-error-guide-provider"),

--- a/apps/desktop/renderer/src/features/ai/AiPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.test.tsx
@@ -211,8 +211,7 @@ describe("AiPanel", () => {
       render(<AiPanel />);
 
       expect(screen.getByTestId("ai-error-code")).toBeInTheDocument();
-      expect(screen.getByText("TIMEOUT")).toBeInTheDocument();
-      expect(screen.getByText("Request timed out")).toBeInTheDocument();
+      expect(screen.getByTestId("ai-error-code")).toHaveTextContent("Request timed out");
     });
   });
 

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -52,6 +52,8 @@ import {
 } from "./ModelPicker";
 import { useAiStream } from "./useAiStream";
 import { onAiModelCatalogUpdated } from "./modelCatalogEvents";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import {
   JUDGE_RESULT_CHANNEL,
   type JudgeResultEvent,
@@ -437,7 +439,7 @@ function buildAiErrorConfigs(args: {
     ? {
         type: "service_error",
         title: t('ai.panel.modelsUnavailable'),
-        description: `${modelsLastError.code}: ${modelsLastError.message}`,
+        description: getUserFacingErrorMessage(modelsLastError),
         errorCode: modelsLastError.code,
       }
     : null;

--- a/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
+++ b/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
@@ -8,6 +8,8 @@ import { Dialog } from "../../components/primitives/Dialog";
 import { Heading } from "../../components/primitives/Heading";
 import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type StatsSummary = {
   wordsWritten: number;
@@ -147,8 +149,8 @@ export function AnalyticsPageContent(): JSX.Element {
       </header>
 
       {error ? (
-        <Text data-testid="analytics-error" size="small" color="muted">
-          {error.code}: {error.message}
+        <Text data-testid="analytics-error" size="small" className="text-[var(--color-error)]" role="alert">
+          {getUserFacingErrorMessage(error)}
         </Text>
       ) : null}
 

--- a/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
@@ -11,6 +11,8 @@ import {
 import { CharacterDetailDialog } from "./CharacterDetailDialog";
 import { characterToMetadataJson, kgToCharacters } from "./characterFromKg";
 import type { Character } from "./types";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 export interface CharacterCardListContainerProps {
   projectId: string;
@@ -155,8 +157,8 @@ export function CharacterCardListContainer({
         <span className="text-sm text-[var(--color-error-default)]">
           {t('character.panelContainer.loadError')}
         </span>
-        <span className="text-xs text-[var(--color-fg-muted)]">
-          {lastError.code}: {lastError.message}
+        <span className="text-xs text-[var(--color-error)]" role="alert">
+          {getUserFacingErrorMessage(lastError)}
         </span>
       </div>
     );

--- a/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
@@ -19,6 +19,8 @@ import {
   characterToMetadataJson,
 } from "./characterFromKg";
 import type { Character } from "./types";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 export interface CharacterPanelContainerProps {
   /** Project ID for KG scope */
@@ -155,8 +157,8 @@ export function CharacterPanelContainer(
         <span className="text-sm text-[var(--color-error-default)]">
           {t('character.panelContainer.loadError')}
         </span>
-        <span className="text-xs text-[var(--color-fg-muted)]">
-          {lastError.code}: {lastError.message}
+        <span className="text-xs text-[var(--color-error)]" role="alert">
+          {getUserFacingErrorMessage(lastError)}
         </span>
       </div>
     );

--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -321,7 +321,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenSettings();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Settings dialog not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.settingsUnavailable"));
           }
         },
       },
@@ -338,7 +338,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenExport();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Export dialog not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.exportUnavailable"));
           }
         },
       },
@@ -355,7 +355,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleSidebar();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.layoutActionFailed"));
           }
         },
       },
@@ -372,7 +372,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleRightPanel();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.layoutActionFailed"));
           }
         },
       },
@@ -389,7 +389,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleZenMode();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.layoutActionFailed"));
           }
         },
       },
@@ -403,7 +403,7 @@ function buildDefaultCommands(ctx: {
         onSelect: async () => {
           ctx.setErrorText(null);
           if (!ctx.currentProjectId) {
-            ctx.setErrorText("NO_PROJECT: Please open a project first");
+            ctx.setErrorText(ctx.t("commandPalette.error.noProject"));
             return;
           }
           if (ctx.documentActions?.onCreateDocument) {
@@ -411,10 +411,10 @@ function buildDefaultCommands(ctx: {
               await ctx.documentActions.onCreateDocument();
               ctx.onOpenChange(false);
             } catch {
-              ctx.setErrorText("ACTION_FAILED: Failed to create document");
+              ctx.setErrorText(ctx.t("commandPalette.error.actionFailed"));
             }
           } else {
-            ctx.setErrorText("ACTION_FAILED: Document actions not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.actionFailed"));
           }
         },
       },
@@ -429,7 +429,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onOpenVersionHistory();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Version history action not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.actionFailed"));
           }
         },
       },
@@ -446,7 +446,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenCreateProject();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Create project dialog not available");
+            ctx.setErrorText(ctx.t("commandPalette.error.actionFailed"));
           }
         },
       },
@@ -655,11 +655,11 @@ export function CommandPalette({
         >
           {/* 错误提示 */}
           {errorText && (
-            <div className="px-3 py-2 mb-2 bg-[var(--color-error-subtle)] rounded-[var(--radius-sm)]">
+            <div role="alert" className="px-3 py-2 mb-2 bg-[var(--color-error-subtle)] rounded-[var(--radius-sm)]">
               <Text
                 data-testid="command-palette-error"
                 size="small"
-                color="error"
+                className="text-[var(--color-error)]"
               >
                 {errorText}
               </Text>

--- a/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
@@ -18,6 +18,8 @@ import { invoke } from "../../lib/ipcClient";
 import { CreateProjectDialog } from "../projects/CreateProjectDialog";
 import { DeleteProjectDialog } from "../projects/DeleteProjectDialog";
 import { RenameProjectDialog } from "./RenameProjectDialog";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import {
   useProjectStore,
   type ProjectListItem,
@@ -425,7 +427,7 @@ function useDashboardActions() {
       });
       setRenameSubmitting(false);
       if (!res.ok) {
-        setRenameErrorText(`${res.error.code}: ${res.error.message}`);
+        setRenameErrorText(getUserFacingErrorMessage(res.error));
         return;
       }
       setRenameDialogOpen(false);
@@ -624,8 +626,8 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
           {lastError ? (
             <div role="alert" className="w-full max-w-xl mb-8">
               <div className="p-3 border border-[var(--color-separator)] rounded-[var(--radius-md)] bg-[var(--color-bg-surface)]">
-                <Text size="small" className="mb-2 block">
-                  {lastError.code}: {lastError.message}
+                <Text size="small" className="mb-2 block text-[var(--color-error)]">
+                  {getUserFacingErrorMessage(lastError)}
                 </Text>
                 <Button
                   variant="secondary"
@@ -709,8 +711,8 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
             role="alert"
             className="px-12 py-3 border-b border-[var(--color-separator)]"
           >
-            <Text size="small" className="mb-2 block">
-              {lastError.code}: {lastError.message}
+            <Text size="small" className="mb-2 block text-[var(--color-error)]">
+              {getUserFacingErrorMessage(lastError)}
             </Text>
             <Button variant="secondary" size="sm" onClick={() => clearError()}>
               {t("dashboard.dismiss")}

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -48,7 +48,7 @@ describe("ExportDialog", () => {
     render(<ExportDialog open={true} onOpenChange={() => {}} />);
 
     expect(screen.getByTestId("export-submit")).toBeDisabled();
-    expect(screen.getByText(/NO_PROJECT:/)).toBeInTheDocument();
+    expect(screen.getByText(/Please open a project first/)).toBeInTheDocument();
   });
 
   it("renders controlled progress view", () => {
@@ -101,12 +101,7 @@ describe("ExportDialog", () => {
     );
 
     expect(screen.getByTestId("export-error")).toBeInTheDocument();
-    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
-      "IO_ERROR",
-    );
-    expect(screen.getByTestId("export-error-message")).toHaveTextContent(
-      "failed",
-    );
+    expect(screen.getByTestId("export-error")).toHaveTextContent("failed");
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
 
@@ -128,10 +123,7 @@ describe("ExportDialog", () => {
     await user.click(screen.getByTestId("export-submit"));
 
     expect(await screen.findByTestId("export-error")).toBeInTheDocument();
-    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
-      "IO_ERROR",
-    );
-    expect(screen.getByTestId("export-error-message")).toHaveTextContent(
+    expect(screen.getByTestId("export-error")).toHaveTextContent(
       "disk write permission denied",
     );
     expect(screen.queryByTestId("export-success")).not.toBeInTheDocument();

--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from "react-i18next";
 import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import { Button, Checkbox, Select, Tooltip } from "../../components/primitives";
 import { invoke } from "../../lib/ipcClient";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 import { Check, File, FileCode, FileOutput, FileText, X } from "lucide-react";
 /**
@@ -417,14 +419,12 @@ function ConfigView({
         {error ? (
           <div
             data-testid="export-error"
+            role="alert"
             className="p-3 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
           >
             <div className="flex items-start gap-3">
-              <div className="flex-1 text-xs text-[var(--color-fg-muted)]">
-                <div data-testid="export-error-code" className="font-mono">
-                  {error.code}
-                </div>
-                <div data-testid="export-error-message">{error.message}</div>
+              <div className="flex-1 text-xs text-[var(--color-error)]">
+                <div data-testid="export-error-message">{getUserFacingErrorMessage(error)}</div>
               </div>
               <Button
                 variant="ghost"

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
@@ -147,7 +147,7 @@ describe("FileTreePanel", () => {
       render(<FileTreePanel projectId="test-project" />);
 
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
+      expect(screen.getByText(/Failed to load files/)).toBeInTheDocument();
       expect(screen.getByText("Dismiss")).toBeInTheDocument();
     });
   });

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -21,6 +21,8 @@ import {
   type DocumentType,
 } from "../../stores/fileStore";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type EditingState =
   | { mode: "idle" }
@@ -1243,8 +1245,8 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
           role="alert"
           className="p-3 border-b border-[var(--color-separator)]"
         >
-          <Text size="small" className="mb-2 block">
-            {state.lastError.code}: {state.lastError.message}
+          <Text size="small" className="mb-2 block text-[var(--color-error)]">
+            {getUserFacingErrorMessage(state.lastError)}
           </Text>
           <Button variant="secondary" size="sm" onClick={() => state.clearError()}>
             {t('files.tree.dismiss')}

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -11,6 +11,8 @@ import type {
 } from "../../components/features/KnowledgeGraph/types";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { useKgStore, type KgEntity, type KgRelation, type KgActions } from "../../stores/kgStore";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import { TimelineView, type TimelineEventItem } from "./TimelineView";
 import { buildForceDirectedGraph } from "./graphRenderAdapter";
 import {
@@ -914,8 +916,8 @@ function KgListView(props: {
           className="p-3 border-b border-[var(--color-separator)]"
         >
           <div className="flex gap-2 items-center">
-            <Text data-testid="kg-error-code" size="code" color="muted">
-              {lastError.code}
+            <Text data-testid="kg-error" size="small" className="text-[var(--color-error)]">
+              {getUserFacingErrorMessage(lastError)}
             </Text>
             <Button
               variant="secondary"
@@ -926,9 +928,6 @@ function KgListView(props: {
               {t('kg.panel.dismiss')}
             </Button>
           </div>
-          <Text size="small" className="mt-1.5 block">
-            {lastError.message}
-          </Text>
         </div>
       ) : null}
 
@@ -1122,8 +1121,8 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
             className="p-3 border-b border-[var(--color-separator)] shrink-0"
           >
             <div className="flex gap-2 items-center">
-              <Text data-testid="kg-error-code" size="code" color="muted">
-                {lastError.code}
+              <Text data-testid="kg-error" size="small" className="text-[var(--color-error)]">
+                {getUserFacingErrorMessage(lastError)}
               </Text>
               <Button
                 variant="secondary"
@@ -1134,9 +1133,6 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                 {t('kg.panel.dismiss')}
               </Button>
             </div>
-            <Text size="small" className="mt-1.5 block">
-              {lastError.message}
-            </Text>
           </div>
         ) : null}
 

--- a/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
@@ -5,6 +5,8 @@ import type { IpcError, IpcResponseData } from "@shared/types/ipc-generated";
 import { Button, Card, Text } from "../../components/primitives";
 import { invoke } from "../../lib/ipcClient";
 import { useProjectStore } from "../../stores/projectStore";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type PanelScope = "global" | "project";
 type SemanticRule = IpcResponseData<"memory:semantic:list">["items"][number];
@@ -494,8 +496,8 @@ export function MemoryPanel(): JSX.Element {
       {state.error ? (
         <Card noPadding className="shrink-0 p-2.5">
           <div className="flex items-center gap-2">
-            <Text data-testid="memory-error-code" size="code" color="muted">
-              {state.error.code}
+            <Text data-testid="memory-error" size="small" className="text-[var(--color-error)]" role="alert">
+              {getUserFacingErrorMessage(state.error)}
             </Text>
             <Button
               variant="ghost"
@@ -506,9 +508,6 @@ export function MemoryPanel(): JSX.Element {
               {t('memory.panel.dismissError')}
             </Button>
           </div>
-          <Text size="small" color="muted" className="mt-1.5 block">
-            {state.error.message}
-          </Text>
         </Card>
       ) : null}
 

--- a/apps/desktop/renderer/src/features/memory/__tests__/MemoryPanel.error.test.tsx
+++ b/apps/desktop/renderer/src/features/memory/__tests__/MemoryPanel.error.test.tsx
@@ -52,10 +52,9 @@ describe("MemoryPanel error handling", () => {
     render(<MemoryPanel />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("memory-error-code")).toHaveTextContent(
-        "INTERNAL_ERROR",
+      expect(screen.getByTestId("memory-error")).toHaveTextContent(
+        "内部错误",
       );
     });
-    expect(screen.getByText("invoke exploded")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -419,7 +419,6 @@ describe("CreateProjectDialog — error and edge cases", () => {
 
       render(<CreateProjectDialog open={true} onOpenChange={vi.fn()} />);
 
-      expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
       expect(screen.getByText(/Failed to create project/)).toBeInTheDocument();
     });
 
@@ -457,7 +456,6 @@ describe("CreateProjectDialog — error and edge cases", () => {
         await user.click(screen.getByTestId("create-project-submit"));
 
         await waitFor(() => {
-          expect(screen.getByText(/NAME_CONFLICT/)).toBeInTheDocument();
           expect(screen.getByText(/Project already exists/)).toBeInTheDocument();
         });
 
@@ -503,7 +501,6 @@ describe("CreateProjectDialog — error and edge cases", () => {
         await user.click(screen.getByTestId("create-project-submit"));
 
         await waitFor(() => {
-          expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
           expect(screen.getByText(/Disk full/)).toBeInTheDocument();
         });
 

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -18,6 +18,8 @@ import {
 import { useProjectStore } from "../../stores/projectStore";
 import { useTemplateStore } from "../../stores/templateStore";
 import { CreateTemplateDialog } from "./CreateTemplateDialog";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 import { Plus } from "lucide-react";
 // =============================================================================
@@ -314,11 +316,11 @@ function FormContent({
       {lastError && (
         <Text
           size="small"
-          color="muted"
           as="div"
           className="text-[var(--color-error)]"
+          role="alert"
         >
-          {lastError.code}: {lastError.message}
+          {getUserFacingErrorMessage(lastError)}
         </Text>
       )}
 

--- a/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
@@ -8,6 +8,8 @@ import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
 import { useFileStore, type DocumentListItem } from "../../stores/fileStore";
 import "../../i18n";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type StatsSummary = IpcResponseData<"stats:day:gettoday">["summary"];
 
@@ -145,11 +147,10 @@ function TodayStatsSection(props: {
           <Text
             data-testid="info-panel-stats-error"
             size="small"
-            color="muted"
-            className="text-center"
+            className="text-center text-[var(--color-error)]"
+            role="alert"
           >
-            <span data-testid="info-panel-stats-error-code">{error.code}</span>:{" "}
-            {error.message}
+            {getUserFacingErrorMessage(error)}
           </Text>
         </Card>
       </section>

--- a/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
@@ -10,6 +10,8 @@ import { Text } from "../../components/primitives/Text";
 import { useJudgeEnsure } from "../../hooks/useJudgeEnsure";
 import { invoke } from "../../lib/ipcClient";
 import { useProjectStore } from "../../stores/projectStore";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import {
   QualityGatesPanelContent,
   type CheckGroup,
@@ -38,7 +40,7 @@ function formatJudgeState(state: JudgeModelState, t: TFunction): {
     case "not_ready":
       return { label: t('rightPanel.quality.notReady'), status: "not_ready" };
     case "error":
-      return { label: t('rightPanel.quality.errorWithCode', { code: state.error.code }), status: "error" };
+      return { label: t('rightPanel.quality.errorWithCode', { code: getUserFacingErrorMessage(state.error) }), status: "error" };
   }
 }
 
@@ -106,12 +108,10 @@ function JudgeStatusSection(props: {
             <Text
               data-testid="quality-panel-judge-error"
               size="small"
-              color="muted"
+              className="text-[var(--color-error)]"
+              role="alert"
             >
-              <span data-testid="quality-panel-judge-error-code">
-                {error.code}
-              </span>
-              : {error.message}
+              {getUserFacingErrorMessage(error)}
             </Text>
           </div>
         </div>
@@ -191,12 +191,10 @@ function ConstraintsSection(props: {
         <Text
           data-testid="quality-panel-constraints-error"
           size="small"
-          color="muted"
+          className="text-[var(--color-error)]"
+          role="alert"
         >
-          <span data-testid="quality-panel-constraints-error-code">
-            {error.code}
-          </span>
-          : {error.message}
+          {getUserFacingErrorMessage(error)}
         </Text>
       </Card>
     );

--- a/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
@@ -8,6 +8,8 @@ import { Input } from "../../components/primitives/Input";
 import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
 import { emitAiModelCatalogUpdated } from "../ai/modelCatalogEvents";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type AiSettings = IpcResponseData<"ai:config:get">;
 
@@ -39,7 +41,7 @@ export function AiSettingsSection(): JSX.Element {
     const res = await invoke("ai:config:get", {});
     if (!res.ok) {
       setStatus("idle");
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getUserFacingErrorMessage(res.error));
       return;
     }
 
@@ -101,7 +103,7 @@ export function AiSettingsSection(): JSX.Element {
 
     const res = await invoke("ai:config:update", { patch });
     if (!res.ok) {
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getUserFacingErrorMessage(res.error));
       return;
     }
 
@@ -118,7 +120,7 @@ export function AiSettingsSection(): JSX.Element {
 
     const res = await invoke("ai:config:test", {});
     if (!res.ok) {
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getUserFacingErrorMessage(res.error));
       return;
     }
 
@@ -128,7 +130,9 @@ export function AiSettingsSection(): JSX.Element {
     }
 
     setTestResult(
-      `${res.data.error?.code ?? "ERROR"}: ${res.data.error?.message ?? "failed"} (${res.data.latencyMs}ms)`,
+      res.data.error
+        ? getUserFacingErrorMessage(res.data.error)
+        : t('settings.ai.connectionFailed'),
     );
   }
 
@@ -193,7 +197,7 @@ export function AiSettingsSection(): JSX.Element {
       </div>
 
       {errorText ? (
-        <Text data-testid="ai-error" size="small" color="muted">
+        <Text data-testid="ai-error" size="small" className="text-[var(--color-error)]" role="alert">
           {errorText}
         </Text>
       ) : null}

--- a/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
@@ -6,6 +6,8 @@ import { invoke } from "../../lib/ipcClient";
 import { runFireAndForget } from "../../lib/fireAndForget";
 import { Button, Heading, Text } from "../../components/primitives";
 import { useJudgeEnsure } from "../../hooks/useJudgeEnsure";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type JudgeModelState =
   IpcChannelSpec["judge:model:getstate"]["response"]["state"];
@@ -15,7 +17,7 @@ type JudgeModelState =
  */
 function formatState(state: JudgeModelState): string {
   if (state.status === "error") {
-    return `error (${state.error.code})`;
+    return getUserFacingErrorMessage(state.error);
   }
   return state.status;
 }
@@ -51,7 +53,7 @@ export function JudgeSection(): JSX.Element {
           clearError();
           return;
         }
-        setErrorText(`${res.error.code}: ${res.error.message}`);
+        setErrorText(getUserFacingErrorMessage(res.error));
       },
       (error) => {
         if (canceled) {
@@ -79,7 +81,7 @@ export function JudgeSection(): JSX.Element {
       return;
     }
 
-    setErrorText(`${result.error.code}: ${result.error.message}`);
+    setErrorText(getUserFacingErrorMessage(result.error));
     setState({
       status: "error",
       error: { code: result.error.code, message: result.error.message },
@@ -90,7 +92,7 @@ export function JudgeSection(): JSX.Element {
     ? { status: "downloading" }
     : state;
   const displayError = ensureError
-    ? `${ensureError.code}: ${ensureError.message}`
+    ? getUserFacingErrorMessage(ensureError)
     : errorText;
 
   return (
@@ -122,7 +124,7 @@ export function JudgeSection(): JSX.Element {
         </Button>
 
         {displayError ? (
-          <Text data-testid="judge-error" size="small" color="muted">
+          <Text data-testid="judge-error" size="small" className="text-[var(--color-error)]" role="alert">
             {displayError}
           </Text>
         ) : null}

--- a/apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx
+++ b/apps/desktop/renderer/src/features/settings/__tests__/AiSettingsSection.test.tsx
@@ -124,7 +124,7 @@ describe("AiSettingsSection", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("ai-test-result")).toHaveTextContent(
-        "AI_AUTH_FAILED",
+        "Proxy unauthorized",
       );
     });
   });

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
@@ -265,7 +265,7 @@ describe("VersionHistoryContainer", () => {
     await user.click(screen.getByTestId("version-preview-trigger"));
 
     const error = await screen.findByTestId("version-preview-error");
-    expect(error).toHaveTextContent("NOT_FOUND: Version not found");
+    expect(error).toHaveTextContent("Version not found");
   });
 
   it("restore requires confirmation and refreshes editor only after confirm", async () => {

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -18,6 +18,8 @@ import { invoke } from "../../lib/ipcClient";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { RESTORE_VERSION_CONFIRM_COPY } from "./restoreConfirmCopy";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 import { useVersionPreferencesStore } from "../../stores/versionPreferencesStore";
 import { i18n } from "../../i18n";
 
@@ -671,8 +673,8 @@ const {
           </div>
         ) : null}
         {branchMergeStatus === "error" && branchMergeError ? (
-          <div className="text-[11px] text-[var(--color-error)]">
-            {branchMergeError.code}: {branchMergeError.message}
+          <div role="alert" className="text-[11px] text-[var(--color-error)]">
+            {getUserFacingErrorMessage(branchMergeError)}
           </div>
         ) : null}
       </div>
@@ -723,9 +725,9 @@ const {
         </div>
       ) : null}
       {previewStatus === "error" && previewError ? (
-        <div className="px-3 py-2 text-xs text-[var(--color-error)]">
+        <div role="alert" className="px-3 py-2 text-xs text-[var(--color-error)]">
           <span data-testid="version-preview-error">
-            {previewError.code}: {previewError.message}
+            {getUserFacingErrorMessage(previewError)}
           </span>
         </div>
       ) : null}

--- a/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
@@ -3,6 +3,8 @@ import { Dialog } from "../../components/primitives/Dialog";
 import { Button } from "../../components/primitives/Button";
 import { Textarea } from "../../components/primitives/Textarea";
 import { Text } from "../../components/primitives/Text";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 type PreviewVersion = {
   versionId: string;
@@ -73,10 +75,11 @@ export function VersionPreviewDialog(
         {!props.loading && props.error ? (
           <div
             data-testid="version-preview-error"
+            role="alert"
             className="rounded-[var(--radius-sm)] border border-[var(--color-error)] bg-[var(--color-error-subtle)] p-3"
           >
             <Text size="small" className="text-[var(--color-error)]">
-              {props.error.code}: {props.error.message}
+              {getUserFacingErrorMessage(props.error)}
             </Text>
           </div>
         ) : null}

--- a/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
+++ b/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
@@ -5,6 +5,8 @@
 import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { invoke } from "../../lib/ipcClient";
+// TODO: A0-20 合并后重命名为 getHumanErrorMessage
+import { getUserFacingErrorMessage } from "../../lib/errorMessages";
 
 export type CompareState = {
   status: "idle" | "loading" | "ready" | "error";
@@ -62,7 +64,7 @@ export function useVersionCompare() {
           setCompareState({
             status: "error",
             diffText: "",
-            error: `${res.error.code}: ${res.error.message}`,
+            error: getUserFacingErrorMessage(res.error),
           });
           return;
         }

--- a/apps/desktop/renderer/src/i18n/command-palette-error-keys.test.ts
+++ b/apps/desktop/renderer/src/i18n/command-palette-error-keys.test.ts
@@ -1,0 +1,103 @@
+/**
+ * A0-21 — CommandPalette i18n 错误 key 完整性测试
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const LOCALES_DIR = path.resolve(__dirname, "../i18n/locales");
+
+function loadLocale(name: string): Record<string, unknown> {
+  const raw = fs.readFileSync(path.join(LOCALES_DIR, `${name}.json`), "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+type Nested = Record<string, unknown>;
+
+function getNestedValue(obj: Nested, keyPath: string): unknown {
+  const parts = keyPath.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Nested)[part];
+  }
+  return current;
+}
+
+const REQUIRED_ERROR_KEYS = [
+  "settingsUnavailable",
+  "exportUnavailable",
+  "layoutActionFailed",
+  "noProject",
+  "actionFailed",
+] as const;
+
+describe("CommandPalette i18n 错误 key 完整性", () => {
+  const zhCN = loadLocale("zh-CN");
+  const en = loadLocale("en");
+
+  it("zh-CN.json 包含全部 commandPalette.error.* key", () => {
+    const errors = getNestedValue(zhCN, "workbench.commandPalette.error") as
+      | Record<string, string>
+      | undefined;
+    expect(errors).toBeDefined();
+    for (const key of REQUIRED_ERROR_KEYS) {
+      expect(errors).toHaveProperty(key);
+      expect(errors![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("en.json 包含全部 commandPalette.error.* key", () => {
+    const errors = getNestedValue(en, "workbench.commandPalette.error") as
+      | Record<string, string>
+      | undefined;
+    expect(errors).toBeDefined();
+    for (const key of REQUIRED_ERROR_KEYS) {
+      expect(errors).toHaveProperty(key);
+      expect(errors![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("zh-CN 和 en 的 key 数量一致", () => {
+    const zhErrors = getNestedValue(
+      zhCN,
+      "workbench.commandPalette.error",
+    ) as Record<string, string>;
+    const enErrors = getNestedValue(
+      en,
+      "workbench.commandPalette.error",
+    ) as Record<string, string>;
+    expect(Object.keys(zhErrors).length).toBe(Object.keys(enErrors).length);
+  });
+
+  it("所有值不含 ACTION_FAILED 或 NO_PROJECT 前缀", () => {
+    for (const [localeName, locale] of [
+      ["zh-CN", zhCN],
+      ["en", en],
+    ] as const) {
+      const errors = getNestedValue(
+        locale,
+        "workbench.commandPalette.error",
+      ) as Record<string, string>;
+      for (const [key, value] of Object.entries(errors)) {
+        expect(
+          value,
+          `${localeName}.commandPalette.error.${key}`,
+        ).not.toMatch(/ACTION_FAILED|NO_PROJECT/u);
+      }
+    }
+  });
+
+  it("export.error.noProject 值不含 NO_PROJECT 前缀", () => {
+    for (const [localeName, locale] of [
+      ["zh-CN", zhCN],
+      ["en", en],
+    ] as const) {
+      const val = getNestedValue(locale, "export.error.noProject") as string;
+      expect(val, `${localeName}.export.error.noProject`).not.toMatch(
+        /NO_PROJECT/u,
+      );
+    }
+  });
+});

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -27,6 +27,13 @@
         "command": "Command",
         "file": "File",
         "recent": "Recent"
+      },
+      "error": {
+        "settingsUnavailable": "Settings dialog is currently unavailable",
+        "exportUnavailable": "Export dialog is currently unavailable",
+        "layoutActionFailed": "Layout action failed",
+        "noProject": "Please open a project first",
+        "actionFailed": "Action failed, please try again later"
       }
     },
     "statusBar": {
@@ -812,6 +819,7 @@
       "notConfigured": "Not configured",
       "configured": "Configured",
       "connectionSuccess": "Connection successful ({{latency}}ms)",
+      "connectionFailed": "Connection failed",
       "title": "AI Configuration",
       "save": "Save",
       "testConnection": "Test Connection"
@@ -1114,7 +1122,7 @@
     },
     "defaultDocumentTitle": "Untitled Document",
     "error": {
-      "noProject": "NO_PROJECT: Please open a project first",
+      "noProject": "Please open a project first",
       "unknown": "Export failed due to unknown error"
     }
   },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -27,6 +27,13 @@
         "command": "命令",
         "file": "文件",
         "recent": "最近使用"
+      },
+      "error": {
+        "settingsUnavailable": "设置对话框暂不可用",
+        "exportUnavailable": "导出对话框暂不可用",
+        "layoutActionFailed": "布局操作失败",
+        "noProject": "请先打开一个项目",
+        "actionFailed": "操作失败，请稍后重试"
       }
     },
     "statusBar": {
@@ -812,6 +819,7 @@
       "notConfigured": "未配置",
       "configured": "已配置",
       "connectionSuccess": "连接成功 ({{latency}}ms)",
+      "connectionFailed": "连接失败",
       "title": "AI 配置",
       "save": "保存",
       "testConnection": "测试连接"
@@ -1114,7 +1122,7 @@
     },
     "defaultDocumentTitle": "未命名文档",
     "error": {
-      "noProject": "NO_PROJECT: 请先打开一个项目",
+      "noProject": "请先打开一个项目",
       "unknown": "由于未知错误导出失败"
     }
   },

--- a/apps/desktop/renderer/src/lib/error-surface-closure.test.ts
+++ b/apps/desktop/renderer/src/lib/error-surface-closure.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A0-21 错误展示组件收口 — 全局泄露检测测试
+ *
+ * 扫描 renderer 源码目录，确保无 error.code / error.message 直接渲染模式，
+ * 也无 ACTION_FAILED / NO_PROJECT 硬编码字符串。
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDERER_SRC = path.resolve(__dirname, "..");
+
+/** 排除的文件 — errorMessages.ts 本身、测试文件及 ErrorBoundary（框架组件） */
+function shouldSkip(filePath: string): boolean {
+  const base = path.basename(filePath);
+  if (base === "errorMessages.ts" || base === "errorMessages.test.ts") return true;
+  if (/\.test\.\w+$/u.test(base) || /\.spec\.\w+$/u.test(base)) return true;
+  if (base === "ipc-generated.ts" || base === "ipc-contract.ts") return true;
+  // ErrorBoundary 使用 JS Error.name / Error.message，非 IPC 错误码
+  if (base === "ErrorBoundary.tsx" || base === "RegionErrorBoundary.tsx") return true;
+  return false;
+}
+
+/** 递归收集 .ts / .tsx 文件 */
+function collectFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(full, acc);
+    } else if (/\.tsx?$/u.test(entry.name) && !shouldSkip(full)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const JSX_DIRECT_RENDER_PATTERNS = [
+  /\{\s*\w*[Ee]rror\.\s*code\s*\}/u,
+  /\{\s*\w*[Ee]rror\.\s*message\s*\}/u,
+  /\{\s*state\.\w*[Ee]rror\.\s*code\s*\}/u,
+  /\{\s*state\.\w*[Ee]rror\.\s*message\s*\}/u,
+  /\{\s*last[Ee]rror\.\s*code\s*\}/u,
+  /\{\s*last[Ee]rror\.\s*message\s*\}/u,
+  /\{\s*props\.\w*[Ee]rror\.\s*code\s*\}/u,
+  /\{\s*props\.\w*[Ee]rror\.\s*message\s*\}/u,
+  /\{\s*\w*[Ee]rror\.\s*errorCode\s*\}/u,
+];
+
+const TEMPLATE_STRING_PATTERNS = [
+  /`[^`]*\$\{[^}]*\.error\.code\}[^`]*`/u,
+  /`[^`]*\$\{[^}]*\.error\.message\}[^`]*`/u,
+  /`[^`]*\$\{[^}]*error\.code\}[^`]*`/u,
+  /`[^`]*\$\{[^}]*error\.message\}[^`]*`/u,
+];
+
+const HARDCODED_ERROR_STRINGS = [
+  /"ACTION_FAILED:/u,
+  /"NO_PROJECT:/u,
+];
+
+describe("A0-21 错误展示收口 — 全局泄露检测", () => {
+  const files = collectFiles(RENDERER_SRC);
+
+  it("renderer 源码中无 JSX 直接渲染 error.code / error.message 模式", () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      if (!file.endsWith(".tsx")) continue;
+      const content = fs.readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const pattern of JSX_DIRECT_RENDER_PATTERNS) {
+          if (pattern.test(line)) {
+            const rel = path.relative(RENDERER_SRC, file);
+            violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("renderer 源码中无模板字符串拼接 error.code / error.message 模式", () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const pattern of TEMPLATE_STRING_PATTERNS) {
+          if (pattern.test(line)) {
+            const rel = path.relative(RENDERER_SRC, file);
+            violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("renderer 源码中无 ACTION_FAILED: / NO_PROJECT: 硬编码字符串", () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        for (const pattern of HARDCODED_ERROR_STRINGS) {
+          if (pattern.test(line)) {
+            const rel = path.relative(RENDERER_SRC, file);
+            violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/desktop/renderer/src/lib/errorMessages.ts
+++ b/apps/desktop/renderer/src/lib/errorMessages.ts
@@ -19,10 +19,10 @@ const USER_FACING_MESSAGE_BY_CODE: Partial<
 };
 
 export function getUserFacingErrorMessage(error: {
-  code: IpcErrorCode;
+  code: IpcErrorCode | string;
   message: string;
 }): string {
-  const resolver = USER_FACING_MESSAGE_BY_CODE[error.code];
+  const resolver = USER_FACING_MESSAGE_BY_CODE[error.code as IpcErrorCode];
   if (!resolver) {
     return error.message;
   }

--- a/apps/desktop/tests/e2e/ai-runtime.spec.ts
+++ b/apps/desktop/tests/e2e/ai-runtime.spec.ts
@@ -120,7 +120,7 @@ test("ai runtime: timeout maps to SKILL_TIMEOUT", async () => {
   await runInput(page, "E2E_TIMEOUT");
 
   await expect(page.getByTestId("ai-error-code")).toContainText(
-    "SKILL_TIMEOUT",
+    "Skill execution timed out",
   );
 
   await electronApp.close();
@@ -134,7 +134,7 @@ test("ai runtime: upstream error maps to LLM_API_ERROR", async () => {
   await runInput(page, "E2E_UPSTREAM_ERROR");
 
   await expect(page.getByTestId("ai-error-code")).toContainText(
-    "LLM_API_ERROR",
+    "Fake upstream error",
   );
 
   await electronApp.close();

--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -253,8 +253,10 @@ test.describe("Command Palette + Shortcuts", () => {
     // Export button should be disabled (no project)
     await expect(page.getByTestId("export-submit")).toBeDisabled();
 
-    // Should show NO_PROJECT message
-    await expect(page.getByText(/NO_PROJECT/)).toBeVisible();
+    // ExportDialog now renders a human-readable no-project message.
+    await expect(
+      page.getByText(/Please open a project first|请先打开一个项目/),
+    ).toBeVisible();
 
     // Close dialog
     await page.keyboard.press("Escape");

--- a/apps/desktop/tests/e2e/settings-dialog.spec.ts
+++ b/apps/desktop/tests/e2e/settings-dialog.spec.ts
@@ -48,7 +48,7 @@ test("settings-dialog: shortcut opens + theme persists + ai settings errors obse
   await first.page.keyboard.press("Control+,");
   await expect(first.page.getByTestId("settings-dialog")).toBeVisible();
 
-  // AI settings: invalid empty baseUrl should show INVALID_ARGUMENT (observable failure)
+  // AI settings: invalid empty baseUrl should show the user-facing validation message.
   await first.page.getByTestId("settings-nav-ai").click();
   await expect(first.page.getByTestId("ai-save-btn")).toBeVisible();
   await first.page
@@ -57,7 +57,7 @@ test("settings-dialog: shortcut opens + theme persists + ai settings errors obse
   await first.page.getByTestId("ai-base-url").fill("");
   await first.page.getByTestId("ai-save-btn").click();
   await expect(first.page.getByTestId("ai-error")).toContainText(
-    "INVALID_ARGUMENT",
+    "proxy baseUrl is required when proxy enabled",
   );
 
   // Theme: switch to light and persist across restart

--- a/apps/desktop/tests/e2e/skills.spec.ts
+++ b/apps/desktop/tests/e2e/skills.spec.ts
@@ -116,7 +116,7 @@ test("skills: list + toggle disables run + command palette opens", async () => {
   }
 
   await runInput(page, "hello");
-  await expect(page.getByTestId("ai-error-code")).toContainText("UNSUPPORTED");
+  await expect(page.getByTestId("ai-error-code")).toContainText("Skill is disabled");
 
   await page.keyboard.press("Control+P");
   await expect(page.getByTestId("command-palette")).toBeVisible();


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

A0-21 错误表面收口：将所有前端 error.code/error.message 直接渲染替换为 `getUserFacingErrorMessage()` 调用，用户端不再暴露内部错误码。

## 关联 Issue

- Closes #988

## 用户影响

- 用户在所有面板看到的错误提示从raw error code（如 `IO_ERROR: failed`）变为人类可读消息（如 `failed`）
- 所有错误区域添加 `role="alert"` 无障碍属性
- CommandPalette 错误消息国际化

## 不修最坏后果

- 用户在 18+ 个面板看到裸露的内部错误码，影响产品品质
- 无 `role="alert"` 导致屏幕阅读器无法感知错误状态
- CommandPalette 错误消息未国际化

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm vitest run` — 266 files, 1799 tests 全部通过
- [x] 新增 `error-surface-closure.test.ts` 全局扫描守卫（3 tests）
- [x] 新增 `command-palette-error-keys.test.ts` i18n 完整性验证（5 tests）
- [x] 更新 8 个现有测试文件以验证人类可读消息

## 回滚点

- 回滚 commit: `18b0f1f6`（前一个 commit `3ace72c5`）
- 回滚后需要恢复的数据或配置：无

## 非自动化检查（Tier 3）

- [x] **品牌调性**：全部使用 `var(--color-error)` Design Token，未引入 Tailwind 原始色值
- [x] **无障碍**：所有动态错误区域使用 `role="alert"`
- [ ] **字体渲染**：N/A（无字体变更）
- [ ] **CJK 场景**：N/A（错误消息通过 i18n 已有中文翻译）

## 修改清单（34 文件, +372 -112）

### 核心实现（20 文件）
| # | 文件 | 变更 |
|---|------|------|
| 1 | `errorMessages.ts` | 签名扩展 `code: IpcErrorCode \| string` |
| 2 | `ExportDialog.tsx` | 收口 error 显示 |
| 3 | `QualityPanel.tsx` | Judge + Constraints 两处收口 |
| 4 | `MemoryPanel.tsx` | code+message 合并为单一展示 |
| 5 | `VersionHistoryContainer.tsx` | branchMergeError + previewError |
| 6 | `VersionPreviewDialog.tsx` | props.error 收口 |
| 7 | `CreateProjectDialog.tsx` | lastError 收口 |
| 8 | `KnowledgeGraphPanel.tsx` | 两处错误区域收口 |
| 9 | `JudgeSection.tsx` | formatState + setErrorText + displayError |
| 10 | `AiSettingsSection.tsx` | 三处 setErrorText + test result |
| 11 | `DashboardPage.tsx` | setRenameErrorText + 两处 JSX |
| 12 | `AnalyticsPage.tsx` | 收口 |
| 13 | `InfoPanel.tsx` | 移除分离的 code span |
| 14 | `CommandPalette.tsx` | 10 处硬编码字符串 → ctx.t() |
| 15 | `AiErrorCard.tsx` | errorCode → getUserFacingErrorMessage |
| 16 | `FileTreePanel.tsx` | 全局扫描发现并修复 |
| 17 | `CharacterCardListContainer.tsx` | 全局扫描发现并修复 |
| 18 | `CharacterPanelContainer.tsx` | 全局扫描发现并修复 |
| 19 | `AppShell.tsx` | 全局扫描发现并修复 |
| 20 | `useVersionCompare.ts` | 模板字符串收口 |

### i18n（2 文件）
| 文件 | 变更 |
|------|------|
| `zh-CN.json` | +5 commandPalette.error 键 + connectionFailed |
| `en.json` | 同上 |

### 新增测试（2 文件）
| 文件 | 测试数 |
|------|--------|
| `error-surface-closure.test.ts` | 3 |
| `command-palette-error-keys.test.ts` | 5 |

### 更新测试（8 文件）
ExportDialog, AiPanel, AiPanel.error-guide, AiDialogs, FileTreePanel, CreateProjectDialog, VersionHistoryContainer, MemoryPanel.error, AiSettingsSection
