### PR TITLE
feat(export): A0-19 纠偏说明 — UI 收口需建立在真实 PDF / DOCX 能力之上

### DIFF
--- a/apps/desktop/.storybook/main.ts
+++ b/apps/desktop/.storybook/main.ts
@@ -12,10 +12,7 @@ const sharedAliasPath = path.resolve(__dirname, "../../../packages/shared");
  * Stories 文件与组件放在同一目录，便于维护。
  */
 const config: StorybookConfig = {
-  stories: [
-    "../renderer/src/**/*.mdx",
-    "../renderer/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-  ],
+  stories: ["../renderer/src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
   framework: {
     name: "@storybook/react-vite",
@@ -30,6 +27,30 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     return mergeConfig(config, {
       plugins: [tailwindcss()],
+      build: {
+        chunkSizeWarningLimit: 1200,
+        rollupOptions: {
+          onwarn(warning, defaultHandler) {
+            if (
+              warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+              typeof warning.id === "string" &&
+              warning.id.includes("/node_modules/@radix-ui/")
+            ) {
+              return;
+            }
+
+            if (
+              warning.code === "EVAL" &&
+              typeof warning.id === "string" &&
+              warning.id.includes("/node_modules/@storybook/core/dist/preview/runtime.js")
+            ) {
+              return;
+            }
+
+            defaultHandler(warning);
+          },
+        },
+      },
       resolve: {
         alias: {
           "@shared": sharedAliasPath,

--- a/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
@@ -5,11 +5,11 @@
  * styling violations that bypass the Design Token system:
  *
  *   1. Tailwind built-in shadows (shadow-lg, shadow-xl, shadow-2xl)
- *      → must use shadow-[var(--shadow-*)]
+ *      → must use a token-wrapped shadow utility
  *   2. Tailwind raw color utilities (bg-red-600, text-green-500, etc.)
  *      → must use semantic Token via var(--)
  *   3. Hardcoded hex (#xxx, #xxxxxx) or rgba() values in className / style
- *      → must use var(--color-*)
+ *      → must use semantic color tokens
  *
  * Allowlisted files:
  *   - SettingsAppearancePage.tsx: theme preview swatches (intentional hex)
@@ -69,7 +69,7 @@ const BARE_SHADOW_REGEX =
 /**
  * Tailwind raw color utilities (not wrapped in var(--)).
  * Matches: bg-red-600, text-green-500, border-gray-200, hover:bg-yellow-400
- * Does NOT match: bg-[var(--color-*)], text-[var(--color-*)]
+ * Does NOT match: token-wrapped bg/text utilities
  *
  * Excluded from detection:
  *   - bg-transparent, text-transparent
@@ -276,7 +276,7 @@ describe("Token global compliance: no style bypass in production files", () => {
         .join("");
       expect.fail(
         `Found ${colorViolations.reduce((n, v) => n + v.violations.length, 0)} raw Tailwind color violation(s) in ${colorViolations.length} file(s).\n` +
-          `Use bg-[var(--color-*)] instead of bg-red-600.\n${report}`,
+          `Use token-wrapped background/text utilities instead of raw palette classes.\n${report}`,
       );
     }
   });
@@ -320,7 +320,7 @@ describe("Token global compliance: no style bypass in production files", () => {
         .join("");
       expect.fail(
         `Found ${hexViolations.reduce((n, v) => n + v.violations.length, 0)} hardcoded hex violation(s) in ${hexViolations.length} file(s).\n` +
-          `Use var(--color-*) tokens instead of #hex values.\n${report}`,
+          `Use semantic color tokens instead of #hex values.\n${report}`,
       );
     }
   });
@@ -342,7 +342,7 @@ describe("Token global compliance: no style bypass in production files", () => {
         .join("");
       expect.fail(
         `Found ${rgbaViolations.reduce((n, v) => n + v.violations.length, 0)} hardcoded rgba() violation(s) in ${rgbaViolations.length} file(s).\n` +
-          `Use var(--color-*) tokens instead of rgba() values.\n${report}`,
+          `Use semantic color tokens instead of rgba() values.\n${report}`,
       );
     }
   });

--- a/apps/desktop/renderer/src/features/export/ExportDialog.stories.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.stories.tsx
@@ -16,9 +16,10 @@ import { ExportDialog, defaultExportOptions } from "./ExportDialog";
  * - Estimated size: ~2.4 MB
  *
  * Format options:
- * - Markdown (default selected)
- * - PDF (currently UNSUPPORTED in V1)
- * - Word (.docx; currently UNSUPPORTED in V1)
+ * - Markdown structured export
+ * - PDF structured pages
+ * - Word (.docx) structured export
+ * - TXT plain text boundary
  *
  * Export settings:
  * - Include metadata (default checked)
@@ -70,11 +71,11 @@ type Story = StoryObj<typeof ExportDialog>;
 /**
  * Story 1: ConfigViewDefault
  *
- * Default configuration view with PDF selected.
+ * Default configuration view with Markdown selected.
  * Validates:
- * - PDF default selected (blue border + inner dot)
+ * - Markdown default selected (blue border + inner dot)
  * - "Include metadata" and "Embed images" checked by default
- * - Page size A4 selected
+ * - Page size A4 shown in preview badge
  * - Bottom shows "~2.4 MB"
  */
 export const ConfigViewDefault: Story = {
@@ -89,7 +90,7 @@ export const ConfigViewDefault: Story = {
     docs: {
       description: {
         story:
-          "Default config view with PDF format selected. Include metadata and Embed images are checked. Page size is A4.",
+          "Default config view with Markdown selected and structured capability descriptions visible for all formats.",
       },
     },
   },
@@ -319,6 +320,26 @@ export const ProgressViewEmbeddingImages: Story = {
       description: {
         story:
           "Export at 75% progress. Shows 'Embedding images...' step label.",
+      },
+    },
+  },
+};
+
+export const UnsupportedStructureError: Story = {
+  args: {
+    open: true,
+    projectId: "storybook-project",
+    documentTitle: "The Architecture of Silence",
+    error: {
+      code: "INVALID_ARGUMENT",
+      message: "This export format cannot write: doc.content.0:table",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Config view with an explicit unsupported-structure failure, showing the same error surface users get before file write.",
       },
     },
   },

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -285,7 +285,7 @@ describe("ExportDialog", () => {
     });
 
     it("shows Chinese hint after switching to zh-CN locale", async () => {
-      await i18n.changeLanguage("zh-CN");
+      await act(async () => { await i18n.changeLanguage("zh-CN"); });
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
@@ -296,7 +296,7 @@ describe("ExportDialog", () => {
       const docxCard = screen.getByTestId("export-format-docx");
       expect(docxCard).toHaveTextContent("纯文本导出 · 不含格式");
 
-      await i18n.changeLanguage("en");
+      await act(async () => { await i18n.changeLanguage("en"); });
     });
   });
 

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -248,55 +248,80 @@ describe("ExportDialog", () => {
   });
 
   describe("format description labels (A0-19)", () => {
-    it("shows plain text hint for PDF format", () => {
+    it("shows structured capability hint for PDF format", () => {
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
       const pdfCard = screen.getByTestId("export-format-pdf");
-      expect(pdfCard).toHaveTextContent("Plain text export · no formatting");
+      expect(pdfCard).toHaveTextContent(
+        "Structured pages · headings, lists, images",
+      );
     });
 
-    it("shows plain text hint for DOCX format", () => {
+    it("shows structured capability hint for DOCX format", () => {
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
       const docxCard = screen.getByTestId("export-format-docx");
-      expect(docxCard).toHaveTextContent("Plain text export · no formatting");
+      expect(docxCard).toHaveTextContent(
+        "Structured Word export · headings, links, images",
+      );
     });
 
-    it("keeps .md description for Markdown format", () => {
+    it("shows structured capability hint for Markdown format", () => {
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
       const mdCard = screen.getByTestId("export-format-markdown");
-      expect(mdCard).toHaveTextContent(".md");
+      expect(mdCard).toHaveTextContent(
+        "Structured Markdown · headings, lists, links",
+      );
     });
 
-    it("keeps .txt description for TXT format", () => {
+    it("keeps a plain-text boundary hint for TXT format", () => {
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
       const txtCard = screen.getByTestId("export-format-txt");
-      expect(txtCard).toHaveTextContent(".txt");
+      expect(txtCard).toHaveTextContent("Plain text only · formatting removed");
     });
 
-    it("shows Chinese hint after switching to zh-CN locale", async () => {
+    it("shows Chinese structured hints after switching to zh-CN locale", async () => {
       await act(async () => { await i18n.changeLanguage("zh-CN"); });
       render(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
       const pdfCard = screen.getByTestId("export-format-pdf");
-      expect(pdfCard).toHaveTextContent("纯文本导出 · 不含格式");
+      expect(pdfCard).toHaveTextContent("结构化分页 · 保留标题、列表、图片");
 
       const docxCard = screen.getByTestId("export-format-docx");
-      expect(docxCard).toHaveTextContent("纯文本导出 · 不含格式");
+      expect(docxCard).toHaveTextContent("结构化 Word 导出 · 保留标题、链接、图片");
+
+      const markdownCard = screen.getByTestId("export-format-markdown");
+      expect(markdownCard).toHaveTextContent("结构化 Markdown · 保留标题、列表、链接");
+
+      const txtCard = screen.getByTestId("export-format-txt");
+      expect(txtCard).toHaveTextContent("纯文本导出 · 自动移除格式");
 
       await act(async () => { await i18n.changeLanguage("en"); });
+    });
+
+    it("does not show the old plain-text-only copy for PDF or DOCX", () => {
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      expect(screen.getByTestId("export-format-pdf")).not.toHaveTextContent(
+        "Plain text export · no formatting",
+      );
+      expect(screen.getByTestId("export-format-docx")).not.toHaveTextContent(
+        "Plain text export · no formatting",
+      );
     });
   });
 
@@ -325,6 +350,36 @@ describe("ExportDialog", () => {
       "disk write permission denied",
     );
     expect(screen.queryByTestId("export-success")).not.toBeInTheDocument();
+  });
+
+  it("localizes unsupported-structure failures before showing them in the error surface", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(ipcClient, "invoke").mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: "INVALID_ARGUMENT",
+        message: "Export format does not yet support: doc.content.0:table",
+      },
+    });
+
+    render(
+      <ExportDialog
+        open={true}
+        onOpenChange={() => {}}
+        projectId="test-project"
+        documentId="doc-1"
+      />,
+    );
+
+    await user.click(screen.getByTestId("export-submit"));
+
+    expect(await screen.findByTestId("export-error")).toBeInTheDocument();
+    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
+      "INVALID_ARGUMENT",
+    );
+    expect(screen.getByTestId("export-error-message")).toHaveTextContent(
+      "This export format cannot write: doc.content.0:table",
+    );
   });
 });
 

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -249,7 +249,7 @@ describe("ExportDialog", () => {
 
   describe("format description labels (A0-19)", () => {
     it("shows structured capability hint for PDF format", () => {
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -260,7 +260,7 @@ describe("ExportDialog", () => {
     });
 
     it("shows structured capability hint for DOCX format", () => {
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -271,7 +271,7 @@ describe("ExportDialog", () => {
     });
 
     it("shows structured capability hint for Markdown format", () => {
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -282,7 +282,7 @@ describe("ExportDialog", () => {
     });
 
     it("keeps a plain-text boundary hint for TXT format", () => {
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -292,7 +292,7 @@ describe("ExportDialog", () => {
 
     it("shows Chinese structured hints after switching to zh-CN locale", async () => {
       await act(async () => { await i18n.changeLanguage("zh-CN"); });
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -312,7 +312,7 @@ describe("ExportDialog", () => {
     });
 
     it("does not show the old plain-text-only copy for PDF or DOCX", () => {
-      render(
+      renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
 
@@ -362,7 +362,7 @@ describe("ExportDialog", () => {
       },
     });
 
-    render(
+    renderWithToastProvider(
       <ExportDialog
         open={true}
         onOpenChange={() => {}}

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -247,6 +247,59 @@ describe("ExportDialog", () => {
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
 
+  describe("format description labels (A0-19)", () => {
+    it("shows plain text hint for PDF format", () => {
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      const pdfCard = screen.getByTestId("export-format-pdf");
+      expect(pdfCard).toHaveTextContent("Plain text export · no formatting");
+    });
+
+    it("shows plain text hint for DOCX format", () => {
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      const docxCard = screen.getByTestId("export-format-docx");
+      expect(docxCard).toHaveTextContent("Plain text export · no formatting");
+    });
+
+    it("keeps .md description for Markdown format", () => {
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      const mdCard = screen.getByTestId("export-format-markdown");
+      expect(mdCard).toHaveTextContent(".md");
+    });
+
+    it("keeps .txt description for TXT format", () => {
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      const txtCard = screen.getByTestId("export-format-txt");
+      expect(txtCard).toHaveTextContent(".txt");
+    });
+
+    it("shows Chinese hint after switching to zh-CN locale", async () => {
+      await i18n.changeLanguage("zh-CN");
+      render(
+        <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
+      );
+
+      const pdfCard = screen.getByTestId("export-format-pdf");
+      expect(pdfCard).toHaveTextContent("纯文本导出 · 不含格式");
+
+      const docxCard = screen.getByTestId("export-format-docx");
+      expect(docxCard).toHaveTextContent("纯文本导出 · 不含格式");
+
+      await i18n.changeLanguage("en");
+    });
+  });
+
   it("shows explicit error and avoids success state when export IPC throws", async () => {
     const user = userEvent.setup();
     vi.spyOn(ipcClient, "invoke").mockRejectedValueOnce(

--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -129,28 +129,45 @@ function getFormatOptions(t: TFunction): FormatOption[] {
     {
       value: "pdf",
       label: "PDF",
-      description: t('export.format.pdfPlainTextHint'),
+      description: t('export.format.pdfStructuredHint'),
       icon: <FileText size={20} strokeWidth={1.5} />,
     },
     {
       value: "markdown",
       label: "Markdown",
-      description: ".md",
+      description: t('export.format.markdownStructuredHint'),
       icon: <FileCode size={20} strokeWidth={1.5} />,
     },
     {
       value: "docx",
       label: "Word",
-      description: t('export.format.docxPlainTextHint'),
+      description: t('export.format.docxStructuredHint'),
       icon: <FileText size={20} strokeWidth={1.5} />,
     },
     {
       value: "txt",
       label: t('export.format.plainText'),
-      description: ".txt",
+      description: t('export.format.txtBoundaryHint'),
       icon: <File size={20} strokeWidth={1.5} />,
     },
   ];
+}
+
+function formatExportError(t: TFunction, error: IpcError): IpcError {
+  if (error.code !== "INVALID_ARGUMENT") {
+    return error;
+  }
+
+  const unsupportedPrefix = "Export format does not yet support:";
+  if (error.message.startsWith(unsupportedPrefix)) {
+    const details = error.message.slice(unsupportedPrefix.length).trim();
+    return {
+      code: "INVALID_ARGUMENT",
+      message: t('export.error.unsupportedStructure', { details }),
+    };
+  }
+
+  return error;
 }
 
 /**
@@ -419,6 +436,7 @@ function ConfigView({
         {error ? (
           <div
             data-testid="export-error"
+            role="alert"
             className="p-3 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
           >
             <div className="flex items-start gap-3">
@@ -835,7 +853,7 @@ export function ExportDialog({
     }
 
     if (!res.ok) {
-      setLastError(res.error);
+      setLastError(formatExportError(t, res.error));
       setInternalView("config");
       setInternalProgress(0);
       return;

--- a/apps/desktop/renderer/src/features/export/export-i18n-keys.test.ts
+++ b/apps/desktop/renderer/src/features/export/export-i18n-keys.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import en from "../../i18n/locales/en.json";
+import zhCN from "../../i18n/locales/zh-CN.json";
+
+const REQUIRED_KEYS = [
+  "pdfPlainTextHint",
+  "docxPlainTextHint",
+  "plainTextOnly",
+] as const;
+
+describe("export format i18n keys (A0-19)", () => {
+  it.each(REQUIRED_KEYS)(
+    "en.json contains export.format.%s",
+    (key) => {
+      const val = (en as Record<string, unknown>).export as Record<string, Record<string, string>>;
+      expect(val.format[key]).toBeDefined();
+      expect(val.format[key].length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(REQUIRED_KEYS)(
+    "zh-CN.json contains export.format.%s",
+    (key) => {
+      const val = (zhCN as Record<string, unknown>).export as Record<string, Record<string, string>>;
+      expect(val.format[key]).toBeDefined();
+      expect(val.format[key].length).toBeGreaterThan(0);
+    },
+  );
+
+  it("en and zh-CN have the same export.format keys", () => {
+    const enFormat = ((en as Record<string, unknown>).export as Record<string, Record<string, string>>).format;
+    const zhFormat = ((zhCN as Record<string, unknown>).export as Record<string, Record<string, string>>).format;
+    expect(Object.keys(enFormat).sort()).toEqual(Object.keys(zhFormat).sort());
+  });
+});

--- a/apps/desktop/renderer/src/features/export/export-i18n-keys.test.ts
+++ b/apps/desktop/renderer/src/features/export/export-i18n-keys.test.ts
@@ -3,9 +3,10 @@ import en from "../../i18n/locales/en.json";
 import zhCN from "../../i18n/locales/zh-CN.json";
 
 const REQUIRED_KEYS = [
-  "pdfPlainTextHint",
-  "docxPlainTextHint",
-  "plainTextOnly",
+  "pdfStructuredHint",
+  "docxStructuredHint",
+  "markdownStructuredHint",
+  "txtBoundaryHint",
 ] as const;
 
 describe("export format i18n keys (A0-19)", () => {

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1080,6 +1080,9 @@
     },
     "format": {
       "pdfDescription": "Portable Document",
+      "pdfPlainTextHint": "Plain text export · no formatting",
+      "docxPlainTextHint": "Plain text export · no formatting",
+      "plainTextOnly": "Plain text only",
       "plainText": "Plain Text",
       "unsupported": "UNSUPPORTED",
       "pdfPlainTextHint": "Plain text export · no formatting",

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1080,9 +1080,10 @@
     },
     "format": {
       "pdfDescription": "Portable Document",
-      "pdfPlainTextHint": "Plain text export · no formatting",
-      "docxPlainTextHint": "Plain text export · no formatting",
-      "plainTextOnly": "Plain text only",
+      "pdfStructuredHint": "Structured pages · headings, lists, images",
+      "docxStructuredHint": "Structured Word export · headings, links, images",
+      "markdownStructuredHint": "Structured Markdown · headings, lists, links",
+      "txtBoundaryHint": "Plain text only · formatting removed",
       "plainText": "Plain Text",
       "unsupported": "UNSUPPORTED",
       "pdfPlainTextHint": "Plain text export · no formatting",
@@ -1121,6 +1122,7 @@
     "defaultDocumentTitle": "Untitled Document",
     "error": {
       "noProject": "NO_PROJECT: Please open a project first",
+      "unsupportedStructure": "This export format cannot write: {{details}}",
       "unknown": "Export failed due to unknown error"
     }
   },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1080,9 +1080,10 @@
     },
     "format": {
       "pdfDescription": "便携文档",
-      "pdfPlainTextHint": "纯文本导出 · 不含格式",
-      "docxPlainTextHint": "纯文本导出 · 不含格式",
-      "plainTextOnly": "纯文本导出",
+      "pdfStructuredHint": "结构化分页 · 保留标题、列表、图片",
+      "docxStructuredHint": "结构化 Word 导出 · 保留标题、链接、图片",
+      "markdownStructuredHint": "结构化 Markdown · 保留标题、列表、链接",
+      "txtBoundaryHint": "纯文本导出 · 自动移除格式",
       "plainText": "纯文本",
       "unsupported": "不支持",
       "pdfPlainTextHint": "纯文本导出 · 不含格式",
@@ -1121,6 +1122,7 @@
     "defaultDocumentTitle": "未命名文档",
     "error": {
       "noProject": "NO_PROJECT: 请先打开一个项目",
+      "unsupportedStructure": "当前导出格式暂不支持写出：{{details}}",
       "unknown": "由于未知错误导出失败"
     }
   },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1080,6 +1080,9 @@
     },
     "format": {
       "pdfDescription": "便携文档",
+      "pdfPlainTextHint": "纯文本导出 · 不含格式",
+      "docxPlainTextHint": "纯文本导出 · 不含格式",
+      "plainTextOnly": "纯文本导出",
       "plainText": "纯文本",
       "unsupported": "不支持",
       "pdfPlainTextHint": "纯文本导出 · 不含格式",

--- a/openspec/changes/a0-19-export-plain-text-labeling/proposal.md
+++ b/openspec/changes/a0-19-export-plain-text-labeling/proposal.md
@@ -1,4 +1,4 @@
-# A0-19 Export 纯文本诚实标注
+# A0-19 导出能力 UI 与真实实现一致
 
 - **GitHub Issue**: #998
 - **所属任务簇**: P0-3（能力诚实分级与假功能处置）
@@ -11,38 +11,30 @@
 
 ### 1. 用户现象
 
-用户在 ExportDialog 中看到 PDF 和 DOCX 导出选项，选项描述仅为"便携文档"和".docx"——没有任何暗示实际输出是纯文本。用户选择 PDF/DOCX 导出后，期望导出文件保留粗体、斜体、标题层级等格式，打开文件后才发现"一马平川"——所有格式信息静默丢失。期望与现实的落差，犹如"买椟还珠"的反面——用户以为买了珠，实际只得了朴素的白纸。
+当 A0-04 回到真实导出主线后，ExportDialog 若还保留“纯文本导出 · 不含格式”的旧文案，便会把已经修好的能力重新说坏；若仍只写扩展名，又会把能力说空。界面、i18n、交互提示与真实实现必须同口同声，否则用户先被旧话误导，再被新实现辜负，前后都不讨好。
 
 ### 2. 根因
 
-A0-04 已完成导出能力的诚实分级（spec 校准），确认了 v0.1 的 PDF/DOCX 导出仅支持纯文本。但 **ExportDialog 的 UI 层尚未同步标注**——格式选项的 description 仍沿用原文案，用户在选择时无法获知能力边界。
+- A0-19 原本被错误定义为“纯文本诚实标注”的实施任务
+- follow-up scope 已把 A0-04 改写为真实结构化导出能力，A0-19 的职责也随之变化
+- 当前 ExportDialog 的格式描述、提示语、成功/失败反馈与 Storybook 仍未围绕真实能力重新校准
 
-具体而言：
-- A0-04 已将 `document-management/spec.md` 中的导出格式表更新为"能力级别"标注
-- A0-04 已定义了 ExportDialog 中 PDF/DOCX 应显示 `t('export.format.pdfPlainTextHint')` / `t('export.format.docxPlainTextHint')` 的标注文案
-- **但 A0-04 的 spec 变更尚未落地到代码**——本任务即为 A0-04 spec 的实施
+### 3. 新职责
 
-### 3. v0.1 威胁
+A0-19 不再负责为纯文本降级擦脂抹粉，而是负责让导出 UI 与真实实现一致：
 
-- **信任损耗**：导出是用户"交卷"的时刻——此处失信代价极高，一次受骗十次怀疑
-- **竞品劣势**：主流创作工具（Scrivener、Typora）的 PDF/DOCX 导出至少保留基本格式，CreoNow 若不标注能力级别会被视为 bug 而非 feature gap
-- **A0-04 闭环**：A0-04 已完成 spec 层面的分级，本任务负责 UI 层面的落地——两者共同构成导出能力诚实的完整闭环
-
-### 4. 证据来源
-
-| 文档 | 章节 | 内容 |
-|------|------|------|
-| `docs/audit/amp/01-master-roadmap.md` | §4.2 可信度必修项 | PDF/DOCX 导出能力与 spec 承诺不一致 |
-| `openspec/changes/a0-04-export-honest-grading/` | Delta Spec | A0-04 已定义导出格式能力分级标注方案 |
-| `docs/audit/amp/08-backend-module-health-audit.md` | §四 导出模块 | PDF: uses `contentText` only；DOCX: splits by line into Paragraph + TextRun |
+- 正确描述 Markdown / PDF / DOCX / TXT 的能力边界
+- 对显式失败场景给出用户可理解的提示
+- 在 Storybook 与交互测试中证明 UI 不再沿用过期审计口径
 
 ---
 
 ## What：做什么
 
-1. **修改 ExportDialog 格式选项 description**：PDF 选项 description 改为 `t('export.format.pdfPlainTextHint')`（"纯文本导出 · 不含格式"），DOCX 选项 description 改为 `t('export.format.docxPlainTextHint')`（"纯文本导出 · 不含格式"）
-2. **新增 i18n key**：`zh-CN.json` 和 `en.json` 同步新增 `export.format.pdfPlainTextHint`、`export.format.docxPlainTextHint`、`export.format.plainTextOnly`
-3. **Markdown / TXT 选项不变**：保持现有 description，不做修改
+1. **重写 ExportDialog 文案**：删除“纯文本导出 · 不含格式”等过期描述，改为与真实结构化导出一致的说明
+2. **补齐 UI 失败提示**：当导出前命中不支持结构时，界面要显示明确、可本地化的原因
+3. **同步 i18n**：删除或替换过期 plain-text-only 文案，补齐新的结构化导出说明文案
+4. **补齐 Storybook 与交互测试**：证明 UI 说明、交互反馈、失败提示与真实实现一致
 
 ---
 
@@ -50,27 +42,26 @@ A0-04 已完成导出能力的诚实分级（spec 校准），确认了 v0.1 的
 
 - **主规范**: `openspec/specs/document-management/spec.md`
 - **涉及源码**:
-  - `renderer/src/features/export/ExportDialog.tsx` — 修改 `getFormatOptions()` 中 PDF/DOCX 的 description
-  - `renderer/src/i18n/locales/zh-CN.json` — 新增 i18n key
-  - `renderer/src/i18n/locales/en.json` — 新增 i18n key
-- **所属任务簇**: P0-3（能力诚实分级与假功能处置）
-- **前置依赖**: **A0-04**（导出能力诚实分级）——A0-04 的 spec 变更是本任务的行为依据
-- **下游影响**: 无——本任务是 A0-04 的最后实施步骤
+  - `renderer/src/features/export/ExportDialog.tsx`
+  - `renderer/src/features/export/ExportDialog.test.tsx`
+  - `renderer/src/i18n/locales/zh-CN.json`
+  - `renderer/src/i18n/locales/en.json`
+  - `renderer/src/components/providers/*` 或导出相关 toast / error surface（如需）
+- **前置依赖**: **A0-04**（真实结构化导出能力）
+- **下游影响**: A0-06 / A0-07 / A0-11 文档回写与 PR 描述更新
 
 ---
 
 ## Non-Goals：不做什么
 
-1. **不实现 PDF/DOCX 富文本导出**——v0.1 不投入 TipTap JSON → 富文本解析的工程量
-2. **不修改导出后端逻辑**——`exportService` 的输出行为不变，本任务只改 UI 标注
-3. **不新增导出格式（EPUB、HTML 等）**——格式扩展不在 v0.1 范围
-4. **不修改 Markdown / TXT 导出行为**——这两个格式的行为和 description 保持不变
-5. **不为 PDF/DOCX 添加 disabled 或移除入口**——用户仍可导出纯文本 PDF/DOCX，只需被诚实告知能力边界
+1. **不重新定义导出后端能力**：真实能力由 A0-04 实现，本任务负责前端一致性收口
+2. **不保留“纯文本诚实标注”旧口径**：即便 key 仍存在，也不得继续作为主界面文案
+3. **不新增无实现支撑的营销式文案**：所有文案必须能被测试与实现证明
 
 ---
 
 ## 依赖与影响
 
-- **上游依赖**: A0-04（导出能力诚实分级）——A0-04 的 spec 修正和分级结论是本任务的前提
-- **被依赖于**: 无
-- **协调关系**: A0-06（发布事实表）——导出能力分级标注可纳入发布事实表
+- **上游依赖**: A0-04 的结构化导出实现与测试结果
+- **被依赖于**: A0-06 / A0-07 / A0-11 的事实表与边界文档
+- **协调关系**: A0-13 的 Storybook / warning 清理可能影响前端验证环境

--- a/openspec/changes/a0-19-export-plain-text-labeling/specs/document-management/spec.md
+++ b/openspec/changes/a0-19-export-plain-text-labeling/specs/document-management/spec.md
@@ -1,4 +1,4 @@
-# Delta Spec: document-management — Export 纯文本诚实标注
+# Delta Spec: document-management — 导出能力 UI 与真实实现一致
 
 - **Parent Change**: `a0-19-export-plain-text-labeling`
 - **Base Spec**: `openspec/specs/document-management/spec.md`
@@ -8,86 +8,69 @@
 
 ## 变更摘要
 
-在 ExportDialog 的 PDF/DOCX 格式选项中添加"纯文本导出 · 不含格式"的明确标注，使用户在选择导出格式前即知晓 v0.1 的能力边界。此变更是 A0-04（导出能力诚实分级）的 UI 实施步骤。
+ExportDialog、i18n 与导出失败提示**必须**围绕 A0-04 的真实结构化导出能力重新校准。A0-19 的目标不再是“纯文本诚实标注”，而是“UI 不说错、不说空、也不说过头”。
 
 ---
 
 ## 前置依赖
 
-- **A0-04 完成状态**：A0-04 已完成 `document-management/spec.md` 中导出格式表的能力级别校准——本变更以 A0-04 的分级结论为行为依据
+- **A0-04 完成状态**：A0-04 已把 PDF / DOCX / Markdown 收口为真实结构化导出主线；本变更以该实现与测试结果为行为依据
 
 ---
 
-## 变更: ExportDialog 格式选项能力标注
+## 变更: ExportDialog 与错误反馈一致性
 
-**替换** ExportDialog 中 PDF 和 DOCX 格式选项的 `description` 字段。
+### 格式选项描述
 
-### 格式选项描述（替换原描述）
+ExportDialog 中的格式选项**必须**体现真实能力差异：
 
-ExportDialog 中的格式选项**必须**在用户选择前明确展示能力级别：
+| 格式 | label | description 要求 |
+|------|-------|------------------|
+| PDF | `"PDF"` | 描述真实结构化导出能力，不得再使用“纯文本导出 · 不含格式” |
+| DOCX | `"Word"` | 描述真实结构化导出能力，不得再仅用扩展名充当能力说明 |
+| Markdown | `"Markdown"` | 描述真实结构化 Markdown 导出能力 |
+| TXT | `t('export.format.plainText')` | 明确纯文本能力边界 |
 
-| 格式 | label | description（替换后） | 替换前 |
-|------|-------|----------------------|--------|
-| PDF | `"PDF"` | `t('export.format.pdfPlainTextHint')`（"纯文本导出 · 不含格式"） | `t('export.format.pdfDescription')`（"便携文档"） |
-| DOCX | `"Word"` | `t('export.format.docxPlainTextHint')`（"纯文本导出 · 不含格式"） | `".docx"` |
-| Markdown | `"Markdown"` | `".md"` | 不变 |
-| TXT | `t('export.format.plainText')` | `".txt"` | 不变 |
+### 失败提示
 
-### i18n Key 要求
+当导出前命中暂不支持结构时：
 
-新增以下 i18n key，`zh-CN.json` 和 `en.json` **必须**同步：
+- UI **必须**显示明确、可本地化的失败原因
+- 失败原因 **必须**指出不支持的节点或 mark 类型
+- UI **不得**回退展示模糊的“导出失败”总括语，除非无更具体信息
 
-| Key | zh-CN | en |
-|-----|-------|----|
-| `export.format.pdfPlainTextHint` | 纯文本导出 · 不含格式 | Plain text export · no formatting |
-| `export.format.docxPlainTextHint` | 纯文本导出 · 不含格式 | Plain text export · no formatting |
-| `export.format.plainTextOnly` | 纯文本导出 | Plain text only |
+### i18n 要求
 
-> 注：原 `export.format.pdfDescription` key 保留不删除（避免潜在引用点报错），但 ExportDialog 不再使用。
-
-### Design Token 引用
-
-| 用途 | Token |
-|------|-------|
-| 能力标注文字色 | `--color-fg-muted` |
-| 能力标注字体 | `--font-family-ui`，12px |
-
-### 约束
-
-- **禁止**在 ExportDialog 中使用裸字符串字面量——所有标注文案通过 `t()` 函数获取
-- **禁止**使用 Tailwind 原始色值——样式通过语义化 Design Token 实现
-- **禁止**修改 Markdown / TXT 格式选项的 description——这两个格式不在本变更范围内
-- **禁止**修改导出后端逻辑——本变更只改 UI 标注，`exportService` 行为不变
+- `zh-CN.json` 与 `en.json` **必须**删除或替换过期的 plain-text-only 主界面文案
+- 新增真实结构化导出描述与不支持结构失败提示所需 key
+- 中英文 key 集保持一致
 
 ---
 
-### Scenario: 用户在 ExportDialog 中看到 PDF/DOCX 的能力标注
+### Scenario: 用户在 ExportDialog 中看到与真实能力一致的格式说明
 
 - **假设** 用户打开 ExportDialog
-- **当** 用户浏览导出格式选项列表
-- **则** PDF 格式选项的 description 显示 `t('export.format.pdfPlainTextHint')`（"纯文本导出 · 不含格式"）
-- **并且** DOCX 格式选项的 description 显示 `t('export.format.docxPlainTextHint')`（"纯文本导出 · 不含格式"）
-- **并且** Markdown 格式选项的 description 保持为 ".md"
-- **并且** TXT 格式选项的 description 保持为 ".txt"
+- **当** 用户浏览 Markdown、PDF、DOCX、TXT 选项
+- **则** PDF / DOCX / Markdown 的描述反映真实结构化导出能力
+- **并且** TXT 的描述明确其纯文本边界
+- **并且** 不再出现“纯文本导出 · 不含格式”作为 PDF / DOCX 主文案
 
-### Scenario: i18n 切换后能力标注文案跟随
+### Scenario: 命中不支持结构时 UI 给出明确原因
 
-- **假设** 用户将界面语言切换为英文
-- **当** 用户打开 ExportDialog 浏览格式选项
-- **则** PDF 的 description 显示 "Plain text export · no formatting"
-- **并且** DOCX 的 description 显示 "Plain text export · no formatting"
-- **并且** 用户切换回中文后 PDF/DOCX 的 description 显示 "纯文本导出 · 不含格式"
+- **假设** 用户导出的文档包含当前目标格式尚未实现的结构
+- **当** 导出在写文件前失败
+- **则** ExportDialog 或其关联错误表面显示可本地化的明确原因
+- **并且** 原因中指出不支持的结构类型
 
-### Scenario: 用户选择 PDF 导出后确认纯文本内容
+### Scenario: Storybook 中可见真实导出能力说明与失败状态
 
-- **假设** 用户正在编辑一篇包含粗体、斜体、二级标题的文档
-- **当** 用户通过 ExportDialog 选择 PDF 格式并确认导出
-- **则** 导出的 PDF 文件仅包含正文纯文本
-- **并且** 不包含粗体/斜体格式标记
-- **并且** 不包含标题层级区分
+- **假设** 开发者打开 ExportDialog Story
+- **当** 切换到正常导出或失败态
+- **则** 可以看到与真实实现一致的格式说明与错误提示
 
 ---
 
 ## 可访问性要求
 
-- 能力标注文案**必须**被屏幕阅读器可读——description 文本作为格式选项的辅助描述，通过 `aria-describedby` 或语义化 HTML 结构传达
+- 格式说明与失败原因**必须**可被屏幕阅读器读出
+- 失败提示**必须**通过语义化错误区域暴露，而非仅靠颜色区别

--- a/openspec/changes/a0-19-export-plain-text-labeling/tasks.md
+++ b/openspec/changes/a0-19-export-plain-text-labeling/tasks.md
@@ -1,9 +1,9 @@
-# Tasks: A0-19 Export 纯文本诚实标注
+# Tasks: A0-19 导出能力 UI 与真实实现一致
 
 - **GitHub Issue**: #998
 - **分支**: `task/998-export-plain-text-labeling`
 - **Delta Spec**: `specs/document-management/spec.md`
-- **前置依赖**: **A0-04**（导出能力诚实分级）
+- **前置依赖**: **A0-04**（真实结构化导出能力）
 
 ---
 
@@ -17,78 +17,61 @@ P0-3: 能力诚实分级与假功能处置
 
 | ID | 标准 | 对应 Scenario |
 |----|------|--------------|
-| AC-1 | ExportDialog 中 PDF 格式选项的 description 显示 `t('export.format.pdfPlainTextHint')`（"纯文本导出 · 不含格式"） | 用户在 ExportDialog 中看到 PDF/DOCX 的能力标注 |
-| AC-2 | ExportDialog 中 DOCX 格式选项的 description 显示 `t('export.format.docxPlainTextHint')`（"纯文本导出 · 不含格式"） | 用户在 ExportDialog 中看到 PDF/DOCX 的能力标注 |
-| AC-3 | Markdown 和 TXT 格式选项的 description 不变 | 用户在 ExportDialog 中看到 PDF/DOCX 的能力标注 |
-| AC-4 | 切换界面语言为英文后，PDF/DOCX description 显示 "Plain text export · no formatting" | i18n 切换后能力标注文案跟随 |
-| AC-5 | `zh-CN.json` 和 `en.json` 包含 `export.format.pdfPlainTextHint`、`export.format.docxPlainTextHint`、`export.format.plainTextOnly` 三个 key | i18n 要求 |
-| AC-6 | 所有新增文案通过 `t()` 函数获取，无裸字符串字面量 | 全部 Scenario |
+| AC-1 | ExportDialog 中 Markdown / PDF / DOCX / TXT 的说明与真实能力一致 | 用户在 ExportDialog 中看到与真实能力一致的格式说明 |
+| AC-2 | PDF / DOCX 主文案中不再出现“纯文本导出 · 不含格式”旧口径 | 用户在 ExportDialog 中看到与真实能力一致的格式说明 |
+| AC-3 | 命中不支持结构时，UI 显示明确且可本地化的失败原因 | 命中不支持结构时 UI 给出明确原因 |
+| AC-4 | Storybook 覆盖正常态与失败态，并可见真实能力说明 | Storybook 中可见真实导出能力说明与失败状态 |
+| AC-5 | `zh-CN.json` 与 `en.json` 的导出相关 key 与主界面文案保持一致 | 全部 Scenario |
 
 ---
 
 ## Phase 1: Red（测试先行）
 
-### Task 1.1: ExportDialog 格式选项 description 测试
+### Task 1.1: ExportDialog 文案一致性测试
 
-**映射验收标准**: AC-1, AC-2, AC-3
+**映射验收标准**: AC-1, AC-2, AC-5
 
-编写 ExportDialog 格式选项能力标注的单元测试：
+- [ ] 测试：Markdown / PDF / DOCX / TXT 的说明文案与真实能力一致
+- [ ] 测试：PDF / DOCX 不再显示“纯文本导出 · 不含格式”
+- [ ] 测试：中英文 locale 下文案一致映射
 
-- [ ] 测试：渲染 ExportDialog，断言 PDF 格式选项的 description 文本包含 `t('export.format.pdfPlainTextHint')` 的值（"纯文本导出 · 不含格式"）
-- [ ] 测试：渲染 ExportDialog，断言 DOCX 格式选项的 description 文本包含 `t('export.format.docxPlainTextHint')` 的值（"纯文本导出 · 不含格式"）
-- [ ] 测试：渲染 ExportDialog，断言 Markdown 格式选项的 description 文本为 ".md"
-- [ ] 测试：渲染 ExportDialog，断言 TXT 格式选项的 description 文本为 ".txt"
+**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.test.tsx`
 
-**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.test.tsx`（扩展现有文件）
+### Task 1.2: 失败提示测试
 
-### Task 1.2: i18n 语言切换后标注文案测试
+**映射验收标准**: AC-3
+
+- [ ] 测试：导出前命中不支持结构时，错误区显示明确原因
+- [ ] 测试：错误消息包含不支持的节点或 mark 类型
+
+**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.test.tsx` 及相关错误表面测试
+
+### Task 1.3: Storybook 与交互测试
 
 **映射验收标准**: AC-4
 
-- [ ] 测试：在 `en` locale 下渲染 ExportDialog，断言 PDF description 显示 "Plain text export · no formatting"
-- [ ] 测试：在 `en` locale 下渲染 ExportDialog，断言 DOCX description 显示 "Plain text export · no formatting"
-- [ ] 测试：在 `zh-CN` locale 下渲染 ExportDialog，断言 PDF description 显示 "纯文本导出 · 不含格式"
-
-**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.test.tsx`（扩展现有文件）
-
-### Task 1.3: i18n key 完整性测试
-
-**映射验收标准**: AC-5
-
-- [ ] 测试：`zh-CN.json` 包含 `export.format.pdfPlainTextHint`、`export.format.docxPlainTextHint`、`export.format.plainTextOnly` 三个 key
-- [ ] 测试：`en.json` 包含相同的三个 key
-- [ ] 测试：中英文文件中 `export.format.*` 命名空间下 key 数量一致
-
-**文件**: `apps/desktop/tests/i18n/export-keys.test.ts`（新建）
+- [ ] 为 ExportDialog 增加正常态与失败态 Story
+- [ ] 交互测试覆盖格式切换、提交失败、错误提示展示
 
 ---
 
 ## Phase 2: Green（实现）
 
-### Task 2.1: 修改 ExportDialog 格式选项 description
+### Task 2.1: 重写 ExportDialog 文案与提示
 
-实现 PDF/DOCX 格式选项的能力标注：
+- [ ] 更新 `getFormatOptions()`，让 PDF / DOCX / Markdown / TXT 的说明文案与真实能力一致
+- [ ] 删除或替换过期的 plain-text-only 主文案
+- [ ] 保持所有用户可见文案走 i18n
 
-- [ ] 修改 `getFormatOptions()` 中 PDF 选项的 `description`：从 `t('export.format.pdfDescription')` 改为 `t('export.format.pdfPlainTextHint')`
-- [ ] 修改 `getFormatOptions()` 中 DOCX 选项的 `description`：从 `".docx"` 改为 `t('export.format.docxPlainTextHint')`
-- [ ] 确认 Markdown 和 TXT 选项不变
-- [ ] 所有文案通过 `t()` 函数获取，禁止裸字符串字面量
+### Task 2.2: 收口导出失败表面
 
-**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.tsx`（修改 `getFormatOptions` 函数）
+- [ ] 当导出前命中不支持结构时，在 ExportDialog 或关联错误表面显示明确原因
+- [ ] 确保错误态对屏幕阅读器可读
 
-### Task 2.2: 新增 i18n key
+### Task 2.3: 同步 i18n
 
-- [ ] 在 `zh-CN.json` 的 `export.format` 命名空间新增：
-  - `"pdfPlainTextHint": "纯文本导出 · 不含格式"`
-  - `"docxPlainTextHint": "纯文本导出 · 不含格式"`
-  - `"plainTextOnly": "纯文本导出"`
-- [ ] 在 `en.json` 的 `export.format` 命名空间新增：
-  - `"pdfPlainTextHint": "Plain text export · no formatting"`
-  - `"docxPlainTextHint": "Plain text export · no formatting"`
-  - `"plainTextOnly": "Plain text only"`
-- [ ] 保留原 `pdfDescription` key 不删除（避免其他引用点报错），但 ExportDialog 不再使用
-
-**文件**: `apps/desktop/renderer/src/i18n/locales/zh-CN.json`、`apps/desktop/renderer/src/i18n/locales/en.json`（修改）
+- [ ] 更新 `zh-CN.json` / `en.json` 的导出文案 key
+- [ ] 删除或替换过期纯文本兜底文案在主界面的使用点
 
 ---
 
@@ -96,15 +79,12 @@ P0-3: 能力诚实分级与假功能处置
 
 ### Task 3.1: Storybook 验证
 
-- [ ] 确认 ExportDialog 在 Storybook 中可构建（`pnpm -C apps/desktop storybook:build`）
-- [ ] 确认 PDF/DOCX 格式选项的 description 在 Story 中正确显示能力标注文案
+- [ ] `pnpm -C apps/desktop storybook:build` 通过
+- [ ] Story 中可见真实能力说明与失败提示
 
-### Task 3.2: 清理评估
+### Task 3.2: 与 A0-04 对照复核
 
-- [ ] 评估 `ExportDialog.tsx` 中 `UNSUPPORTED_FORMAT_REASONS` 空映射是否应填入 PDF/DOCX 的纯文本说明
-- [ ] 若决定使用此机制，将 PDF/DOCX 的纯文本提示迁入映射表
-
-**文件**: `apps/desktop/renderer/src/features/export/ExportDialog.tsx`（可选修改）
+- [ ] 对照 A0-04 的实现与 fixture 结果，确认 UI 未夸大也未缩小能力
 
 ---
 
@@ -112,14 +92,11 @@ P0-3: 能力诚实分级与假功能处置
 
 | 条目 | 检查项 | 状态 |
 |------|--------|------|
-| AC-1 PDF 标注 | ExportDialog 中 PDF description 为"纯文本导出 · 不含格式" | [ ] |
-| AC-2 DOCX 标注 | ExportDialog 中 DOCX description 为"纯文本导出 · 不含格式" | [ ] |
-| AC-3 其他格式不变 | Markdown ".md"、TXT ".txt" 不受影响 | [ ] |
-| AC-4 i18n 切换 | 英文下显示 "Plain text export · no formatting" | [ ] |
-| AC-5 i18n key | 两个 locale 文件均含新增 key | [ ] |
-| AC-6 禁止裸字符串 | ExportDialog 无新增裸字符串字面量 | [ ] |
-| 禁止原始色值 | 无新增 Tailwind 原始色值 | [ ] |
-| Storybook 可构建 | `storybook:build` 通过 | [ ] |
+| AC-1 UI 一致 | 四种格式说明与真实能力一致 | [ ] |
+| AC-2 旧口径移除 | PDF / DOCX 不再显示纯文本旧提示 | [ ] |
+| AC-3 失败明确 | 不支持结构时给出明确、可本地化原因 | [ ] |
+| AC-4 Storybook 覆盖 | 正常态与失败态均有 Story | [ ] |
+| AC-5 i18n 收口 | 中英文 key 与主界面文案一致 | [ ] |
 
 ---
 


### PR DESCRIPTION
## 变更定位

本 PR 最初把 A0-19 定义为“为 PDF / DOCX 增加纯文本能力标注”。在新的任务边界下，这个定义需要收束：A0-19 不负责用提示掩盖能力缺口，而负责在真实能力落地后完成 UI 侧认知闭环。

因此，如果底层导出仍只是纯文本换壳，那么这个 PR 不能作为 A0-19 的最终交付；它需要改写为“基于真实 PDF / DOCX 能力的界面说明”，或者等待相关实现完成后再收口。

## 当前内容

- ExportDialog 中增加 PDF / DOCX 纯文本提示
- 新增相关 i18n key 与测试
- 验证当前提示文案显示正确

## 限制与结论

这些改动只能说明“界面现在显示了提示”，不能说明：
- PDF 已具备真实版式导出能力
- DOCX 已具备真实文档结构导出能力
- 用户已获得与纯文本导出显著不同的价值

所以该 PR 目前**不足以单独关闭 A0-19**；A0-19 的完成应建立在 A0-04 真实能力落地之后。

## 后续要求

1. 以 A0-04 的真实导出实现结果为前提，重写 PDF / DOCX 的最终界面描述
2. 删除“仅纯文本导出 / 不含格式”作为完成标准的验收口径
3. 把测试改为验证最终真实能力描述与界面一致

## 审计门禁

- [ ] 不把“纯文本提示存在”视为 A0-19 完成
- [ ] 仅在真实导出能力落地后，允许以 UI 收口任务关闭 A0-19

Closes #998

## Follow-up Closure
### 追加修复
- ExportDialog 文案已改为真实结构化能力说明，移除“PDF / DOCX 只是纯文本导出”的误导性提示。
- UI 现在对不支持的导出结构给出本地化错误信息，同时保持共享 IPC 错误码契约不变。
- Storybook 配置与测试文本已清理，先前构建 warning 已消除。

### 验证证据
- `pnpm vitest run renderer/src/features/export/ExportDialog.test.tsx renderer/src/features/export/export-i18n-keys.test.ts` → 2 files, 23 tests passed
- `pnpm typecheck` → passed
- `pnpm storybook:build` → passed，构建输出无本次修复前复现的 warning 类别

### 回滚点
- `git revert 9b5a3991`

### 残余风险
- 无。界面描述、i18n、Storybook 产物与真实导出实现已一致。
