### PR TITLE
ci: add ESLint rule require-describe-in-tests (G0.5-01)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -47,6 +47,7 @@ module.exports = {
       { max: 300, skipBlankLines: true, skipComments: true },
     ],
     "react/react-in-jsx-scope": "off",
+    "creonow/require-describe-in-tests": "error",
   },
   overrides: [
     {
@@ -147,6 +148,19 @@ module.exports = {
       rules: {
         "i18next/no-literal-string": "off",
         "creonow/no-raw-tailwind-tokens": "warn",
+      },
+    },
+    {
+      // Legacy test directories: warn-only until T-MIG migration completes
+      files: [
+        "apps/desktop/main/src/**/*.test.*",
+        "apps/desktop/tests/**/*.test.*",
+        "apps/desktop/tests/**/*.spec.*",
+        "apps/desktop/renderer/src/**/*.snapshot.test.*",
+        "scripts/tests/**/*.test.*",
+      ],
+      rules: {
+        "creonow/require-describe-in-tests": "warn",
       },
     },
     {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -152,10 +152,16 @@ module.exports = {
     },
     {
       // Legacy test directories: warn-only until T-MIG migration completes
+      // Each directory is listed explicitly — no blanket tests/**/*.spec.* wildcard
       files: [
         "apps/desktop/main/src/**/*.test.*",
-        "apps/desktop/tests/**/*.test.*",
-        "apps/desktop/tests/**/*.spec.*",
+        "apps/desktop/tests/unit/**/*.test.*",
+        "apps/desktop/tests/unit/**/*.spec.*",
+        "apps/desktop/tests/integration/**/*.test.*",
+        "apps/desktop/tests/integration/**/*.spec.*",
+        "apps/desktop/tests/e2e/**/*.spec.*",
+        "apps/desktop/tests/perf/**/*.test.*",
+        "apps/desktop/tests/perf/**/*.spec.*",
         "apps/desktop/renderer/src/**/*.snapshot.test.*",
         "scripts/tests/**/*.test.*",
       ],

--- a/docs/references/testing/01-philosophy-and-anti-patterns.md
+++ b/docs/references/testing/01-philosophy-and-anti-patterns.md
@@ -54,7 +54,7 @@ CreoNow 采用 `Red -> Green -> Refactor`：
 - 推荐格式：`it('should <expected behavior> when <condition>')`
 
 ## 仓库中的正例
-
+> **自动化守门**：`describe()` 结构要求现由 ESLint 规则 `creonow/require-describe-in-tests` 自动拦截。新测试文件缺少 `describe()` 将直接阻断 CI；存量目录暂以 warn 过渡，随 T-MIG 批次迁移逐步收紧为 error。
 这些文件值得当作“如何写”的样板：
 
 - `apps/desktop/renderer/src/stores/onboardingStore.test.tsx`

--- a/docs/references/testing/06-guard-and-lint-policy.md
+++ b/docs/references/testing/06-guard-and-lint-policy.md
@@ -15,6 +15,7 @@ Guard 只处理 ESLint 难以覆盖的跨文件、跨层、跨产物一致性问
 - 命名规则
 - i18n 调用约束
 - 禁止某些 API / 语法 / 原始样式值
+- 测试文件结构约束（如 `creonow/require-describe-in-tests`）
 
 原因：
 
@@ -46,6 +47,7 @@ Guard 只处理 ESLint 难以覆盖的跨文件、跨层、跨产物一致性问
 - i18n hardcode
 - import 规范
 - 浅层静态字符串匹配类前端约束
+- 测试结构规范（`require-describe-in-tests`，已完成）
 
 更适合保留为 Guard 的类型：
 

--- a/docs/references/testing/07-test-command-and-ci-map.md
+++ b/docs/references/testing/07-test-command-and-ci-map.md
@@ -38,7 +38,7 @@
 
 | CI Job                       | 实际命令                                                    | 说明                   |
 | ---------------------------- | ----------------------------------------------------------- | ---------------------- |
-| `lint-and-typecheck`         | `pnpm lint` / `pnpm lint:warning-budget` / `pnpm typecheck` | 基础静态门禁           |
+| `lint-and-typecheck`         | `pnpm lint` / `pnpm lint:warning-budget` / `pnpm typecheck` | 基础静态门禁（含 `creonow/require-describe-in-tests`）|
 | `unit-test-core`             | `pnpm test:unit`                                            | root 侧单元测试计划    |
 | `unit-test-renderer`         | `pnpm -C apps/desktop test:run`                             | renderer/store vitest  |
 | `integration-test`           | `pnpm test:integration`                                     | root 侧集成测试        |

--- a/openspec/changes/g05-01-require-describe-in-tests/specs/test-quality/spec.md
+++ b/openspec/changes/g05-01-require-describe-in-tests/specs/test-quality/spec.md
@@ -34,10 +34,13 @@ THEN   该规则不报错
 ### Scenario S-G05-01-03: 存量目录在过渡期只告警不阻断
 
 ```
-GIVEN  `apps/desktop/tests/unit/` 中存在尚未迁移的旧测试文件
+GIVEN  存量目录（main/src、tests/unit、tests/integration、scripts/tests、
+       tests/e2e、tests/perf、renderer/src/**/*.snapshot.test.*）
+       及其 *.spec.* 变体中存在尚未迁移的旧测试文件
 WHEN   运行 `pnpm lint`
 THEN   规则输出 warning
 AND    CI 不因该 warning 直接失败
+AND    lint-ratchet 基线锁定当前 warning 数，新增违规仍被 ratchet 门禁阻断
 ```
 
 ### Scenario S-G05-01-04: 迁移完成的目录收紧为 error

--- a/openspec/changes/g05-01-require-describe-in-tests/tasks.md
+++ b/openspec/changes/g05-01-require-describe-in-tests/tasks.md
@@ -29,7 +29,7 @@ W0.5-GATE: 审计补丁 — 制度门禁补齐
 | AC-2 | `.eslintrc.cjs` 中该规则设为 `"error"` |
 | AC-3 | 新建一个无 `describe()` 的 `.test.ts` 文件 → `pnpm lint` 报错 |
 | AC-4 | 新建一个有 `describe()` 的 `.test.ts` 文件 → `pnpm lint` 通过 |
-| AC-5 | 存量目录（`main/src`、`tests/unit`、`tests/integration`、`scripts/tests`）通过 `overrides` 临时设为 `"warn"`，不阻断 CI |
+| AC-5 | 存量目录（`main/src`、`tests/unit`、`tests/integration`、`scripts/tests`、`tests/e2e`、`tests/perf`、`renderer/src/**/*.snapshot.test.*`）及其 `*.spec.*` 变体通过 `overrides` 临时设为 `"warn"`，不阻断 CI |
 | AC-6 | 该规则有对应的 ESLint rule test（`scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs`） |
 | AC-7 | 同步更新 `01-philosophy-and-anti-patterns.md`、`06-guard-and-lint-policy.md`、`07-test-command-and-ci-map.md` |
 
@@ -63,10 +63,18 @@ W0.5-GATE: 审计补丁 — 制度门禁补齐
 **映射验收标准**: AC-5
 
 - [ ] 在 `.eslintrc.cjs` 的 `overrides` 中对存量目录设为 `"warn"`：
-  - `apps/desktop/tests/unit/**/*.test.*`
-  - `apps/desktop/tests/integration/**/*.test.*`
   - `apps/desktop/main/src/**/*.test.*`
+  - `apps/desktop/tests/unit/**/*.test.*`
+  - `apps/desktop/tests/unit/**/*.spec.*`
+  - `apps/desktop/tests/integration/**/*.test.*`
+  - `apps/desktop/tests/integration/**/*.spec.*`
+  - `apps/desktop/tests/e2e/**/*.spec.*`
+  - `apps/desktop/tests/perf/**/*.test.*`
+  - `apps/desktop/tests/perf/**/*.spec.*`
+  - `apps/desktop/renderer/src/**/*.snapshot.test.*`
   - `scripts/tests/**/*.test.*`
+
+> **发现说明**：初始 spec 仅列出 4 个目录的 `*.test.*` 模式。实施时排查发现 E2E（21 文件）、perf（7 文件）、snapshot（2 文件）以及 unit/integration 的 `*.spec.*` 变体（27 文件）同样缺少 `describe()` 包装。按 P1 原则「开发中发现 spec 遗漏场景，先更新 spec 再实现」同步扩展。
 
 ### Task 2.3: 文档同步
 

--- a/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
+++ b/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
@@ -1,0 +1,111 @@
+// @ts-nocheck — ESLint RuleTester is JS-only; skip TS checks
+const { RuleTester } = require("eslint");
+const rule = require("../require-describe-in-tests.cjs");
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("creonow/require-describe-in-tests", rule, {
+  valid: [
+    // Has describe() — should pass
+    {
+      code: `
+        import { describe, it, expect } from 'vitest';
+        describe('MyModule', () => {
+          it('should work', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      filename: "src/foo.test.ts",
+    },
+    // Has nested describe() — should pass
+    {
+      code: `
+        import { describe, it } from 'vitest';
+        describe('outer', () => {
+          describe('inner', () => {
+            it('works', () => {});
+          });
+        });
+      `,
+      filename: "src/bar.test.ts",
+    },
+    // Non-test file without describe — should not trigger
+    {
+      code: `export const x = 1;`,
+      filename: "src/utils.ts",
+    },
+    // Non-test file (.tsx) without describe — should not trigger
+    {
+      code: `export default function App() { return null; }`,
+      filename: "src/App.tsx",
+    },
+    // .spec.ts with describe — should pass
+    {
+      code: `
+        describe('spec file', () => {
+          it('works', () => {});
+        });
+      `,
+      filename: "tests/e2e/login.spec.ts",
+    },
+    // describe inside conditional still counts
+    {
+      code: `
+        if (process.env.CI) {
+          describe('conditional', () => {
+            it('runs on CI', () => {});
+          });
+        }
+      `,
+      filename: "src/cond.test.ts",
+    },
+  ],
+  invalid: [
+    // No describe() in .test.ts — should error
+    {
+      code: `
+        import { it, expect } from 'vitest';
+        it('should work', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      filename: "src/foo.test.ts",
+      errors: [{ messageId: "missingDescribe" }],
+    },
+    // No describe() in .test.tsx — should error
+    {
+      code: `
+        test('renders', () => {
+          expect(true).toBe(true);
+        });
+      `,
+      filename: "src/Comp.test.tsx",
+      errors: [{ messageId: "missingDescribe" }],
+    },
+    // Script-style test file — should error
+    {
+      code: `
+        async function main() {
+          console.log('testing...');
+        }
+        main();
+      `,
+      filename: "scripts/tests/check.test.ts",
+      errors: [{ messageId: "missingDescribe" }],
+    },
+    // No describe() in .spec.ts — should error
+    {
+      code: `
+        it('bare spec', () => {});
+      `,
+      filename: "tests/e2e/bare.spec.ts",
+      errors: [{ messageId: "missingDescribe" }],
+    },
+  ],
+});

--- a/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
+++ b/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
@@ -65,6 +65,33 @@ tester.run("creonow/require-describe-in-tests", rule, {
       `,
       filename: "src/cond.test.ts",
     },
+    // test.describe() — Playwright style
+    {
+      code: `
+        test.describe('suite', () => {
+          test('x', () => {});
+        });
+      `,
+      filename: "tests/e2e/foo.spec.ts",
+    },
+    // describe.skip()
+    {
+      code: `
+        describe.skip('suite', () => {
+          it('x', () => {});
+        });
+      `,
+      filename: "src/foo.test.ts",
+    },
+    // describe.only()
+    {
+      code: `
+        describe.only('suite', () => {
+          it('x', () => {});
+        });
+      `,
+      filename: "src/foo.test.ts",
+    },
   ],
   invalid: [
     // No describe() in .test.ts — should error

--- a/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
+++ b/scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs
@@ -136,3 +136,5 @@ tester.run("creonow/require-describe-in-tests", rule, {
     },
   ],
 });
+
+console.log("✅ require-describe-in-tests: all tests passed");

--- a/scripts/eslint-rules/index.cjs
+++ b/scripts/eslint-rules/index.cjs
@@ -12,6 +12,7 @@ const noRawTailwindTokens = require("./no-raw-tailwind-tokens.cjs");
 const noNativeHtmlElement = require("./no-native-html-element.cjs");
 const noRawErrorCodeInUi = require("./no-raw-error-code-in-ui.cjs");
 const noHardcodedDimension = require("./no-hardcoded-dimension.cjs");
+const requireDescribeInTests = require("./require-describe-in-tests.cjs");
 
 module.exports = {
   rules: {
@@ -19,5 +20,6 @@ module.exports = {
     "no-native-html-element": noNativeHtmlElement,
     "no-raw-error-code-in-ui": noRawErrorCodeInUi,
     "no-hardcoded-dimension": noHardcodedDimension,
+    "require-describe-in-tests": requireDescribeInTests,
   },
 };

--- a/scripts/eslint-rules/require-describe-in-tests.cjs
+++ b/scripts/eslint-rules/require-describe-in-tests.cjs
@@ -34,11 +34,39 @@ const rule = {
 
     return {
       CallExpression(node) {
-        if (
-          node.callee.type === "Identifier" &&
-          node.callee.name === "describe"
-        ) {
+        const callee = node.callee;
+
+        // Bare describe(...)
+        if (callee.type === "Identifier" && callee.name === "describe") {
           hasDescribe = true;
+          return;
+        }
+
+        if (callee.type === "MemberExpression") {
+          const obj = callee.object;
+          const prop = callee.property;
+
+          // test.describe(...) — Playwright style
+          if (
+            obj.type === "Identifier" &&
+            obj.name === "test" &&
+            prop.type === "Identifier" &&
+            prop.name === "describe"
+          ) {
+            hasDescribe = true;
+            return;
+          }
+
+          // describe.skip(...) / describe.only(...) / describe.each(...)
+          if (
+            obj.type === "Identifier" &&
+            obj.name === "describe" &&
+            prop.type === "Identifier" &&
+            ["skip", "only", "each"].includes(prop.name)
+          ) {
+            hasDescribe = true;
+            return;
+          }
         }
       },
 

--- a/scripts/eslint-rules/require-describe-in-tests.cjs
+++ b/scripts/eslint-rules/require-describe-in-tests.cjs
@@ -1,0 +1,57 @@
+/**
+ * Custom ESLint rule: require-describe-in-tests
+ *
+ * Requires test files (.test.ts, .test.tsx, .spec.ts, .spec.tsx)
+ * to contain at least one `describe()` call, enforcing structured
+ * test organization over script-style or bare-block patterns.
+ *
+ * @see docs/references/testing/01-philosophy-and-anti-patterns.md
+ * @see docs/references/testing/06-guard-and-lint-policy.md
+ */
+
+const TEST_FILE_PATTERN = /\.(test|spec)\.[tj]sx?$/;
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require test files to contain at least one describe() block.",
+    },
+    messages: {
+      missingDescribe:
+        "Test files must use describe() to organize tests. Wrap your test cases in a describe() block.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getFilename();
+    if (!TEST_FILE_PATTERN.test(filename)) return {};
+
+    let hasDescribe = false;
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "describe"
+        ) {
+          hasDescribe = true;
+        }
+      },
+
+      "Program:exit"(node) {
+        if (!hasDescribe) {
+          context.report({
+            node,
+            messageId: "missingDescribe",
+          });
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/scripts/lint-baseline.json
+++ b/scripts/lint-baseline.json
@@ -1,18 +1,19 @@
 {
-  "version": "2026-03-08",
-  "generatedAt": "2026-03-08T08:51:33.462Z",
+  "version": "2026-03-11",
+  "generatedAt": "2026-03-11T20:00:00.000Z",
   "source": "eslint-json",
   "governance": {
-    "issue": "#1037",
-    "reason": "Wave 0 gate rules (G0-01/G0-03) added as warn-level; baseline updated to include initial debt"
+    "issue": "#1072",
+    "reason": "G0.5-01: require-describe-in-tests rule added as warn for legacy files; baseline updated to include initial debt"
   },
   "snapshot": {
-    "totalViolations": 297,
+    "totalViolations": 702,
     "byRule": {
       "creonow/no-hardcoded-dimension": 63,
       "creonow/no-native-html-element": 222,
       "creonow/no-raw-error-code-in-ui": 8,
-      "creonow/no-raw-tailwind-tokens": 4
+      "creonow/no-raw-tailwind-tokens": 4,
+      "creonow/require-describe-in-tests": 405
     }
   }
 }


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

新增 ESLint 规则 `creonow/require-describe-in-tests`，自动拦截缺少 `describe()` 的新测试文件，堵住 GAP-8 测试结构退化漏洞。

## 关联 Issue

- Closes #1072

## 用户影响

- 新增测试文件如果不使用 `describe()` 组织，`pnpm lint` 将直接报错（error），阻断 CI
- 存量目录暂设为 warn 不阻断，随 T-MIG 批次迁移逐步收紧

## 不修最坏后果

- 新 PR 可继续引入脚本式测试，测试结构规范永远只是口头约定，机器不守门

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm lint` — 0 errors, 695 warnings
- [x] `pnpm lint:warning-budget` — PASS (baseline=702, current=695, delta=-7)
- [x] `node scripts/eslint-rules/__tests__/require-describe-in-tests.test.cjs` — 全部通过
- [x] 文档同步：01-philosophy、06-guard-and-lint-policy、07-ci-map

## 回滚点

- 回滚 commit：revert 本 commit 即可
- 回滚后需恢复：`scripts/lint-baseline.json` 还原至之前版本

## 非自动化检查（Tier 3）

N/A（本 PR 仅涉及 ESLint 规则 / 配置 / 文档，无 UI 改动）
