### PR TITLE
ci: 后端 coverage threshold 门禁 (G0.5-02)

### DIFF
--- a/apps/desktop/vitest.config.core.ts
+++ b/apps/desktop/vitest.config.core.ts
@@ -73,6 +73,12 @@ export default defineConfig({
       exclude: [
         "main/src/**/*.test.{ts,tsx}",
       ],
+      thresholds: {
+        statements: 5,
+        branches: 3,
+        functions: 6,
+        lines: 4,
+      },
     },
   },
 });

--- a/docs/references/testing/07-test-command-and-ci-map.md
+++ b/docs/references/testing/07-test-command-and-ci-map.md
@@ -75,7 +75,7 @@
 ### Coverage
 
 - renderer 侧已有 coverage threshold。
-- backend/core 侧未来可继续收紧，但不应在未准备好时口头宣称“已强制”。
+- backend/core 侧已设置 coverage threshold（statements: 5%, branches: 3%, functions: 6%, lines: 4%），配置位于 `vitest.config.core.ts`，CI 通过 `pnpm test:coverage:core` 校验阈值并阻断下行。
 
 ### Storybook
 
@@ -116,22 +116,11 @@
 
 ### 1. 后端 coverage threshold 对齐
 
-现状：
+**已完成**（G0.5-02, Issue #1073）。
 
-- `apps/desktop/vitest.config.ts` 已对 renderer coverage 设置阈值。
-- `apps/desktop/vitest.config.core.ts` 尚未设置同级别的 backend threshold。
-
-第二阶段动作：
-
-1. 先基于 `pnpm test:coverage:core` 连续收集基线。
-2. 为 backend/core 设定首个可达阈值，而不是直接照搬 renderer 数字。
-3. 将 `coverage-gate` 从“上传 artifact”升级为“校验阈值 + 失败阻断”。
-
-升级条件：
-
-- backend coverage 连续多轮稳定
-- 历史盲区已有补测
-- 失败成本低于维护收益
+- `apps/desktop/vitest.config.core.ts` 已配置 coverage thresholds：statements 5%, branches 3%, functions 6%, lines 4%。
+- 阈值基于当前 baseline - 2% 设定，阻断覆盖率下行。
+- 后续可随补测进度逐步收紧阈值。
 
 ### 2. spec-scenario-test 映射门禁
 


### PR DESCRIPTION
## Summary

为后端 `vitest.config.core.ts` 增加 coverage thresholds，阻断覆盖率下行。

**Closes #1073**

## Changes

- `apps/desktop/vitest.config.core.ts`：添加 `thresholds` 配置
  - statements: 5%, branches: 3%, functions: 6%, lines: 4%
  - 基于当前 baseline（stmts 7%, branches 5.23%, functions 8.65%, lines 6.89%）减 2%，向下取整
- `docs/references/testing/07-test-command-and-ci-map.md`：更新后端 coverage 状态描述

## Verification Evidence

### AC-1: 四项阈值均 > 0 ✅
```
thresholds: { statements: 5, branches: 3, functions: 6, lines: 4 }
```

### AC-2: 当前代码通过阈值 ✅
```
Tests  45 passed (45)
```
（无 threshold 违规错误）

### AC-3: 阻断生效验证 ✅
临时调高到 100% 后输出：
```
ERROR: Coverage for lines (6.89%) does not meet global threshold (100%)
ERROR: Coverage for functions (8.65%) does not meet global threshold (100%)
ERROR: Coverage for statements (7%) does not meet global threshold (100%)
ERROR: Coverage for branches (5.23%) does not meet global threshold (100%)
```

### AC-4: 文档已同步 ✅

## Rollback

还原 `vitest.config.core.ts` 中的 `thresholds` 块即可回退。

## Audit Gate

- [ ] 审计 Agent 发布 FINAL-VERDICT + ACCEPT 后方可启用 auto-merge