### PR TITLE
chore: add scripts/review-audit.sh — AGENTS.md §6.4 一键审计入口

### DIFF
--- a/.github/agents/creonow-audit.agent.md
+++ b/.github/agents/creonow-audit.agent.md
@@ -9,6 +9,7 @@ Your only job is to audit an existing PR against the repository delivery contrac
 
 Always:
 - Read `AGENTS.md`, `docs/delivery-skill.md`, and the linked spec before judging the PR.
+- Run `scripts/review-audit.sh` as the one-shot entry point for all §6.4 mandatory audit commands before writing any audit comment.
 - Publish all three comment stages when applicable: `PRE-AUDIT`, `RE-AUDIT`, and `FINAL-VERDICT`.
 - Give a real conclusion: `ACCEPT` or `REJECT`.
 - Include evidence commands and concrete findings in every review cycle.

--- a/docs/references/testing/07-test-command-and-ci-map.md
+++ b/docs/references/testing/07-test-command-and-ci-map.md
@@ -142,15 +142,16 @@
 
 ### 3. 审计脚本化与 reviewer wrapper
 
-目标：
+**状态：已落地（G0.5-04）**
 
-- 把 `git diff --check`、`pytest -q scripts/tests`、`python3 -m py_compile ...` 等审计必跑命令收口成一个 reviewer 入口。
+`scripts/review-audit.sh` 一键封装 `AGENTS.md` §6.4 全部 6 条审计必跑命令。
 
-第二阶段动作：
+```bash
+scripts/review-audit.sh              # 默认 diff base = origin/main
+scripts/review-audit.sh <base-ref>   # 自定义 base
+```
 
-1. 设计 `scripts/review-audit.sh` 或等价 wrapper。
-2. 输出统一摘要，方便贴入 PR comment。
-3. 评估是否需要配套测试模板 / 脚手架，避免“先搭空架子，后无人使用”。
+输出包含逐条标题、`[OK]`/`[FAIL]`/`[SKIP]` 前缀，以及汇总结论。
 
 原则：
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@
 | `agent_pr_preflight.sh`              | 提交前 / PR 前的预检查                          | 阶段 5：提交前       |
 | `agent_pr_automerge_and_sync.sh`   | 创建 PR；默认不开 auto-merge，显式开启时需审计通过（仅 gh 通道） | 阶段 5：提交与合并 |
 | `agent_github_delivery.py`        | GitHub 能力探测、PR/评论模板、gh/MCP 通道选择   | 阶段 5：提交与合并 |
+| `review-audit.sh`                   | AGENTS.md §6.4 审计必跑命令一键入口             | 审计：PRE-AUDIT 前 |
 | `agent_worktree_cleanup.sh`          | 清理 worktree                                   | 阶段 6：收口         |
 | `ipc-acceptance-gate.ts`             | IPC acceptance SLO 门禁                         | 阶段 4：实现与测试   |
 | `test-discovery-consistency-gate.ts` | 测试发现与执行计划一致性校验                    | 阶段 4：实现与测试   |

--- a/scripts/review-audit.sh
+++ b/scripts/review-audit.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# scripts/review-audit.sh — AGENTS.md §6.4 审计必跑命令一键入口
+# 用法：scripts/review-audit.sh [<base-ref>]
+#   base-ref  可选，diff 的基准引用（默认 origin/main）
+
+set -uo pipefail
+
+BASE_REF="${1:-origin/main}"
+TOTAL=6
+PASS=0
+FAIL=0
+SKIP=0
+
+run_step() {
+  local idx="$1"; shift
+  local title="$1"; shift
+
+  printf '\n=== [%d/%d] %s ===\n' "$idx" "$TOTAL" "$title"
+  if "$@"; then
+    (( PASS++ ))
+    printf '[OK]  %s\n' "$title"
+  else
+    (( FAIL++ ))
+    printf '[FAIL] %s (exit %d)\n' "$title" "$?"
+  fi
+}
+
+# ── 1/6 ──────────────────────────────────────────────
+run_step 1 "git diff --numstat" \
+  git diff --numstat "$BASE_REF"
+
+# ── 2/6 ──────────────────────────────────────────────
+run_step 2 "git diff --check" \
+  git diff --check "$BASE_REF"
+
+# ── 3/6 ──────────────────────────────────────────────
+run_step 3 "git diff --ignore-cr-at-eol --name-status" \
+  git diff --ignore-cr-at-eol --name-status "$BASE_REF"
+
+# ── 4/6 ──────────────────────────────────────────────
+run_step 4 "bash -n scripts/agent_pr_automerge_and_sync.sh" \
+  bash -n scripts/agent_pr_automerge_and_sync.sh
+
+# ── 5/6 ──────────────────────────────────────────────
+if command -v pytest &>/dev/null; then
+  run_step 5 "pytest -q scripts/tests" \
+    pytest -q scripts/tests
+else
+  printf '\n=== [5/%d] pytest -q scripts/tests ===\n' "$TOTAL"
+  printf '[SKIP] pytest not found in PATH\n'
+  (( SKIP++ ))
+fi
+
+# ── 6/6 ──────────────────────────────────────────────
+run_step 6 "test -x scripts/agent_pr_automerge_and_sync.sh" \
+  test -x scripts/agent_pr_automerge_and_sync.sh
+
+# ── 汇总 ─────────────────────────────────────────────
+printf '\n══════════════════════════════════════\n'
+printf '审计命令汇总: %d PASS / %d FAIL / %d SKIP（共 %d）\n' \
+  "$PASS" "$FAIL" "$SKIP" "$TOTAL"
+
+if (( FAIL > 0 )); then
+  printf '结论：存在失败项，请检查上方输出。\n'
+  exit 1
+fi
+printf '结论：全部通过。\n'

--- a/scripts/review-audit.sh
+++ b/scripts/review-audit.sh
@@ -20,8 +20,9 @@ run_step() {
     (( PASS++ ))
     printf '[OK]  %s\n' "$title"
   else
+    local rc=$?
     (( FAIL++ ))
-    printf '[FAIL] %s (exit %d)\n' "$title" "$?"
+    printf '[FAIL] %s (exit %d)\n' "$title" "$rc"
   fi
 }
 
@@ -52,8 +53,8 @@ else
 fi
 
 # ── 6/6 ──────────────────────────────────────────────
-run_step 6 "test -x scripts/agent_pr_automerge_and_sync.sh" \
-  test -x scripts/agent_pr_automerge_and_sync.sh
+run_step 6 "test -x scripts/agent_pr_automerge_and_sync.sh && echo EXEC_OK" \
+  bash -c 'test -x scripts/agent_pr_automerge_and_sync.sh && echo EXEC_OK'
 
 # ── 汇总 ─────────────────────────────────────────────
 printf '\n══════════════════════════════════════\n'


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

新增 `scripts/review-audit.sh` 一键封装 AGENTS.md §6.4 全部 6 条审计必跑命令，让审计 Agent 可单命令收口所有审计检查。

## 关联 Issue

- Closes #1075

## 用户影响

- 审计 Agent 可通过 `scripts/review-audit.sh` 一键执行所有审计必跑命令，无需手动逐条拼装
- `creonow-audit` agent 自动引用该脚本作为标准入口

## 不修最坏后果

- 审计证据收集效率低，遗漏风险高
- GAP-6 持续停留在「文档有承诺，脚本未落地」状态

## 验证证据

- [x] `bash -n scripts/review-audit.sh` 语法检查通过
- [x] `scripts/review-audit.sh` 实际运行 6/6 PASS
- [x] `test -x scripts/review-audit.sh` 可执行权限确认
- 本 PR 仅涉及 shell 脚本与文档，不涉及 TypeScript / 前端组件

## 回滚点

- 回滚 commit：`git revert <merge-sha>`
- 回滚后无需恢复数据或配置

## 非自动化检查（Tier 3）

- N/A（仅改 scripts/ 与文档，无 UI 改动）