### PR TITLE
docs: 补充 E2E 关键路径映射表（G0.5-05）

### DIFF
--- a/docs/references/testing/05-e2e-testing-patterns.md
+++ b/docs/references/testing/05-e2e-testing-patterns.md
@@ -1,6 +1,5 @@
 # E2E 测试模式
 
-
 ## E2E 的职责
 
 E2E 只守关键用户路径，不做全栈细枝末节的重复劳动。
@@ -100,36 +99,37 @@ CreoNow 的交付主平台是 Windows，因此 E2E 需要显式考虑：
 > **维护说明**：新增或删除 E2E 文件时，必须同步更新本表。覆盖状态标记：
 > ✅ 完整覆盖 ｜ ⚠️ 部分覆盖 ｜ ❌ 未覆盖
 
-| # | 关键用户路径 | E2E 文件 | 覆盖状态 | 备注 |
-|---|-------------|----------|---------|------|
-| 1 | 应用启动 | `app-launch.spec.ts`, `db-bootstrap.spec.ts` | ✅ | 应用启动 + 安全沙箱校验 + 数据库初始化 |
-| 2 | 项目切换 / 文档打开 | `project-lifecycle.spec.ts`, `documents-filetree.spec.ts`, `dashboard-project-actions.spec.ts` | ✅ | 项目创建/重启恢复 + 文件树 CRUD + 仪表盘操作 |
-| 3 | 编辑与保存 | `editor-autosave.spec.ts`, `version-history.spec.ts` | ✅ | autosave + 手动保存 Ctrl+S + 版本快照（见下方说明） |
-| 4 | 命令面板 | `command-palette.spec.ts` | ✅ | 命令面板唤起 + 9 条快捷键路径 |
-| 5 | AI 成功 / 失败 / 取消 | `ai-runtime.spec.ts`, `ai-apply.spec.ts`, `proxy-error-semantics.spec.ts` | ✅ | 成功/延迟/超时/上游错误/取消/冲突/代理配置 |
-| 6 | 导出 | `export-markdown.spec.ts` | ⚠️ | 见下方处理结论 |
-| 7 | 设置与关键面板 | `settings-dialog.spec.ts`, `theme.spec.ts`, `layout-panels.spec.ts` | ✅ | 快捷键唤起 + 主题持久化 + 面板布局 |
+| #   | 关键用户路径          | E2E 文件                                                                                       | 覆盖状态 | 备注                                                |
+| --- | --------------------- | ---------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| 1   | 应用启动              | `app-launch.spec.ts`, `db-bootstrap.spec.ts`                                                   | ✅       | 应用启动 + 安全沙箱校验 + 数据库初始化              |
+| 2   | 项目切换 / 文档打开   | `project-lifecycle.spec.ts`, `documents-filetree.spec.ts`, `dashboard-project-actions.spec.ts` | ✅       | 项目创建/重启恢复 + 文件树 CRUD + 仪表盘操作        |
+| 3   | 编辑与保存            | `editor-autosave.spec.ts`, `version-history.spec.ts`                                           | ✅       | autosave + 手动保存 Ctrl+S + 版本快照（见下方说明） |
+| 4   | 命令面板              | `command-palette.spec.ts`                                                                      | ✅       | 命令面板唤起 + 9 条快捷键路径                       |
+| 5   | AI 成功 / 失败 / 取消 | `ai-runtime.spec.ts`, `ai-apply.spec.ts`, `proxy-error-semantics.spec.ts`                      | ✅       | 成功/延迟/超时/上游错误/取消/冲突/代理配置          |
+| 6   | 导出                  | `export-markdown.spec.ts`                                                                      | ⚠️       | 见下方处理结论                                      |
+| 7   | 设置与关键面板        | `settings-dialog.spec.ts`, `theme.spec.ts`, `layout-panels.spec.ts`                            | ✅       | 快捷键唤起 + 主题持久化 + 面板布局                  |
 
 ### 补充关联 E2E（未列入七条关键路径但覆盖产品核心功能）
 
-| E2E 文件 | 覆盖范围 |
-|----------|---------|
-| `search-rag.spec.ts` | FTS 命中 + 语义 RAG 检索 + 降级 + 截断 |
-| `outline-panel.spec.ts` | 大纲面板导航 + 空态 + 动态更新 |
-| `rightpanel-info-quality.spec.ts` | 右侧信息与质量面板 |
-| `knowledge-graph.spec.ts` | 知识图谱侧边栏 CRUD + 上下文注入 |
-| `memory-preference-learning.spec.ts` | 记忆偏好学习 |
-| `memory-semantic-recall.spec.ts` | 语义记忆召回 |
-| `skills.spec.ts` | 技能列表 + 切换 + 命令面板 |
-| `judge.spec.ts` | 评判器状态转移 |
-| `analytics.spec.ts` | 统计指标 |
-| `system-dialog.spec.ts` | 系统对话框取消/确认 |
+| E2E 文件                             | 覆盖范围                               |
+| ------------------------------------ | -------------------------------------- |
+| `search-rag.spec.ts`                 | FTS 命中 + 语义 RAG 检索 + 降级 + 截断 |
+| `outline-panel.spec.ts`              | 大纲面板导航 + 空态 + 动态更新         |
+| `rightpanel-info-quality.spec.ts`    | 右侧信息与质量面板                     |
+| `knowledge-graph.spec.ts`            | 知识图谱侧边栏 CRUD + 上下文注入       |
+| `memory-preference-learning.spec.ts` | 记忆偏好学习                           |
+| `memory-semantic-recall.spec.ts`     | 语义记忆召回                           |
+| `skills.spec.ts`                     | 技能列表 + 切换 + 命令面板             |
+| `judge.spec.ts`                      | 评判器状态转移                         |
+| `analytics.spec.ts`                  | 统计指标                               |
+| `system-dialog.spec.ts`              | 系统对话框取消/确认                    |
 
 ### ⚠️ 空洞处理结论
 
 #### 编辑与保存（✅ 完整覆盖）
 
 **现状**：手动保存（Ctrl+S）已由现有 E2E 覆盖：
+
 - `editor-autosave.spec.ts` 第 112 行：显式测试 `${modKey}+S` 快捷键触发手动保存，并验证 `actor === "user"` 的版本快照生成
 - `version-history.spec.ts` 第 62 行：通过 `${modKey}+S` 创建用户版本后验证快照读取完整字段
 
@@ -142,6 +142,7 @@ CreoNow 的交付主平台是 Windows，因此 E2E 需要显式考虑：
 **处理结论：markdown E2E 作为导出路径冒烟测试保留，其余格式由单元测试覆盖。**
 
 理由：
+
 1. 四种格式共享同一 IPC 通道和 ExportService 调度逻辑，markdown E2E 已验证完整通路
 2. 各格式的差异点（渲染逻辑）已由后端单元测试覆盖：
    - `export-markdown.test.ts` — markdown 渲染

--- a/docs/references/testing/05-e2e-testing-patterns.md
+++ b/docs/references/testing/05-e2e-testing-patterns.md
@@ -102,22 +102,19 @@ CreoNow 的交付主平台是 Windows，因此 E2E 需要显式考虑：
 
 | # | 关键用户路径 | E2E 文件 | 覆盖状态 | 备注 |
 |---|-------------|----------|---------|------|
-| 1 | 启动与初始化 | `app-launch.spec.ts`, `db-bootstrap.spec.ts` | ✅ | 应用启动 + 安全沙箱校验 + 数据库初始化 |
-| 2 | 编辑与保存 | `editor-autosave.spec.ts` | ⚠️ | 见下方处理结论 |
-| 3 | AI 对话 | `ai-runtime.spec.ts`, `ai-apply.spec.ts`, `proxy-error-semantics.spec.ts` | ✅ | 成功/延迟/超时/上游错误/取消/冲突/代理配置 |
-| 4 | 导出 | `export-markdown.spec.ts` | ⚠️ | 见下方处理结论 |
-| 5 | 设置 | `settings-dialog.spec.ts`, `theme.spec.ts`, `layout-panels.spec.ts` | ✅ | 快捷键唤起 + 主题持久化 + 面板布局 |
-| 6 | 搜索 | `search-rag.spec.ts` | ✅ | FTS 命中 + 语义 RAG 检索 + 降级 + 截断 |
-| 7 | 版本/备份 | `version-history.spec.ts` | ✅ | 快照读取 + NOT_FOUND/INVALID_ARGUMENT 错误路径 |
+| 1 | 应用启动 | `app-launch.spec.ts`, `db-bootstrap.spec.ts` | ✅ | 应用启动 + 安全沙箱校验 + 数据库初始化 |
+| 2 | 项目切换 / 文档打开 | `project-lifecycle.spec.ts`, `documents-filetree.spec.ts`, `dashboard-project-actions.spec.ts` | ✅ | 项目创建/重启恢复 + 文件树 CRUD + 仪表盘操作 |
+| 3 | 编辑与保存 | `editor-autosave.spec.ts`, `version-history.spec.ts` | ✅ | autosave + 手动保存 Ctrl+S + 版本快照（见下方说明） |
+| 4 | 命令面板 | `command-palette.spec.ts` | ✅ | 命令面板唤起 + 9 条快捷键路径 |
+| 5 | AI 成功 / 失败 / 取消 | `ai-runtime.spec.ts`, `ai-apply.spec.ts`, `proxy-error-semantics.spec.ts` | ✅ | 成功/延迟/超时/上游错误/取消/冲突/代理配置 |
+| 6 | 导出 | `export-markdown.spec.ts` | ⚠️ | 见下方处理结论 |
+| 7 | 设置与关键面板 | `settings-dialog.spec.ts`, `theme.spec.ts`, `layout-panels.spec.ts` | ✅ | 快捷键唤起 + 主题持久化 + 面板布局 |
 
 ### 补充关联 E2E（未列入七条关键路径但覆盖产品核心功能）
 
 | E2E 文件 | 覆盖范围 |
 |----------|---------|
-| `command-palette.spec.ts` | 命令面板唤起 + 9 条快捷键路径 |
-| `project-lifecycle.spec.ts` | 项目创建 + `.creonow` 目录 + 重启恢复 |
-| `dashboard-project-actions.spec.ts` | 仪表盘项目操作（重命名/复制/归档/取消归档） |
-| `documents-filetree.spec.ts` | 文件树 CRUD + 当前文档恢复 |
+| `search-rag.spec.ts` | FTS 命中 + 语义 RAG 检索 + 降级 + 截断 |
 | `outline-panel.spec.ts` | 大纲面板导航 + 空态 + 动态更新 |
 | `rightpanel-info-quality.spec.ts` | 右侧信息与质量面板 |
 | `knowledge-graph.spec.ts` | 知识图谱侧边栏 CRUD + 上下文注入 |
@@ -130,19 +127,13 @@ CreoNow 的交付主平台是 Windows，因此 E2E 需要显式考虑：
 
 ### ⚠️ 空洞处理结论
 
-#### 编辑与保存（⚠️ 部分覆盖）
+#### 编辑与保存（✅ 完整覆盖）
 
-**现状**：`editor-autosave.spec.ts` 验证"输入文字 → autosave → 重启后内容保留"，即自动保存路径。缺少手动编辑 + 手动保存（Ctrl+S）的 E2E。
+**现状**：手动保存（Ctrl+S）已由现有 E2E 覆盖：
+- `editor-autosave.spec.ts` 第 112 行：显式测试 `${modKey}+S` 快捷键触发手动保存，并验证 `actor === "user"` 的版本快照生成
+- `version-history.spec.ts` 第 62 行：通过 `${modKey}+S` 创建用户版本后验证快照读取完整字段
 
-**处理结论：降级为单元/集成测试覆盖，E2E 补充为增强项。**
-
-理由：
-1. CreoNow 以 autosave 为主保存机制，手动保存（Ctrl+S）触发的是同一条 `editorSaveQueue` 写入管线
-2. 手动保存管线已由 `editorSaveQueue.test.ts`、`editorStore.saveQueue.test.ts`、`editorStore.test.ts` 三个单元测试覆盖
-3. autosave E2E 已验证了从编辑器输入到磁盘持久化的完整 IPC 通路
-4. 手动保存 E2E 的边际收益低于维护成本
-
-> 如后续需补充手动保存 E2E，可新建 `editor-manual-save.spec.ts`。
+**结论：编辑与保存路径已完整覆盖，包括 autosave 和手动保存两条管线。**
 
 #### 导出（⚠️ 部分覆盖）
 

--- a/docs/references/testing/05-e2e-testing-patterns.md
+++ b/docs/references/testing/05-e2e-testing-patterns.md
@@ -92,3 +92,70 @@ CreoNow 的交付主平台是 Windows，因此 E2E 需要显式考虑：
 - 外部依赖是否全部受控？
 - 失败后能否从日志 / artifact 快速定位？
 - 是否有可以下沉到集成层的断言被误放到了 E2E？
+
+---
+
+## 关键路径 ↔ E2E 映射表
+
+> **维护说明**：新增或删除 E2E 文件时，必须同步更新本表。覆盖状态标记：
+> ✅ 完整覆盖 ｜ ⚠️ 部分覆盖 ｜ ❌ 未覆盖
+
+| # | 关键用户路径 | E2E 文件 | 覆盖状态 | 备注 |
+|---|-------------|----------|---------|------|
+| 1 | 启动与初始化 | `app-launch.spec.ts`, `db-bootstrap.spec.ts` | ✅ | 应用启动 + 安全沙箱校验 + 数据库初始化 |
+| 2 | 编辑与保存 | `editor-autosave.spec.ts` | ⚠️ | 见下方处理结论 |
+| 3 | AI 对话 | `ai-runtime.spec.ts`, `ai-apply.spec.ts`, `proxy-error-semantics.spec.ts` | ✅ | 成功/延迟/超时/上游错误/取消/冲突/代理配置 |
+| 4 | 导出 | `export-markdown.spec.ts` | ⚠️ | 见下方处理结论 |
+| 5 | 设置 | `settings-dialog.spec.ts`, `theme.spec.ts`, `layout-panels.spec.ts` | ✅ | 快捷键唤起 + 主题持久化 + 面板布局 |
+| 6 | 搜索 | `search-rag.spec.ts` | ✅ | FTS 命中 + 语义 RAG 检索 + 降级 + 截断 |
+| 7 | 版本/备份 | `version-history.spec.ts` | ✅ | 快照读取 + NOT_FOUND/INVALID_ARGUMENT 错误路径 |
+
+### 补充关联 E2E（未列入七条关键路径但覆盖产品核心功能）
+
+| E2E 文件 | 覆盖范围 |
+|----------|---------|
+| `command-palette.spec.ts` | 命令面板唤起 + 9 条快捷键路径 |
+| `project-lifecycle.spec.ts` | 项目创建 + `.creonow` 目录 + 重启恢复 |
+| `dashboard-project-actions.spec.ts` | 仪表盘项目操作（重命名/复制/归档/取消归档） |
+| `documents-filetree.spec.ts` | 文件树 CRUD + 当前文档恢复 |
+| `outline-panel.spec.ts` | 大纲面板导航 + 空态 + 动态更新 |
+| `rightpanel-info-quality.spec.ts` | 右侧信息与质量面板 |
+| `knowledge-graph.spec.ts` | 知识图谱侧边栏 CRUD + 上下文注入 |
+| `memory-preference-learning.spec.ts` | 记忆偏好学习 |
+| `memory-semantic-recall.spec.ts` | 语义记忆召回 |
+| `skills.spec.ts` | 技能列表 + 切换 + 命令面板 |
+| `judge.spec.ts` | 评判器状态转移 |
+| `analytics.spec.ts` | 统计指标 |
+| `system-dialog.spec.ts` | 系统对话框取消/确认 |
+
+### ⚠️ 空洞处理结论
+
+#### 编辑与保存（⚠️ 部分覆盖）
+
+**现状**：`editor-autosave.spec.ts` 验证"输入文字 → autosave → 重启后内容保留"，即自动保存路径。缺少手动编辑 + 手动保存（Ctrl+S）的 E2E。
+
+**处理结论：降级为单元/集成测试覆盖，E2E 补充为增强项。**
+
+理由：
+1. CreoNow 以 autosave 为主保存机制，手动保存（Ctrl+S）触发的是同一条 `editorSaveQueue` 写入管线
+2. 手动保存管线已由 `editorSaveQueue.test.ts`、`editorStore.saveQueue.test.ts`、`editorStore.test.ts` 三个单元测试覆盖
+3. autosave E2E 已验证了从编辑器输入到磁盘持久化的完整 IPC 通路
+4. 手动保存 E2E 的边际收益低于维护成本
+
+> 如后续需补充手动保存 E2E，可新建 `editor-manual-save.spec.ts`。
+
+#### 导出（⚠️ 部分覆盖）
+
+**现状**：`export-markdown.spec.ts` 验证 markdown 格式导出写入磁盘。Spec 支持 pdf/docx/txt/markdown 四种格式，仅 markdown 有 E2E。
+
+**处理结论：markdown E2E 作为导出路径冒烟测试保留，其余格式由单元测试覆盖。**
+
+理由：
+1. 四种格式共享同一 IPC 通道和 ExportService 调度逻辑，markdown E2E 已验证完整通路
+2. 各格式的差异点（渲染逻辑）已由后端单元测试覆盖：
+   - `export-markdown.test.ts` — markdown 渲染
+   - `export-pdf.test.ts` — PDF 渲染
+   - `export-txt-docx.test.ts` — TXT/DOCX 渲染
+3. pdf/docx 的 E2E 依赖系统级渲染引擎，环境脆弱且 CI 复现成本高
+
+> 如后续需提升导出 E2E 覆盖率，优先补充 `export-txt.spec.ts`（无外部依赖），pdf/docx 建议维持单元测试。


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

在 `docs/references/testing/05-e2e-testing-patterns.md` 中补充 7 条关键用户路径与 E2E 测试文件的精确映射表，明确覆盖空洞并给出处理结论。

## 关联 Issue

- Closes #1076

## 用户影响

- 开发者和审计 Agent 可直接查表判断哪些关键路径有 E2E 覆盖、哪些有空洞
- 后续新增/删除 E2E 文件须同步更新映射表

## 不修最坏后果

- 关键用户路径的 E2E 覆盖状态全凭经验判断，无法审计；空洞修复无据可依

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm lint` — 通过
- [x] 映射表覆盖全部 7 条关键路径（AC-1）
- [x] 所有覆盖空洞均有明确处理结论（AC-2）
- [x] 纯文档变更，无新增 E2E 文件（AC-3）

## 变更概要（当前 HEAD）

Canonical 7 条关键路径覆盖状态：

| # | 关键路径 | 覆盖状态 | 说明 |
|---|---------|---------|------|
| 1 | 应用启动 | ✅ 完整 | `app-launch.spec.ts` + `db-bootstrap.spec.ts` |
| 2 | 项目切换/文档打开 | ✅ 完整 | `project-lifecycle.spec.ts` + `documents-filetree.spec.ts` + `dashboard-project-actions.spec.ts` |
| 3 | 编辑与保存 | ✅ 完整 | `editor-autosave.spec.ts`(L112: `${modKey}+S`) + `version-history.spec.ts`(L62)，autosave 和手动保存两条管线均覆盖 |
| 4 | 命令面板 | ✅ 完整 | `command-palette.spec.ts` |
| 5 | AI 成功/失败/取消 | ✅ 完整 | `ai-runtime.spec.ts` + `ai-apply.spec.ts` + `proxy-error-semantics.spec.ts` |
| 6 | 导出 | ⚠️ 部分 | `export-markdown.spec.ts` 冒烟覆盖；pdf/docx/txt 由单元测试覆盖（共享 IPC 通道，E2E 环境脆弱） |
| 7 | 设置与关键面板 | ✅ 完整 | `settings-dialog.spec.ts` + `theme.spec.ts` + `layout-panels.spec.ts` |

另附 10 个补充关联 E2E 文件索引表。

## 回滚点

- 单文件文档变更，`git revert` 即可
- 回滚后无需恢复额外数据或配置

## 非自动化检查（Tier 3）

N/A（本 PR 仅涉及文档，无 UI 改动）
