### PR TITLE
fix(i18n): 清除 error 文案中的技术码泄露（A0-22）

### DIFF
--- a/apps/desktop/renderer/src/__tests__/i18n-error-copy-cleanup.test.ts
+++ b/apps/desktop/renderer/src/__tests__/i18n-error-copy-cleanup.test.ts
@@ -1,0 +1,111 @@
+/**
+ * A0-22: i18n 错误文案修正
+ *
+ * 确保 locale 文件中没有泄露技术错误码前缀（如 "NO_PROJECT:"）
+ * 或裸露的 {{code}} / {{errorCode}} 插值。
+ */
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const LOCALES_DIR = resolve(CURRENT_DIR, "..", "i18n", "locales");
+
+function loadLocale(lang: string): Record<string, unknown> {
+  const raw = readFileSync(resolve(LOCALES_DIR, `${lang}.json`), "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function flattenValues(
+  obj: Record<string, unknown>,
+  prefix = "",
+): Array<{ key: string; value: string }> {
+  const result: Array<{ key: string; value: string }> = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === "string") {
+      result.push({ key: path, value: v });
+    } else if (typeof v === "object" && v !== null) {
+      result.push(
+        ...flattenValues(v as Record<string, unknown>, path),
+      );
+    }
+  }
+  return result;
+}
+
+/** Matches UPPERCASE_CODE: prefix patterns (≥3 chars, excludes URLs) */
+const ERROR_CODE_PREFIX = /\b[A-Z_]{3,}:\s/;
+
+/** Matches {{code}} or {{errorCode}} interpolations */
+const CODE_INTERPOLATION = /\{\{(code|errorCode|error_code)\}\}/;
+
+describe("A0-22: i18n error copy cleanup", () => {
+  for (const lang of ["zh-CN", "en"]) {
+    describe(`${lang} locale`, () => {
+      const entries = flattenValues(loadLocale(lang));
+
+      it("export.error.noProject 不含 error code 前缀", () => {
+        const entry = entries.find((e) => e.key === "export.error.noProject");
+        expect(entry).toBeDefined();
+        expect(entry!.value).not.toMatch(ERROR_CODE_PREFIX);
+      });
+
+      it("rightPanel.quality.errorWithCode 不含 {{code}} 插值", () => {
+        const entry = entries.find(
+          (e) => e.key === "rightPanel.quality.errorWithCode",
+        );
+        expect(entry).toBeDefined();
+        expect(entry!.value).not.toMatch(CODE_INTERPOLATION);
+      });
+
+      it("所有 error 相关 key 不含 error code 前缀", () => {
+        const errorEntries = entries.filter(
+          (e) =>
+            e.key.toLowerCase().includes("error") &&
+            !e.key.includes("http"),
+        );
+        const leaks = errorEntries.filter((e) =>
+          ERROR_CODE_PREFIX.test(e.value),
+        );
+        expect(leaks).toEqual([]);
+      });
+
+      it("所有 key 不含裸 {{code}} / {{errorCode}} 插值", () => {
+        const leaks = entries.filter((e) =>
+          CODE_INTERPOLATION.test(e.value),
+        );
+        expect(leaks).toEqual([]);
+      });
+    });
+  }
+
+  it("zh-CN export.error.noProject 具体值正确", () => {
+    const zh = flattenValues(loadLocale("zh-CN"));
+    const entry = zh.find((e) => e.key === "export.error.noProject");
+    expect(entry!.value).toBe("请先打开一个项目");
+  });
+
+  it("en export.error.noProject 具体值正确", () => {
+    const en = flattenValues(loadLocale("en"));
+    const entry = en.find((e) => e.key === "export.error.noProject");
+    expect(entry!.value).toBe("Please open a project first");
+  });
+
+  it("zh-CN rightPanel.quality.errorWithCode 具体值正确", () => {
+    const zh = flattenValues(loadLocale("zh-CN"));
+    const entry = zh.find(
+      (e) => e.key === "rightPanel.quality.errorWithCode",
+    );
+    expect(entry!.value).toBe("质量检测遇到问题");
+  });
+
+  it("en rightPanel.quality.errorWithCode 具体值正确", () => {
+    const en = flattenValues(loadLocale("en"));
+    const entry = en.find(
+      (e) => e.key === "rightPanel.quality.errorWithCode",
+    );
+    expect(entry!.value).toBe("Quality check encountered an issue");
+  });
+});

--- a/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
@@ -38,7 +38,7 @@ function formatJudgeState(state: JudgeModelState, t: TFunction): {
     case "not_ready":
       return { label: t('rightPanel.quality.notReady'), status: "not_ready" };
     case "error":
-      return { label: t('rightPanel.quality.errorWithCode', { code: state.error.code }), status: "error" };
+      return { label: t('rightPanel.quality.errorWithCode'), status: "error" };
   }
 }
 

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1121,7 +1121,7 @@
     },
     "defaultDocumentTitle": "Untitled Document",
     "error": {
-      "noProject": "NO_PROJECT: Please open a project first",
+      "noProject": "Please open a project first",
       "unsupportedStructure": "This export format cannot write: {{details}}",
       "unknown": "Export failed due to unknown error"
     }
@@ -1283,7 +1283,7 @@
       "ready": "Ready",
       "downloading": "Downloading...",
       "notReady": "Not ready",
-      "errorWithCode": "Error ({{code}})",
+      "errorWithCode": "Quality check encountered an issue",
       "loadingJudgeStatus": "Loading judge status...",
       "judgeStatusUnavailable": "Judge status unavailable",
       "judgeModelLabel": "Judge Model:",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1121,7 +1121,7 @@
     },
     "defaultDocumentTitle": "未命名文档",
     "error": {
-      "noProject": "NO_PROJECT: 请先打开一个项目",
+      "noProject": "请先打开一个项目",
       "unsupportedStructure": "当前导出格式暂不支持写出：{{details}}",
       "unknown": "由于未知错误导出失败"
     }
@@ -1283,7 +1283,7 @@
       "ready": "就绪",
       "downloading": "下载中...",
       "notReady": "未就绪",
-      "errorWithCode": "错误 ({{code}})",
+      "errorWithCode": "质量检测遇到问题",
       "loadingJudgeStatus": "加载评判状态...",
       "judgeStatusUnavailable": "评判状态不可用",
       "judgeModelLabel": "评判模型：",


### PR DESCRIPTION
## 变更说明

清除 locale 文件中泄露的技术错误码前缀和裸 `{{code}}` 插值。用户看到的错误文案应为人话描述，而非内部码。

### 具体修改

| 文件 | 变更 |
|------|------|
| `zh-CN.json` | `export.error.noProject` 移除 `NO_PROJECT:` 前缀 |
| `en.json` | `export.error.noProject` 移除 `NO_PROJECT:` 前缀 |
| `zh-CN.json` | `rightPanel.quality.errorWithCode` → `质量检测遇到问题` |
| `en.json` | `rightPanel.quality.errorWithCode` → `Quality check encountered an issue` |
| `QualityPanel.tsx` | 移除 `t()` 中的 `{ code }` 参数传递 |

### 验证证据

- 12 条新测试全通过（`i18n-error-copy-cleanup.test.ts`）
- Python 扫描确认两个 locale 文件零技术码泄露
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)

### 回滚点

还原 4 个 i18n value + 1 处组件代码即可回退。

Closes #989