### PR TITLE
fix(ui): 占位 UI 收口（A0-15）

### DIFF
--- a/apps/desktop/renderer/src/__tests__/placeholder-ui-closure.test.ts
+++ b/apps/desktop/renderer/src/__tests__/placeholder-ui-closure.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A0-15: 占位 UI 收口
+ *
+ * 验证：
+ * - 禁用按钮有 aria-disabled
+ * - "View More" / "Search All Projects" 已移除
+ * - ChatHistory 不含 console.info
+ * - common.comingSoon / common.featureInDevelopment i18n key 存在
+ */
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const RENDERER_SRC = resolve(CURRENT_DIR, "..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(RENDERER_SRC, relativePath), "utf-8");
+}
+
+function loadLocale(lang: string): Record<string, unknown> {
+  const raw = readFileSync(
+    resolve(RENDERER_SRC, `i18n/locales/${lang}.json`),
+    "utf-8",
+  );
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("A0-15: placeholder UI closure", () => {
+  describe("i18n common namespace", () => {
+    for (const lang of ["zh-CN", "en"]) {
+      it(`${lang} 包含 common.comingSoon key`, () => {
+        const data = loadLocale(lang);
+        const common = data["common"] as Record<string, string> | undefined;
+        expect(common).toBeDefined();
+        expect(common!["comingSoon"]).toBeDefined();
+        expect(typeof common!["comingSoon"]).toBe("string");
+        expect(common!["comingSoon"].length).toBeGreaterThan(0);
+      });
+
+      it(`${lang} 包含 common.featureInDevelopment key`, () => {
+        const data = loadLocale(lang);
+        const common = data["common"] as Record<string, string> | undefined;
+        expect(common).toBeDefined();
+        expect(common!["featureInDevelopment"]).toBeDefined();
+        expect(typeof common!["featureInDevelopment"]).toBe("string");
+        expect(common!["featureInDevelopment"].length).toBeGreaterThan(0);
+      });
+    }
+  });
+
+  describe("SearchPanel: noisy links removed", () => {
+    it("不渲染 searchAllProjects 按钮", () => {
+      const source = readSource("features/search/SearchPanel.tsx");
+      expect(source).not.toContain("searchAllProjects");
+    });
+
+    it("不渲染 viewMore 按钮", () => {
+      const source = readSource("features/search/SearchPanel.tsx");
+      expect(source).not.toContain("results.viewMore");
+    });
+  });
+
+  describe("ChatHistory: 无 console.info 泄露", () => {
+    it("RightPanel onSelectChat 不含 console.info", () => {
+      const source = readSource("components/layout/RightPanel.tsx");
+      // Check that the ChatHistory onSelectChat handler doesn't use console.info
+      const onSelectChatBlock = source.slice(
+        source.indexOf("onSelectChat"),
+        source.indexOf("onSelectChat") + 300,
+      );
+      expect(onSelectChatBlock).not.toContain("console.info");
+    });
+  });
+
+  describe("SettingsAccount: 禁用按钮有 aria-disabled", () => {
+    it("SettingsAccount 包含 aria-disabled=\"true\"", () => {
+      const source = readSource(
+        "features/settings-dialog/SettingsAccount.tsx",
+      );
+      expect(source).toContain('aria-disabled="true"');
+    });
+
+    it("SettingsAccount 包含 Tooltip 包裹", () => {
+      const source = readSource(
+        "features/settings-dialog/SettingsAccount.tsx",
+      );
+      expect(source).toContain("Tooltip");
+      expect(source).toContain("featureInDevelopment");
+    });
+  });
+
+  describe("VersionHistoryPanel: Restore 按钮已禁用", () => {
+    it("VersionCard 中 Restore 按钮包含 disabled 属性", () => {
+      const source = readSource(
+        "features/version-history/VersionHistoryPanel.tsx",
+      );
+      // The selected version card restore button should be disabled
+      const restoreSection = source.slice(
+        source.indexOf('versionHistory.panel.restore') - 200,
+        source.indexOf('versionHistory.panel.restore') + 50,
+      );
+      expect(restoreSection).toContain("disabled");
+    });
+  });
+});

--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -195,12 +195,8 @@ export function RightPanel(props: {
               <ChatHistory
                 open={aiHistoryOpen}
                 onOpenChange={setAiHistoryOpen}
-                onSelectChat={(chatId) => {
+                onSelectChat={(_chatId) => {
                   setAiHistoryOpen(false);
-                  // TODO: Load chat by ID when chat persistence is implemented (P1 scope)
-                  console.info(
-                    `[ChatHistory] select chat: ${chatId} — chat persistence not yet available`,
-                  );
                 }}
               />
             </div>

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -10,7 +10,7 @@ import { Toggle } from "../../components/primitives/Toggle";
 import { useFileStore } from "../../stores/fileStore";
 import { useSearchStore, type SearchStatus } from "../../stores/searchStore";
 
-import { ArrowRight, ChevronDown, ChevronUp, CornerDownLeft, FileText, Folder, Frown, Globe, Lightbulb, RefreshCw, Search, Share2, Sparkles, TriangleAlert, X } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp, CornerDownLeft, FileText, Folder, Frown, Lightbulb, RefreshCw, Search, Share2, Sparkles, TriangleAlert, X } from "lucide-react";
 /**
  * Search category filter options.
  */
@@ -437,13 +437,7 @@ function SearchResultsArea(props: {
             {t("search.suggestionsText")}
           </p>
         </div>
-        <Button
-          variant="primary"
-          className="mt-6 !px-4 !py-2 !h-auto !bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] !text-sm !font-medium !rounded-lg hover:!bg-[var(--color-info)] hover:!brightness-110"
-        >
-          <Globe className="w-4 h-4" size={16} strokeWidth={1.5} />
-          {t("search.searchAllProjects")}
-        </Button>
+
         <Button
           variant="ghost"
           onClick={props.onClearQuery}
@@ -515,16 +509,7 @@ function SearchResultsArea(props: {
           </ResultGroup>
         )}
 
-      {props.totalResults > 5 && (
-        <div className="p-2 text-center border-t border-[var(--color-separator)] mt-2">
-          <Button
-            variant="ghost"
-            className="!text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-info)] !py-2 w-full !h-auto"
-          >
-            {t("search.results.viewMore", { count: props.totalResults - 5 })}
-          </Button>
-        </div>
-      )}
+
     </>
   );
 }

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Avatar, Button, Text } from "../../components/primitives";
+import { Tooltip } from "../../components/primitives/Tooltip";
 
 /**
  * Subscription plan types
@@ -161,14 +162,18 @@ export function SettingsAccount({
 
           <div className="flex gap-3">
             {account.plan === "free" && (
-              <Button variant="primary" size="sm" onClick={onUpgrade} disabled>
-                {t('settingsDialog.account.upgradeToPro')}
-              </Button>
+              <Tooltip content={t('common.featureInDevelopment')}>
+                <Button variant="primary" size="sm" onClick={onUpgrade} disabled aria-disabled="true">
+                  {t('settingsDialog.account.upgradeToPro')}
+                </Button>
+              </Tooltip>
             )}
             {account.plan !== "free" && (
-              <Button variant="secondary" size="sm" disabled>
-                {t('settingsDialog.account.manageSubscription')}
-              </Button>
+              <Tooltip content={t('common.featureInDevelopment')}>
+                <Button variant="secondary" size="sm" disabled aria-disabled="true">
+                  {t('settingsDialog.account.manageSubscription')}
+                </Button>
+              </Tooltip>
             )}
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
@@ -193,14 +198,17 @@ export function SettingsAccount({
                 {t('settingsDialog.account.deleteAccountDescription')}
               </Text>
             </div>
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={onDeleteAccount}
-              disabled
-            >
-              {t('settingsDialog.account.deleteAccount')}
-            </Button>
+            <Tooltip content={t('common.featureInDevelopment')}>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={onDeleteAccount}
+                disabled
+                aria-disabled="true"
+              >
+                {t('settingsDialog.account.deleteAccount')}
+              </Button>
+            </Tooltip>
           </div>
           <Text size="small" color="muted" as="p" className="mt-3">
             {t('settingsDialog.account.comingSoon')}

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -339,7 +339,7 @@ function WordChangeBadge({ change }: { change: WordChange }) {
  */
 function HoverActions({
   versionId,
-  onRestore,
+  onRestore: _onRestore,
   onCompare,
   onPreview,
 }: {
@@ -372,8 +372,9 @@ function HoverActions({
       <Tooltip content="Restore">
         <button
           type="button"
-          onClick={() => onRestore?.(versionId)}
-          className="focus-ring p-1.5 rounded-md hover:bg-[var(--color-bg-overlay)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+          disabled
+          aria-disabled="true"
+          className="focus-ring p-1.5 rounded-md text-[var(--color-fg-muted)] opacity-50 cursor-not-allowed transition-colors"
         >
           <RestoreIcon />
         </button>
@@ -468,8 +469,9 @@ function VersionCard({
           <Button
             variant="secondary"
             size="sm"
-            onClick={() => onRestore?.(version.id)}
-            className="!h-7 !text-[10px] !px-0 !bg-[var(--color-bg-active)] hover:!bg-[var(--color-bg-selected)]"
+            disabled
+            aria-disabled="true"
+            className="!h-7 !text-[10px] !px-0 !bg-[var(--color-bg-active)] opacity-50 cursor-not-allowed"
           >
             {t("versionHistory.panel.restore")}
           </Button>

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -879,7 +879,7 @@
       "writingExperience": "Writing Experience",
       "dataAndStorage": "Data & Storage",
       "editorDefaults": "Editor Defaults",
-      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra \u201c{{marker}}\u201d marker."
+      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra “{{marker}}” marker."
     },
     "appearance": {
       "colorWhite": "White",
@@ -1463,5 +1463,9 @@
       "VERSION_ROLLBACK_CONFLICT": "Version rollback conflict.",
       "VERSION_SNAPSHOT_COMPACTED": "Version snapshot has been compacted."
     }
+  },
+  "common": {
+    "comingSoon": "Coming Soon",
+    "featureInDevelopment": "This feature is under development"
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -879,7 +879,7 @@
       "writingExperience": "写作体验",
       "dataAndStorage": "数据与存储",
       "editorDefaults": "编辑器默认值",
-      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的\u201c{{marker}}\u201d标记。"
+      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的“{{marker}}”标记。"
     },
     "appearance": {
       "colorWhite": "白色",
@@ -1463,5 +1463,9 @@
       "VERSION_ROLLBACK_CONFLICT": "版本回滚冲突",
       "VERSION_SNAPSHOT_COMPACTED": "版本快照已压缩"
     }
+  },
+  "common": {
+    "comingSoon": "即将推出",
+    "featureInDevelopment": "功能正在开发中"
   }
 }


### PR DESCRIPTION
## 变更说明

收口未实现功能入口：禁用按钮配 Tooltip 提示、移除空链接、消除 console 日志泄露。

### 具体修改

| 组件 | 变更 |
|------|------|
| SettingsAccount | 3 个禁用按钮包裹 `<Tooltip>` + `aria-disabled` |
| SearchPanel | 移除无 `onClick` 的 View More / Search All Projects 按钮 |
| RightPanel | ChatHistory `onSelectChat` 移除 `console.info` |
| VersionHistoryPanel | Restore 按钮标记 `disabled` + `aria-disabled` |
| i18n | 新增 `common.comingSoon` / `common.featureInDevelopment` (zh-CN/en) |

### 验证证据

- 10 条新测试全通过
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)

### 回滚点

还原 7 个文件即可回退。

Closes #995