### PR TITLE
feat(skill-router): A0-05 否定语境守卫 — isNegated + 双重否定 + 37 测试

### DIFF
--- a/apps/desktop/main/src/services/skills/__tests__/skillRouter.negation.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skillRouter.negation.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+
+import { inferSkillFromInput, isNegated } from "../skillRouter";
+
+// ─── S-NEG-1: 中文"不要 + 关键词"否定路由到 chat ───
+
+describe("isNegated — 中文否定词检测", () => {
+  it("'不要续写' — 不要 negates 续写", () => {
+    const input = "不要续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("'别帮我扩写' — 别 negates 扩写", () => {
+    const input = "别帮我扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(true);
+  });
+
+  it("'不想让你翻译' — 不想 negates 翻译", () => {
+    const input = "不想让你翻译";
+    expect(isNegated(input, input.indexOf("翻译"), "翻译")).toBe(true);
+  });
+
+  it("'不用总结了' — 不用 negates 总结", () => {
+    const input = "不用总结了";
+    expect(isNegated(input, input.indexOf("总结"), "总结")).toBe(true);
+  });
+
+  it("'不需要续写' — 不需要 negates 续写", () => {
+    const input = "不需要续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("'停止续写' — 停止 negates 续写", () => {
+    const input = "停止续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("'禁止扩写' — 禁止 negates 扩写", () => {
+    const input = "禁止扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(true);
+  });
+
+  it("'取消翻译' — 取消 negates 翻译", () => {
+    const input = "取消翻译";
+    expect(isNegated(input, input.indexOf("翻译"), "翻译")).toBe(true);
+  });
+
+  it("'不必续写' — 不必 negates 续写", () => {
+    const input = "不必续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(true);
+  });
+
+  it("'无需总结' — 无需 negates 总结", () => {
+    const input = "无需总结";
+    expect(isNegated(input, input.indexOf("总结"), "总结")).toBe(true);
+  });
+});
+
+// ─── S-NEG-3: 英文否定词检测 ───
+
+describe("isNegated — 英文否定词检测", () => {
+  it("'don't continue writing' negates continue writing", () => {
+    const input = "don't continue writing";
+    expect(isNegated(input, input.indexOf("continue writing"), "continue writing")).toBe(true);
+  });
+
+  it("'do not expand this' negates expand", () => {
+    const input = "do not expand this";
+    expect(isNegated(input, input.indexOf("expand"), "expand")).toBe(true);
+  });
+
+  it("'stop summarize' negates summarize", () => {
+    const input = "stop summarize";
+    expect(isNegated(input, input.indexOf("summarize"), "summarize")).toBe(true);
+  });
+
+  it("'never translate this' negates translate", () => {
+    const input = "never translate this";
+    expect(isNegated(input, input.indexOf("translate"), "translate")).toBe(true);
+  });
+
+  it("'no expand please' negates expand", () => {
+    const input = "no expand please";
+    expect(isNegated(input, input.indexOf("expand"), "expand")).toBe(true);
+  });
+
+  it("'cancel rewrite' negates rewrite", () => {
+    const input = "cancel rewrite";
+    expect(isNegated(input, input.indexOf("rewrite"), "rewrite")).toBe(true);
+  });
+});
+
+// ─── S-NEG-4: 双重否定恢复正向意图 ───
+
+describe("isNegated — 双重否定 = 正向", () => {
+  it("'不是不想续写' — 双重否定 → false", () => {
+    const input = "不是不想续写";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(false);
+  });
+
+  it("'并非不要扩写' — 双重否定 → false", () => {
+    const input = "并非不要扩写";
+    expect(isNegated(input, input.indexOf("扩写"), "扩写")).toBe(false);
+  });
+
+  it("'不是不要翻译' — 双重否定 → false", () => {
+    const input = "不是不要翻译";
+    expect(isNegated(input, input.indexOf("翻译"), "翻译")).toBe(false);
+  });
+
+  it("'并非不想总结' — 双重否定 → false", () => {
+    const input = "并非不想总结";
+    expect(isNegated(input, input.indexOf("总结"), "总结")).toBe(false);
+  });
+});
+
+// ─── S-NEG-5: 正向关键词无否定前缀 → 不被否定 ───
+
+describe("isNegated — 正向输入不误判", () => {
+  it("'帮我续写这个段落' — 无否定 → false", () => {
+    const input = "帮我续写这个段落";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(false);
+  });
+
+  it("'请帮我翻译' — 无否定 → false", () => {
+    const input = "请帮我翻译";
+    expect(isNegated(input, input.indexOf("翻译"), "翻译")).toBe(false);
+  });
+
+  it("'expand this paragraph' — no negation → false", () => {
+    const input = "expand this paragraph";
+    expect(isNegated(input, input.indexOf("expand"), "expand")).toBe(false);
+  });
+});
+
+// ─── S-NEG-6: 否定词超出检测窗口 ───
+
+describe("isNegated — 否定词超出窗口不触发", () => {
+  it("'我不喜欢上次的结果，这次请帮我续写得更好一些' — 不 距离续写太远", () => {
+    const input = "我不喜欢上次的结果，这次请帮我续写得更好一些";
+    expect(isNegated(input, input.indexOf("续写"), "续写")).toBe(false);
+  });
+
+  it("'I said no earlier but please expand this now' — no is far from expand", () => {
+    const input = "I said no earlier but please expand this now";
+    expect(isNegated(input, input.indexOf("expand"), "expand")).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════
+// inferSkillFromInput 集成测试 — 否定场景
+// ═══════════════════════════════════════════════════
+
+describe("inferSkillFromInput — 否定场景路由到 chat", () => {
+  // S-NEG-1
+  it("'不要续写，我想自己写' → chat", () => {
+    expect(
+      inferSkillFromInput({ input: "不要续写，我想自己写", hasSelection: false }),
+    ).toBe("builtin:chat");
+  });
+
+  // S-NEG-2
+  it("'别帮我扩写这段' + hasSelection → chat", () => {
+    expect(
+      inferSkillFromInput({ input: "别帮我扩写这段", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+
+  // S-NEG-3
+  it("'don't continue writing this' → chat", () => {
+    expect(
+      inferSkillFromInput({ input: "don't continue writing this", hasSelection: false }),
+    ).toBe("builtin:chat");
+  });
+
+  // S-NEG-7: REWRITE_KEYWORDS 路径
+  it("'不用改写' + hasSelection → chat（rewrite 路径受保护）", () => {
+    expect(
+      inferSkillFromInput({ input: "不用改写", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+
+  it("'不用改' + hasSelection → chat（短改写指令 + 否定）", () => {
+    expect(
+      inferSkillFromInput({ input: "不用改", hasSelection: true }),
+    ).toBe("builtin:chat");
+  });
+
+  // S-NEG-8: 显式覆盖不受否定守卫影响
+  it("'不要续写' + explicitSkillId → 显式覆盖优先", () => {
+    expect(
+      inferSkillFromInput({
+        input: "不要续写",
+        hasSelection: false,
+        explicitSkillId: "builtin:continue",
+      }),
+    ).toBe("builtin:continue");
+  });
+});
+
+describe("inferSkillFromInput — 双重否定恢复正向", () => {
+  // S-NEG-4
+  it("'不是不想续写，请帮我续写后面的内容' → continue", () => {
+    expect(
+      inferSkillFromInput({
+        input: "不是不想续写，请帮我续写后面的内容",
+        hasSelection: false,
+      }),
+    ).toBe("builtin:continue");
+  });
+});
+
+describe("inferSkillFromInput — 正向匹配回归", () => {
+  // S-NEG-5
+  it("'帮我续写这个段落' → continue", () => {
+    expect(
+      inferSkillFromInput({ input: "帮我续写这个段落", hasSelection: false }),
+    ).toBe("builtin:continue");
+  });
+
+  it("'头脑风暴一下' → brainstorm", () => {
+    expect(
+      inferSkillFromInput({ input: "头脑风暴一下", hasSelection: false }),
+    ).toBe("builtin:brainstorm");
+  });
+
+  it("'请写下去' → continue", () => {
+    expect(
+      inferSkillFromInput({ input: "请写下去", hasSelection: false }),
+    ).toBe("builtin:continue");
+  });
+
+  it("empty input + hasSelection → polish", () => {
+    expect(
+      inferSkillFromInput({ input: "", hasSelection: true }),
+    ).toBe("builtin:polish");
+  });
+
+  // S-NEG-6: 否定词超出窗口 → 正常匹配
+  it("'我不喜欢上次的结果，这次请帮我续写得更好一些' → continue（窗口外否定）", () => {
+    expect(
+      inferSkillFromInput({
+        input: "我不喜欢上次的结果，这次请帮我续写得更好一些",
+        hasSelection: false,
+      }),
+    ).toBe("builtin:continue");
+  });
+});

--- a/apps/desktop/main/src/services/skills/skillRouter.ts
+++ b/apps/desktop/main/src/services/skills/skillRouter.ts
@@ -54,6 +54,72 @@ const REWRITE_KEYWORDS: readonly string[] = [
   "改", "重写", "改写", "rewrite", "修改",
 ];
 
+// ─── 否定语境守卫 ───
+
+const CN_NEGATION_WORDS: readonly string[] = [
+  "不需要", "不想", "不要", "不用", "不必", "无需",
+  "停止", "取消", "禁止", "别",
+];
+
+const EN_NEGATION_WORDS: readonly string[] = [
+  "don't", "do not", "stop", "never", "cancel", "without", "not ", "no ",
+];
+
+const CN_DOUBLE_NEGATION_PREFIXES: readonly string[] = [
+  "不是不想", "不是不要", "并非不要", "并非不想",
+];
+
+/** 否定检测窗口：关键词前方 N 个字符 */
+const CN_WINDOW = 6;
+const EN_WINDOW = 12;
+
+/**
+ * 判断 input 中位于 keywordIndex 的 keyword 是否被否定修饰。
+ * 规则：在关键词前方窗口内搜索否定词；若命中再检查双重否定。
+ */
+export function isNegated(
+  input: string,
+  keywordIndex: number,
+  _keyword: string,
+): boolean {
+  const windowStart = Math.max(0, keywordIndex - Math.max(CN_WINDOW, EN_WINDOW));
+  const prefix = input.slice(windowStart, keywordIndex);
+
+  // 先检查双重否定（优先级高于单否定）
+  for (const dp of CN_DOUBLE_NEGATION_PREFIXES) {
+    if (prefix.includes(dp)) {
+      return false;
+    }
+  }
+
+  // 中文否定词——使用中文窗口
+  const cnStart = Math.max(0, keywordIndex - CN_WINDOW);
+  const cnPrefix = input.slice(cnStart, keywordIndex);
+  for (const neg of CN_NEGATION_WORDS) {
+    if (cnPrefix.includes(neg)) {
+      return true;
+    }
+  }
+
+  // 英文否定词——使用英文窗口
+  const enStart = Math.max(0, keywordIndex - EN_WINDOW);
+  const enPrefix = input.slice(enStart, keywordIndex).toLowerCase();
+  for (const neg of EN_NEGATION_WORDS) {
+    if (enPrefix.includes(neg)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** 检查 input 是否包含 keyword，且该 keyword 未被否定修饰 */
+function matchesKeyword(input: string, keyword: string): boolean {
+  const idx = input.indexOf(keyword);
+  if (idx === -1) return false;
+  return !isNegated(input, idx, keyword);
+}
+
 export function inferSkillFromInput(args: InferSkillArgs): string {
   // 1. Explicit override
   if (args.explicitSkillId?.trim()) {
@@ -68,7 +134,7 @@ export function inferSkillFromInput(args: InferSkillArgs): string {
       return "builtin:polish";
     }
 
-    const isRewriteIntent = REWRITE_KEYWORDS.some((kw) => input.includes(kw));
+    const isRewriteIntent = REWRITE_KEYWORDS.some((kw) => matchesKeyword(input, kw));
     if (isRewriteIntent && input.length < 20) {
       return "builtin:rewrite";
     }
@@ -76,7 +142,7 @@ export function inferSkillFromInput(args: InferSkillArgs): string {
 
   // 3. Keyword matching
   for (const rule of KEYWORD_RULES) {
-    if (rule.keywords.some((kw) => input.includes(kw))) {
+    if (rule.keywords.some((kw) => matchesKeyword(input, kw))) {
       return rule.skillId;
     }
   }


### PR DESCRIPTION
## Summary

Implement negation guard for `inferSkillFromInput` keyword routing.

Closes #987

## Changes

### `skillRouter.ts`
- Add `isNegated(input, keywordIndex, keyword)` exported function
- CN negation words: 不要/别/不想/不用/不需要/停止/取消/禁止/不必/无需
- EN negation words: don't/do not/stop/never/cancel/without/not/no
- Double negation patterns: 不是不想/不是不要/并非不要/并非不想 → 正向
- Detection window: CN 6 chars, EN 12 chars before keyword
- `matchesKeyword()` helper replaces raw `input.includes(kw)`
- Both `KEYWORD_RULES` and `REWRITE_KEYWORDS` paths protected
- Explicit override (`explicitSkillId`) unaffected

### `skillRouter.negation.test.ts` (new)
- 37 tests covering all 8 acceptance criteria (AC-1 through AC-8)
- Unit tests for `isNegated`: CN negation, EN negation, double negation, window boundary, positive input
- Integration tests for `inferSkillFromInput`: negation → chat, double negation → skill, rewrite path, explicit override

## Verification

| Check | Result |
|-------|--------|
| vitest (negation) | 37/37 ✅ |
| vitest (original skillRouter) | All pass ✅ |
| typecheck | ✅ |
| lint | 0 errors ✅ |

## Rollback

Revert commit `ad4787c8`. No schema or state changes.