### PR TITLE
feat(settings): A0-14 Settings General 持久化 — PreferenceStore 体系收口

### DIFF
--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsDialog.tsx
@@ -3,15 +3,19 @@ import { useTranslation } from "react-i18next";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 
 import { Button, Text } from "../../components/primitives";
+import { createPreferenceStore } from "../../lib/preferences";
 import { AnalyticsPageContent } from "../analytics/AnalyticsPage";
 import { AppearanceSection } from "../settings/AppearanceSection";
 import { AiSettingsSection } from "../settings/AiSettingsSection";
 import { JudgeSection } from "../settings/JudgeSection";
 import {
   SettingsGeneral,
-  defaultGeneralSettings,
   type GeneralSettings,
 } from "./SettingsGeneral";
+import {
+  loadGeneralSettings,
+  persistGeneralSetting,
+} from "./settingsGeneralPersistence";
 import {
   SettingsAccount,
   defaultAccountSettings,
@@ -168,8 +172,14 @@ export function SettingsDialog({
   const { showToast } = useAppToast();
   const navItems = getNavItems(t);
   const [activeTab, setActiveTab] = React.useState<SettingsTab>(defaultTab);
+
+  const preferences = React.useMemo(
+    () => createPreferenceStore(window.localStorage),
+    [],
+  );
+
   const [generalSettings, setGeneralSettings] = React.useState<GeneralSettings>(
-    defaultGeneralSettings,
+    () => loadGeneralSettings(preferences),
   );
   const [accountSettings] = React.useState<AccountSettings>(
     defaultAccountSettings,
@@ -178,8 +188,15 @@ export function SettingsDialog({
   const setShowAiMarks = useVersionPreferencesStore((s) => s.setShowAiMarks);
 
   const handleSettingsChange = React.useCallback((settings: GeneralSettings) => {
-    setGeneralSettings(settings);
-  }, []);
+    setGeneralSettings((prev) => {
+      for (const key of Object.keys(settings) as Array<keyof GeneralSettings>) {
+        if (settings[key] !== prev[key]) {
+          persistGeneralSetting(preferences, key, settings[key]);
+        }
+      }
+      return settings;
+    });
+  }, [preferences]);
 
   const handleShowAiMarksChange = React.useCallback(
     (enabled: boolean) => {

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -6,10 +6,6 @@ import { Slider } from "../../components/primitives/Slider";
 import { Select } from "../../components/primitives";
 import { FormField } from "../../components/composites/FormField";
 import { i18n } from "../../i18n";
-import {
-  getLanguagePreference,
-  setLanguagePreference,
-} from "../../i18n/languagePreference";
 
 /**
  * Settings state for General page
@@ -22,6 +18,7 @@ export interface GeneralSettings {
   backupInterval: string;
   defaultTypography: string;
   interfaceScale: number;
+  language: string;
 }
 
 /**
@@ -97,22 +94,17 @@ export function SettingsGeneral({
     { value: "en", label: "English" },
   ], [t]);
 
-  const [currentLanguage, setCurrentLanguage] = React.useState(
-    () => getLanguagePreference(),
-  );
-
-  const handleLanguageChange = React.useCallback((value: string) => {
-    setCurrentLanguage(value);
-    setLanguagePreference(value);
-    void i18n.changeLanguage(value);
-  }, []);
-
-  const updateSetting = <K extends keyof GeneralSettings>(
+  const updateSetting = React.useCallback(<K extends keyof GeneralSettings>(
     key: K,
     value: GeneralSettings[K],
   ) => {
     onSettingsChange({ ...settings, [key]: value });
-  };
+  }, [settings, onSettingsChange]);
+
+  const handleLanguageChange = React.useCallback((value: string) => {
+    updateSetting("language", value);
+    void i18n.changeLanguage(value);
+  }, [updateSetting]);
 
   return (
     <div className="max-w-[560px]">
@@ -130,7 +122,7 @@ export function SettingsGeneral({
         <FormField label={t('settings.general.displayLanguage')} htmlFor="display-language" help={t('settings.general.displayLanguageHelp')}>
           <Select
             options={languageOptions}
-            value={currentLanguage}
+            value={settings.language}
             onValueChange={handleLanguageChange}
             fullWidth
           />
@@ -252,4 +244,5 @@ export const defaultGeneralSettings: GeneralSettings = {
   backupInterval: "5min",
   defaultTypography: "inter",
   interfaceScale: 100,
+  language: "zh-CN",
 };

--- a/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.test.ts
+++ b/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  createPreferenceStore,
+  type PreferenceStore,
+} from "../../lib/preferences";
+import { defaultGeneralSettings } from "./SettingsGeneral";
+import {
+  loadGeneralSettings,
+  persistGeneralSetting,
+} from "./settingsGeneralPersistence";
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+describe("Settings General persistence", () => {
+  let storage: Storage;
+  let store: PreferenceStore;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+    store = createPreferenceStore(storage);
+  });
+
+  // ─── AC-3: 未持久化时使用默认值 ───
+
+  describe("loadGeneralSettings — 无持久化数据", () => {
+    it("返回 defaultGeneralSettings", () => {
+      const settings = loadGeneralSettings(store);
+      expect(settings).toEqual(defaultGeneralSettings);
+    });
+  });
+
+  // ─── AC-3: 已持久化值回读 ───
+
+  describe("loadGeneralSettings — 已有持久化数据", () => {
+    it("读取持久化的布尔值", () => {
+      store.set("creonow.settings.focusMode" as never, false);
+      store.set("creonow.settings.typewriterScroll" as never, true);
+      const settings = loadGeneralSettings(store);
+      expect(settings.focusMode).toBe(false);
+      expect(settings.typewriterScroll).toBe(true);
+    });
+
+    it("读取持久化的字符串值", () => {
+      store.set("creonow.settings.backupInterval" as never, "1hour");
+      store.set("creonow.settings.defaultTypography" as never, "merriweather");
+      const settings = loadGeneralSettings(store);
+      expect(settings.backupInterval).toBe("1hour");
+      expect(settings.defaultTypography).toBe("merriweather");
+    });
+
+    it("读取持久化的数值", () => {
+      store.set("creonow.settings.interfaceScale" as never, 120);
+      const settings = loadGeneralSettings(store);
+      expect(settings.interfaceScale).toBe(120);
+    });
+
+    it("读取持久化的语言值", () => {
+      store.set("creonow.settings.language" as never, "en");
+      const settings = loadGeneralSettings(store);
+      expect(settings.language).toBe("en");
+    });
+
+    it("部分持久化 + 部分缺失 → 混合", () => {
+      store.set("creonow.settings.focusMode" as never, false);
+      // 不设置其他键
+      const settings = loadGeneralSettings(store);
+      expect(settings.focusMode).toBe(false);
+      expect(settings.typewriterScroll).toBe(false); // default
+      expect(settings.smartPunctuation).toBe(true); // default
+    });
+  });
+
+  // ─── AC-4: 写入即时同步 ───
+
+  describe("persistGeneralSetting — 即时写入", () => {
+    it("布尔值写入后可读回", () => {
+      persistGeneralSetting(store, "focusMode", false);
+      expect(store.get("creonow.settings.focusMode" as never)).toBe(false);
+    });
+
+    it("字符串值写入后可读回", () => {
+      persistGeneralSetting(store, "backupInterval", "15min");
+      expect(store.get("creonow.settings.backupInterval" as never)).toBe("15min");
+    });
+
+    it("数值写入后可读回", () => {
+      persistGeneralSetting(store, "interfaceScale", 90);
+      expect(store.get("creonow.settings.interfaceScale" as never)).toBe(90);
+    });
+
+    it("语言写入后可读回", () => {
+      persistGeneralSetting(store, "language", "en");
+      expect(store.get("creonow.settings.language" as never)).toBe("en");
+    });
+  });
+
+  // ─── AC-5: 关闭后重新打开保持值 ───
+
+  describe("roundtrip — 写入 → 新 store 实例读取", () => {
+    it("全部设置 roundtrip 成功", () => {
+      persistGeneralSetting(store, "focusMode", false);
+      persistGeneralSetting(store, "typewriterScroll", true);
+      persistGeneralSetting(store, "smartPunctuation", false);
+      persistGeneralSetting(store, "localAutoSave", false);
+      persistGeneralSetting(store, "backupInterval", "1hour");
+      persistGeneralSetting(store, "defaultTypography", "jetbrains");
+      persistGeneralSetting(store, "interfaceScale", 80);
+      persistGeneralSetting(store, "language", "en");
+
+      // 模拟重新打开：用同一 storage 创建新 store
+      const store2 = createPreferenceStore(storage);
+      const loaded = loadGeneralSettings(store2);
+
+      expect(loaded).toEqual({
+        focusMode: false,
+        typewriterScroll: true,
+        smartPunctuation: false,
+        localAutoSave: false,
+        backupInterval: "1hour",
+        defaultTypography: "jetbrains",
+        interfaceScale: 80,
+        language: "en",
+      });
+    });
+  });
+
+  // ─── AC-7: 损坏 JSON 回退到默认值 ───
+
+  describe("loadGeneralSettings — 损坏数据", () => {
+    it("损坏的 JSON 回退到默认值", () => {
+      // 直接向 storage 写入非法 JSON
+      storage.setItem("creonow.settings.focusMode", "NOT_VALID_JSON{{{");
+      const settings = loadGeneralSettings(store);
+      // PreferenceStore 自动处理损坏值（removeItem + return null）
+      expect(settings.focusMode).toBe(defaultGeneralSettings.focusMode);
+    });
+  });
+
+  // ─── AC-1: PreferenceKey 包含 settings 键 ───
+
+  describe("PreferenceKey — settings 键可用", () => {
+    it("set/get creonow.settings.focusMode 成功", () => {
+      store.set("creonow.settings.focusMode" as never, true);
+      expect(store.get("creonow.settings.focusMode" as never)).toBe(true);
+    });
+
+    it("set/get creonow.settings.language 成功", () => {
+      store.set("creonow.settings.language" as never, "zh-CN");
+      expect(store.get("creonow.settings.language" as never)).toBe("zh-CN");
+    });
+  });
+});

--- a/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.ts
+++ b/apps/desktop/renderer/src/features/settings-dialog/settingsGeneralPersistence.ts
@@ -1,0 +1,43 @@
+import type { PreferenceStore, PreferenceKey } from "../../lib/preferences";
+import { defaultGeneralSettings, type GeneralSettings } from "./SettingsGeneral";
+
+type SettingsKeyName =
+  | "focusMode"
+  | "typewriterScroll"
+  | "smartPunctuation"
+  | "localAutoSave"
+  | "backupInterval"
+  | "defaultTypography"
+  | "interfaceScale"
+  | "language";
+
+function prefKey(name: SettingsKeyName): PreferenceKey {
+  return `creonow.settings.${name}` as PreferenceKey;
+}
+
+/**
+ * 从 PreferenceStore 加载 General 设置；缺失键回退到 defaultGeneralSettings。
+ */
+export function loadGeneralSettings(store: PreferenceStore): GeneralSettings {
+  return {
+    focusMode: store.get<boolean>(prefKey("focusMode")) ?? defaultGeneralSettings.focusMode,
+    typewriterScroll: store.get<boolean>(prefKey("typewriterScroll")) ?? defaultGeneralSettings.typewriterScroll,
+    smartPunctuation: store.get<boolean>(prefKey("smartPunctuation")) ?? defaultGeneralSettings.smartPunctuation,
+    localAutoSave: store.get<boolean>(prefKey("localAutoSave")) ?? defaultGeneralSettings.localAutoSave,
+    backupInterval: store.get<string>(prefKey("backupInterval")) ?? defaultGeneralSettings.backupInterval,
+    defaultTypography: store.get<string>(prefKey("defaultTypography")) ?? defaultGeneralSettings.defaultTypography,
+    interfaceScale: store.get<number>(prefKey("interfaceScale")) ?? defaultGeneralSettings.interfaceScale,
+    language: store.get<string>(prefKey("language")) ?? defaultGeneralSettings.language,
+  };
+}
+
+/**
+ * 持久化单个 General 设置项。
+ */
+export function persistGeneralSetting<K extends keyof GeneralSettings>(
+  store: PreferenceStore,
+  key: K,
+  value: GeneralSettings[K],
+): void {
+  store.set(prefKey(key as SettingsKeyName), value);
+}

--- a/apps/desktop/renderer/src/lib/preferences.ts
+++ b/apps/desktop/renderer/src/lib/preferences.ts
@@ -16,6 +16,15 @@ export type PreferenceKey =
   | `${typeof APP_ID}.theme.${"mode"}`
   | `${typeof APP_ID}.editor.${"showAiMarks"}`
   | `${typeof APP_ID}.onboarding.${"completed"}`
+  | `${typeof APP_ID}.settings.${
+      | "focusMode"
+      | "typewriterScroll"
+      | "smartPunctuation"
+      | "localAutoSave"
+      | "backupInterval"
+      | "defaultTypography"
+      | "interfaceScale"
+      | "language"}`
   | `${typeof APP_ID}.version`;
 
 export interface PreferenceStore {
@@ -47,7 +56,8 @@ function isCreonowKey(key: string): key is PreferenceKey {
     key.startsWith(`${APP_ID}.layout.`) ||
     key.startsWith(`${APP_ID}.theme.`) ||
     key.startsWith(`${APP_ID}.editor.`) ||
-    key.startsWith(`${APP_ID}.onboarding.`)
+    key.startsWith(`${APP_ID}.onboarding.`) ||
+    key.startsWith(`${APP_ID}.settings.`)
   );
 }
 


### PR DESCRIPTION
## Summary

Persist all General settings to PreferenceStore (localStorage). Settings now survive dialog close/reopen.

Closes #994

## Changes

### `preferences.ts`
- Extend `PreferenceKey` with 8 `creonow.settings.*` keys (focusMode, typewriterScroll, smartPunctuation, localAutoSave, backupInterval, defaultTypography, interfaceScale, language)
- Extend `isCreonowKey()` to recognize `creonow.settings.` prefix

### `SettingsGeneral.tsx`
- Add `language: string` to `GeneralSettings` interface and defaults
- Remove direct `getLanguagePreference`/`setLanguagePreference` imports
- Language now managed through unified `settings.language` prop
- `updateSetting` wrapped in `useCallback`

### `SettingsDialog.tsx`
- Init state from `loadGeneralSettings(preferences)` instead of hardcoded defaults
- `handleSettingsChange` persists changed keys via `persistGeneralSetting`

### `settingsGeneralPersistence.ts` (new)
- `loadGeneralSettings(store)`: read 8 keys, fallback to defaults
- `persistGeneralSetting(store, key, value)`: write single setting

### `settingsGeneralPersistence.test.ts` (new)
- 14 tests: load defaults, load persisted, write/read roundtrip, corrupted JSON fallback

## Verification

| Check | Result |
|-------|--------|
| Persistence tests | 14/14 ✅ |
| SettingsDialog tests | 6/6 ✅ |
| Language tests | 3/3 ✅ |
| Toast integration | 2/2 ✅ |
| typecheck | ✅ |
| lint | 0 errors ✅ |

## Rollback

Revert commit `e97b3292`. No migration needed — PreferenceStore keys are additive.