### PR TITLE
feat(renderer): 全局错误兜底 — unhandledrejection/error 捕获、Toast 去重、IPC 日志

### DIFF
--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -18,6 +18,7 @@ import { registerExportIpcHandlers } from "./ipc/export";
 import { registerJudgeIpcHandlers } from "./ipc/judge";
 import { registerKnowledgeGraphIpcHandlers } from "./ipc/knowledgeGraph";
 import { registerEmbeddingIpcHandlers } from "./ipc/embedding";
+import { registerLoggingIpcHandlers } from "./ipc/logging";
 import { registerMemoryIpcHandlers } from "./ipc/memory";
 import { registerProjectIpcHandlers } from "./ipc/project";
 import { registerRagIpcHandlers } from "./ipc/rag";
@@ -437,6 +438,11 @@ function registerIpcHandlers(deps: {
     ipcMain: guardedIpcMain,
     db: deps.db,
     logger: deps.logger,
+  });
+
+  registerLoggingIpcHandlers({
+    ipcMain: guardedIpcMain,
+    userDataDir: deps.userDataDir,
   });
 
   registerEmbeddingIpcHandlers({

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -889,6 +889,16 @@ export const ipcContract = {
         summary: STATS_SUMMARY_SCHEMA,
       }),
     },
+    "log:renderererror:write": {
+      request: s.object({
+        source: s.union(s.literal("unhandledrejection"), s.literal("error")),
+        name: s.string(),
+        message: s.string(),
+        stack: s.optional(s.string()),
+        timestamp: s.string(),
+      }),
+      response: s.object({}),
+    },
     "export:document:markdown": {
       request: s.object({
         projectId: s.string(),

--- a/apps/desktop/main/src/ipc/logging.ts
+++ b/apps/desktop/main/src/ipc/logging.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { IpcMain } from "electron";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+
+function getRendererErrorLogPath(userDataDir: string): string {
+  return path.join(userDataDir, "logs", "renderer-errors.log");
+}
+
+const MAX_LOG_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+function rotateIfNeeded(logPath: string): void {
+  try {
+    const stat = fs.statSync(logPath);
+    if (stat.size <= MAX_LOG_SIZE_BYTES) {
+      return;
+    }
+    const content = fs.readFileSync(logPath, "utf8");
+    const lines = content.split("\n");
+    const halfIndex = Math.floor(lines.length / 2);
+    fs.writeFileSync(logPath, lines.slice(halfIndex).join("\n"), "utf8");
+  } catch {
+    // Rotation failure is non-fatal
+  }
+}
+
+/**
+ * Register `log:renderererror:write` IPC handler.
+ *
+ * Why: renderer 全局未处理异常需要落盘到主进程日志，
+ * 以便在 DevTools 不可用时仍可追溯错误历史。
+ */
+export function registerLoggingIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  userDataDir: string;
+}): void {
+  deps.ipcMain.handle(
+    "log:renderererror:write",
+    async (
+      _event,
+      payload: {
+        source: "unhandledrejection" | "error";
+        name: string;
+        message: string;
+        stack?: string;
+        timestamp: string;
+      },
+    ): Promise<IpcResponse<Record<string, never>>> => {
+      try {
+        const logPath = getRendererErrorLogPath(deps.userDataDir);
+        fs.mkdirSync(path.dirname(logPath), { recursive: true });
+        rotateIfNeeded(logPath);
+        fs.appendFileSync(logPath, `${JSON.stringify(payload)}\n`, "utf8");
+        return { ok: true, data: {} };
+      } catch (err) {
+        console.error("renderer error log write failed", err);
+        return { ok: true, data: {} };
+      }
+    },
+  );
+}

--- a/apps/desktop/renderer/src/components/providers/ToastIntegrationBridge.tsx
+++ b/apps/desktop/renderer/src/components/providers/ToastIntegrationBridge.tsx
@@ -1,13 +1,23 @@
+import React from "react";
 import { useAutoSaveToast, useAiErrorToast } from "../../hooks/useToastIntegration";
+import { useAppToast } from "./AppToastProvider";
+import { bindGlobalErrorToast } from "../../lib/globalErrorToastBridge";
 
 /**
  * ToastIntegrationBridge — 无 UI 输出的桥接组件
  *
  * 在 App.tsx 中挂载于所有 Store Provider 和 AppToastProvider 内部，
  * 监听 editorStore / aiStore 状态变化并触发相应 Toast。
+ * 同时绑定全局错误兜底的 Toast 回调。
  */
 export function ToastIntegrationBridge(): null {
   useAutoSaveToast();
   useAiErrorToast();
+
+  const { showToast } = useAppToast();
+  React.useEffect(() => {
+    bindGlobalErrorToast(showToast);
+  }, [showToast]);
+
   return null;
 }

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1463,5 +1463,11 @@
       "VERSION_ROLLBACK_CONFLICT": "Version rollback conflict.",
       "VERSION_SNAPSHOT_COMPACTED": "Version snapshot has been compacted."
     }
+  },
+  "globalError": {
+    "toast": {
+      "title": "Unexpected system error",
+      "description": "Some features may be affected. Please retry the operation. If the problem persists, restart the app."
+    }
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1463,5 +1463,11 @@
       "VERSION_ROLLBACK_CONFLICT": "版本回滚冲突",
       "VERSION_SNAPSHOT_COMPACTED": "版本快照已压缩"
     }
+  },
+  "globalError": {
+    "toast": {
+      "title": "系统遇到意外问题",
+      "description": "部分功能可能受影响，请尝试重新操作。如问题持续，请重启应用。"
+    }
   }
 }

--- a/apps/desktop/renderer/src/lib/globalErrorHandlers.test.ts
+++ b/apps/desktop/renderer/src/lib/globalErrorHandlers.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  installGlobalErrorHandlers,
+  type GlobalErrorEntry,
+} from "./globalErrorHandlers";
+
+describe("installGlobalErrorHandlers", () => {
+  let onError: ReturnType<typeof vi.fn<(entry: GlobalErrorEntry) => void>>;
+  let onToast: ReturnType<typeof vi.fn<(entry: GlobalErrorEntry) => void>>;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onError = vi.fn();
+    onToast = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    vi.useRealTimers();
+  });
+
+  // ─── unhandledrejection 捕获 (AC-1, AC-2) ───
+
+  it("PromiseRejectionEvent(Error) → onError 收到 source='unhandledrejection'", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    const err = new Error("IPC timeout");
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: err,
+      }),
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    const entry: GlobalErrorEntry = onError.mock.calls[0][0];
+    expect(entry.source).toBe("unhandledrejection");
+    expect(entry.name).toBe("Error");
+    expect(entry.message).toBe("IPC timeout");
+    expect(entry.stack).toBeDefined();
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("PromiseRejectionEvent(非 Error) → name='UnknownError'", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: "raw rejection",
+      }),
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    const entry: GlobalErrorEntry = onError.mock.calls[0][0];
+    expect(entry.name).toBe("UnknownError");
+    expect(entry.message).toBe("raw rejection");
+  });
+
+  it("卸载后不再捕获 unhandledrejection", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+    cleanup();
+
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: new Error("after cleanup"),
+      }),
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  // ─── error 捕获 (AC-3) ───
+
+  it("ErrorEvent(TypeError) → onError 收到 source='error'", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    const err = new TypeError("Cannot read properties of undefined");
+    window.dispatchEvent(
+      new ErrorEvent("error", { error: err, message: err.message }),
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    const entry: GlobalErrorEntry = onError.mock.calls[0][0];
+    expect(entry.source).toBe("error");
+    expect(entry.name).toBe("TypeError");
+    expect(entry.message).toBe("Cannot read properties of undefined");
+  });
+
+  it("ErrorEvent(无 error 对象) → name='UnknownError'", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "Script error" }),
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    const entry: GlobalErrorEntry = onError.mock.calls[0][0];
+    expect(entry.name).toBe("UnknownError");
+    expect(entry.message).toBe("Script error");
+  });
+
+  it("卸载后不再捕获 error", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+    cleanup();
+
+    // Re-install a no-op listener to prevent jsdom from throwing
+    const noop = (e: ErrorEvent): void => {
+      e.preventDefault();
+    };
+    window.addEventListener("error", noop);
+    window.dispatchEvent(
+      new ErrorEvent("error", { error: new Error("after cleanup") }),
+    );
+    window.removeEventListener("error", noop);
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  // ─── Toast 去重 (AC-4, AC-5) ───
+
+  it("同一 name+message 1000ms 内触发 3 次 → onToast 仅调用 1 次", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    for (let i = 0; i < 3; i++) {
+      window.dispatchEvent(
+        new PromiseRejectionEvent("unhandledrejection", {
+          promise: Promise.resolve(),
+          reason: new Error("same error"),
+        }),
+      );
+    }
+
+    expect(onToast).toHaveBeenCalledOnce();
+  });
+
+  it("去重不影响日志 — 3 次触发 → onError 3 次", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    for (let i = 0; i < 3; i++) {
+      window.dispatchEvent(
+        new PromiseRejectionEvent("unhandledrejection", {
+          promise: Promise.resolve(),
+          reason: new Error("same error"),
+        }),
+      );
+    }
+
+    expect(onError).toHaveBeenCalledTimes(3);
+  });
+
+  it("冷却过期后可再次触发 onToast", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: new Error("same error"),
+      }),
+    );
+    expect(onToast).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1001);
+
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: new Error("same error"),
+      }),
+    );
+    expect(onToast).toHaveBeenCalledTimes(2);
+  });
+
+  it("不同 name+message 200ms 内各触发 1 次 → onToast 2 次", () => {
+    cleanup = installGlobalErrorHandlers({ onError, onToast });
+
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: new TypeError("error A"),
+      }),
+    );
+    vi.advanceTimersByTime(200);
+    window.dispatchEvent(
+      new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: new RangeError("error B"),
+      }),
+    );
+
+    expect(onToast).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/renderer/src/lib/globalErrorHandlers.ts
+++ b/apps/desktop/renderer/src/lib/globalErrorHandlers.ts
@@ -1,0 +1,88 @@
+/**
+ * 渲染进程全局未处理异常兜底。
+ *
+ * Why: 未被业务 .catch() / try-catch 捕获的 async rejection 和 runtime error
+ * 只会停留在 DevTools 控制台，用户毫无感知。此模块在 React 挂载前注册
+ * window 级监听器，确保这些遗漏的异常被拦截、通知用户、并落盘日志。
+ */
+
+export interface GlobalErrorEntry {
+  source: "unhandledrejection" | "error";
+  name: string;
+  message: string;
+  stack: string | undefined;
+  timestamp: string;
+}
+
+const DEDUP_WINDOW_MS = 1000;
+
+export function installGlobalErrorHandlers(options: {
+  onError: (entry: GlobalErrorEntry) => void;
+  onToast: (entry: GlobalErrorEntry) => void;
+}): () => void {
+  const dedupMap = new Map<string, number>();
+
+  function process(entry: GlobalErrorEntry): void {
+    options.onError(entry);
+
+    const key = `${entry.name}:${entry.message}`;
+    const now = Date.now();
+    const lastTime = dedupMap.get(key);
+    if (lastTime !== undefined && now - lastTime < DEDUP_WINDOW_MS) {
+      return;
+    }
+    dedupMap.set(key, now);
+    options.onToast(entry);
+  }
+
+  function onUnhandledRejection(event: PromiseRejectionEvent): void {
+    event.preventDefault();
+    const reason: unknown = event.reason;
+    const entry: GlobalErrorEntry =
+      reason instanceof Error
+        ? {
+            source: "unhandledrejection",
+            name: reason.name,
+            message: reason.message,
+            stack: reason.stack,
+            timestamp: new Date().toISOString(),
+          }
+        : {
+            source: "unhandledrejection",
+            name: "UnknownError",
+            message: String(reason),
+            stack: undefined,
+            timestamp: new Date().toISOString(),
+          };
+    process(entry);
+  }
+
+  function onError(event: ErrorEvent): void {
+    const err: unknown = event.error;
+    const entry: GlobalErrorEntry =
+      err instanceof Error
+        ? {
+            source: "error",
+            name: err.name,
+            message: err.message,
+            stack: err.stack,
+            timestamp: new Date().toISOString(),
+          }
+        : {
+            source: "error",
+            name: "UnknownError",
+            message: event.message || String(err),
+            stack: undefined,
+            timestamp: new Date().toISOString(),
+          };
+    process(entry);
+  }
+
+  window.addEventListener("unhandledrejection", onUnhandledRejection);
+  window.addEventListener("error", onError);
+
+  return () => {
+    window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    window.removeEventListener("error", onError);
+  };
+}

--- a/apps/desktop/renderer/src/lib/globalErrorToastBridge.ts
+++ b/apps/desktop/renderer/src/lib/globalErrorToastBridge.ts
@@ -1,0 +1,26 @@
+/**
+ * 全局错误兜底 Toast 桥接。
+ *
+ * Why: globalErrorHandlers 在 React 挂载前注册，但 Toast API 需要 React
+ * 上下文。此模块提供一个 mutable ref，由 React 层（ToastIntegrationBridge）
+ * 在挂载时绑定，由 main.tsx 的 onToast 回调在错误发生时调用。
+ */
+
+type ToastFn = (opts: {
+  title: string;
+  description: string;
+  variant: "error";
+}) => void;
+
+let toastRef: ToastFn | null = null;
+
+export function bindGlobalErrorToast(fn: ToastFn): void {
+  toastRef = fn;
+}
+
+export function fireGlobalErrorToast(opts: {
+  title: string;
+  description: string;
+}): void {
+  toastRef?.({ ...opts, variant: "error" });
+}

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -7,6 +7,36 @@ import { I18nextProvider } from "react-i18next";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/patterns";
 import { i18n } from "./i18n";
+import {
+  installGlobalErrorHandlers,
+  type GlobalErrorEntry,
+} from "./lib/globalErrorHandlers";
+import { fireGlobalErrorToast } from "./lib/globalErrorToastBridge";
+
+// ─── 全局错误兜底（AC-8: 在 ReactDOM.createRoot().render() 之前注册）───
+
+installGlobalErrorHandlers({
+  onError: (entry: GlobalErrorEntry) => {
+    const invoke = window.creonow?.invoke;
+    if (invoke) {
+      invoke("log:renderererror:write", {
+        source: entry.source,
+        name: entry.name,
+        message: entry.message,
+        stack: entry.stack,
+        timestamp: entry.timestamp,
+      }).catch((err: unknown) => {
+        console.error("Failed to log renderer error via IPC", err);
+      });
+    }
+  },
+  onToast: () => {
+    fireGlobalErrorToast({
+      title: i18n.t("globalError.toast.title"),
+      description: i18n.t("globalError.toast.description"),
+    });
+  },
+});
 
 // Signal that React app has mounted
 if (typeof window.__CN_E2E__ !== "object") {

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -196,6 +196,7 @@ export const IPC_CHANNELS = [
   "knowledge:rules:inject",
   "knowledge:suggestion:accept",
   "knowledge:suggestion:dismiss",
+  "log:renderererror:write",
   "memory:clear:all",
   "memory:clear:project",
   "memory:distill:progress",
@@ -1752,6 +1753,16 @@ export type IpcChannelSpec = {
     response: {
       dismissed: true;
     };
+  };
+  "log:renderererror:write": {
+    request: {
+      message: string;
+      name: string;
+      source: "unhandledrejection" | "error";
+      stack?: string;
+      timestamp: string;
+    };
+    response: Record<string, never>;
   };
   "memory:clear:all": {
     request: {

--- a/scripts/contract-generate.ts
+++ b/scripts/contract-generate.ts
@@ -58,6 +58,7 @@ const DOMAIN_REGISTRY: Readonly<Record<string, string>> = {
   file: "Document Management",
   judge: "AI Service",
   knowledge: "Knowledge Graph",
+  log: "Logging",
   memory: "Memory System",
   project: "Project Management",
   rag: "Search and Retrieval",


### PR DESCRIPTION
## 变更说明

渲染进程全局错误兜底机制，捕获所有未处理的 `unhandledrejection` 和 `error` 事件，通过 Toast 通知用户并通过 IPC 写入日志文件。

### 核心实现

- **`globalErrorHandlers.ts`**：`installGlobalErrorHandlers({ onError, onToast })`，在 `ReactDOM.createRoot().render()` 之前注册
  - `onError`：每次错误均调用（日志落盘，不去重）
  - `onToast`：1000ms 内同一 `name+message` 仅触发一次（Toast 去重）
  - 支持 Error 和非 Error rejection
  - 返回 cleanup 函数

- **`globalErrorToastBridge.ts`**：解耦 pre-React 注册与 React 上下文的 Toast 回调桥接

- **IPC `log:renderererror:write`**：新增 IPC 通道 + main 进程 JSON Lines 落盘（5MB 自动轮转）

- **i18n**：`globalError.toast.title/description`（zh-CN + en）

### 验证

- 10 项单元测试全部通过
- typecheck ✅
- lint 0 errors / 691 warnings ✅

### 回滚点

回滚 `main.tsx` 中 `installGlobalErrorHandlers()` 调用即可完全禁用该功能。

Closes #993