### PR TITLE
fix(judge): Judge 能力降级为规则引擎——方案 B 实施 (#997)

### DIFF
--- a/apps/desktop/main/src/services/judge/__tests__/judgeService.test.ts
+++ b/apps/desktop/main/src/services/judge/__tests__/judgeService.test.ts
@@ -39,7 +39,7 @@ async function runTests(): Promise<void> {
     assert.equal(svc.getState().status, "ready");
   }
 
-  // ── S3: ensure in non-E2E mode → returns MODEL_NOT_READY ──
+  // ── S3: ensure in non-E2E (rule-engine) mode → transitions to ready ──
   {
     const svc = createJudgeService({
       logger: createLogger(),
@@ -48,9 +48,10 @@ async function runTests(): Promise<void> {
 
     const result = await svc.ensure();
 
-    assert.equal(result.ok, false);
-    if (result.ok) throw new Error("unreachable");
-    assert.equal(result.error.code, "MODEL_NOT_READY");
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("unreachable");
+    assert.equal(result.data.status, "ready");
+    assert.equal(svc.getState().status, "ready");
   }
 
   console.log("judgeService.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/judge/judgeService.ts
+++ b/apps/desktop/main/src/services/judge/judgeService.ts
@@ -100,20 +100,22 @@ export function createJudgeService(deps: {
   }
 
   /**
-   * Ensure the judge model is available (real or degraded for E2E).
+   * Ensure the judge quality engine is available.
+   *
+   * Why: v0.1 uses a rule-based quality engine that is always ready.
+   * No model download needed — baseline rules (perspective mismatch,
+   * repetition detection) run deterministically in-process.
    */
   async function runEnsure(timeoutMs: number): Promise<ServiceResult<true>> {
-    if (!deps.isE2E) {
-      return ipcError(
-        "MODEL_NOT_READY",
-        "Judge model ensure is not implemented (non-E2E build)",
-      );
+    if (deps.isE2E) {
+      return await withTimeout(async () => {
+        await sleep(25);
+        return true as const;
+      }, timeoutMs);
     }
 
-    return await withTimeout(async () => {
-      await sleep(25);
-      return true as const;
-    }, timeoutMs);
+    // Rule engine is always ready — no model download required.
+    return { ok: true, data: true as const };
   }
 
   return {

--- a/apps/desktop/renderer/src/components/layout/__snapshots__/workbench.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/components/layout/__snapshots__/workbench.stories.snapshot.test.ts.snap
@@ -2295,7 +2295,7 @@ exports[`workbench stories snapshots > [WB-TEST-01] should cover icon bar + righ
             <h4
               class="font-[var(--font-family-ui)] text-[13px] font-medium leading-[1.4] tracking-normal text-[var(--color-fg-default)] mb-2 font-semibold text-[13px]"
             >
-              Judge Model
+              Quality Check
             </h4>
             <div
               class="rounded-[var(--radius-xl)] bg-[var(--color-bg-surface)] transition-all duration-[var(--duration-fast)] ease-[var(--ease-default)] border border-[var(--color-border-default)] p-6 p-3 rounded-[var(--radius-md)]"
@@ -2312,7 +2312,7 @@ exports[`workbench stories snapshots > [WB-TEST-01] should cover icon bar + righ
                   <span
                     class="text-xs leading-[1.4] font-normal font-[var(--font-family-ui)] text-[var(--color-fg-muted)]"
                   >
-                    Loading judge status...
+                    Loading quality check status...
                   </span>
                 </div>
               </div>

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -832,7 +832,7 @@
       "light": "Light"
     },
     "judge": {
-      "title": "Judge model",
+      "title": "Quality Check",
       "status": "Status:",
       "loading": "loading",
       "ensure": "Ensure"
@@ -904,12 +904,12 @@
       "navGeneral": "General",
       "navAppearance": "Appearance",
       "navAi": "AI",
-      "navJudge": "Judge",
+      "navJudge": "Quality",
       "navAnalytics": "Analytics",
       "navAccount": "Account",
       "title": "Settings",
       "close": "Close",
-      "description": "Configure application settings including appearance, AI, judge, and analytics."
+      "description": "Configure application settings including appearance, AI, quality check, and analytics."
     },
     "export": {
       "formatPdf": "PDF",
@@ -1284,9 +1284,9 @@
       "downloading": "Downloading...",
       "notReady": "Not ready",
       "errorWithCode": "Error ({{code}})",
-      "loadingJudgeStatus": "Loading judge status...",
-      "judgeStatusUnavailable": "Judge status unavailable",
-      "judgeModelLabel": "Judge Model:",
+      "loadingJudgeStatus": "Loading quality check status...",
+      "judgeStatusUnavailable": "Quality check unavailable",
+      "judgeModelLabel": "Quality Check:",
       "initialize": "Initialize",
       "retry": "Retry",
       "loadingConstraints": "Loading constraints...",
@@ -1295,8 +1295,8 @@
       "rulesCount_other": "{{count}} rules",
       "moreCount": "+{{count}} more",
       "systemGroup": "System",
-      "judgeModelCheck": "Judge Model",
-      "judgeModelDescription": "Local AI model for quality evaluation",
+      "judgeModelCheck": "Quality Check",
+      "judgeModelDescription": "Rule-based quality checks for writing",
       "available": "Available",
       "writingConstraints": "Writing Constraints",
       "activeConstraints": "Active Constraints",
@@ -1305,7 +1305,7 @@
       "rulesDefinedCount_other": "{{count}} rules defined",
       "panelTitle": "Quality",
       "noProjectSelected": "No project selected",
-      "judgeModelHeading": "Judge Model",
+      "judgeModelHeading": "Quality Check",
       "projectConstraints": "Project Constraints"
     }
   },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -832,7 +832,7 @@
       "light": "浅色"
     },
     "judge": {
-      "title": "评判模型",
+      "title": "质量检查",
       "status": "状态：",
       "loading": "加载中",
       "ensure": "确认"
@@ -904,12 +904,12 @@
       "navGeneral": "通用",
       "navAppearance": "外观",
       "navAi": "AI",
-      "navJudge": "评判",
+      "navJudge": "质量",
       "navAnalytics": "数据分析",
       "navAccount": "账户",
       "title": "设置",
       "close": "关闭",
-      "description": "配置应用设置，包括外观、AI、评判和数据分析。"
+      "description": "配置应用设置，包括外观、AI、质量检查和数据分析。"
     },
     "export": {
       "formatPdf": "PDF",
@@ -1284,9 +1284,9 @@
       "downloading": "下载中...",
       "notReady": "未就绪",
       "errorWithCode": "错误 ({{code}})",
-      "loadingJudgeStatus": "加载评判状态...",
-      "judgeStatusUnavailable": "评判状态不可用",
-      "judgeModelLabel": "评判模型：",
+      "loadingJudgeStatus": "加载质量检查状态...",
+      "judgeStatusUnavailable": "质量检查不可用",
+      "judgeModelLabel": "质量检查：",
       "initialize": "初始化",
       "retry": "重试",
       "loadingConstraints": "加载约束条件...",
@@ -1295,8 +1295,8 @@
       "rulesCount_other": "{{count}} 条规则",
       "moreCount": "+{{count}} 条",
       "systemGroup": "系统",
-      "judgeModelCheck": "评判模型",
-      "judgeModelDescription": "用于质量评估的本地 AI 模型",
+      "judgeModelCheck": "质量检查",
+      "judgeModelDescription": "基于规则的写作质量检查",
       "available": "可用",
       "writingConstraints": "写作约束",
       "activeConstraints": "活跃约束",
@@ -1305,7 +1305,7 @@
       "rulesDefinedCount_other": "已定义 {{count}} 条规则",
       "panelTitle": "质量",
       "noProjectSelected": "未选择项目",
-      "judgeModelHeading": "评判模型",
+      "judgeModelHeading": "质量检查",
       "projectConstraints": "项目约束"
     }
   },


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

Judge 能力降级决策实施（方案 B）：将 Judge 从"永远 MODEL_NOT_READY"的假功能转为"基于规则引擎的质量检查"——即开即用，零配置。

## 关联 Issue

- Closes #997

## 用户影响

- **之前**：用户点击"质量检查"按钮 → 永远看到"模型未就绪"（MODEL_NOT_READY），有入口无能力
- **之后**：规则引擎直接就绪（视角一致性检测 + 重复片段检测），点击即可获得基础质量反馈
- UI 文案从"Judge Model / 评判模型"更新为"Quality Check / 质量检查"，如实反映当前能力

## 不修最坏后果

- 用户持续面对"功能存在但无法使用"的假 UI，违反 P0-3 能力诚实原则
- QualityPanel 在 v0.1 发布时沦为欺骗性入口

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm lint` — 0 errors, 691 warnings（全部预存）
- [x] `pnpm --filter @creonow/desktop exec vitest run` — 270 files, 1853 tests passed
- [x] `pnpm --filter @creonow/desktop exec vitest run --config vitest.config.core.ts` — 10 files, 45 tests passed
- [x] `npx tsx judgeService.test.ts` — all assertions passed（含更新后的 S3）
- [x] 变更文件 Prettier 格式检查通过

## 回滚点

- 回滚 commit: `86a8d4d6`
- 回滚后恢复：`judgeService.ts` 的 `runEnsure()` 恢复 `MODEL_NOT_READY` stub，i18n 恢复 "Judge Model" 文案

## 非自动化检查（Tier 3）

- [x] **字体渲染**：i18n 文案变更仅涉及"Quality Check / 质量检查"等纯文本替换，无新字体引入
- [x] **品牌调性**：无新样式引入，仅文案更新，所有现有 Design Token 不变
- [x] **无障碍**：无 UI 结构变更，QualityPanel 的 aria 属性和 data-testid 不变
- [x] **CJK 场景**："质量检查"文案长度与"评判模型"相当，无截断风险
