### PR TITLE
docs(release): Windows 首发边界核查（re-impl） (#1000)

### DIFF
--- a/docs/release/v0.1-windows-boundary.md
+++ b/docs/release/v0.1-windows-boundary.md
@@ -2,141 +2,153 @@
 
 ## 一、核查概述
 
-| 项目 | 内容 |
-|------|------|
-| 核查目标 | 评估 CreoNow v0.1 在 Windows 平台的首发就绪状态 |
-| 核查日期 | 2026-03-09 |
-| 核查方法 | 静态代码搜索 + 配置文件审查 + CI 工作流分析 |
-| 核查范围 | 代码签名、自动更新、备份能力、崩溃可观测性、安装/卸载、路径处理 |
-| 核查分支 | `task/1000-a0-07-windows-release-boundary-audit` |
+| 项目       | 内容                                                             |
+| ---------- | ---------------------------------------------------------------- |
+| 核查目标   | 评估 CreoNow v0.1 在 Windows 平台的首发就绪状态                  |
+| 核查日期   | 2026-03-12（二次核查，基于 2026-03-09 初稿修订）                 |
+| 核查方法   | 静态代码搜索 + 配置文件审查 + CI 工作流分析                      |
+| 核查范围   | 代码签名、自动更新、备份能力、崩溃可观测性                       |
+| 核查分支   | `task/1000-a0-07-windows-release-boundary-audit`                 |
+| 关联 Issue | #1000                                                            |
+| 证据来源   | `docs/audit/amp/06-windows-release-readiness.md`、代码库静态搜索 |
+
+> **核查方法论**：对每个维度执行"配置文件审查 → 源码搜索 → CI 工作流验证"三步，所有结论附可复现的命令输出。就绪度仅授予有代码证据支撑的维度——"代码仓库里不存在"即为 ❌。
 
 ---
 
 ## 二、维度核查详情
 
-### 2.1 代码签名
+### 2.1 代码签名（Code Signing）
 
-**当前状态**：未配置。
+**当前状态**：❌ 未就绪——零配置、零流程。
 
 `electron-builder.json` 中无 `win.sign`、`win.certificateFile`、`win.certificatePassword` 等签名字段。CI 工作流 (`ci.yml`) 的 `windows-build` job 中无签名步骤、无 `CSC_LINK` / `CSC_KEY_PASSWORD` 环境变量注入。`package.json` 中无签名相关 scripts。
 
 **证据**：
 
 ```bash
-# electron-builder.json 签名配置搜索（无结果）
+# electron-builder.json 完整 win 配置——无任何签名字段
+$ cat apps/desktop/electron-builder.json
+{
+  "win": {
+    "target": [
+      { "target": "nsis", "arch": ["x64"] },
+      { "target": "zip", "arch": ["x64"] }
+    ]
+  }
+}
+
+# 签名配置搜索（无结果）
 $ grep -i "sign\|certificate\|csc" apps/desktop/electron-builder.json
 # (no matches)
 
 # CI 签名步骤搜索（无结果）
-$ grep -rn "sign\|certificate\|CSC_\|WIN_CSC" .github/workflows/
+$ grep -rni "sign\|certificate\|CSC_\|WIN_CSC" .github/workflows/
 # (no matches)
-
-# electron-builder.json 完整 win 配置：
-"win": {
-  "target": [
-    { "target": "nsis", "arch": ["x64"] },
-    { "target": "zip", "arch": ["x64"] }
-  ]
-}
 ```
 
-**就绪度标记**：❌ 未就绪
-
 **v0.1 处置建议**：
-- 未签名的 Windows 安装程序将触发 SmartScreen 警告，严重影响用户首次安装体验。
-- v0.1 发布文档中应诚实声明：「安装包未经代码签名，Windows SmartScreen 可能弹出安全警告」。
-- 方向性建议：v0.2 前购置 EV 代码签名证书并集成到 CI 签名流程。
+
+- 未签名安装包将触发 Windows SmartScreen 蓝色警告屏——对首发用户而言等于"开发者不可信"的第一印象。
+- **v0.1 发布文档须声明**：「安装包未经代码签名，Windows SmartScreen 可能弹出安全警告，请选择『仍要运行』继续安装」。
+- **方向性建议**：v0.2 前购置 EV 代码签名证书，集成到 CI `windows-build` job（`CSC_LINK` + `CSC_KEY_PASSWORD` secrets），消除 SmartScreen 拦截。
 
 ---
 
-### 2.2 自动更新
+### 2.2 自动更新（Auto-Update）
 
-**当前状态**：未配置。
+**当前状态**：❌ 未就绪——全链路缺失。
 
-`electron-builder.json` 中无 `publish` provider 配置。`package.json` 中无 `electron-updater` 依赖。主进程代码中无 `autoUpdater` / `checkForUpdates` 调用。无更新通知 IPC handler 或 UI。
+`electron-builder.json` 无 `publish` provider。`package.json` 无 `electron-updater` 依赖。主进程无 `autoUpdater` 代码。渲染进程无更新通知 UI。IPC 层无更新相关 handler。
 
 **证据**：
 
 ```bash
-# publish 配置搜索（无结果）
+# publish 配置（无结果）
 $ grep -i "publish" apps/desktop/electron-builder.json
 # (no matches)
 
-# electron-updater 依赖搜索（无结果）
+# electron-updater 依赖（无结果）
 $ grep "electron-updater" apps/desktop/package.json
 # (no dependency)
 
-# 主进程 autoUpdater 搜索（无结果）
-$ grep -rn "autoUpdater\|electron-updater\|checkForUpdate" apps/desktop/main/src/
-# (no autoUpdater code)
+# 主进程 autoUpdater / checkForUpdate（无结果）
+$ grep -rni "autoUpdater\|electron-updater\|checkForUpdate" apps/desktop/main/src/
+# (no matches)
 
-# 更新通知 IPC 搜索（无结果）
-$ grep -rn "update-available\|update-downloaded\|update.*notify" apps/desktop/ --include='*.ts' --include='*.tsx'
-# (no update IPC)
+# 更新通知 IPC / UI（无结果）
+$ grep -rni "update-available\|update-downloaded\|update.*notify" apps/desktop/ --include='*.ts' --include='*.tsx'
+# (no matches)
 ```
 
-**就绪度标记**：❌ 未就绪
-
 **v0.1 处置建议**：
-- v0.1 用户需手动下载新版本安装。
-- 发布文档应声明：「v0.1 不支持应用内自动更新，新版本需从官方渠道重新下载」。
-- 方向性建议：v0.2 接入 `electron-updater` + GitHub Releases 或自建 update feed。
+
+- v0.1 无应用内更新能力，用户须从官方渠道手动下载新版本覆盖安装。
+- **v0.1 发布文档须声明**：「v0.1 不支持应用内自动更新，新版本需从官方渠道重新下载安装」。
+- **方向性建议**：v0.2 接入 `electron-updater`，配置 `publish` provider（GitHub Releases 或自建 update feed），实现 check → download → notify → install 全链路。
 
 ---
 
-### 2.3 备份能力
+### 2.3 备份能力（Backup）
 
-**当前状态**：UI 已先行，后端能力未闭环。
+**当前状态**：❌ 未就绪——A0-08（#1035）正式结论确认为 **100% Phantom Feature**。
 
-设置界面 (`SettingsGeneral.tsx`) 已展示「备份间隔」选择器（5min / 10min / 15min / 30min 等选项），版本历史面板 (`VersionHistoryPanel`) 已有 auto-save 相关 UI。但备份调度的后端实现状态需由 A0-08（#1035）正式核查。
+设置界面 (`SettingsGeneral.tsx`) 展示了「备份间隔」选择器（5min / 15min / 1hour），版本历史面板显示"上次备份：2 分钟前"。然而 A0-08 核查（`openspec/changes/a0-08-backup-capability-decision/decision.md`）逐项证实：
+
+- **Q1**: UI Select 已渲染，但选择值仅停留在 React `useState`，对话框关闭即丢失。
+- **Q2**: 无 PreferenceStore 写入、无 localStorage 持久化、无 IPC 保存链路。
+- **Q3–Q10**: 后端无调度器、无快照引擎、无存储写入、无恢复链路——**零后端实现**。
 
 **证据**：
 
 ```bash
-# 设置 UI 中的备份间隔选项（存在）
+# UI 壳存在
 $ grep -n "backupInterval" apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
 # L22:  backupInterval: string;
 # L66:  const backupIntervalOptions = [
 # L190: <FormField label={t('settings.general.backupInterval')} ...>
-# L193: value={settings.backupInterval}
-# L252: backupInterval: "5min",
 
-# A0-08 正式核查结论（2026-03-08）：备份功能为 100% Phantom Feature
-# 仅有 UI Select 壳 + 硬编码假时间戳，零后端实现
-# Q1-Q10 完整核查见 openspec/changes/a0-08-backup-capability-decision/decision.md
+# A0-08 正式核查结论（2026-03-08）
+$ head -8 openspec/changes/a0-08-backup-capability-decision/decision.md
+# 核查结论: 备份功能为 100% 假功能（Phantom Feature）——仅有 UI 壳，零后端实现。
 
-# docs/release/ 目录此前不存在
-$ ls docs/release/
-# (目录为本次核查新建)
+# 后端 backup 相关代码搜索（无结果）
+$ grep -rni "backup.*schedule\|backup.*engine\|backup.*snapshot" apps/desktop/main/src/
+# (no matches)
 ```
 
-**就绪度标记**：❌ 未就绪——A0-08 正式结论确认备份功能为 100% Phantom Feature（仅有 UI 壳，零后端实现）
-
 **v0.1 处置建议**：
-- A0-08 结论为"后端完全未实现"，v0.1 必须隐藏备份间隔设置或移除相关 UI。
-- 发布文档应如实描述：备份功能不存在，"上次备份：2 分钟前"为硬编码假数据。
+
+- **必须**在 v0.1 发布前隐藏或移除备份间隔 UI，避免用户误以为数据有备份保护。
+- **v0.1 发布文档须声明**：「v0.1 不提供自动备份功能，请自行保管创作内容」。
+- **方向性建议**：视产品规划决定备份路径（本地定时快照 vs 云端同步），对应 A0-17（#996）后续跟进。
 
 ---
 
-### 2.4 崩溃可观测性
+### 2.4 崩溃可观测性（Crash Observability）
 
-**当前状态**：本地异常捕获已建立，外部上报管线缺失。
+**当前状态**：⚠️ 部分就绪——本地捕获已建立，远程上报管线缺失。
 
-**已覆盖范围**：
-- 主进程：`globalExceptionHandlers.ts`（121 行）注册 `uncaughtException` + `unhandledRejection` 监听，捕获后记录结构化日志、触发优雅退出（10s 超时保护）。已有完整测试覆盖。
-- 渲染进程：`ErrorBoundary` 组件捕获 React 渲染时崩溃，显示错误详情和重载按钮；`RegionErrorBoundary` 提供区域级隔离。
-- 异步任务：`fireAndForget.ts` 统一捕获 fire-and-forget 任务的 rejection。
+**已覆盖（本地保护层）**：
 
-**盲区**：
-- 无 Sentry / Bugsnag / Electron `crashReporter` 等外部上报接入。
-- `fireAndForget.ts` 仍有 `TODO(C9): wire to central telemetry once available`，当前仅输出到 console。
-- 崩溃日志未持久化到磁盘文件（主进程通过 `Logger` 写日志，但渲染进程仅 console）。
+| 层级     | 组件                                   | 覆盖范围                                                                                             |
+| -------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 主进程   | `globalExceptionHandlers.ts`（121 行） | `uncaughtException` + `unhandledRejection` → 结构化日志 + 优雅退出（10s 超时保护）；已有完整单元测试 |
+| 渲染进程 | `ErrorBoundary`                        | React 渲染时崩溃 → 错误详情 + 重载按钮                                                               |
+| 渲染进程 | `RegionErrorBoundary`                  | 区域级隔离，局部崩溃不影响全局                                                                       |
+| 异步任务 | `fireAndForget.ts`                     | 统一捕获 fire-and-forget 的 rejection                                                                |
+
+**盲区（远程上报层）**：
+
+- 无 Sentry / Bugsnag / Electron `crashReporter` 等外部上报服务接入。
+- `fireAndForget.ts` L35 仍标注 `TODO(C9): wire to central telemetry once available`，当前仅输出到 console。
+- 渲染进程崩溃日志未持久化到磁盘（主进程通过 `Logger` 写日志，渲染进程仅 console）。
 
 **证据**：
 
 ```bash
-# 主进程全局异常处理（已配置）
-$ grep -rn "uncaughtException\|unhandledRejection" apps/desktop/main/src/globalExceptionHandlers.ts
+# 主进程全局异常处理（已配置，121 行）
+$ grep -n "uncaughtException\|unhandledRejection" apps/desktop/main/src/globalExceptionHandlers.ts
 # L3:  type FatalEventSource = "uncaughtException" | "unhandledRejection";
 # L110: deps.processLike.on("uncaughtException", ...)
 # L114: deps.processLike.on("unhandledRejection", ...)
@@ -145,8 +157,12 @@ $ grep -rn "uncaughtException\|unhandledRejection" apps/desktop/main/src/globalE
 $ grep -rn "ErrorBoundary" apps/desktop/renderer/src/components/patterns/ErrorBoundary.tsx
 # L32: export class ErrorBoundary extends React.Component<...>
 
+# RegionErrorBoundary（区域级隔离）
+$ grep -n "RegionErrorBoundary" apps/desktop/renderer/src/components/patterns/RegionErrorBoundary.tsx
+# L16: export class RegionErrorBoundary extends React.Component<...>
+
 # 外部上报搜索（无结果）
-$ grep -rn "sentry\|bugsnag\|crashReporter" apps/desktop/ --include='*.ts' --include='*.tsx'
+$ grep -rni "sentry\|bugsnag\|crashReporter" apps/desktop/ --include='*.ts' --include='*.tsx'
 # (no crash reporting service)
 
 # telemetry TODO 仍存在
@@ -154,108 +170,22 @@ $ grep -n "TODO" apps/desktop/renderer/src/lib/fireAndForget.ts
 # L35: // TODO(C9): wire to central telemetry once available
 ```
 
-**就绪度标记**：⚠️ 部分就绪——本地捕获可用，外部上报缺失
-
 **v0.1 处置建议**：
-- v0.1 可依赖现有本地异常捕获保护用户体验（崩溃时优雅退出 + ErrorBoundary 隔离）。
-- 发布文档应声明：「v0.1 不包含自动崩溃上报，如遇问题请手动反馈」。
-- 方向性建议：v0.2 接入 Sentry 或自建 telemetry，补齐 `fireAndForget.ts` TODO。
 
----
-
-### 2.5 安装/卸载
-
-**当前状态**：基础 NSIS 安装已配置，无自定义卸载逻辑。
-
-`electron-builder.json` 配置了 NSIS 安装器（非一键安装，允许用户选择安装目录）和 zip 打包，均为 x64 架构。无自定义安装脚本、无卸载钩子、无开机自启配置。
-
-**证据**：
-
-```bash
-# electron-builder.json NSIS 配置
-"win": {
-  "target": [
-    { "target": "nsis", "arch": ["x64"] },
-    { "target": "zip", "arch": ["x64"] }
-  ]
-},
-"nsis": {
-  "oneClick": false,
-  "perMachine": false,
-  "allowToChangeInstallationDirectory": true
-}
-
-# CI windows-build job（ci.yml L366-L407）
-# 运行 `pnpm -C apps/desktop build:win` 产出 NSIS + zip 构建物
-# 构建物上传至 GitHub Actions artifact
-
-# package.json build:win 脚本
-$ grep -n "build:win" apps/desktop/package.json
-# L13: "build:win": "pnpm rebuild:native && pnpm build && electron-builder --win nsis zip --config electron-builder.json"
-```
-
-**就绪度标记**：⚠️ 部分就绪——可安装，但安装体验受未签名影响
-
-**v0.1 处置建议**：
-- NSIS 安装器功能可用，用户可正常安装/卸载。
-- 主要风险来自未签名导致的 SmartScreen 拦截（见 2.1 节）。
-- 卸载时不会自动清理 `%APPDATA%/CreoNow` 用户数据（electron-builder 默认行为）——如需清理应在文档中说明。
-
----
-
-### 2.6 路径处理
-
-**当前状态**：已采取平台兼容措施。
-
-代码库中广泛使用 Node.js `path` 模块的跨平台 API（`path.join`、`path.resolve`、`path.sep`），关键位置已做 Windows 反斜杠兼容处理。
-
-**证据**：
-
-```bash
-# runtimePathResolver.ts 使用 path.sep 检测路径标记
-$ grep -n "path.sep" apps/desktop/main/src/runtimePathResolver.ts
-# L13: const distMainMarker = `${path.sep}dist${path.sep}main`;
-# L14: const sourceMainMarker = `${path.sep}main${path.sep}src`;
-
-# contextFs.ts 反斜杠归一化
-$ grep -n 'split.*\\\\' apps/desktop/main/src/services/context/contextFs.ts
-# L213: const normalized = creonowPath.trim().split("\\").join("/");
-
-# db/paths.ts 使用 path.join 构建数据库路径
-$ cat apps/desktop/main/src/db/paths.ts
-# path.join(userDataDir, "data") — 跨平台安全
-
-# exportService.ts 同时检查正反斜杠
-$ grep -n 'includes' apps/desktop/main/src/services/export/exportService.ts
-# L49: return !segment.includes("/") && !segment.includes("\\");
-
-# A0-04 后的结构化导出仍复用同一安全路径拼装
-# 4 种导出都写入 exports/<projectId>/，仅文件内容渲染从派生纯文本切换为编辑器 JSON 主线
-
-# projectService.ts 移除尾部斜杠（兼容两种）
-$ grep -n 'trimmedPath' apps/desktop/main/src/services/projects/projectService.ts
-# L211: const trimmedPath = resolvedPath.replace(/[\\/]+$/, "");
-```
-
-**就绪度标记**：✅ 就绪
-
-**v0.1 处置建议**：
-- 路径处理已采用跨平台 `path` API，Windows CI E2E 测试（`windows-e2e` job）可验证实际行为。
-- 结构化 Markdown / PDF / DOCX 导出仅改变内容渲染主线，不改变 Windows 路径与文件名安全策略。
-- 无需额外处置。
+- v0.1 可依赖现有本地异常捕获保护用户体验——崩溃时优雅退出而非黑屏，局部错误有 ErrorBoundary 隔离。
+- **v0.1 发布文档须声明**：「v0.1 不包含自动崩溃上报，如遇问题请通过 [反馈渠道] 手动反馈」。
+- **方向性建议**：v0.2 接入 Sentry 或自建 telemetry pipeline，补齐 `fireAndForget.ts` TODO，实现渲染进程日志持久化。
 
 ---
 
 ## 三、就绪度总表
 
-| 维度 | 就绪度 | 关键证据 | v0.1 处置 |
-|------|--------|----------|-----------|
-| 代码签名 | ❌ 未就绪 | `electron-builder.json` 无签名配置；CI 无签名步骤 | 发布文档声明未签名；v0.2 前购置证书 |
-| 自动更新 | ❌ 未就绪 | 无 `electron-updater` 依赖；无 `publish` 配置；无更新代码 | 发布文档声明手动更新；v0.2 接入 |
-| 备份能力 | ❌ 未就绪 | A0-08 正式结论：100% Phantom Feature，零后端实现 | 隐藏备份 UI 或移除相关入口 |
-| 崩溃可观测性 | ⚠️ 部分就绪 | 主进程 `globalExceptionHandlers` + 渲染进程 `ErrorBoundary` 已就位；无外部上报 | 可用于 v0.1 本地保护；声明无自动上报 |
-| 安装/卸载 | ⚠️ 部分就绪 | NSIS + zip 构建可用；受未签名 SmartScreen 影响 | 可用但需在文档中说明 SmartScreen 警告 |
-| 路径处理 | ✅ 就绪 | 全局使用 `path` 模块跨平台 API；Windows CI E2E 覆盖 | 无需额外处置 |
+| 维度         | 就绪度      | 关键证据                                                                                      | v0.1 处置                             |
+| ------------ | ----------- | --------------------------------------------------------------------------------------------- | ------------------------------------- |
+| 代码签名     | ❌ 未就绪   | `electron-builder.json` 无签名配置；CI 无签名步骤                                             | 发布文档声明未签名 + SmartScreen 提示 |
+| 自动更新     | ❌ 未就绪   | 无 `electron-updater` 依赖；无 `publish` 配置；无更新代码                                     | 发布文档声明手动更新                  |
+| 备份能力     | ❌ 未就绪   | A0-08 正式结论：100% Phantom Feature，零后端实现                                              | 隐藏或移除备份 UI                     |
+| 崩溃可观测性 | ⚠️ 部分就绪 | 主进程 `globalExceptionHandlers` + `ErrorBoundary` + `RegionErrorBoundary` 已就位；无远程上报 | 本地保护可用；声明无自动上报          |
 
 ---
 
@@ -263,22 +193,22 @@ $ grep -n 'trimmedPath' apps/desktop/main/src/services/projects/projectService.t
 
 ### 可在 v0.1 对外承诺的能力
 
-- **路径处理**：代码已跨平台兼容，Windows E2E 测试覆盖。
-- **崩溃防护**（本地层面）：主进程异常捕获 + 渲染进程 ErrorBoundary 可保障基本用户体验。
-- **安装**：NSIS 安装包可正常生成和安装。
+- **崩溃防护**（本地层面）：主进程全局异常捕获 + 渲染进程 ErrorBoundary 双层保护，崩溃时优雅退出而非黑屏，已有单元测试覆盖。
 
 ### 需在发布文档中诚实声明「暂不承诺」的能力
 
-1. **代码签名**：安装包未签名，Windows SmartScreen 将弹出安全警告。
-2. **自动更新**：v0.1 不支持应用内自动更新，新版本需手动下载。
-3. **崩溃自动上报**：v0.1 不包含远程崩溃上报，问题需用户手动反馈。
-4. **备份能力**：具体处置取决于 A0-08（#1035）正式结论。
+| 序号 | 能力         | 用户须知                                         |
+| ---- | ------------ | ------------------------------------------------ |
+| 1    | 代码签名     | 安装包未签名，SmartScreen 弹出安全警告属正常现象 |
+| 2    | 自动更新     | v0.1 不支持应用内自动更新，新版本需手动下载      |
+| 3    | 崩溃自动上报 | v0.1 不包含远程崩溃上报，问题需用户手动反馈      |
+| 4    | 备份         | v0.1 不提供自动备份功能，请自行保管创作内容      |
 
 ### 方向性建议（不承诺具体计划）
 
-| 维度 | 方向 |
-|------|------|
-| 代码签名 | 购置 EV 证书 → CI 集成签名 → 消除 SmartScreen 警告 |
+| 维度     | 方向                                                            |
+| -------- | --------------------------------------------------------------- |
+| 代码签名 | 购置 EV 证书 → CI 集成签名 → 消除 SmartScreen 警告              |
 | 自动更新 | 接入 `electron-updater` → 配置 GitHub Releases / S3 update feed |
-| 崩溃上报 | 接入 Sentry 或自建 telemetry → 补齐 `fireAndForget.ts` TODO |
-| 备份 | 待 A0-08 结论确定路径 |
+| 崩溃上报 | 接入 Sentry 或自建 telemetry → 补齐 `fireAndForget.ts` TODO     |
+| 备份     | 视 A0-17（#996）结论确定实现路径                                |


### PR DESCRIPTION
## Summary

Windows v0.1 首发就绪度核查报告（二次核查修订版），聚焦四大维度：

1. **代码签名** — ❌ 未就绪：`electron-builder.json` 无签名配置，CI 无签名步骤
2. **自动更新** — ❌ 未就绪：无 `electron-updater` 依赖，无 `publish` provider
3. **备份能力** — ❌ 未就绪：A0-08 正式结论确认为 100% Phantom Feature
4. **崩溃可观测性** — ⚠️ 部分就绪：本地捕获已建立，远程上报缺失

### Changes
- 聚焦 proposal 定义的四维度，移除超范围的安装/卸载和路径处理章节
- 二次核查确认代码证据与当前 `main` HEAD 一致
- 备份维度引用 A0-08 正式结论（而非初稿中的模糊引用）
- 就绪度总表收窄为四行

### Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm prettier --check docs/release/v0.1-windows-boundary.md` ✅

### Rollback
还原 `docs/release/v0.1-windows-boundary.md` 至 `main` 版本即可。

Closes #1000