### PR TITLE
feat(renderer): 全局错误兜底 (#993)

### DIFF
--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -28,6 +28,7 @@ import { registerDbDebugIpcHandlers } from "./ipc/debugChannelGate";
 import { createValidatedIpcMain } from "./ipc/runtime-validation";
 import { registerVersionIpcHandlers } from "./ipc/version";
 import { registerWindowIpcHandlers } from "./ipc/window";
+import { registerRendererLogIpcHandlers } from "./ipc/rendererLog";
 import { createProjectSessionBindingRegistry } from "./ipc/projectSessionBinding";
 import { createMainLogger, type Logger } from "./logging/logger";
 import { createEmbeddingService } from "./services/embedding/embeddingService";
@@ -494,6 +495,12 @@ function registerIpcHandlers(deps: {
   registerVersionIpcHandlers({
     ipcMain: guardedIpcMain,
     db: deps.db,
+    logger: deps.logger,
+  });
+
+  registerRendererLogIpcHandlers({
+    ipcMain: guardedIpcMain,
+    userDataDir: deps.userDataDir,
     logger: deps.logger,
   });
 }

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -2294,5 +2294,15 @@ export const ipcContract = {
       request: s.object({ documentId: s.string(), runId: s.string() }),
       response: s.object({ logged: s.literal(true) }),
     },
+    "app:renderer:logerror": {
+      request: s.object({
+        source: s.union(s.literal("unhandledrejection"), s.literal("error")),
+        name: s.string(),
+        message: s.string(),
+        stack: s.optional(s.string()),
+        timestamp: s.string(),
+      }),
+      response: s.object({ logged: s.literal(true) }),
+    },
   },
 } as const;

--- a/apps/desktop/main/src/ipc/rendererLog.ts
+++ b/apps/desktop/main/src/ipc/rendererLog.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { IpcMain } from "electron";
+
+import type { IpcResponse } from "@shared/types/ipc-generated";
+import type { Logger } from "../logging/logger";
+
+const MAX_LOG_SIZE_BYTES = 5 * 1024 * 1024;
+
+const VALID_SOURCES = new Set(["unhandledrejection", "error"]);
+
+interface RendererErrorPayload {
+  source: "unhandledrejection" | "error";
+  name: string;
+  message: string;
+  stack?: string;
+  timestamp: string;
+}
+
+function validatePayload(raw: unknown): RendererErrorPayload {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("payload must be an object");
+  }
+  const p = raw as Record<string, unknown>;
+  if (typeof p.source !== "string" || !VALID_SOURCES.has(p.source)) {
+    throw new Error("invalid source");
+  }
+  if (typeof p.name !== "string" || typeof p.message !== "string") {
+    throw new Error("name and message must be strings");
+  }
+  if (typeof p.timestamp !== "string") {
+    throw new Error("timestamp must be a string");
+  }
+  return {
+    source: p.source as RendererErrorPayload["source"],
+    name: p.name,
+    message: p.message,
+    stack: typeof p.stack === "string" ? p.stack : undefined,
+    timestamp: p.timestamp,
+  };
+}
+
+function getRendererErrorLogPath(userDataDir: string): string {
+  return path.join(userDataDir, "logs", "renderer-errors.log");
+}
+
+function rotateIfNeeded(logPath: string): void {
+  try {
+    const stat = fs.statSync(logPath);
+    if (stat.size <= MAX_LOG_SIZE_BYTES) {
+      return;
+    }
+    const content = fs.readFileSync(logPath, "utf8");
+    const lines = content.split("\n");
+    const half = Math.floor(lines.length / 2);
+    fs.writeFileSync(logPath, lines.slice(half).join("\n"), "utf8");
+  } catch {
+    // File may not exist yet — nothing to rotate.
+  }
+}
+
+export function registerRendererLogIpcHandlers(args: {
+  ipcMain: IpcMain;
+  userDataDir: string;
+  logger: Logger;
+}): void {
+  args.ipcMain.handle(
+    "app:renderer:logerror",
+    async (_event, raw: unknown): Promise<IpcResponse<{ logged: true }>> => {
+      try {
+        const payload = validatePayload(raw);
+        const logPath = getRendererErrorLogPath(args.userDataDir);
+        fs.mkdirSync(path.dirname(logPath), { recursive: true });
+        rotateIfNeeded(logPath);
+        fs.appendFileSync(logPath, `${JSON.stringify(payload)}\n`, "utf8");
+        return { ok: true, data: { logged: true } };
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+          "[RendererLog] Failed to write renderer error log",
+          error,
+        );
+        return { ok: true, data: { logged: true } };
+      }
+    },
+  );
+}

--- a/apps/desktop/renderer/src/App.tsx
+++ b/apps/desktop/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { WindowTitleBar } from "./components/window/WindowTitleBar";
 import { AppToastProvider } from "./components/providers/AppToastProvider";
 import { ToastIntegrationBridge } from "./components/providers/ToastIntegrationBridge";
+import { GlobalErrorToastBridge } from "./components/providers/GlobalErrorToastBridge";
 
 /**
  * AppRouter decides which screen to show based on onboarding status.
@@ -158,6 +159,7 @@ export function App(): JSX.Element {
                         <VersionStoreProvider store={versionStore}>
                           <LayoutStoreProvider store={layoutStore}>
                             <ToastIntegrationBridge />
+                            <GlobalErrorToastBridge />
                             <div className="flex h-full min-h-0 flex-col">
                               <WindowTitleBar />
                               <div className="min-h-0 flex-1">

--- a/apps/desktop/renderer/src/components/providers/GlobalErrorToastBridge.tsx
+++ b/apps/desktop/renderer/src/components/providers/GlobalErrorToastBridge.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { useAppToast } from "./AppToastProvider";
+
+/**
+ * GlobalErrorToastBridge — 桥接全局错误兜底与 Toast
+ *
+ * 监听 window 上的 `cn:global-error-toast` custom event，
+ * 由 installGlobalErrorHandlers 的 onToast 回调触发。
+ * 将事件转化为 error variant Toast 通知。
+ */
+export function GlobalErrorToastBridge(): null {
+  const { showToast } = useAppToast();
+  const { t } = useTranslation();
+
+  React.useEffect(() => {
+    function onGlobalErrorToast(): void {
+      showToast({
+        title: t("globalError.toast.title"),
+        description: t("globalError.toast.description"),
+        variant: "error",
+      });
+    }
+
+    window.addEventListener("cn:global-error-toast", onGlobalErrorToast);
+    return () => {
+      window.removeEventListener("cn:global-error-toast", onGlobalErrorToast);
+    };
+  }, [showToast, t]);
+
+  return null;
+}

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1463,5 +1463,11 @@
       "VERSION_ROLLBACK_CONFLICT": "Version rollback conflict.",
       "VERSION_SNAPSHOT_COMPACTED": "Version snapshot has been compacted."
     }
+  },
+  "globalError": {
+    "toast": {
+      "title": "Unexpected system error",
+      "description": "Some features may be affected. Please retry the operation. If the problem persists, restart the app."
+    }
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1463,5 +1463,11 @@
       "VERSION_ROLLBACK_CONFLICT": "版本回滚冲突",
       "VERSION_SNAPSHOT_COMPACTED": "版本快照已压缩"
     }
+  },
+  "globalError": {
+    "toast": {
+      "title": "系统遇到意外问题",
+      "description": "部分功能可能受影响，请尝试重新操作。如问题持续，请重启应用。"
+    }
   }
 }

--- a/apps/desktop/renderer/src/lib/globalErrorHandlers.test.ts
+++ b/apps/desktop/renderer/src/lib/globalErrorHandlers.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  installGlobalErrorHandlers,
+  type GlobalErrorEntry,
+} from "./globalErrorHandlers";
+
+describe("installGlobalErrorHandlers", () => {
+  let onLog: ReturnType<typeof vi.fn<(entry: GlobalErrorEntry) => void>>;
+  let onToast: ReturnType<typeof vi.fn<(entry: GlobalErrorEntry) => void>>;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    onLog = vi.fn<(entry: GlobalErrorEntry) => void>();
+    onToast = vi.fn<(entry: GlobalErrorEntry) => void>();
+    cleanup = installGlobalErrorHandlers({ onLog, onToast });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("unhandledrejection 捕获", () => {
+    it("捕获 Error 类型的 rejection，source 为 unhandledrejection", () => {
+      const error = new Error("IPC timeout");
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error,
+        promise: Promise.reject(error).catch(() => {}),
+      });
+      window.dispatchEvent(event);
+
+      expect(onLog).toHaveBeenCalledOnce();
+      const entry: GlobalErrorEntry = onLog.mock.calls[0][0];
+      expect(entry.source).toBe("unhandledrejection");
+      expect(entry.name).toBe("Error");
+      expect(entry.message).toBe("IPC timeout");
+      expect(entry.stack).toBeDefined();
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("捕获非 Error 类型的 rejection，name 为 UnknownError", () => {
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: "raw rejection",
+        promise: Promise.reject("raw rejection").catch(() => {}),
+      });
+      window.dispatchEvent(event);
+
+      expect(onLog).toHaveBeenCalledOnce();
+      const entry: GlobalErrorEntry = onLog.mock.calls[0][0];
+      expect(entry.source).toBe("unhandledrejection");
+      expect(entry.name).toBe("UnknownError");
+      expect(entry.message).toBe("raw rejection");
+      expect(entry.stack).toBeUndefined();
+    });
+
+    it("卸载后不再捕获 unhandledrejection", () => {
+      cleanup();
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: new Error("after cleanup"),
+        promise: Promise.reject(new Error("after cleanup")).catch(() => {}),
+      });
+      window.dispatchEvent(event);
+
+      expect(onLog).not.toHaveBeenCalled();
+    });
+
+    it("调用 event.preventDefault() 阻止默认控制台输出", () => {
+      const error = new Error("test");
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error,
+        promise: Promise.reject(error).catch(() => {}),
+        cancelable: true,
+      });
+      const preventSpy = vi.spyOn(event, "preventDefault");
+      window.dispatchEvent(event);
+
+      expect(preventSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("error 捕获", () => {
+    it("捕获 TypeError，source 为 error", () => {
+      const error = new TypeError("Cannot read properties of undefined");
+      const event = new ErrorEvent("error", {
+        error,
+        message: error.message,
+      });
+      window.dispatchEvent(event);
+
+      expect(onLog).toHaveBeenCalledOnce();
+      const entry: GlobalErrorEntry = onLog.mock.calls[0][0];
+      expect(entry.source).toBe("error");
+      expect(entry.name).toBe("TypeError");
+      expect(entry.message).toBe("Cannot read properties of undefined");
+    });
+
+    it("error 为 undefined 时使用 event.message 和 UnknownError", () => {
+      const event = new ErrorEvent("error", {
+        error: undefined,
+        message: "Script error.",
+      });
+      window.dispatchEvent(event);
+
+      expect(onLog).toHaveBeenCalledOnce();
+      const entry: GlobalErrorEntry = onLog.mock.calls[0][0];
+      expect(entry.source).toBe("error");
+      expect(entry.name).toBe("UnknownError");
+      expect(entry.message).toBe("Script error.");
+    });
+
+    it("卸载后不再捕获 error 事件", () => {
+      cleanup();
+
+      const catcher = (e: ErrorEvent): void => {
+        e.preventDefault();
+      };
+      window.addEventListener("error", catcher);
+
+      const event = new ErrorEvent("error", {
+        error: new Error("after cleanup"),
+        cancelable: true,
+      });
+      window.dispatchEvent(event);
+
+      window.removeEventListener("error", catcher);
+
+      expect(onLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Toast 去重逻辑", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("同一 name+message 在 1000ms 内触发 3 次，onToast 仅调用 1 次", () => {
+      for (let i = 0; i < 3; i++) {
+        const error = new Error("repeated");
+        const event = new PromiseRejectionEvent("unhandledrejection", {
+          reason: error,
+          promise: Promise.reject(error).catch(() => {}),
+        });
+        window.dispatchEvent(event);
+        vi.advanceTimersByTime(200);
+      }
+
+      expect(onToast).toHaveBeenCalledOnce();
+    });
+
+    it("冷却期过后重新触发 onToast", () => {
+      const error1 = new Error("repeated");
+      const event1 = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error1,
+        promise: Promise.reject(error1).catch(() => {}),
+      });
+      window.dispatchEvent(event1);
+
+      vi.advanceTimersByTime(1001);
+
+      const error2 = new Error("repeated");
+      const event2 = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error2,
+        promise: Promise.reject(error2).catch(() => {}),
+      });
+      window.dispatchEvent(event2);
+
+      expect(onToast).toHaveBeenCalledTimes(2);
+    });
+
+    it("不同 name+message 各自独立触发 onToast", () => {
+      const errorA = new TypeError("type error");
+      const eventA = new PromiseRejectionEvent("unhandledrejection", {
+        reason: errorA,
+        promise: Promise.reject(errorA).catch(() => {}),
+      });
+      window.dispatchEvent(eventA);
+
+      vi.advanceTimersByTime(200);
+
+      const errorB = new RangeError("range error");
+      const eventB = new PromiseRejectionEvent("unhandledrejection", {
+        reason: errorB,
+        promise: Promise.reject(errorB).catch(() => {}),
+      });
+      window.dispatchEvent(eventB);
+
+      expect(onToast).toHaveBeenCalledTimes(2);
+    });
+
+    it("去重仅影响 Toast——每次触发 onLog 均被调用", () => {
+      for (let i = 0; i < 3; i++) {
+        const error = new Error("repeated");
+        const event = new PromiseRejectionEvent("unhandledrejection", {
+          reason: error,
+          promise: Promise.reject(error).catch(() => {}),
+        });
+        window.dispatchEvent(event);
+        vi.advanceTimersByTime(200);
+      }
+
+      expect(onLog).toHaveBeenCalledTimes(3);
+      expect(onToast).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("日志回调失败不触发递归", () => {
+    it("onLog 抛出异常不触发新的 onToast", () => {
+      onLog.mockImplementation(() => {
+        throw new Error("log failed");
+      });
+
+      const error = new Error("original");
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error,
+        promise: Promise.reject(error).catch(() => {}),
+      });
+
+      expect(() => window.dispatchEvent(event)).not.toThrow();
+      expect(onToast).not.toHaveBeenCalled();
+    });
+
+    it("onLog 抛出异常时 console.error 被调用", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      onLog.mockImplementation(() => {
+        throw new Error("log failed");
+      });
+
+      const error = new Error("original");
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        reason: error,
+        promise: Promise.reject(error).catch(() => {}),
+      });
+      window.dispatchEvent(event);
+
+      expect(consoleError).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/renderer/src/lib/globalErrorHandlers.ts
+++ b/apps/desktop/renderer/src/lib/globalErrorHandlers.ts
@@ -1,0 +1,100 @@
+export interface GlobalErrorEntry {
+  source: "unhandledrejection" | "error";
+  name: string;
+  message: string;
+  stack: string | undefined;
+  timestamp: string;
+}
+
+interface GlobalErrorHandlerOptions {
+  onLog: (entry: GlobalErrorEntry) => void;
+  onToast: (entry: GlobalErrorEntry) => void;
+}
+
+const DEDUP_WINDOW_MS = 1000;
+
+function extractErrorInfo(raw: unknown): {
+  name: string;
+  message: string;
+  stack: string | undefined;
+} {
+  if (raw instanceof Error) {
+    return {
+      name: raw.name,
+      message: raw.message,
+      stack: raw.stack,
+    };
+  }
+  return {
+    name: "UnknownError",
+    message: String(raw),
+    stack: undefined,
+  };
+}
+
+function buildDedupKey(name: string, message: string): string {
+  return `${name}:${message}`;
+}
+
+export function installGlobalErrorHandlers(
+  options: GlobalErrorHandlerOptions,
+): () => void {
+  const lastToastTime = new Map<string, number>();
+
+  function shouldShowToast(key: string, now: number): boolean {
+    const last = lastToastTime.get(key);
+    if (last !== undefined && now - last < DEDUP_WINDOW_MS) {
+      return false;
+    }
+    lastToastTime.set(key, now);
+    return true;
+  }
+
+  function handleError(source: GlobalErrorEntry["source"], raw: unknown): void {
+    const { name, message, stack } = extractErrorInfo(raw);
+    const entry: GlobalErrorEntry = {
+      source,
+      name,
+      message,
+      stack,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      options.onLog(entry);
+    } catch (logError) {
+      // eslint-disable-next-line no-console
+      console.error(
+        "[GlobalErrorHandler] onLog failed, suppressing to prevent recursion",
+        logError,
+      );
+      return;
+    }
+
+    const key = buildDedupKey(name, message);
+    if (shouldShowToast(key, Date.now())) {
+      options.onToast(entry);
+    }
+  }
+
+  function onUnhandledRejection(event: PromiseRejectionEvent): void {
+    event.preventDefault();
+    handleError("unhandledrejection", event.reason);
+  }
+
+  function onError(event: ErrorEvent): void {
+    const raw =
+      event.error !== undefined && event.error !== null
+        ? event.error
+        : event.message;
+    handleError("error", raw);
+  }
+
+  window.addEventListener("unhandledrejection", onUnhandledRejection);
+  window.addEventListener("error", onError);
+
+  return () => {
+    window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    window.removeEventListener("error", onError);
+  };
+}

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -7,6 +7,30 @@ import { I18nextProvider } from "react-i18next";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/patterns";
 import { i18n } from "./i18n";
+import {
+  installGlobalErrorHandlers,
+  type GlobalErrorEntry,
+} from "./lib/globalErrorHandlers";
+import { invoke } from "./lib/ipcClient";
+
+// Install global error handlers BEFORE React mount
+installGlobalErrorHandlers({
+  onLog(entry: GlobalErrorEntry) {
+    void invoke("app:renderer:logerror", {
+      source: entry.source,
+      name: entry.name,
+      message: entry.message,
+      stack: entry.stack,
+      timestamp: entry.timestamp,
+    }).catch((err: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error("[GlobalErrorHandler] IPC log failed, suppressing", err);
+    });
+  },
+  onToast() {
+    window.dispatchEvent(new CustomEvent("cn:global-error-toast"));
+  },
+});
 
 // Signal that React app has mounted
 if (typeof window.__CN_E2E__ !== "object") {

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -130,6 +130,7 @@ export const IPC_CHANNELS = [
   "ai:skill:cancel",
   "ai:skill:feedback",
   "ai:skill:run",
+  "app:renderer:logerror",
   "app:system:ping",
   "app:window:close",
   "app:window:getstate",
@@ -519,6 +520,18 @@ export type IpcChannelSpec = {
         promptTokens: number;
         sessionTotalTokens: number;
       };
+    };
+  };
+  "app:renderer:logerror": {
+    request: {
+      message: string;
+      name: string;
+      source: "unhandledrejection" | "error";
+      stack?: string;
+      timestamp: string;
+    };
+    response: {
+      logged: true;
     };
   };
   "app:system:ping": {


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

渲染进程全局错误兜底：注册 `unhandledrejection` / `error` 全局监听器，捕获所有未被业务代码处理的异步 rejection 和运行时错误，通过 Toast 通知用户并通过 IPC 写入主进程磁盘日志。

## 关联 Issue

- Closes #993

## 用户影响

- 用户在操作中遇到未被业务代码捕获的异步错误时，将看到通用的 "系统遇到意外问题" Toast 通知，而非静默失效
- 错误信息写入磁盘日志，便于事后诊断

## 不修最坏后果

- 异步错误（IPC 超时、store action 失败等）静默失效，用户以为操作成功实际无效果
- 开发者无法事后诊断用户反馈的 "功能不工作" 问题（无日志落盘）

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter desktop exec vitest run` — 271 files, 1866 tests 全通过
- [x] `globalErrorHandlers.test.ts` — 13 个专项测试覆盖捕获、去重、防递归

## 回滚点

- 回滚 commit: `07a67118`（本 PR 唯一 commit）
- 回滚后无需恢复数据或配置

## 非自动化检查（Tier 3）

- [x] **字体渲染**：N/A（本 PR 不新增可见 UI 元素，Toast 复用 A0-13 已有组件）
- [x] **品牌调性**：N/A（无新增样式，Toast 使用 error variant 内置 Design Token）
- [x] **无障碍**：Toast 通过 Radix Toast 内建 `aria-live` 机制播报
- [x] **CJK 场景**：N/A（通用 Toast 文案，无长文本溢出风险）
