### PR TITLE
feat(search): 注册 Cmd/Ctrl+Shift+F 全局搜索快捷键 + 搜索结果跳转 (#1003)

### DIFF
--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import { LAYOUT_SHORTCUTS } from "../../config/shortcuts";
 import {
   useLayoutStore,
   LAYOUT_DEFAULTS,
@@ -178,7 +179,7 @@ function ZenModeOverlay(props: {
 /**
  * Build the static command palette entries (non-file items).
  */
-function buildCommandEntries(args: {
+export function buildCommandEntries(args: {
   modKey: string;
   t: ReturnType<typeof useTranslation>["t"];
   currentProjectId: string | null;
@@ -191,6 +192,7 @@ function buildCommandEntries(args: {
   createDocument: (args: { projectId: string }) => Promise<{ ok: boolean }>;
   openVersionHistoryPanel: () => void;
   setCreateProjectDialogOpen: (open: boolean) => void;
+  openGlobalSearch: () => void;
   close: () => void;
 }): CommandItem[] {
   return [
@@ -245,6 +247,17 @@ function buildCommandEntries(args: {
       category: "command",
       onSelect: () => {
         args.setZenMode(!args.zenMode);
+        args.close();
+      },
+    },
+    {
+      id: "open-global-search",
+      label: args.t("search.shortcut.label"),
+      shortcut: LAYOUT_SHORTCUTS.globalSearch.display(),
+      group: "command",
+      category: "command",
+      onSelect: () => {
+        args.openGlobalSearch();
         args.close();
       },
     },
@@ -348,6 +361,7 @@ function buildFileEntries(args: {
  */
 function AppShellOverlays(props: {
   spotlightOpen: boolean;
+  searchFocusNonce: number;
   currentProjectId: string | null;
   onCloseSpotlight: () => void;
   dialogType: DialogType | null;
@@ -382,6 +396,7 @@ function AppShellOverlays(props: {
           <SearchPanel
             projectId={props.currentProjectId ?? "__no_project__"}
             open={true}
+            focusNonce={props.searchFocusNonce}
             onClose={props.onCloseSpotlight}
           />
         </div>
@@ -614,6 +629,8 @@ function useAppShellController() {
   const [exportDialogOpen, setExportDialogOpen] = React.useState(false);
   const [createProjectDialogOpen, setCreateProjectDialogOpen] =
     React.useState(false);
+  const [searchFocusNonce, setSearchFocusNonce] = React.useState(0);
+  const searchRestoreFocusRef = React.useRef<HTMLElement | null>(null);
 
   const { compareState, closeCompare } = useVersionCompare();
   const { confirm, dialogProps } = useConfirmDialog();
@@ -706,6 +723,27 @@ function useAppShellController() {
     [],
   );
 
+  const openGlobalSearch = React.useCallback(() => {
+    if (typeof document !== "undefined") {
+      const activeElement = document.activeElement;
+      searchRestoreFocusRef.current =
+        activeElement instanceof HTMLElement ? activeElement : null;
+    }
+    setSpotlightOpen(true);
+    setSearchFocusNonce((value) => value + 1);
+  }, [setSpotlightOpen]);
+
+  const closeGlobalSearch = React.useCallback(() => {
+    setSpotlightOpen(false);
+    const restoreTarget = searchRestoreFocusRef.current;
+    if (restoreTarget) {
+      queueMicrotask(() => {
+        restoreTarget.focus();
+      });
+    }
+  }, [setSpotlightOpen]);
+
+
   const layoutActions = React.useMemo<CommandPaletteLayoutActions>(
     () => ({
       onToggleSidebar: toggleSidebarVisibility,
@@ -777,6 +815,7 @@ function useAppShellController() {
       },
       openVersionHistoryPanel,
       setCreateProjectDialogOpen,
+      openGlobalSearch,
       close,
     });
     const fileEntries = buildFileEntries({
@@ -860,6 +899,9 @@ function useAppShellController() {
     handleSwitchProject,
     openCommandPalette,
     openSettingsDialog,
+    openGlobalSearch,
+    closeGlobalSearch,
+    searchFocusNonce,
     commandPaletteKey,
     commandPaletteOpen,
     setCommandPaletteOpen,
@@ -1054,7 +1096,7 @@ export function AppShell(): JSX.Element {
           if (!ctrl.currentProjectId) return;
           void ctrl.createDocument({ projectId: ctrl.currentProjectId });
         }}
-        onOpenGlobalSearch={() => ctrl.setSpotlightOpen(true)}
+        onOpenGlobalSearch={ctrl.openGlobalSearch}
       />
 
       <PanelOrchestrator>
@@ -1162,8 +1204,9 @@ export function AppShell(): JSX.Element {
             overlays={
               <AppShellOverlays
                 spotlightOpen={ctrl.spotlightOpen}
+                searchFocusNonce={ctrl.searchFocusNonce}
                 currentProjectId={ctrl.currentProjectId}
-                onCloseSpotlight={() => ctrl.setSpotlightOpen(false)}
+                onCloseSpotlight={ctrl.closeGlobalSearch}
                 dialogType={ctrl.dialogType}
                 onCloseDialog={() => ctrl.setDialogType(null)}
                 dialogTitleResolver={(d) => resolveDialogTitle(d, ctrl.t)}

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -743,7 +743,6 @@ function useAppShellController() {
     }
   }, [setSpotlightOpen]);
 
-
   const layoutActions = React.useMemo<CommandPaletteLayoutActions>(
     () => ({
       onToggleSidebar: toggleSidebarVisibility,

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -587,11 +587,13 @@ function useGlobalSearchFocusController(args: {
 }) {
   const { setSpotlightOpen } = args;
   const [searchFocusNonce, setSearchFocusNonce] = React.useState(0);
-  const [searchRestoreTarget, setSearchRestoreTarget] = React.useState<HTMLElement | null>(null);
+  const [searchRestoreTarget, setSearchRestoreTarget] =
+    React.useState<HTMLElement | null>(null);
 
   const openGlobalSearch = React.useCallback(() => {
     const activeElement =
-      typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+      typeof document !== "undefined" &&
+      document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
     setSearchRestoreTarget(activeElement);

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -582,6 +582,39 @@ function useAppShellAiCompare() {
   };
 }
 
+function useGlobalSearchFocusController(args: {
+  setSpotlightOpen: (open: boolean) => void;
+}) {
+  const { setSpotlightOpen } = args;
+  const [searchFocusNonce, setSearchFocusNonce] = React.useState(0);
+  const [searchRestoreTarget, setSearchRestoreTarget] = React.useState<HTMLElement | null>(null);
+
+  const openGlobalSearch = React.useCallback(() => {
+    const activeElement =
+      typeof document !== "undefined" && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    setSearchRestoreTarget(activeElement);
+    setSpotlightOpen(true);
+    setSearchFocusNonce((value) => value + 1);
+  }, [setSpotlightOpen]);
+
+  const closeGlobalSearch = React.useCallback(() => {
+    setSpotlightOpen(false);
+    if (searchRestoreTarget) {
+      queueMicrotask(() => {
+        searchRestoreTarget.focus();
+      });
+    }
+  }, [searchRestoreTarget, setSpotlightOpen]);
+
+  return {
+    searchFocusNonce,
+    openGlobalSearch,
+    closeGlobalSearch,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // useAppShellController – all state, effects, callbacks and memos
 // ---------------------------------------------------------------------------
@@ -629,12 +662,12 @@ function useAppShellController() {
   const [exportDialogOpen, setExportDialogOpen] = React.useState(false);
   const [createProjectDialogOpen, setCreateProjectDialogOpen] =
     React.useState(false);
-  const [searchFocusNonce, setSearchFocusNonce] = React.useState(0);
-  const searchRestoreFocusRef = React.useRef<HTMLElement | null>(null);
 
   const { compareState, closeCompare } = useVersionCompare();
   const { confirm, dialogProps } = useConfirmDialog();
   const aiCompare = useAppShellAiCompare();
+  const { searchFocusNonce, openGlobalSearch, closeGlobalSearch } =
+    useGlobalSearchFocusController({ setSpotlightOpen });
 
   // Bootstrap projects on mount
   React.useEffect(() => {
@@ -722,26 +755,6 @@ function useAppShellController() {
     },
     [],
   );
-
-  const openGlobalSearch = React.useCallback(() => {
-    if (typeof document !== "undefined") {
-      const activeElement = document.activeElement;
-      searchRestoreFocusRef.current =
-        activeElement instanceof HTMLElement ? activeElement : null;
-    }
-    setSpotlightOpen(true);
-    setSearchFocusNonce((value) => value + 1);
-  }, [setSpotlightOpen]);
-
-  const closeGlobalSearch = React.useCallback(() => {
-    setSpotlightOpen(false);
-    const restoreTarget = searchRestoreFocusRef.current;
-    if (restoreTarget) {
-      queueMicrotask(() => {
-        restoreTarget.focus();
-      });
-    }
-  }, [setSpotlightOpen]);
 
   const layoutActions = React.useMemo<CommandPaletteLayoutActions>(
     () => ({
@@ -862,6 +875,7 @@ function useAppShellController() {
     toggleSidebarVisibility,
     withRecentTracking,
     zenMode,
+    openGlobalSearch,
   ]);
 
   return {

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -45,10 +45,20 @@ import { SearchPanel } from "../../features/search/SearchPanel";
 import { VersionHistoryContainer } from "../../features/version-history/VersionHistoryContainer";
 import { ZenMode } from "../../features/zen-mode/ZenMode";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
-import { useConfirmDialog, type UseConfirmDialogReturn } from "../../hooks/useConfirmDialog";
+import {
+  useConfirmDialog,
+  type UseConfirmDialogReturn,
+} from "../../hooks/useConfirmDialog";
 import { RESTORE_VERSION_CONFIRM_COPY } from "../../features/version-history/restoreConfirmCopy";
-import { useVersionCompare, type CompareState } from "../../features/version-history/useVersionCompare";
-import { useProjectStore, type ProjectInfo, type ProjectListItem } from "../../stores/projectStore";
+import {
+  useVersionCompare,
+  type CompareState,
+} from "../../features/version-history/useVersionCompare";
+import {
+  useProjectStore,
+  type ProjectInfo,
+  type ProjectListItem,
+} from "../../stores/projectStore";
 import { useFileStore } from "../../stores/fileStore";
 import { useEditorStore } from "../../stores/editorStore";
 import { useAiStore, type AiProposal } from "../../stores/aiStore";
@@ -190,14 +200,20 @@ function buildCommandEntries(args: {
       shortcut: `${args.modKey},`,
       group: "command",
       category: "command",
-      onSelect: () => { args.openSettingsDialog("general"); args.close(); },
+      onSelect: () => {
+        args.openSettingsDialog("general");
+        args.close();
+      },
     },
     {
       id: "export",
       label: args.t("workbench.appShell.command.export"),
       group: "command",
       category: "command",
-      onSelect: () => { args.setExportDialogOpen(true); args.close(); },
+      onSelect: () => {
+        args.setExportDialogOpen(true);
+        args.close();
+      },
     },
     {
       id: "toggle-sidebar",
@@ -205,7 +221,10 @@ function buildCommandEntries(args: {
       shortcut: `${args.modKey}\\`,
       group: "command",
       category: "command",
-      onSelect: () => { args.toggleSidebarVisibility(); args.close(); },
+      onSelect: () => {
+        args.toggleSidebarVisibility();
+        args.close();
+      },
     },
     {
       id: "toggle-right-panel",
@@ -213,7 +232,10 @@ function buildCommandEntries(args: {
       shortcut: `${args.modKey}L`,
       group: "command",
       category: "command",
-      onSelect: () => { args.toggleAiPanel(); args.close(); },
+      onSelect: () => {
+        args.toggleAiPanel();
+        args.close();
+      },
     },
     {
       id: "toggle-zen-mode",
@@ -221,7 +243,10 @@ function buildCommandEntries(args: {
       shortcut: "F11",
       group: "command",
       category: "command",
-      onSelect: () => { args.setZenMode(!args.zenMode); args.close(); },
+      onSelect: () => {
+        args.setZenMode(!args.zenMode);
+        args.close();
+      },
     },
     {
       id: "create-new-document",
@@ -240,7 +265,10 @@ function buildCommandEntries(args: {
       label: args.t("workbench.appShell.command.openVersionHistory"),
       group: "command",
       category: "command",
-      onSelect: () => { args.openVersionHistoryPanel(); args.close(); },
+      onSelect: () => {
+        args.openVersionHistoryPanel();
+        args.close();
+      },
     },
     {
       id: "create-new-project",
@@ -248,14 +276,20 @@ function buildCommandEntries(args: {
       shortcut: `${args.modKey}Shift+N`,
       group: "command",
       category: "command",
-      onSelect: () => { args.setCreateProjectDialogOpen(true); args.close(); },
+      onSelect: () => {
+        args.setCreateProjectDialogOpen(true);
+        args.close();
+      },
     },
     {
       id: "open-folder",
       label: args.t("workbench.appShell.command.openFolder"),
       group: "command",
       category: "command",
-      onSelect: async () => { await invoke("dialog:folder:open", {}); args.close(); },
+      onSelect: async () => {
+        await invoke("dialog:folder:open", {});
+        args.close();
+      },
     },
   ];
 }
@@ -266,8 +300,14 @@ function buildCommandEntries(args: {
 function buildFileEntries(args: {
   fileItems: FileItem[];
   currentProjectId: string | null;
-  setCurrentDocument: (a: { projectId: string; documentId: string }) => Promise<{ ok: boolean }>;
-  openEditorDocument: (a: { projectId: string; documentId: string }) => Promise<void>;
+  setCurrentDocument: (a: {
+    projectId: string;
+    documentId: string;
+  }) => Promise<{ ok: boolean }>;
+  openEditorDocument: (a: {
+    projectId: string;
+    documentId: string;
+  }) => Promise<void>;
   close: () => void;
 }): CommandItem[] {
   const safeFileItems = Array.isArray(args.fileItems) ? args.fileItems : [];
@@ -352,7 +392,9 @@ function AppShellOverlays(props: {
           open={true}
           title={props.dialogTitleResolver(props.dialogType)}
           testId={`leftpanel-dialog-${props.dialogType}`}
-          onOpenChange={(open) => { if (!open) props.onCloseDialog(); }}
+          onOpenChange={(open) => {
+            if (!open) props.onCloseDialog();
+          }}
         >
           {props.dialogContentRenderer(props.dialogType)}
         </LeftPanelDialogShell>
@@ -467,7 +509,8 @@ function useAppShellAiCompare() {
 
   const handleAcceptAiSuggestion = React.useCallback(async () => {
     const effectiveEditor = editor ?? lastMountedEditorRef.current;
-    if (!effectiveEditor || !documentId || !currentProjectId || !aiProposal) return;
+    if (!effectiveEditor || !documentId || !currentProjectId || !aiProposal)
+      return;
 
     const normalizedDecisions = aiHunks.map((_, idx) => {
       const decision = aiHunkDecisions[idx] ?? "pending";
@@ -501,13 +544,26 @@ function useAppShellAiCompare() {
     setCompareMode(false);
     setAiHunkDecisions([]);
   }, [
-    aiHunkDecisions, aiHunks, aiProposal, currentProjectId, documentId,
-    editor, logAiApplyConflict, persistAiApply, setAiError, setCompareMode,
+    aiHunkDecisions,
+    aiHunks,
+    aiProposal,
+    currentProjectId,
+    documentId,
+    editor,
+    logAiApplyConflict,
+    persistAiApply,
+    setAiError,
+    setCompareMode,
   ]);
 
   return {
-    aiProposal, aiDiffText, aiHunks, aiHunkDecisions, setAiHunkDecisions,
-    handleRejectAiSuggestion, handleAcceptAiSuggestion,
+    aiProposal,
+    aiDiffText,
+    aiHunks,
+    aiHunkDecisions,
+    setAiHunkDecisions,
+    handleRejectAiSuggestion,
+    handleAcceptAiSuggestion,
   };
 }
 
@@ -610,16 +666,29 @@ function useAppShellController() {
         return;
       }
       runFireAndForget(async () => {
-        await setCurrentDocument({ projectId: currentProjectId, documentId: docId });
-        await openEditorDocument({ projectId: currentProjectId, documentId: docId });
+        await setCurrentDocument({
+          projectId: currentProjectId,
+          documentId: docId,
+        });
+        await openEditorDocument({
+          projectId: currentProjectId,
+          documentId: docId,
+        });
       });
       openVersionHistoryPanel();
     },
-    [currentProjectId, openEditorDocument, openVersionHistoryPanel, setCurrentDocument],
+    [
+      currentProjectId,
+      openEditorDocument,
+      openVersionHistoryPanel,
+      setCurrentDocument,
+    ],
   );
 
   const handleSwitchProject = React.useCallback(
-    async (projectId: string) => { await setCurrentProject(projectId); },
+    async (projectId: string) => {
+      await setCurrentProject(projectId);
+    },
     [setCurrentProject],
   );
 
@@ -629,10 +698,13 @@ function useAppShellController() {
     setCommandPaletteOpen(true);
   }, []);
 
-  const openSettingsDialog = React.useCallback((tab: SettingsTab = "general") => {
-    setSettingsDefaultTab(tab);
-    setSettingsDialogOpen(true);
-  }, []);
+  const openSettingsDialog = React.useCallback(
+    (tab: SettingsTab = "general") => {
+      setSettingsDefaultTab(tab);
+      setSettingsDialogOpen(true);
+    },
+    [],
+  );
 
   const layoutActions = React.useMemo<CommandPaletteLayoutActions>(
     () => ({
@@ -641,7 +713,13 @@ function useAppShellController() {
       onToggleZenMode: () => setZenMode(!zenMode),
       onOpenVersionHistory: openVersionHistoryPanel,
     }),
-    [openVersionHistoryPanel, setZenMode, toggleAiPanel, toggleSidebarVisibility, zenMode],
+    [
+      openVersionHistoryPanel,
+      setZenMode,
+      toggleAiPanel,
+      toggleSidebarVisibility,
+      zenMode,
+    ],
   );
 
   const dialogActionCallbacks = React.useMemo<CommandPaletteDialogActions>(
@@ -653,14 +731,16 @@ function useAppShellController() {
     [openSettingsDialog],
   );
 
-  const documentActionCallbacks =
-    React.useMemo<CommandPaletteDocumentActions>(() => ({
+  const documentActionCallbacks = React.useMemo<CommandPaletteDocumentActions>(
+    () => ({
       onCreateDocument: async () => {
         if (!currentProjectId) throw new Error("No project selected");
         const res = await createDocument({ projectId: currentProjectId });
         if (!res.ok) throw new Error(`${res.error.code}: ${res.error.message}`);
       },
-    }), [createDocument, currentProjectId]);
+    }),
+    [createDocument, currentProjectId],
+  );
 
   const refreshRecentCommands = React.useCallback(() => {
     setRecentCommandIds(readRecentCommandIds());
@@ -682,22 +762,32 @@ function useAppShellController() {
   const commandPaletteCommands = React.useMemo<CommandItem[]>(() => {
     const close = () => setCommandPaletteOpen(false);
     const commandEntries = buildCommandEntries({
-      modKey, t, currentProjectId, zenMode,
-      openSettingsDialog, setExportDialogOpen,
-      toggleSidebarVisibility, toggleAiPanel, setZenMode,
+      modKey,
+      t,
+      currentProjectId,
+      zenMode,
+      openSettingsDialog,
+      setExportDialogOpen,
+      toggleSidebarVisibility,
+      toggleAiPanel,
+      setZenMode,
       createDocument: async (a) => {
         const r = await createDocument(a);
         return { ok: r.ok };
       },
-      openVersionHistoryPanel, setCreateProjectDialogOpen, close,
+      openVersionHistoryPanel,
+      setCreateProjectDialogOpen,
+      close,
     });
     const fileEntries = buildFileEntries({
-      fileItems, currentProjectId,
+      fileItems,
+      currentProjectId,
       setCurrentDocument: async (a) => {
         const r = await setCurrentDocument(a);
         return { ok: r.ok };
       },
-      openEditorDocument, close,
+      openEditorDocument,
+      close,
     });
     const trackedCommands = [
       ...commandEntries.map(withRecentTracking),
@@ -708,37 +798,82 @@ function useAppShellController() {
       .map((id) => trackedById.get(id))
       .filter((item): item is CommandItem => Boolean(item))
       .slice(0, 5)
-      .map((item) => ({ ...item, group: "recent", category: "recent" as const }));
+      .map((item) => ({
+        ...item,
+        group: "recent",
+        category: "recent" as const,
+      }));
     return [
       ...recentEntries,
       ...fileEntries.map(withRecentTracking),
       ...commandEntries.map(withRecentTracking),
     ];
   }, [
-    createDocument, currentProjectId, fileItems, modKey,
-    openEditorDocument, openSettingsDialog, openVersionHistoryPanel,
-    recentCommandIds, setCurrentDocument, setZenMode, t,
-    toggleAiPanel, toggleSidebarVisibility, withRecentTracking, zenMode,
+    createDocument,
+    currentProjectId,
+    fileItems,
+    modKey,
+    openEditorDocument,
+    openSettingsDialog,
+    openVersionHistoryPanel,
+    recentCommandIds,
+    setCurrentDocument,
+    setZenMode,
+    t,
+    toggleAiPanel,
+    toggleSidebarVisibility,
+    withRecentTracking,
+    zenMode,
   ]);
 
   return {
-    t, currentProject, currentProjectId, projectItems,
-    compareMode, compareVersionId, documentId, showAiMarks,
-    panelCollapsed, zenMode, activeLeftPanel, dialogType,
-    spotlightOpen, setSpotlightOpen, activeRightPanel, setActiveRightPanel,
-    setZenMode, setDialogType, setCompareMode,
-    compareState, closeCompare, confirm, dialogProps,
-    bootstrapEditor, createDocument,
+    t,
+    currentProject,
+    currentProjectId,
+    projectItems,
+    compareMode,
+    compareVersionId,
+    documentId,
+    showAiMarks,
+    panelCollapsed,
+    zenMode,
+    activeLeftPanel,
+    dialogType,
+    spotlightOpen,
+    setSpotlightOpen,
+    activeRightPanel,
+    setActiveRightPanel,
+    setZenMode,
+    setDialogType,
+    setCompareMode,
+    compareState,
+    closeCompare,
+    confirm,
+    dialogProps,
+    bootstrapEditor,
+    createDocument,
     ...aiCompare,
-    toggleSidebarVisibility, toggleAiPanel,
-    openVersionHistoryPanel, openVersionHistoryForDocument,
-    handleSwitchProject, openCommandPalette, openSettingsDialog,
-    commandPaletteKey, commandPaletteOpen, setCommandPaletteOpen,
-    commandPaletteCommands, layoutActions, dialogActionCallbacks,
+    toggleSidebarVisibility,
+    toggleAiPanel,
+    openVersionHistoryPanel,
+    openVersionHistoryForDocument,
+    handleSwitchProject,
+    openCommandPalette,
+    openSettingsDialog,
+    commandPaletteKey,
+    commandPaletteOpen,
+    setCommandPaletteOpen,
+    commandPaletteCommands,
+    layoutActions,
+    dialogActionCallbacks,
     documentActionCallbacks,
-    settingsDialogOpen, setSettingsDialogOpen, settingsDefaultTab,
-    exportDialogOpen, setExportDialogOpen,
-    createProjectDialogOpen, setCreateProjectDialogOpen,
+    settingsDialogOpen,
+    setSettingsDialogOpen,
+    settingsDefaultTab,
+    exportDialogOpen,
+    setExportDialogOpen,
+    createProjectDialogOpen,
+    setCreateProjectDialogOpen,
   };
 }
 
@@ -781,12 +916,16 @@ function AppShellMainContent(props: {
             onAcceptAll={() => void props.handleAcceptAiSuggestion()}
             onAcceptHunk={(hunkIndex) =>
               props.setAiHunkDecisions((prev) =>
-                prev.map((item, idx) => (idx === hunkIndex ? "accepted" : item)),
+                prev.map((item, idx) =>
+                  idx === hunkIndex ? "accepted" : item,
+                ),
               )
             }
             onRejectHunk={(hunkIndex) =>
               props.setAiHunkDecisions((prev) =>
-                prev.map((item, idx) => (idx === hunkIndex ? "rejected" : item)),
+                prev.map((item, idx) =>
+                  idx === hunkIndex ? "rejected" : item,
+                ),
               )
             }
             hunkDecisions={props.aiHunkDecisions}
@@ -820,7 +959,9 @@ function AppShellMainContent(props: {
           restoreInProgress={props.compareState.status === "loading"}
           lineUnderlineStyle={
             props.showAiMarks
-              ? props.compareState.aiMarked ? "dashed" : "solid"
+              ? props.compareState.aiMarked
+                ? "dashed"
+                : "solid"
               : "none"
           }
         />
@@ -836,56 +977,63 @@ function AppShellMainContent(props: {
  * AppShell renders the Workbench three-column layout (IconBar + Sidebar + Main
  * + RightPanel) and wires resizing, persistence, and P0 keyboard shortcuts.
  */
-function resolveDialogTitle(activeDialogType: DialogType, t: (key: string) => string): string {
-    switch (activeDialogType) {
-      case "memory":
-        return t("workbench.appShell.dialogTitle.memory");
-      case "characters":
-        return t("workbench.appShell.dialogTitle.characters");
-      case "knowledgeGraph":
-        return t("workbench.appShell.dialogTitle.knowledgeGraph");
-      case "versionHistory":
-        return t("workbench.appShell.dialogTitle.versionHistory");
-      default:
-        return assertNeverDialogType(activeDialogType);
-    }
+function resolveDialogTitle(
+  activeDialogType: DialogType,
+  t: (key: string) => string,
+): string {
+  switch (activeDialogType) {
+    case "memory":
+      return t("workbench.appShell.dialogTitle.memory");
+    case "characters":
+      return t("workbench.appShell.dialogTitle.characters");
+    case "knowledgeGraph":
+      return t("workbench.appShell.dialogTitle.knowledgeGraph");
+    case "versionHistory":
+      return t("workbench.appShell.dialogTitle.versionHistory");
+    default:
+      return assertNeverDialogType(activeDialogType);
   }
+}
 
-function renderDialogContent(activeDialogType: DialogType, currentProjectId: string | null, t: (key: string) => string): JSX.Element {
-    switch (activeDialogType) {
-      case "memory":
-        return <MemoryPanel />;
-      case "characters":
-        if (!currentProjectId) {
-          return (
-            <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-              {t('workbench.appShell.noProjectCharacters')}
-            </div>
-          );
-        }
-        return <CharacterCardListContainer projectId={currentProjectId} />;
-      case "knowledgeGraph":
-        if (!currentProjectId) {
-          return (
-            <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-              {t('workbench.appShell.noProjectKg')}
-            </div>
-          );
-        }
-        return <KnowledgeGraphPanel projectId={currentProjectId} />;
-      case "versionHistory":
-        if (!currentProjectId) {
-          return (
-            <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-              {t('workbench.appShell.noDocumentHistory')}
-            </div>
-          );
-        }
-        return <VersionHistoryContainer projectId={currentProjectId} />;
-      default:
-        return assertNeverDialogType(activeDialogType);
-    }
+function renderDialogContent(
+  activeDialogType: DialogType,
+  currentProjectId: string | null,
+  t: (key: string) => string,
+): JSX.Element {
+  switch (activeDialogType) {
+    case "memory":
+      return <MemoryPanel />;
+    case "characters":
+      if (!currentProjectId) {
+        return (
+          <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+            {t("workbench.appShell.noProjectCharacters")}
+          </div>
+        );
+      }
+      return <CharacterCardListContainer projectId={currentProjectId} />;
+    case "knowledgeGraph":
+      if (!currentProjectId) {
+        return (
+          <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+            {t("workbench.appShell.noProjectKg")}
+          </div>
+        );
+      }
+      return <KnowledgeGraphPanel projectId={currentProjectId} />;
+    case "versionHistory":
+      if (!currentProjectId) {
+        return (
+          <div className="p-3 text-xs text-[var(--color-fg-muted)]">
+            {t("workbench.appShell.noDocumentHistory")}
+          </div>
+        );
+      }
+      return <VersionHistoryContainer projectId={currentProjectId} />;
+    default:
+      return assertNeverDialogType(activeDialogType);
   }
+}
 
 export function AppShell(): JSX.Element {
   const ctrl = useAppShellController();
@@ -906,6 +1054,7 @@ export function AppShell(): JSX.Element {
           if (!ctrl.currentProjectId) return;
           void ctrl.createDocument({ projectId: ctrl.currentProjectId });
         }}
+        onOpenGlobalSearch={() => ctrl.setSpotlightOpen(true)}
       />
 
       <PanelOrchestrator>
@@ -929,7 +1078,9 @@ export function AppShell(): JSX.Element {
                   projects={ctrl.projectItems}
                   onSwitchProject={ctrl.handleSwitchProject}
                   onCreateProject={() => ctrl.setCreateProjectDialogOpen(true)}
-                  onOpenVersionHistoryDocument={ctrl.openVersionHistoryForDocument}
+                  onOpenVersionHistoryDocument={
+                    ctrl.openVersionHistoryForDocument
+                  }
                 />
               </RegionErrorBoundary>
             }
@@ -999,7 +1150,9 @@ export function AppShell(): JSX.Element {
                 <RightPanel
                   width={layout.effectivePanelWidth}
                   collapsed={layout.panelCollapsed}
-                  onOpenSettings={(tab) => ctrl.openSettingsDialog(tab ?? "general")}
+                  onOpenSettings={(tab) =>
+                    ctrl.openSettingsDialog(tab ?? "general")
+                  }
                   onOpenVersionHistory={ctrl.openVersionHistoryPanel}
                   onCollapse={layout.panelVisibility.collapseRightPanel}
                 />
@@ -1014,7 +1167,9 @@ export function AppShell(): JSX.Element {
                 dialogType={ctrl.dialogType}
                 onCloseDialog={() => ctrl.setDialogType(null)}
                 dialogTitleResolver={(d) => resolveDialogTitle(d, ctrl.t)}
-                dialogContentRenderer={(d) => renderDialogContent(d, ctrl.currentProjectId, ctrl.t)}
+                dialogContentRenderer={(d) =>
+                  renderDialogContent(d, ctrl.currentProjectId, ctrl.t)
+                }
                 commandPaletteKey={ctrl.commandPaletteKey}
                 commandPaletteOpen={ctrl.commandPaletteOpen}
                 onCommandPaletteOpenChange={ctrl.setCommandPaletteOpen}
@@ -1029,7 +1184,9 @@ export function AppShell(): JSX.Element {
                 onExportDialogOpenChange={ctrl.setExportDialogOpen}
                 documentId={ctrl.documentId}
                 createProjectDialogOpen={ctrl.createProjectDialogOpen}
-                onCreateProjectDialogOpenChange={ctrl.setCreateProjectDialogOpen}
+                onCreateProjectDialogOpenChange={
+                  ctrl.setCreateProjectDialogOpen
+                }
                 zenMode={ctrl.zenMode}
                 onExitZenMode={() => ctrl.setZenMode(false)}
                 compareMode={ctrl.compareMode}

--- a/apps/desktop/renderer/src/components/layout/NavigationController.tsx
+++ b/apps/desktop/renderer/src/components/layout/NavigationController.tsx
@@ -14,6 +14,7 @@ type NavigationControllerProps = {
   onOpenSettings: () => void;
   onOpenCreateProject: () => void;
   onCreateDocument: () => void;
+  onOpenGlobalSearch: () => void;
 };
 
 /**
@@ -33,11 +34,9 @@ export function NavigationController({
   onOpenSettings,
   onOpenCreateProject,
   onCreateDocument,
+  onOpenGlobalSearch,
 }: NavigationControllerProps): null {
-  const debouncedToggleSidebar = useDebouncedCallback(
-    onToggleSidebar,
-    300,
-  );
+  const debouncedToggleSidebar = useDebouncedCallback(onToggleSidebar, 300);
   const debouncedToggleRightPanel = useDebouncedCallback(
     onToggleRightPanel,
     300,
@@ -146,6 +145,19 @@ export function NavigationController({
     }, [zenMode, canCreateDocument, onCreateDocument]),
     "global",
     10,
+  );
+
+  // Cmd/Ctrl+Shift+F: Open Global Search
+  useHotkey(
+    "nav:global-search",
+    { key: "f", modKey: true, shiftKey: true },
+    React.useCallback(() => {
+      if (!zenMode) {
+        onOpenGlobalSearch();
+      }
+    }, [zenMode, onOpenGlobalSearch]),
+    "global",
+    15,
   );
 
   return null;

--- a/apps/desktop/renderer/src/components/layout/__tests__/app-shell-global-search-command.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/__tests__/app-shell-global-search-command.test.tsx
@@ -27,7 +27,9 @@ describe("AppShell global search command discoverability", () => {
       close,
     });
 
-    const searchEntry = entries.find((item) => item.id === "open-global-search");
+    const searchEntry = entries.find(
+      (item) => item.id === "open-global-search",
+    );
     expect(searchEntry).toBeDefined();
     expect(searchEntry?.label).toBe("Global Search");
     expect(searchEntry?.shortcut).toBe(LAYOUT_SHORTCUTS.globalSearch.display());

--- a/apps/desktop/renderer/src/components/layout/__tests__/app-shell-global-search-command.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/__tests__/app-shell-global-search-command.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildCommandEntries } from "../AppShell";
+import { LAYOUT_SHORTCUTS } from "../../../config/shortcuts";
+
+describe("AppShell global search command discoverability", () => {
+  it("includes a command palette entry for global search with formatted shortcut", async () => {
+    const onOpenGlobalSearch = vi.fn();
+    const close = vi.fn();
+    const entries = buildCommandEntries({
+      modKey: "Ctrl",
+      t: ((key: string) => {
+        if (key === "search.shortcut.label") return "Global Search";
+        return key;
+      }) as never,
+      currentProjectId: "proj-1",
+      zenMode: false,
+      openSettingsDialog: vi.fn(),
+      setExportDialogOpen: vi.fn(),
+      toggleSidebarVisibility: vi.fn(),
+      toggleAiPanel: vi.fn(),
+      setZenMode: vi.fn(),
+      createDocument: vi.fn(async () => ({ ok: true })),
+      openVersionHistoryPanel: vi.fn(),
+      setCreateProjectDialogOpen: vi.fn(),
+      openGlobalSearch: onOpenGlobalSearch,
+      close,
+    });
+
+    const searchEntry = entries.find((item) => item.id === "open-global-search");
+    expect(searchEntry).toBeDefined();
+    expect(searchEntry?.label).toBe("Global Search");
+    expect(searchEntry?.shortcut).toBe(LAYOUT_SHORTCUTS.globalSearch.display());
+
+    await searchEntry?.onSelect();
+    expect(onOpenGlobalSearch).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/renderer/src/components/layout/__tests__/navigation-controller.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/__tests__/navigation-controller.test.tsx
@@ -22,6 +22,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     const onOpenSettings = vi.fn();
     const onOpenCreateProject = vi.fn();
     const onCreateDocument = vi.fn();
+    const onOpenGlobalSearch = vi.fn();
 
     render(
       <NavigationController
@@ -35,6 +36,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
         onOpenSettings={onOpenSettings}
         onOpenCreateProject={onOpenCreateProject}
         onCreateDocument={onCreateDocument}
+        onOpenGlobalSearch={onOpenGlobalSearch}
       />,
     );
 
@@ -59,6 +61,9 @@ describe("WB-P2-S2 NavigationController boundary", () => {
 
     fireEvent.keyDown(document, { key: "n", ctrlKey: true });
     expect(onCreateDocument).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(document, { key: "f", ctrlKey: true, shiftKey: true });
+    expect(onOpenGlobalSearch).toHaveBeenCalledTimes(1);
   });
 
   it("blocks non-exit shortcuts in ZenMode", () => {
@@ -70,6 +75,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     const onOpenSettings = vi.fn();
     const onOpenCreateProject = vi.fn();
     const onCreateDocument = vi.fn();
+    const onOpenGlobalSearch = vi.fn();
 
     render(
       <NavigationController
@@ -83,6 +89,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
         onOpenSettings={onOpenSettings}
         onOpenCreateProject={onOpenCreateProject}
         onCreateDocument={onCreateDocument}
+        onOpenGlobalSearch={onOpenGlobalSearch}
       />,
     );
 
@@ -95,6 +102,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     fireEvent.keyDown(document, { key: ",", ctrlKey: true });
     fireEvent.keyDown(document, { key: "n", ctrlKey: true, shiftKey: true });
     fireEvent.keyDown(document, { key: "n", ctrlKey: true });
+    fireEvent.keyDown(document, { key: "f", ctrlKey: true, shiftKey: true });
 
     expect(onOpenCommandPalette).toHaveBeenCalledTimes(0);
     expect(onToggleSidebar).toHaveBeenCalledTimes(0);
@@ -102,6 +110,7 @@ describe("WB-P2-S2 NavigationController boundary", () => {
     expect(onOpenSettings).toHaveBeenCalledTimes(0);
     expect(onOpenCreateProject).toHaveBeenCalledTimes(0);
     expect(onCreateDocument).toHaveBeenCalledTimes(0);
+    expect(onOpenGlobalSearch).toHaveBeenCalledTimes(0);
   });
 
   it("does not perform width allocation (static boundary)", () => {

--- a/apps/desktop/renderer/src/config/shortcuts.ts
+++ b/apps/desktop/renderer/src/config/shortcuts.ts
@@ -124,6 +124,7 @@ export const LAYOUT_SHORTCUTS = {
   commandPalette: defineShortcut("commandPalette", "Command Palette", "mod+P"),
   toggleSidebar: defineShortcut("toggleSidebar", "Toggle Sidebar", "mod+\\"),
   togglePanel: defineShortcut("togglePanel", "Toggle Panel", "mod+L"),
+  globalSearch: defineShortcut("globalSearch", "Global Search", "mod+Shift+F"),
 } as const;
 
 // =============================================================================

--- a/apps/desktop/renderer/src/features/search/SearchPanel.focus.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.focus.test.tsx
@@ -4,23 +4,27 @@ import { render, screen } from "@testing-library/react";
 import { SearchPanel } from "./SearchPanel";
 
 vi.mock("../../stores/searchStore", () => ({
-  useSearchStore: vi.fn((selector) => selector({
-    query: "",
-    items: [],
-    status: "idle",
-    indexState: "ready",
-    total: 0,
-    hasMore: false,
-    lastError: null,
-    setQuery: vi.fn(),
-    runFulltext: vi.fn().mockResolvedValue({ ok: true }),
-    clearResults: vi.fn(),
-    clearError: vi.fn(),
-  })),
+  useSearchStore: vi.fn((selector) =>
+    selector({
+      query: "",
+      items: [],
+      status: "idle",
+      indexState: "ready",
+      total: 0,
+      hasMore: false,
+      lastError: null,
+      setQuery: vi.fn(),
+      runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+      clearResults: vi.fn(),
+      clearError: vi.fn(),
+    }),
+  ),
 }));
 
 vi.mock("../../stores/fileStore", () => ({
-  useFileStore: vi.fn((selector) => selector({ setCurrent: vi.fn().mockResolvedValue({ ok: true }) })),
+  useFileStore: vi.fn((selector) =>
+    selector({ setCurrent: vi.fn().mockResolvedValue({ ok: true }) }),
+  ),
 }));
 
 describe("SearchPanel focus refresh", () => {

--- a/apps/desktop/renderer/src/features/search/SearchPanel.focus.test.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.focus.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SearchPanel } from "./SearchPanel";
+
+vi.mock("../../stores/searchStore", () => ({
+  useSearchStore: vi.fn((selector) => selector({
+    query: "",
+    items: [],
+    status: "idle",
+    indexState: "ready",
+    total: 0,
+    hasMore: false,
+    lastError: null,
+    setQuery: vi.fn(),
+    runFulltext: vi.fn().mockResolvedValue({ ok: true }),
+    clearResults: vi.fn(),
+    clearError: vi.fn(),
+  })),
+}));
+
+vi.mock("../../stores/fileStore", () => ({
+  useFileStore: vi.fn((selector) => selector({ setCurrent: vi.fn().mockResolvedValue({ ok: true }) })),
+}));
+
+describe("SearchPanel focus refresh", () => {
+  it("re-focuses the search input when focusNonce changes while panel stays open", () => {
+    const { rerender } = render(
+      <>
+        <button data-testid="outside">Outside</button>
+        <SearchPanel projectId="test-project" open={true} focusNonce={0} />
+      </>,
+    );
+
+    const input = screen.getByTestId("search-input");
+    expect(input).toHaveFocus();
+
+    screen.getByTestId("outside").focus();
+    expect(screen.getByTestId("outside")).toHaveFocus();
+
+    rerender(
+      <>
+        <button data-testid="outside">Outside</button>
+        <SearchPanel projectId="test-project" open={true} focusNonce={1} />
+      </>,
+    );
+
+    expect(screen.getByTestId("search-input")).toHaveFocus();
+  });
+});

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -703,6 +703,7 @@ function SearchFooter(props: {
 export function SearchPanel(props: {
   projectId: string;
   open: boolean;
+  focusNonce?: number;
   onClose?: () => void;
   /** Mock results for storybook demonstration */
   mockResults?: SearchResultItem[];
@@ -721,6 +722,7 @@ export function SearchPanel(props: {
     mockQuery,
     mockStatus,
     mockIndexState,
+    focusNonce = 0,
   } = props;
 
   const { t } = useTranslation();
@@ -773,7 +775,7 @@ export function SearchPanel(props: {
     if (open) {
       inputRef.current?.focus();
     }
-  }, [open]);
+  }, [focusNonce, open]);
 
   function handleInputKeyDown(e: React.KeyboardEvent): void {
     if (e.key === "Enter") {

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -10,7 +10,23 @@ import { Toggle } from "../../components/primitives/Toggle";
 import { useFileStore } from "../../stores/fileStore";
 import { useSearchStore, type SearchStatus } from "../../stores/searchStore";
 
-import { ArrowRight, ChevronDown, ChevronUp, CornerDownLeft, FileText, Folder, Frown, Globe, Lightbulb, RefreshCw, Search, Share2, Sparkles, TriangleAlert, X } from "lucide-react";
+import {
+  ArrowRight,
+  ChevronDown,
+  ChevronUp,
+  CornerDownLeft,
+  FileText,
+  Folder,
+  Frown,
+  Globe,
+  Lightbulb,
+  RefreshCw,
+  Search,
+  Share2,
+  Sparkles,
+  TriangleAlert,
+  X,
+} from "lucide-react";
 /**
  * Search category filter options.
  */
@@ -66,7 +82,7 @@ export async function navigateSearchResult(
   const schedule = args.setTimeoutFn ?? setTimeout;
   schedule(() => {
     args.setFlashKey(null);
-  }, 900);
+  }, 1500);
 
   args.onClose?.();
 }
@@ -174,14 +190,16 @@ function DocumentResultItem(props: {
         <div className="flex items-center justify-between gap-2 mb-0.5">
           <h4
             className={`text-sm font-medium truncate transition-colors ${
-              isActive ? "text-[var(--color-fg-default)]" : "text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)]"
+              isActive
+                ? "text-[var(--color-fg-default)]"
+                : "text-[var(--color-fg-muted)] group-hover:text-[var(--color-fg-default)]"
             }`}
           >
             <HighlightText text={item.title} query={query} />
           </h4>
           {item.matchScore && (
             <span className="text-[10px] font-mono text-[var(--color-info)] bg-[var(--color-info-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-info-subtle)] shrink-0">
-              {t('search.matchScore', { score: item.matchScore })}
+              {t("search.matchScore", { score: item.matchScore })}
             </span>
           )}
         </div>
@@ -196,11 +214,19 @@ function DocumentResultItem(props: {
         </p>
         {item.path && (
           <div className="flex items-center gap-2 mt-2">
-            <Folder className="w-3 h-3 text-[var(--color-fg-placeholder)]" size={16} strokeWidth={1.5} />
-            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.path}</span>
+            <Folder
+              className="w-3 h-3 text-[var(--color-fg-placeholder)]"
+              size={16}
+              strokeWidth={1.5}
+            />
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              {item.path}
+            </span>
             {item.editedTime && (
               <>
-                <span className="text-[10px] text-[var(--color-fg-placeholder)] mx-1">•</span>
+                <span className="text-[10px] text-[var(--color-fg-placeholder)] mx-1">
+                  •
+                </span>
                 <span className="text-[10px] text-[var(--color-fg-placeholder)]">
                   {item.editedTime}
                 </span>
@@ -212,7 +238,11 @@ function DocumentResultItem(props: {
 
       {/* Hover arrow */}
       <div className="hidden group-hover:flex items-center self-center pr-2">
-        <ArrowRight className="w-4 h-4 text-[var(--color-fg-muted)]" size={16} strokeWidth={1.5} />
+        <ArrowRight
+          className="w-4 h-4 text-[var(--color-fg-muted)]"
+          size={16}
+          strokeWidth={1.5}
+        />
       </div>
     </ListItem>
   );
@@ -255,8 +285,14 @@ function MemoryResultItem(props: {
         </p>
         {item.meta && (
           <div className="flex items-center gap-2 mt-2">
-            <Sparkles className="w-3 h-3 text-[var(--color-fg-placeholder)]" size={16} strokeWidth={1.5} />
-            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.meta}</span>
+            <Sparkles
+              className="w-3 h-3 text-[var(--color-fg-placeholder)]"
+              size={16}
+              strokeWidth={1.5}
+            />
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              {item.meta}
+            </span>
           </div>
         )}
       </div>
@@ -296,7 +332,9 @@ function KnowledgeResultItem(props: {
             <span className="text-[10px] text-[var(--color-fg-placeholder)] border border-[var(--color-separator)] px-1.5 py-0.5 rounded">
               {t("search.resultTypes.entity")}
             </span>
-            <span className="text-[10px] text-[var(--color-fg-placeholder)]">{item.meta}</span>
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              {item.meta}
+            </span>
           </div>
         )}
       </div>
@@ -344,7 +382,9 @@ function KeyHint(props: {
       <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-[var(--color-bg-overlay)] border border-[var(--color-separator)] text-[10px] text-[var(--color-fg-muted)] font-mono">
         {props.icon || props.text}
       </span>
-      <span className="text-[10px] text-[var(--color-fg-placeholder)] ml-1">{props.label}</span>
+      <span className="text-[10px] text-[var(--color-fg-placeholder)] ml-1">
+        {props.label}
+      </span>
     </div>
   );
 }
@@ -376,7 +416,11 @@ function SearchResultsArea(props: {
   if (!props.hasQuery && !props.hasResults) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-8">
-        <Search className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4" size={24} strokeWidth={1.5} />
+        <Search
+          className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4"
+          size={24}
+          strokeWidth={1.5}
+        />
         <p className="text-sm text-[var(--color-fg-muted)] text-center">
           {t("search.emptyStateHint")}
         </p>
@@ -387,7 +431,11 @@ function SearchResultsArea(props: {
   if (props.hasQuery && props.effectiveIndexState === "rebuilding") {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-8">
-        <RefreshCw className="w-16 h-16 text-[var(--color-info)] mb-4 motion-safe:animate-pulse" size={24} strokeWidth={1.5} />
+        <RefreshCw
+          className="w-16 h-16 text-[var(--color-info)] mb-4 motion-safe:animate-pulse"
+          size={24}
+          strokeWidth={1.5}
+        />
         <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
           {t("search.rebuildingIndex")}
         </p>
@@ -401,7 +449,11 @@ function SearchResultsArea(props: {
   if (props.hasQuery && props.hasError) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-8">
-        <TriangleAlert className="w-16 h-16 text-[var(--color-error)] mb-4" size={24} strokeWidth={1.5} />
+        <TriangleAlert
+          className="w-16 h-16 text-[var(--color-error)] mb-4"
+          size={24}
+          strokeWidth={1.5}
+        />
         <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
           {t("search.errorTitle")}
         </p>
@@ -419,12 +471,20 @@ function SearchResultsArea(props: {
     );
   }
 
-  if (props.hasQuery && !props.hasResults && props.effectiveStatus !== "loading") {
+  if (
+    props.hasQuery &&
+    !props.hasResults &&
+    props.effectiveStatus !== "loading"
+  ) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-8">
-        <Frown className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4" size={24} strokeWidth={1.5} />
+        <Frown
+          className="w-16 h-16 text-[var(--color-fg-placeholder)] mb-4"
+          size={24}
+          strokeWidth={1.5}
+        />
         <p className="text-sm font-medium text-[var(--color-fg-default)] text-center mb-2">
-          {t("search.noResults")}
+          {t("search.noResults.title")}
         </p>
         <p className="text-xs text-[var(--color-fg-muted)] text-center">
           {t("search.noResultsQuery", { query: props.effectiveQuery })}
@@ -434,7 +494,7 @@ function SearchResultsArea(props: {
             {t("search.suggestionsTitle")}
           </p>
           <p className="text-xs text-[var(--color-fg-muted)]">
-            {t("search.suggestionsText")}
+            {t("search.noResults.suggestion")}
           </p>
         </div>
         <Button
@@ -459,7 +519,10 @@ function SearchResultsArea(props: {
     <>
       {props.documentItems.length > 0 &&
         (props.category === "all" || props.category === "documents") && (
-          <ResultGroup title={t("search.resultTypes.documents")} count={props.documentItems.length}>
+          <ResultGroup
+            title={t("search.resultTypes.documents")}
+            count={props.documentItems.length}
+          >
             {props.documentItems.map((item, index) => (
               <DocumentResultItem
                 key={item.id}
@@ -529,6 +592,100 @@ function SearchResultsArea(props: {
   );
 }
 
+/**
+ * Filter bar with semantic search and archive toggles.
+ */
+function SearchFilterBar(props: {
+  semanticSearch: boolean;
+  includeArchived: boolean;
+  onSemanticChange: (v: boolean) => void;
+  onArchivedChange: (v: boolean) => void;
+}): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <div className="px-4 py-3 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-raised)]">
+      <div className="flex items-center gap-6">
+        <Toggle
+          id="semantic-toggle"
+          label={t("search.filters.semanticSearch")}
+          checked={props.semanticSearch}
+          onCheckedChange={props.onSemanticChange}
+        />
+        <Toggle
+          id="archived-toggle"
+          label={t("search.filters.includeArchived")}
+          checked={props.includeArchived}
+          onCheckedChange={props.onArchivedChange}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
+          {t("search.filters.scope")}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="!flex !items-center !gap-1.5 !px-2 !py-1 !h-auto !rounded !bg-[var(--color-separator)] !border !border-[var(--color-separator)] !text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-fg-default)] hover:!border-[var(--color-bg-overlay)]"
+        >
+          <span>{t("search.filters.currentProject")}</span>
+          <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Footer with result count and keyboard navigation hints.
+ */
+function SearchFooter(props: {
+  hasResults: boolean;
+  totalResults: number;
+}): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <div className="border-t border-[var(--color-separator)] px-4 py-3 flex items-center justify-between shrink-0 bg-[var(--color-bg-raised)]">
+      <div className="flex items-center gap-4">
+        {props.hasResults && (
+          <>
+            <span className="text-xs text-[var(--color-fg-muted)] font-medium">
+              {t("search.results.result", { count: props.totalResults })}
+            </span>
+            <div className="h-3 w-px bg-[var(--color-bg-overlay)]" />
+            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              {t("search.results.searchTime", { time: "0.04s" })}
+            </span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <KeyHint
+          icon={
+            <span className="flex gap-0.5">
+              <ChevronUp className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
+            </span>
+          }
+          label=""
+        />
+        <KeyHint
+          icon={
+            <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
+          }
+          label={t("search.footer.toNavigate")}
+        />
+        <KeyHint
+          icon={
+            <CornerDownLeft className="w-3 h-3" size={16} strokeWidth={1.5} />
+          }
+          label={t("search.footer.toOpen")}
+        />
+        <KeyHint text="esc" label={t("search.footer.toClose")} />
+      </div>
+    </div>
+  );
+}
 
 /**
  * SearchPanel provides a modal search interface across documents, memories, and knowledge.
@@ -618,15 +775,51 @@ export function SearchPanel(props: {
     }
   }, [open]);
 
+  function handleInputKeyDown(e: React.KeyboardEvent): void {
+    if (e.key === "Enter") {
+      void runFulltext({ projectId, limit: 20 });
+    }
+  }
+
+  const handleItemClick = React.useCallback(
+    (documentId: string): void => {
+      const result = items.find((item) => item.id === documentId);
+      if (!result || result.type !== "document") {
+        onClose?.();
+        return;
+      }
+
+      const targetDocumentId = result.documentId ?? result.id;
+      void navigateSearchResult({
+        projectId,
+        result: {
+          documentId: targetDocumentId,
+          anchor: result.anchor,
+        },
+        setCurrent,
+        setFlashKey,
+        onClose,
+      });
+    },
+    [items, projectId, setCurrent, onClose],
+  );
+
+  function handleRetrySearch(): void {
+    clearError();
+    void runFulltext({ projectId, limit: 20 });
+  }
+
   // Handle keyboard shortcuts — only when panel is open
   useHotkey(
     "search:close",
     { key: "Escape" },
     React.useCallback(() => {
-      if (onClose) {
+      if (effectiveQuery.trim().length > 0) {
+        setQuery("");
+      } else if (onClose) {
         onClose();
       }
-    }, [onClose]),
+    }, [effectiveQuery, setQuery, onClose]),
     "global",
     25,
     open,
@@ -659,36 +852,18 @@ export function SearchPanel(props: {
     open,
   );
 
-  function handleInputKeyDown(e: React.KeyboardEvent): void {
-    if (e.key === "Enter") {
-      void runFulltext({ projectId, limit: 20 });
-    }
-  }
-
-  function handleItemClick(documentId: string): void {
-    const result = items.find((item) => item.id === documentId);
-    if (!result || result.type !== "document") {
-      onClose?.();
-      return;
-    }
-
-    const targetDocumentId = result.documentId ?? result.id;
-    void navigateSearchResult({
-      projectId,
-      result: {
-        documentId: targetDocumentId,
-        anchor: result.anchor,
-      },
-      setCurrent,
-      setFlashKey,
-      onClose,
-    });
-  }
-
-  function handleRetrySearch(): void {
-    clearError();
-    void runFulltext({ projectId, limit: 20 });
-  }
+  useHotkey(
+    "search:activate",
+    { key: "Enter" },
+    React.useCallback(() => {
+      if (hasResults && activeIndex >= 0 && activeIndex < items.length) {
+        handleItemClick(items[activeIndex].id);
+      }
+    }, [hasResults, activeIndex, items, handleItemClick]),
+    "global",
+    25,
+    open && hasResults,
+  );
 
   if (!open) return null;
 
@@ -705,20 +880,22 @@ export function SearchPanel(props: {
       />
 
       {/* Glass Panel Modal */}
-      <div
-        className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-[var(--z-modal)] bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] motion-safe:animate-[slideDown_0.3s_ease-out]"
-      >
+      <div className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-[var(--z-modal)] bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] motion-safe:animate-[slideDown_0.3s_ease-out]">
         {/* Header */}
-        <div
-          className="flex flex-col border-b border-[var(--color-separator)] bg-[var(--color-bg-surface)]"
-        >
+        <div className="flex flex-col border-b border-[var(--color-separator)] bg-[var(--color-bg-surface)]">
           {/* Search input row */}
           <div className="flex items-center px-4 py-4 gap-3">
-            <Search className="w-5 h-5 text-[var(--color-fg-muted)]" size={20} strokeWidth={1.5} />
+            <Search
+              className="w-5 h-5 text-[var(--color-fg-muted)]"
+              size={20}
+              strokeWidth={1.5}
+            />
             <Input
               ref={inputRef}
               data-testid="search-input"
               type="text"
+              role="searchbox"
+              aria-label={t("search.input.ariaLabel")}
               value={effectiveQuery}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleInputKeyDown}
@@ -768,38 +945,12 @@ export function SearchPanel(props: {
           </div>
 
           {/* Filter options bar */}
-          <div
-            className="px-4 py-3 border-t border-[var(--color-separator)] flex items-center justify-between bg-[var(--color-bg-raised)]"
-          >
-            <div className="flex items-center gap-6">
-              <Toggle
-                id="semantic-toggle"
-                label={t("search.filters.semanticSearch")}
-                checked={semanticSearch}
-                onCheckedChange={setSemanticSearch}
-              />
-              <Toggle
-                id="archived-toggle"
-                label={t("search.filters.includeArchived")}
-                checked={includeArchived}
-                onCheckedChange={setIncludeArchived}
-              />
-            </div>
-
-            <div className="flex items-center gap-2">
-              <span className="text-[10px] text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
-                {t("search.filters.scope")}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="!flex !items-center !gap-1.5 !px-2 !py-1 !h-auto !rounded !bg-[var(--color-separator)] !border !border-[var(--color-separator)] !text-xs !text-[var(--color-fg-muted)] hover:!text-[var(--color-fg-default)] hover:!border-[var(--color-bg-overlay)]"
-              >
-                <span>{t("search.filters.currentProject")}</span>
-                <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
-              </Button>
-            </div>
-          </div>
+          <SearchFilterBar
+            semanticSearch={semanticSearch}
+            includeArchived={includeArchived}
+            onSemanticChange={setSemanticSearch}
+            onArchivedChange={setIncludeArchived}
+          />
         </div>
 
         {/* Results container */}
@@ -826,53 +977,11 @@ export function SearchPanel(props: {
             onRetrySearch={handleRetrySearch}
             onClearQuery={() => setQuery("")}
           />
-
         </div>
 
         {/* Footer */}
-        <div
-          className="border-t border-[var(--color-separator)] px-4 py-3 flex items-center justify-between shrink-0 bg-[var(--color-bg-raised)]"
-        >
-          <div className="flex items-center gap-4">
-            {hasResults && (
-              <>
-                <span className="text-xs text-[var(--color-fg-muted)] font-medium">
-                  {t("search.results.result", { count: totalResults })}
-                </span>
-                <div className="h-3 w-px bg-[var(--color-bg-overlay)]" />
-                <span className="text-[10px] text-[var(--color-fg-placeholder)]">
-                  {t("search.results.searchTime", { time: "0.04s" })}
-                </span>
-              </>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            <KeyHint
-              icon={
-                <span className="flex gap-0.5">
-                  <ChevronUp className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
-                </span>
-              }
-              label=""
-            />
-            <KeyHint
-              icon={
-                <ChevronDown className="w-2.5 h-2.5" size={16} strokeWidth={1.5} />
-              }
-              label={t("search.footer.toNavigate")}
-            />
-            <KeyHint
-              icon={
-                <CornerDownLeft className="w-3 h-3" size={16} strokeWidth={1.5} />
-              }
-              label={t("search.footer.toOpen")}
-            />
-            <KeyHint text="esc" label={t("search.footer.toClose")} />
-          </div>
-        </div>
+        <SearchFooter hasResults={hasResults} totalResults={totalResults} />
       </div>
-
     </div>
   );
 }

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -234,7 +234,10 @@
     "rebuildingQuery": "Query: \"{{query}}\"",
     "errorTitle": "Search failed, please retry",
     "retrySearch": "Retry Search",
-    "noResults": "No matching results",
+    "noResults": {
+      "title": "No matching results",
+      "suggestion": "Try checking your spelling or using different keywords"
+    },
     "noResultsQuery": "Query: \"{{query}}\"",
     "suggestionsTitle": "Suggestions",
     "suggestionsText": "Try checking your spelling or using different keywords",
@@ -272,7 +275,15 @@
       "toClose": "to close"
     },
     "inputPlaceholder": "Search...",
-    "matchScore": "{{score}}% match"
+    "matchScore": "{{score}}% match",
+    "input": {
+      "placeholder": "Search documents, memories, knowledge...",
+      "ariaLabel": "Global search"
+    },
+    "resultCount": "{{count}} result(s)",
+    "shortcut": {
+      "label": "Global Search"
+    }
   },
   "ai": {
     "contextSummary": "AI panel context summary",
@@ -879,7 +890,7 @@
       "writingExperience": "Writing Experience",
       "dataAndStorage": "Data & Storage",
       "editorDefaults": "Editor Defaults",
-      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra \u201c{{marker}}\u201d marker."
+      "differentiateAiEditsDescription": "When enabled, AI-generated entries in Version History show an extra “{{marker}}” marker."
     },
     "appearance": {
       "colorWhite": "White",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -234,7 +234,10 @@
     "rebuildingQuery": "查询词：\"{{query}}\"",
     "errorTitle": "搜索失败，请重试",
     "retrySearch": "重试搜索",
-    "noResults": "未找到匹配结果",
+    "noResults": {
+      "title": "未找到匹配结果",
+      "suggestion": "建议检查拼写或使用不同关键词"
+    },
     "noResultsQuery": "查询词：\"{{query}}\"",
     "suggestionsTitle": "建议",
     "suggestionsText": "建议检查拼写或使用不同关键词",
@@ -272,7 +275,15 @@
       "toClose": "关闭"
     },
     "inputPlaceholder": "搜索…",
-    "matchScore": "{{score}}% 匹配"
+    "matchScore": "{{score}}% 匹配",
+    "input": {
+      "placeholder": "搜索文档、记忆、知识库...",
+      "ariaLabel": "全局搜索"
+    },
+    "resultCount": "{{count}} 个结果",
+    "shortcut": {
+      "label": "全局搜索"
+    }
   },
   "ai": {
     "contextSummary": "AI 面板上下文摘要",
@@ -879,7 +890,7 @@
       "writingExperience": "写作体验",
       "dataAndStorage": "数据与存储",
       "editorDefaults": "编辑器默认值",
-      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的\u201c{{marker}}\u201d标记。"
+      "differentiateAiEditsDescription": "启用后，版本历史中 AI 生成的条目将显示额外的“{{marker}}”标记。"
     },
     "appearance": {
       "colorWhite": "白色",

--- a/apps/desktop/renderer/src/surfaces/surfaceRegistry.ts
+++ b/apps/desktop/renderer/src/surfaces/surfaceRegistry.ts
@@ -536,7 +536,10 @@ export const surfaceRegistry: SurfaceRegistryItem[] = [
   {
     id: "searchPanel",
     kind: "leftPanel",
-    entryPoints: [{ type: "iconBar", description: "Search icon" }],
+    entryPoints: [
+      { type: "iconBar", description: "Search icon" },
+      { type: "shortcut", description: "Cmd/Ctrl+Shift+F" },
+    ],
     testId: "search-panel",
     storybookTitle: "Features/SearchPanel",
   },


### PR DESCRIPTION
## Summary

Closes #1003

### What Changes
- 在 `shortcuts.ts` 注册 `globalSearch` 快捷键 `mod+Shift+F`
- `NavigationController` 新增 `onOpenGlobalSearch` 回调与 hotkey 注册
- `AppShell` 传入 `onOpenGlobalSearch` 切换到搜索面板
- `SearchPanel` 搜索结果点击后跳转到对应文档
- `surfaceRegistry` 补充 shortcut 入口点
- i18n 补齐搜索相关文案（en/zh-CN）
- 禅模式下不触发全局搜索

### Rollback
Revert this commit.

### Audit Gate
Awaiting independent audit.