### PR TITLE
feat(autosave): A0-02 保存失败可见化 (#992)

### DIFF
--- a/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
+++ b/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
@@ -260,9 +260,38 @@ describe("A0-02 文档切换 flush 失败 Toast", () => {
     vi.restoreAllMocks();
   });
 
-  it("文档切换时若有 autosaveError 则弹 warning Toast", async () => {
-    const store = createEditorStore({
-      invoke: createMockInvoke({ ok: true, data: {} }),
+  it("openDocument 前的 flush save 失败时，在新文档上下文弹 warning Toast", async () => {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === "file:document:save") {
+        return {
+          ok: false,
+          error: { code: "IO_ERROR", message: "Disk full" },
+        };
+      }
+
+      if (channel === "file:document:read") {
+        return {
+          ok: true,
+          data: {
+            status: "draft",
+            contentJson: '{"type":"doc","content":[]}',
+          },
+        };
+      }
+
+      return { ok: true, data: {} };
+    });
+
+    const store = createEditorStore({ invoke: invoke as never });
+
+    await act(async () => {
+      store.setState({
+        projectId: "proj-1",
+        documentId: "doc-1",
+        lastSavedOrQueuedJson: '{"type":"doc","content":[{"type":"paragraph"}]}',
+        autosaveStatus: "idle",
+        autosaveError: null,
+      });
     });
 
     render(
@@ -273,22 +302,17 @@ describe("A0-02 文档切换 flush 失败 Toast", () => {
       </AppToastProvider>,
     );
 
-    // 设置初始文档
     await act(async () => {
-      store.setState({
-        documentId: "doc-1",
-        autosaveError: null,
-      });
-    });
-
-    // 模拟 flush 失败后切换文档：先设 error，然后切换 documentId
-    await act(async () => {
-      store.setState({
-        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      await store.getState().openDocument({
+        projectId: "proj-1",
         documentId: "doc-2",
       });
     });
 
+    expect(invoke).toHaveBeenCalledWith(
+      "file:document:save",
+      expect.objectContaining({ documentId: "doc-1", reason: "autosave" }),
+    );
     expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -297,7 +321,7 @@ describe("A0-02 文档切换 flush 失败 Toast", () => {
     ).toBeInTheDocument();
   });
 
-  it("文档切换时若无 autosaveError 则不弹 Toast", async () => {
+  it("普通 autosaveError 或文档切换本身不应误触 flush warning Toast", async () => {
     const store = createEditorStore({
       invoke: createMockInvoke({ ok: true, data: {} }),
     });
@@ -313,7 +337,7 @@ describe("A0-02 文档切换 flush 失败 Toast", () => {
     await act(async () => {
       store.setState({
         documentId: "doc-1",
-        autosaveError: null,
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
       });
     });
 

--- a/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
+++ b/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+import { AppToastProvider } from "../components/providers/AppToastProvider";
+import { SaveIndicator } from "../components/layout/SaveIndicator";
+import {
+  useAutoSaveToast,
+  useFlushErrorToast,
+} from "../hooks/useToastIntegration";
+import { createEditorStore, EditorStoreProvider } from "../stores/editorStore";
+
+/**
+ * A0-02: 自动保存失败可见化
+ *
+ * 测试覆盖：
+ * - SaveIndicator 四态渲染
+ * - SaveIndicator 点击重试
+ * - Toast 失败触发（含 dedup）
+ * - 文档切换 flush 失败 Toast
+ * - saved → idle 自动转换（fake timers）
+ */
+
+function createMockInvoke(result: {
+  ok: boolean;
+  data?: unknown;
+  error?: unknown;
+}) {
+  return vi.fn().mockResolvedValue(result);
+}
+
+function AutoSaveToastConsumer(): JSX.Element {
+  useAutoSaveToast();
+  return <div data-testid="autosave-consumer" />;
+}
+
+function FlushErrorToastConsumer(): JSX.Element {
+  useFlushErrorToast();
+  return <div data-testid="flush-consumer" />;
+}
+
+describe("A0-02 SaveIndicator 四态渲染", () => {
+  it("idle 状态不显示文字", () => {
+    render(<SaveIndicator autosaveStatus="idle" onRetry={vi.fn()} />);
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("");
+    expect(el).toHaveAttribute("data-status", "idle");
+  });
+
+  it("saving 状态显示 Saving... 和 spinner", () => {
+    render(<SaveIndicator autosaveStatus="saving" onRetry={vi.fn()} />);
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("Saving...");
+    expect(el).toHaveAttribute("data-status", "saving");
+    expect(screen.getByTestId("save-spinner")).toBeInTheDocument();
+  });
+
+  it("saved 状态显示 Saved", () => {
+    render(<SaveIndicator autosaveStatus="saved" onRetry={vi.fn()} />);
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("Saved");
+    expect(el).toHaveAttribute("data-status", "saved");
+  });
+
+  it("error 状态显示 Save failed 并可点击", () => {
+    const retry = vi.fn();
+    render(<SaveIndicator autosaveStatus="error" onRetry={retry} />);
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("Save failed");
+    expect(el).toHaveAttribute("data-status", "error");
+    expect(el).toHaveAttribute("role", "button");
+  });
+});
+
+describe("A0-02 SaveIndicator 点击重试", () => {
+  it("error 状态点击触发 onRetry", () => {
+    const retry = vi.fn();
+    render(<SaveIndicator autosaveStatus="error" onRetry={retry} />);
+    fireEvent.click(screen.getByTestId("editor-autosave-status"));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("error 状态键盘 Enter 触发 onRetry", () => {
+    const retry = vi.fn();
+    render(<SaveIndicator autosaveStatus="error" onRetry={retry} />);
+    fireEvent.keyDown(screen.getByTestId("editor-autosave-status"), {
+      key: "Enter",
+    });
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("非 error 状态点击不触发 onRetry", () => {
+    const retry = vi.fn();
+    render(<SaveIndicator autosaveStatus="saved" onRetry={retry} />);
+    fireEvent.click(screen.getByTestId("editor-autosave-status"));
+    expect(retry).not.toHaveBeenCalled();
+  });
+});
+
+describe("A0-02 saved → idle 自动转换", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("saved 状态 2 秒后自动回到 idle", () => {
+    render(<SaveIndicator autosaveStatus="saved" onRetry={vi.fn()} />);
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("Saved");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(el).toHaveTextContent("");
+    expect(el).toHaveAttribute("data-status", "idle");
+  });
+
+  it("saved 期间如果变 error，不应回到 idle", () => {
+    const { rerender } = render(
+      <SaveIndicator autosaveStatus="saved" onRetry={vi.fn()} />,
+    );
+    const el = screen.getByTestId("editor-autosave-status");
+    expect(el).toHaveTextContent("Saved");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    rerender(<SaveIndicator autosaveStatus="error" onRetry={vi.fn()} />);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByTestId("editor-autosave-status")).toHaveTextContent(
+      "Save failed",
+    );
+  });
+});
+
+describe("A0-02 Toast 失败触发 + dedup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("autosave error 触发 error Toast", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <AutoSaveToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        documentId: "doc-1",
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      });
+    });
+
+    expect(screen.getByText("Save failed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Unable to save document. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("同一 documentId 连续 error 只弹一次 Toast（dedup）", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <AutoSaveToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    // 第一次 error
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        documentId: "doc-1",
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      });
+    });
+
+    const toasts1 = screen.getAllByText("Save failed");
+    expect(toasts1).toHaveLength(1);
+
+    // 状态回 saving 再回 error（同一 documentId）
+    await act(async () => {
+      store.setState({ autosaveStatus: "saving" });
+    });
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        autosaveError: { code: "IO_ERROR", message: "Disk full again" },
+      });
+    });
+
+    // 仍然只有 1 个 toast（dedup 生效，同一 documentId 连续失败）
+    const toasts2 = screen.getAllByText("Save failed");
+    expect(toasts2).toHaveLength(1);
+  });
+
+  it("不同 documentId 的 error 可以再次弹 Toast", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <AutoSaveToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    // doc-1 error
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        documentId: "doc-1",
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      });
+    });
+
+    // 切换到 doc-2 error
+    await act(async () => {
+      store.setState({ autosaveStatus: "idle" });
+    });
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        documentId: "doc-2",
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      });
+    });
+
+    // 两个 toast 都存在
+    const toasts = screen.getAllByText("Save failed");
+    expect(toasts.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("A0-02 文档切换 flush 失败 Toast", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("文档切换时若有 autosaveError 则弹 warning Toast", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <FlushErrorToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    // 设置初始文档
+    await act(async () => {
+      store.setState({
+        documentId: "doc-1",
+        autosaveError: null,
+      });
+    });
+
+    // 模拟 flush 失败后切换文档：先设 error，然后切换 documentId
+    await act(async () => {
+      store.setState({
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+        documentId: "doc-2",
+      });
+    });
+
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Some changes could not be saved before switching documents.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("文档切换时若无 autosaveError 则不弹 Toast", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <FlushErrorToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    await act(async () => {
+      store.setState({
+        documentId: "doc-1",
+        autosaveError: null,
+      });
+    });
+
+    await act(async () => {
+      store.setState({
+        documentId: "doc-2",
+        autosaveError: null,
+      });
+    });
+
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  });
+});
+
+describe("A0-02 retry 成功后的 toast", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("error → saved 转换时弹 retry 成功 Toast", async () => {
+    const store = createEditorStore({
+      invoke: createMockInvoke({ ok: true, data: {} }),
+    });
+
+    render(
+      <AppToastProvider>
+        <EditorStoreProvider store={store}>
+          <AutoSaveToastConsumer />
+        </EditorStoreProvider>
+      </AppToastProvider>,
+    );
+
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "error",
+        documentId: "doc-1",
+        autosaveError: { code: "IO_ERROR", message: "Disk full" },
+      });
+    });
+
+    await act(async () => {
+      store.setState({
+        autosaveStatus: "saved",
+        autosaveError: null,
+      });
+    });
+
+    expect(screen.getByText("Document saved successfully")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
+++ b/apps/desktop/renderer/src/__tests__/autosave-visibility.test.tsx
@@ -288,7 +288,8 @@ describe("A0-02 文档切换 flush 失败 Toast", () => {
       store.setState({
         projectId: "proj-1",
         documentId: "doc-1",
-        lastSavedOrQueuedJson: '{"type":"doc","content":[{"type":"paragraph"}]}',
+        lastSavedOrQueuedJson:
+          '{"type":"doc","content":[{"type":"paragraph"}]}',
         autosaveStatus: "idle",
         autosaveError: null,
       });

--- a/apps/desktop/renderer/src/components/layout/SaveIndicator.aria-live.test.tsx
+++ b/apps/desktop/renderer/src/components/layout/SaveIndicator.aria-live.test.tsx
@@ -9,4 +9,19 @@ describe("SaveIndicator aria-live (WB-FE-ARIA-S4)", () => {
     const indicator = screen.getByTestId("editor-autosave-status");
     expect(indicator).toHaveAttribute("aria-live", "polite");
   });
+
+  it("error 状态应含 role='button' 和 aria-label", () => {
+    render(<SaveIndicator autosaveStatus="error" onRetry={vi.fn()} />);
+
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveAttribute("role", "button");
+    expect(indicator).toHaveAttribute("aria-label");
+  });
+
+  it("非 error 状态应含 role='status'", () => {
+    render(<SaveIndicator autosaveStatus="saving" onRetry={vi.fn()} />);
+
+    const indicator = screen.getByTestId("editor-autosave-status");
+    expect(indicator).toHaveAttribute("role", "status");
+  });
 });

--- a/apps/desktop/renderer/src/components/layout/SaveIndicator.tsx
+++ b/apps/desktop/renderer/src/components/layout/SaveIndicator.tsx
@@ -47,25 +47,55 @@ export function SaveIndicator(props: {
   }, [props.autosaveStatus]);
 
   const isError = displayStatus === "error";
+  const isSaving = displayStatus === "saving";
+  const isSaved = displayStatus === "saved";
   const label = getSaveLabel(displayStatus, t);
+
+  if (isError) {
+    return (
+      <span
+        data-testid="editor-autosave-status"
+        role="button"
+        aria-label={t("workbench.saveIndicator.retryLabel")}
+        aria-live="polite"
+        data-status={displayStatus}
+        tabIndex={0}
+        onClick={() => props.onRetry()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            props.onRetry();
+          }
+        }}
+        className="text-[var(--color-error)] bg-[var(--color-error-subtle)] px-1.5 rounded cursor-pointer underline"
+      >
+        {label}
+      </span>
+    );
+  }
 
   return (
     <span
       data-testid="editor-autosave-status"
+      role="status"
       aria-live="polite"
       data-status={displayStatus}
-      onClick={() => {
-        if (isError) {
-          props.onRetry();
-        }
-      }}
       className={
-        isError
-          ? "text-[var(--color-error)] cursor-pointer underline"
-          : "text-[var(--color-fg-muted)] cursor-default"
+        isSaved ? "text-[var(--color-success)]" : "text-[var(--color-fg-muted)]"
       }
     >
-      {label}
+      {isSaving ? (
+        <>
+          <span
+            className="inline-block w-3 h-3 mr-1 border-2 border-current border-t-transparent rounded-full animate-spin align-middle"
+            aria-hidden="true"
+            data-testid="save-spinner"
+          />
+          {label}
+        </>
+      ) : (
+        label
+      )}
     </span>
   );
 }

--- a/apps/desktop/renderer/src/components/providers/ToastIntegrationBridge.tsx
+++ b/apps/desktop/renderer/src/components/providers/ToastIntegrationBridge.tsx
@@ -1,5 +1,6 @@
 import {
   useAutoSaveToast,
+  useFlushErrorToast,
   useAiErrorToast,
 } from "../../hooks/useToastIntegration";
 
@@ -11,6 +12,7 @@ import {
  */
 export function ToastIntegrationBridge(): null {
   useAutoSaveToast();
+  useFlushErrorToast();
   useAiErrorToast();
   return null;
 }

--- a/apps/desktop/renderer/src/hooks/useToastIntegration.ts
+++ b/apps/desktop/renderer/src/hooks/useToastIntegration.ts
@@ -80,7 +80,9 @@ export function useFlushErrorToast(): void {
   const { showToast } = useAppToast();
   const documentId = useEditorStore((s) => s.documentId);
   const pendingFlushError = useEditorStore((s) => s.pendingFlushError);
-  const clearPendingFlushError = useEditorStore((s) => s.clearPendingFlushError);
+  const clearPendingFlushError = useEditorStore(
+    (s) => s.clearPendingFlushError,
+  );
 
   React.useEffect(() => {
     if (!pendingFlushError || !documentId) {

--- a/apps/desktop/renderer/src/hooks/useToastIntegration.ts
+++ b/apps/desktop/renderer/src/hooks/useToastIntegration.ts
@@ -78,23 +78,26 @@ export function useAutoSaveToast(): void {
 export function useFlushErrorToast(): void {
   const { t } = useTranslation();
   const { showToast } = useAppToast();
-  const autosaveError = useEditorStore((s) => s.autosaveError);
   const documentId = useEditorStore((s) => s.documentId);
-  const prevDocIdRef = React.useRef(documentId);
+  const pendingFlushError = useEditorStore((s) => s.pendingFlushError);
+  const clearPendingFlushError = useEditorStore((s) => s.clearPendingFlushError);
 
   React.useEffect(() => {
-    const prevDocId = prevDocIdRef.current;
-    prevDocIdRef.current = documentId;
-
-    // 文档切换后，如果仍有 autosaveError，说明上一篇的 flush 失败
-    if (prevDocId !== null && documentId !== prevDocId && autosaveError) {
-      showToast({
-        title: t("toast.autosave.flushError.title"),
-        description: t("toast.autosave.flushError.description"),
-        variant: "warning",
-      });
+    if (!pendingFlushError || !documentId) {
+      return;
     }
-  }, [documentId, autosaveError, showToast, t]);
+
+    if (documentId === pendingFlushError.documentId) {
+      return;
+    }
+
+    showToast({
+      title: t("toast.autosave.flushError.title"),
+      description: t("toast.autosave.flushError.description"),
+      variant: "warning",
+    });
+    clearPendingFlushError();
+  }, [clearPendingFlushError, documentId, pendingFlushError, showToast, t]);
 }
 
 /**

--- a/apps/desktop/renderer/src/hooks/useToastIntegration.ts
+++ b/apps/desktop/renderer/src/hooks/useToastIntegration.ts
@@ -9,14 +9,16 @@ import { useOptionalAiStore } from "../stores/aiStore";
  * useAutoSaveToast — 监听 editorStore.autosaveStatus 变化，触发 Toast
  *
  * - "saved" → success toast
- * - "error" → error toast with retry action
+ * - "error" → error toast with retry action (deduped per documentId)
  */
 export function useAutoSaveToast(): void {
   const { t } = useTranslation();
   const { showToast } = useAppToast();
   const autosaveStatus = useEditorStore((s) => s.autosaveStatus);
+  const documentId = useEditorStore((s) => s.documentId);
   const retryLastAutosave = useEditorStore((s) => s.retryLastAutosave);
   const prevStatusRef = React.useRef(autosaveStatus);
+  const lastErrorDocIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     const prev = prevStatusRef.current;
@@ -28,11 +30,26 @@ export function useAutoSaveToast(): void {
     }
 
     if (autosaveStatus === "saved") {
-      showToast({
-        title: t("toast.save.success.title"),
-        variant: "success",
-      });
+      // 如果之前是 error → saved，说明 retry 成功
+      if (prev === "error") {
+        lastErrorDocIdRef.current = null;
+        showToast({
+          title: t("toast.autosave.retrySuccess.title"),
+          variant: "success",
+        });
+      } else {
+        showToast({
+          title: t("toast.save.success.title"),
+          variant: "success",
+        });
+      }
     } else if (autosaveStatus === "error") {
+      // Dedup: 同一 documentId 连续失败只弹一次 toast
+      if (lastErrorDocIdRef.current === documentId) {
+        return;
+      }
+      lastErrorDocIdRef.current = documentId;
+
       showToast({
         title: t("toast.save.error.title"),
         description: t("toast.save.error.description"),
@@ -44,8 +61,40 @@ export function useAutoSaveToast(): void {
           },
         },
       });
+    } else {
+      // 非 error 状态时重置 dedup 标记
+      if (autosaveStatus !== "saving") {
+        lastErrorDocIdRef.current = null;
+      }
     }
-  }, [autosaveStatus, showToast, t, retryLastAutosave]);
+  }, [autosaveStatus, documentId, showToast, t, retryLastAutosave]);
+}
+
+/**
+ * useFlushErrorToast — 监听文档切换时 flush 失败，显示警告 toast
+ *
+ * 当 autosaveError 存在且 documentId 发生变化时触发
+ */
+export function useFlushErrorToast(): void {
+  const { t } = useTranslation();
+  const { showToast } = useAppToast();
+  const autosaveError = useEditorStore((s) => s.autosaveError);
+  const documentId = useEditorStore((s) => s.documentId);
+  const prevDocIdRef = React.useRef(documentId);
+
+  React.useEffect(() => {
+    const prevDocId = prevDocIdRef.current;
+    prevDocIdRef.current = documentId;
+
+    // 文档切换后，如果仍有 autosaveError，说明上一篇的 flush 失败
+    if (prevDocId !== null && documentId !== prevDocId && autosaveError) {
+      showToast({
+        title: t("toast.autosave.flushError.title"),
+        description: t("toast.autosave.flushError.description"),
+        variant: "warning",
+      });
+    }
+  }, [documentId, autosaveError, showToast, t]);
 }
 
 /**

--- a/apps/desktop/renderer/src/i18n/__tests__/toast-keys.test.ts
+++ b/apps/desktop/renderer/src/i18n/__tests__/toast-keys.test.ts
@@ -17,6 +17,9 @@ const REQUIRED_TOAST_KEYS = [
   "toast.ai.error.title",
   "toast.ai.error.description",
   "toast.settings.success.title",
+  "toast.autosave.retrySuccess.title",
+  "toast.autosave.flushError.title",
+  "toast.autosave.flushError.description",
 ] as const;
 
 function getNestedValue(obj: Record<string, unknown>, path: string): unknown {

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -936,7 +936,8 @@
       "manageSubscription": "Manage Subscription",
       "dangerZone": "Danger Zone",
       "deleteAccount": "Delete Account",
-      "deleteAccountDescription": "Permanently delete your account and all associated data."
+      "deleteAccountDescription": "Permanently delete your account and all associated data.",
+      "comingSoonTooltip": "Account features coming soon"
     },
     "general": {
       "zhCN": "Chinese (Simplified)",
@@ -1543,9 +1544,12 @@
       "title": "Unexpected system error",
       "description": "Some features may be affected. Please retry the operation. If the problem persists, restart the app."
     }
-  }
-,
+  },
   "versionControl": {
     "restoreComingSoon": "Version restore coming soon"
+  },
+  "common": {
+    "comingSoon": "Coming soon",
+    "featureInDevelopment": "This feature is under development"
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -47,7 +47,8 @@
     "saveIndicator": {
       "saving": "Saving...",
       "saved": "Saved",
-      "error": "Save failed"
+      "error": "Save failed",
+      "retryLabel": "Retry save"
     },
     "infoPanel": {
       "openVersionHistory": "View Version History"
@@ -1410,6 +1411,15 @@
     "settings": {
       "success": {
         "title": "Settings saved"
+      }
+    },
+    "autosave": {
+      "retrySuccess": {
+        "title": "Document saved successfully"
+      },
+      "flushError": {
+        "title": "Unsaved changes",
+        "description": "Some changes could not be saved before switching documents."
       }
     }
   },

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -936,7 +936,8 @@
       "manageSubscription": "管理订阅",
       "dangerZone": "危险操作",
       "deleteAccount": "删除账户",
-      "deleteAccountDescription": "永久删除你的账户及所有关联数据。"
+      "deleteAccountDescription": "永久删除你的账户及所有关联数据。",
+      "comingSoonTooltip": "账户功能即将推出"
     },
     "general": {
       "zhCN": "中文 (简体)",
@@ -1543,9 +1544,12 @@
       "title": "系统遇到意外问题",
       "description": "部分功能可能受影响，请尝试重新操作。如问题持续，请重启应用。"
     }
-  }
-,
+  },
   "versionControl": {
     "restoreComingSoon": "版本恢复功能即将推出"
+  },
+  "common": {
+    "comingSoon": "即将推出",
+    "featureInDevelopment": "此功能正在开发中"
   }
 }

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -47,7 +47,8 @@
     "saveIndicator": {
       "saving": "保存中...",
       "saved": "已保存",
-      "error": "保存失败"
+      "error": "保存失败",
+      "retryLabel": "重试保存"
     },
     "infoPanel": {
       "openVersionHistory": "查看版本历史"
@@ -1410,6 +1411,15 @@
     "settings": {
       "success": {
         "title": "设置已保存"
+      }
+    },
+    "autosave": {
+      "retrySuccess": {
+        "title": "文档保存成功"
+      },
+      "flushError": {
+        "title": "未保存的更改",
+        "description": "切换文档前部分更改未能保存。"
       }
     }
   },

--- a/apps/desktop/renderer/src/stores/editorAutosaveHelpers.ts
+++ b/apps/desktop/renderer/src/stores/editorAutosaveHelpers.ts
@@ -1,0 +1,167 @@
+import type { IpcError } from "@shared/types/ipc-generated";
+
+import type { IpcInvoke } from "../lib/ipcTypes";
+import type { EditorSaveRequest } from "./editorSaveQueue";
+import type { EditorStore } from "./editorStore";
+
+type EditorStoreDeps = {
+  get: () => EditorStore;
+  set: (patch: Partial<EditorStore>) => void;
+};
+
+type ExecuteSaveDeps = EditorStoreDeps & {
+  invoke: IpcInvoke;
+};
+
+function isCurrentRequest(
+  state: Pick<EditorStore, "projectId" | "documentId">,
+  request: Pick<EditorSaveRequest, "projectId" | "documentId">,
+): boolean {
+  return (
+    state.projectId === request.projectId &&
+    state.documentId === request.documentId
+  );
+}
+
+function toUnexpectedSaveError(error: unknown): IpcError {
+  return {
+    code: "INTERNAL_ERROR",
+    message:
+      error instanceof Error
+        ? error.message
+        : "file:document:save threw unexpectedly",
+  };
+}
+
+export function createSaveQueueUnexpectedErrorHandler(deps: EditorStoreDeps) {
+  return ({
+    request,
+    error,
+  }: {
+    request: EditorSaveRequest;
+    error: unknown;
+  }) => {
+    if (!isCurrentRequest(deps.get(), request)) {
+      return;
+    }
+
+    deps.set({
+      autosaveStatus: "error",
+      autosaveError: {
+        code: "INTERNAL_ERROR",
+        message:
+          error instanceof Error
+            ? error.message
+            : "editor save queue failed unexpectedly",
+      },
+    });
+  };
+}
+
+export function createRetryLastAutosaveAction(deps: EditorStoreDeps) {
+  return async () => {
+    const state = deps.get();
+    if (
+      !state.projectId ||
+      !state.documentId ||
+      !state.lastSavedOrQueuedJson ||
+      state.lastSavedOrQueuedJson.length === 0
+    ) {
+      return;
+    }
+
+    deps.set({ autosaveError: null });
+    await state.save({
+      projectId: state.projectId,
+      documentId: state.documentId,
+      contentJson: state.lastSavedOrQueuedJson,
+      actor: "auto",
+      reason: "autosave",
+    });
+  };
+}
+
+export function createFlushPendingAutosaveAction(deps: EditorStoreDeps) {
+  return async () => {
+    const state = deps.get();
+    if (
+      !state.projectId ||
+      !state.documentId ||
+      !state.lastSavedOrQueuedJson ||
+      state.lastSavedOrQueuedJson.length === 0
+    ) {
+      deps.set({ pendingFlushError: null });
+      return;
+    }
+
+    await state.save({
+      projectId: state.projectId,
+      documentId: state.documentId,
+      contentJson: state.lastSavedOrQueuedJson,
+      actor: "auto",
+      reason: "autosave",
+    });
+
+    const current = deps.get();
+    if (
+      isCurrentRequest(current, {
+        projectId: state.projectId,
+        documentId: state.documentId,
+      }) &&
+      current.autosaveStatus === "error" &&
+      current.autosaveError
+    ) {
+      deps.set({
+        pendingFlushError: {
+          documentId: state.documentId,
+          error: current.autosaveError,
+        },
+      });
+      return;
+    }
+
+    deps.set({ pendingFlushError: null });
+  };
+}
+
+export function createSaveQueueExecuteSave(deps: ExecuteSaveDeps) {
+  return async (request: EditorSaveRequest) => {
+    if (isCurrentRequest(deps.get(), request)) {
+      deps.set({
+        autosaveStatus: "saving",
+        lastSavedOrQueuedJson: request.contentJson,
+      });
+    }
+
+    try {
+      const res = await deps.invoke("file:document:save", {
+        projectId: request.projectId,
+        documentId: request.documentId,
+        contentJson: request.contentJson,
+        actor: request.actor,
+        reason: request.reason,
+      });
+
+      if (!res.ok) {
+        if (isCurrentRequest(deps.get(), request)) {
+          deps.set({ autosaveStatus: "error", autosaveError: res.error });
+        }
+        return;
+      }
+
+      if (isCurrentRequest(deps.get(), request)) {
+        deps.set({
+          autosaveStatus: "saved",
+          autosaveError: null,
+        });
+      }
+    } catch (error) {
+      if (isCurrentRequest(deps.get(), request)) {
+        deps.set({
+          autosaveStatus: "error",
+          autosaveError: toUnexpectedSaveError(error),
+        });
+      }
+    }
+  };
+}

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -30,6 +30,11 @@ export type EntityCompletionCandidate = {
   type: IpcRequest<"knowledge:entity:create">["type"];
 };
 
+export type PendingFlushError = {
+  documentId: string;
+  error: IpcError;
+};
+
 export type EntityCompletionSession = {
   open: boolean;
   query: string;
@@ -55,6 +60,7 @@ export type EditorState = {
   capacityWarning: string | null;
   autosaveStatus: AutosaveStatus;
   autosaveError: IpcError | null;
+  pendingFlushError: PendingFlushError | null;
   entityCompletionSession: EntityCompletionSession;
   /** Whether compare mode is active (showing DiffView instead of Editor) */
   compareMode: boolean;
@@ -79,6 +85,7 @@ export type EditorActions = {
   }) => Promise<void>;
   retryLastAutosave: () => Promise<void>;
   flushPendingAutosave: () => Promise<void>;
+  clearPendingFlushError: () => void;
   setAutosaveStatus: (status: AutosaveStatus) => void;
   setDocumentCharacterCount: (count: number) => void;
   setCapacityWarning: (warning: string | null) => void;
@@ -228,6 +235,7 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
       capacityWarning: null,
       autosaveStatus: "idle",
       autosaveError: null,
+      pendingFlushError: null,
       entityCompletionSession: createInitialEntityCompletionSession(),
       compareMode: false,
       compareVersionId: null,
@@ -340,6 +348,15 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
       },
 
       openDocument: async ({ projectId, documentId }) => {
+        const current = get();
+        if (
+          current.projectId === projectId &&
+          current.documentId &&
+          current.documentId !== documentId
+        ) {
+          await current.flushPendingAutosave();
+        }
+
         set({
           bootstrapStatus: "loading",
           projectId,
@@ -458,6 +475,7 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
           !state.lastSavedOrQueuedJson ||
           state.lastSavedOrQueuedJson.length === 0
         ) {
+          set({ pendingFlushError: null });
           return;
         }
 
@@ -468,6 +486,28 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
           actor: "auto",
           reason: "autosave",
         });
+
+        const current = get();
+        if (
+          current.projectId === state.projectId &&
+          current.documentId === state.documentId &&
+          current.autosaveStatus === "error" &&
+          current.autosaveError
+        ) {
+          set({
+            pendingFlushError: {
+              documentId: state.documentId,
+              error: current.autosaveError,
+            },
+          });
+          return;
+        }
+
+        set({ pendingFlushError: null });
+      },
+
+      clearPendingFlushError: () => {
+        set({ pendingFlushError: null });
       },
     };
   });

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -7,10 +7,13 @@ import type {
   IpcInvokeResult,
   IpcRequest,
 } from "@shared/types/ipc-generated";
+import { createEditorSaveQueue } from "./editorSaveQueue";
 import {
-  createEditorSaveQueue,
-  type EditorSaveRequest,
-} from "./editorSaveQueue";
+  createFlushPendingAutosaveAction,
+  createRetryLastAutosaveAction,
+  createSaveQueueUnexpectedErrorHandler,
+  createSaveQueueExecuteSave,
+} from "./editorAutosaveHelpers";
 import type { IpcInvoke } from "../lib/ipcTypes";
 
 export type { IpcInvoke };
@@ -124,107 +127,6 @@ function createInitialEntityCompletionSession(): EntityCompletionSession {
   };
 }
 
-function createSaveQueueUnexpectedErrorHandler(deps: {
-  get: () => EditorStore;
-  set: (patch: Partial<EditorStore>) => void;
-}) {
-  return ({
-    request,
-    error,
-  }: {
-    request: EditorSaveRequest;
-    error: unknown;
-  }) => {
-    const stillCurrent =
-      deps.get().projectId === request.projectId &&
-      deps.get().documentId === request.documentId;
-    if (!stillCurrent) {
-      return;
-    }
-
-    deps.set({
-      autosaveStatus: "error",
-      autosaveError: {
-        code: "INTERNAL_ERROR",
-        message:
-          error instanceof Error
-            ? error.message
-            : "editor save queue failed unexpectedly",
-      },
-    });
-  };
-}
-
-function createRetryLastAutosaveAction(deps: {
-  get: () => EditorStore;
-  set: (patch: Partial<EditorStore>) => void;
-}) {
-  return async () => {
-    const state = deps.get();
-    if (
-      !state.projectId ||
-      !state.documentId ||
-      !state.lastSavedOrQueuedJson ||
-      state.lastSavedOrQueuedJson.length === 0
-    ) {
-      return;
-    }
-
-    deps.set({ autosaveError: null });
-    await state.save({
-      projectId: state.projectId,
-      documentId: state.documentId,
-      contentJson: state.lastSavedOrQueuedJson,
-      actor: "auto",
-      reason: "autosave",
-    });
-  };
-}
-
-function createFlushPendingAutosaveAction(deps: {
-  get: () => EditorStore;
-  set: (patch: Partial<EditorStore>) => void;
-}) {
-  return async () => {
-    const state = deps.get();
-    if (
-      !state.projectId ||
-      !state.documentId ||
-      !state.lastSavedOrQueuedJson ||
-      state.lastSavedOrQueuedJson.length === 0
-    ) {
-      deps.set({ pendingFlushError: null });
-      return;
-    }
-
-    await state.save({
-      projectId: state.projectId,
-      documentId: state.documentId,
-      contentJson: state.lastSavedOrQueuedJson,
-      actor: "auto",
-      reason: "autosave",
-    });
-
-    const current = deps.get();
-    if (
-      current.projectId === state.projectId &&
-      current.documentId === state.documentId &&
-      current.autosaveStatus === "error" &&
-      current.autosaveError
-    ) {
-      deps.set({
-        pendingFlushError: {
-          documentId: state.documentId,
-          error: current.autosaveError,
-        },
-      });
-      return;
-    }
-
-    deps.set({ pendingFlushError: null });
-  };
-}
-
 /**
  * Create a zustand store for editor/document state.
  *
@@ -240,63 +142,11 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
         get,
         set: (patch) => set(patch),
       }),
-      executeSave: async (request: EditorSaveRequest) => {
-        const isCurrent =
-          get().projectId === request.projectId &&
-          get().documentId === request.documentId;
-        if (isCurrent) {
-          set({
-            autosaveStatus: "saving",
-            lastSavedOrQueuedJson: request.contentJson,
-          });
-        }
-
-        try {
-          const res = await deps.invoke("file:document:save", {
-            projectId: request.projectId,
-            documentId: request.documentId,
-            contentJson: request.contentJson,
-            actor: request.actor,
-            reason: request.reason,
-          });
-
-          if (!res.ok) {
-            const stillCurrent =
-              get().projectId === request.projectId &&
-              get().documentId === request.documentId;
-            if (stillCurrent) {
-              set({ autosaveStatus: "error", autosaveError: res.error });
-            }
-            return;
-          }
-
-          const stillCurrent =
-            get().projectId === request.projectId &&
-            get().documentId === request.documentId;
-          if (stillCurrent) {
-            set({
-              autosaveStatus: "saved",
-              autosaveError: null,
-            });
-          }
-        } catch (error) {
-          const stillCurrent =
-            get().projectId === request.projectId &&
-            get().documentId === request.documentId;
-          if (stillCurrent) {
-            set({
-              autosaveStatus: "error",
-              autosaveError: {
-                code: "INTERNAL_ERROR",
-                message:
-                  error instanceof Error
-                    ? error.message
-                    : "file:document:save threw unexpectedly",
-              },
-            });
-          }
-        }
-      },
+      executeSave: createSaveQueueExecuteSave({
+        get,
+        set: (patch) => set(patch),
+        invoke: deps.invoke,
+      }),
     });
 
     return {

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -155,6 +155,76 @@ function createSaveQueueUnexpectedErrorHandler(deps: {
   };
 }
 
+function createRetryLastAutosaveAction(deps: {
+  get: () => EditorStore;
+  set: (patch: Partial<EditorStore>) => void;
+}) {
+  return async () => {
+    const state = deps.get();
+    if (
+      !state.projectId ||
+      !state.documentId ||
+      !state.lastSavedOrQueuedJson ||
+      state.lastSavedOrQueuedJson.length === 0
+    ) {
+      return;
+    }
+
+    deps.set({ autosaveError: null });
+    await state.save({
+      projectId: state.projectId,
+      documentId: state.documentId,
+      contentJson: state.lastSavedOrQueuedJson,
+      actor: "auto",
+      reason: "autosave",
+    });
+  };
+}
+
+function createFlushPendingAutosaveAction(deps: {
+  get: () => EditorStore;
+  set: (patch: Partial<EditorStore>) => void;
+}) {
+  return async () => {
+    const state = deps.get();
+    if (
+      !state.projectId ||
+      !state.documentId ||
+      !state.lastSavedOrQueuedJson ||
+      state.lastSavedOrQueuedJson.length === 0
+    ) {
+      deps.set({ pendingFlushError: null });
+      return;
+    }
+
+    await state.save({
+      projectId: state.projectId,
+      documentId: state.documentId,
+      contentJson: state.lastSavedOrQueuedJson,
+      actor: "auto",
+      reason: "autosave",
+    });
+
+    const current = deps.get();
+    if (
+      current.projectId === state.projectId &&
+      current.documentId === state.documentId &&
+      current.autosaveStatus === "error" &&
+      current.autosaveError
+    ) {
+      deps.set({
+        pendingFlushError: {
+          documentId: state.documentId,
+          error: current.autosaveError,
+        },
+      });
+      return;
+    }
+
+    deps.set({ pendingFlushError: null });
+  };
+}
+
 /**
  * Create a zustand store for editor/document state.
  *
@@ -454,65 +524,15 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
         return true;
       },
 
-      retryLastAutosave: async () => {
-        const state = get();
-        if (
-          !state.projectId ||
-          !state.documentId ||
-          !state.lastSavedOrQueuedJson ||
-          state.lastSavedOrQueuedJson.length === 0
-        ) {
-          return;
-        }
+      retryLastAutosave: createRetryLastAutosaveAction({
+        get,
+        set: (patch) => set(patch),
+      }),
 
-        set({ autosaveError: null });
-        await state.save({
-          projectId: state.projectId,
-          documentId: state.documentId,
-          contentJson: state.lastSavedOrQueuedJson,
-          actor: "auto",
-          reason: "autosave",
-        });
-      },
-
-      flushPendingAutosave: async () => {
-        const state = get();
-        if (
-          !state.projectId ||
-          !state.documentId ||
-          !state.lastSavedOrQueuedJson ||
-          state.lastSavedOrQueuedJson.length === 0
-        ) {
-          set({ pendingFlushError: null });
-          return;
-        }
-
-        await state.save({
-          projectId: state.projectId,
-          documentId: state.documentId,
-          contentJson: state.lastSavedOrQueuedJson,
-          actor: "auto",
-          reason: "autosave",
-        });
-
-        const current = get();
-        if (
-          current.projectId === state.projectId &&
-          current.documentId === state.documentId &&
-          current.autosaveStatus === "error" &&
-          current.autosaveError
-        ) {
-          set({
-            pendingFlushError: {
-              documentId: state.documentId,
-              error: current.autosaveError,
-            },
-          });
-          return;
-        }
-
-        set({ pendingFlushError: null });
-      },
+      flushPendingAutosave: createFlushPendingAutosaveAction({
+        get,
+        set: (patch) => set(patch),
+      }),
 
       clearPendingFlushError: () => {
         set({ pendingFlushError: null });

--- a/apps/desktop/renderer/src/stores/editorStore.tsx
+++ b/apps/desktop/renderer/src/stores/editorStore.tsx
@@ -128,7 +128,13 @@ function createSaveQueueUnexpectedErrorHandler(deps: {
   get: () => EditorStore;
   set: (patch: Partial<EditorStore>) => void;
 }) {
-  return ({ request, error }: { request: EditorSaveRequest; error: unknown }) => {
+  return ({
+    request,
+    error,
+  }: {
+    request: EditorSaveRequest;
+    error: unknown;
+  }) => {
     const stillCurrent =
       deps.get().projectId === request.projectId &&
       deps.get().documentId === request.documentId;
@@ -278,7 +284,9 @@ export function createEditorStore(deps: { invoke: IpcInvoke }) {
         if (currentRes.ok) {
           documentId = currentRes.data.documentId;
         } else if (currentRes.error.code === "NOT_FOUND") {
-          const listRes = await deps.invoke("file:document:list", { projectId });
+          const listRes = await deps.invoke("file:document:list", {
+            projectId,
+          });
           if (!shouldCommit()) return;
           if (!listRes.ok) {
             set({ bootstrapStatus: "error" });


### PR DESCRIPTION
## Summary

A0-02: 自动保存失败可见化 — 让用户在保存失败时能及时感知并重试。

### Changes

1. **SaveIndicator 四态渲染**
   - `idle`: hidden
   - `saving`: spinner + "Saving..." (muted color)
   - `saved`: "Saved" (success color, 2s auto-fade to idle)
   - `error`: "Save failed" (error color + subtle bg, clickable/keyboard retry)

2. **Toast on failure with dedup**
   - 同一 documentId 连续失败只弹一次 error Toast
   - Toast 含 Retry action button
   - error → saved 转换时弹 retry 成功 Toast

3. **Document switch flush failure toast**
   - 文档切换时若 flush 失败，在新文档上下文弹 warning Toast

4. **Accessibility**
   - Error state: `role="button"` + `aria-label` + keyboard support (Enter/Space)
   - Other states: `role="status"` + `aria-live="polite"`

5. **i18n**
   - Added `toast.autosave.retrySuccess.title`, `toast.autosave.flushError.title/description`
   - Added `workbench.saveIndicator.retryLabel` for aria-label
   - Both en.json and zh-CN.json

### Tests (15 new tests)
- SaveIndicator 4-state rendering (4)
- Click/keyboard retry (3)
- saved → idle auto-transition with fake timers (2)
- Toast failure trigger + dedup (3)
- Document switch flush failure toast (2)
- Retry success toast (1)

### Validation
- `pnpm typecheck`: ✅ pass
- `pnpm lint`: ✅ 0 errors
- `pnpm test:run`: ✅ 1876 tests pass (271 files)
- `prettier --write`: ✅ formatted

Closes #992