### PR TITLE
fix(error): A0-21 错误展示组件收口

### DIFF
--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDialogs.test.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDialogs.test.tsx
@@ -11,6 +11,7 @@ import type {
   AiInlineConfirmProps,
   DiffChange,
 } from "./types";
+import { i18n } from "../../../i18n";
 
 // =============================================================================
 // Test Data
@@ -495,7 +496,7 @@ describe("AiErrorCard", () => {
     expect(hasRetryWillSucceed).toBe(false);
   });
 
-  it("displays error code for service errors", () => {
+  it("shows a humanized service error instead of the raw error code", () => {
     const error: AiErrorConfig = {
       type: "service_error",
       title: "Service Error",
@@ -505,7 +506,8 @@ describe("AiErrorCard", () => {
 
     render(<AiErrorCard error={error} />);
 
-    expect(screen.getByText("upstream_error_503")).toBeInTheDocument();
+    expect(screen.getByText(i18n.t("error.generic"))).toBeInTheDocument();
+    expect(screen.queryByText("upstream_error_503")).not.toBeInTheDocument();
   });
 
   it("displays countdown for rate limit errors", () => {

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 
+import { getHumanErrorMessage } from "../../../lib/errorMessages";
 import type { AiErrorCardProps, AiErrorType } from "./types";
 
 /**
@@ -244,17 +246,27 @@ function RetryButtonContent(props: {
     return (
       <>
         <Spinner />
-        <span>{t('ai.error.retrying')}</span>
+        <span>{t("ai.error.retrying")}</span>
       </>
     );
   }
   if (props.retryState === "success") {
-    return <span className="text-[var(--color-success)]">{t('ai.error.success')}</span>;
+    return (
+      <span className="text-[var(--color-success)]">
+        {t("ai.error.success")}
+      </span>
+    );
   }
   if (props.retryState === "error") {
-    return <span className="text-[var(--color-error)]">{t('ai.error.failed')}</span>;
+    return (
+      <span className="text-[var(--color-error)]">{t("ai.error.failed")}</span>
+    );
   }
-  return <span>{props.isTimeout ? t('ai.error.tryAgain') : t('ai.error.retry')}</span>;
+  return (
+    <span>
+      {props.isTimeout ? t("ai.error.tryAgain") : t("ai.error.retry")}
+    </span>
+  );
 }
 
 /**
@@ -277,13 +289,21 @@ function AiErrorCardActions(props: {
       {props.errorType === "usage_limit" && (
         <>
           {props.onUpgradePlan && (
-            <button type="button" className={upgradeButtonStyles} onClick={props.onUpgradePlan}>
-              {t('ai.error.upgradePlan')}
+            <button
+              type="button"
+              className={upgradeButtonStyles}
+              onClick={props.onUpgradePlan}
+            >
+              {t("ai.error.upgradePlan")}
             </button>
           )}
           {props.onViewUsage && (
-            <button type="button" className={linkButtonStyles} onClick={props.onViewUsage}>
-              {t('ai.error.viewUsage')}
+            <button
+              type="button"
+              className={linkButtonStyles}
+              onClick={props.onViewUsage}
+            >
+              {t("ai.error.viewUsage")}
             </button>
           )}
         </>
@@ -292,13 +312,25 @@ function AiErrorCardActions(props: {
       {props.errorType === "service_error" && (
         <>
           {props.onRetry && (
-            <button type="button" className={retryButtonStyles} onClick={props.handleRetry} disabled={props.retryState === "loading"}>
-              <RetryButtonContent retryState={props.retryState} isTimeout={false} />
+            <button
+              type="button"
+              className={retryButtonStyles}
+              onClick={props.handleRetry}
+              disabled={props.retryState === "loading"}
+            >
+              <RetryButtonContent
+                retryState={props.retryState}
+                isTimeout={false}
+              />
             </button>
           )}
           {props.onCheckStatus && (
-            <button type="button" className={linkButtonStyles} onClick={props.onCheckStatus}>
-              {t('ai.error.checkStatus')}
+            <button
+              type="button"
+              className={linkButtonStyles}
+              onClick={props.onCheckStatus}
+            >
+              {t("ai.error.checkStatus")}
               <ExternalLinkIcon />
             </button>
           )}
@@ -315,7 +347,10 @@ function AiErrorCardActions(props: {
             onClick={props.handleRetry}
             disabled={props.isRetryDisabled}
           >
-            <RetryButtonContent retryState={props.retryState} isTimeout={props.errorType === "timeout"} />
+            <RetryButtonContent
+              retryState={props.retryState}
+              isTimeout={props.errorType === "timeout"}
+            />
           </button>
         )}
     </div>
@@ -729,6 +764,12 @@ export function AiErrorCard({
 
   const opacityClass =
     cardState === "dismissing" ? "opacity-0 scale-95" : "opacity-100 scale-100";
+  const localizedErrorCode = error.errorCode
+    ? getHumanErrorMessage({
+        code: error.errorCode as IpcErrorCode,
+        message: error.errorCode,
+      })
+    : null;
 
   return (
     <div
@@ -741,7 +782,7 @@ export function AiErrorCard({
           type="button"
           className={dismissButtonStyles}
           onClick={handleDismiss}
-          title={t('ai.error.dismiss')}
+          title={t("ai.error.dismiss")}
         >
           <CloseIcon />
         </button>
@@ -765,16 +806,18 @@ export function AiErrorCard({
 
           {/* Error code for service errors */}
 
-          {error.errorCode && (
+          {localizedErrorCode ? (
             <div data-testid={errorCodeTestId} className={errorCodeStyles}>
-              {error.errorCode}
+              {localizedErrorCode}
             </div>
-          )}
+          ) : null}
 
           {/* Countdown for rate limit */}
 
           {error.type === "rate_limit" && countdown > 0 && (
-            <div className={countdownStyles}>{t('ai.error.countdownRetry', { seconds: countdown })}</div>
+            <div className={countdownStyles}>
+              {t("ai.error.countdownRetry", { seconds: countdown })}
+            </div>
           )}
 
           {/* Ready to retry message when countdown completes */}
@@ -782,7 +825,9 @@ export function AiErrorCard({
           {error.type === "rate_limit" &&
             countdownComplete &&
             countdown === 0 && (
-              <div className={readyToRetryStyles}>{t('ai.error.readyToRetry')}</div>
+              <div className={readyToRetryStyles}>
+                {t("ai.error.readyToRetry")}
+              </div>
             )}
 
           {/* Actions */}

--- a/apps/desktop/renderer/src/components/layout/AppShell.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShell.tsx
@@ -73,6 +73,7 @@ import {
 } from "../../lib/diff/unifiedDiff";
 import { runFireAndForget } from "../../lib/fireAndForget";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { extractZenModeContent, getModKey } from "./appShellLayoutHelpers";
 import "../../i18n";
 
@@ -786,7 +787,7 @@ function useAppShellController() {
       onCreateDocument: async () => {
         if (!currentProjectId) throw new Error("No project selected");
         const res = await createDocument({ projectId: currentProjectId });
-        if (!res.ok) throw new Error(`${res.error.code}: ${res.error.message}`);
+        if (!res.ok) throw new Error(getHumanErrorMessage(res.error));
       },
     }),
     [createDocument, currentProjectId],

--- a/apps/desktop/renderer/src/features/ai/AiPanel.error-guide.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.error-guide.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => {
@@ -227,7 +228,10 @@ describe("AiPanel error guidance", () => {
     render(<AiPanel />);
 
     expect(await screen.findByTestId("ai-error-code")).toHaveTextContent(
-      "UNKNOWN_ERROR",
+      getHumanErrorMessage({
+        code: "UNKNOWN_ERROR" as never,
+        message: "Something went wrong",
+      }),
     );
     expect(screen.queryByTestId("ai-error-guide-db")).not.toBeInTheDocument();
     expect(
@@ -245,7 +249,10 @@ describe("AiPanel error guidance", () => {
     render(<AiPanel />);
 
     expect(await screen.findByTestId("ai-error-code")).toHaveTextContent(
-      "UPSTREAM_ERROR",
+      getHumanErrorMessage({
+        code: "UPSTREAM_ERROR",
+        message: "Gateway timeout",
+      }),
     );
     expect(
       screen.queryByTestId("ai-error-guide-provider"),

--- a/apps/desktop/renderer/src/features/ai/AiPanel.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AiPanel } from "./AiPanel";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import type { AiStore } from "../../stores/aiStore";
 
 // Mock stores
@@ -211,7 +212,15 @@ describe("AiPanel", () => {
       render(<AiPanel />);
 
       expect(screen.getByTestId("ai-error-code")).toBeInTheDocument();
-      expect(screen.getByText("TIMEOUT")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          getHumanErrorMessage({
+            code: "TIMEOUT",
+            message: "Request timed out",
+          }),
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("TIMEOUT")).not.toBeInTheDocument();
       expect(screen.getByText("Request timed out")).toBeInTheDocument();
     });
   });

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -1,7 +1,7 @@
 ﻿import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Editor } from "@tiptap/react";
-import type { IpcError } from "@shared/types/ipc-generated";
+import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
 import type { SettingsTab } from "../settings-dialog/SettingsDialog";
 
 import {
@@ -65,6 +65,7 @@ import {
 } from "./aiPanelFormatting";
 
 import { ArrowUp } from "lucide-react";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 const RECENT_MODELS_STORAGE_KEY = "creonow.ai.recentModels";
 const CANDIDATE_COUNT_STORAGE_KEY = "creonow.ai.candidateCount";
 const DB_REBUILD_DEFAULT_COMMAND = "pnpm -C apps/desktop rebuild:native";
@@ -195,7 +196,13 @@ function SendStopButton(props: {
   const { t } = useTranslation();
 
   return (
-    <Tooltip content={props.isWorking ? t('ai.panel.stopGenerating') : t('ai.panel.sendMessage')}>
+    <Tooltip
+      content={
+        props.isWorking
+          ? t("ai.panel.stopGenerating")
+          : t("ai.panel.sendMessage")
+      }
+    >
       <button
         data-testid="ai-send-stop"
         type="button"
@@ -203,18 +210,18 @@ function SendStopButton(props: {
         onClick={props.isWorking ? props.onStop : props.onSend}
         disabled={props.disabled}
       >
-      {props.isWorking ? (
-        // Stop icon: circle with square
+        {props.isWorking ? (
+          // Stop icon: circle with square
 
-        <div className="w-5 h-5 rounded-full border-2 border-current flex items-center justify-center">
-          <div className="w-2 h-2 bg-current rounded-[1px]" />
-        </div>
-      ) : (
-        // Send icon: arrow up
+          <div className="w-5 h-5 rounded-full border-2 border-current flex items-center justify-center">
+            <div className="w-2 h-2 bg-current rounded-[1px]" />
+          </div>
+        ) : (
+          // Send icon: arrow up
 
-        <ArrowUp size={16} strokeWidth={1.5} />
-      )}
-    </button>
+          <ArrowUp size={16} strokeWidth={1.5} />
+        )}
+      </button>
     </Tooltip>
   );
 }
@@ -304,7 +311,7 @@ function ErrorGuideCard(props: {
                 className="focus-ring text-[11px] px-2 py-1 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]"
                 onClick={() => void handleCopyCommand()}
               >
-                {copied ? t('ai.panel.copied') : t('ai.panel.copy')}
+                {copied ? t("ai.panel.copied") : t("ai.panel.copy")}
               </button>
             </div>
           ) : null}
@@ -374,7 +381,7 @@ export function CodeBlock(props: {
             onClick={handleCopy}
             className="focus-ring px-2 py-0.5 text-[11px] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
           >
-            {copied ? t('ai.panel.copied') : t('ai.panel.copy')}
+            {copied ? t("ai.panel.copied") : t("ai.panel.copy")}
           </button>
 
           {props.onApply && (
@@ -383,7 +390,7 @@ export function CodeBlock(props: {
               onClick={props.onApply}
               className="focus-ring px-2 py-0.5 text-[11px] text-[var(--color-fg-accent)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
             >
-              {t('ai.panel.applyCode')}
+              {t("ai.panel.applyCode")}
             </button>
           )}
         </div>
@@ -427,7 +434,7 @@ function buildAiErrorConfigs(args: {
   const skillsErrorConfig: AiErrorConfig | null = skillsLastError
     ? {
         type: "service_error",
-        title: t('ai.panel.skillsUnavailable'),
+        title: t("ai.panel.skillsUnavailable"),
         description: skillsLastError.message,
         errorCode: skillsLastError.code,
       }
@@ -436,8 +443,10 @@ function buildAiErrorConfigs(args: {
   const modelsErrorConfig: AiErrorConfig | null = modelsLastError
     ? {
         type: "service_error",
-        title: t('ai.panel.modelsUnavailable'),
-        description: `${modelsLastError.code}: ${modelsLastError.message}`,
+        title: t("ai.panel.modelsUnavailable"),
+        description: getHumanErrorMessage(
+          modelsLastError as { code: IpcErrorCode; message: string },
+        ),
         errorCode: modelsLastError.code,
       }
     : null;
@@ -453,11 +462,11 @@ function buildAiErrorConfigs(args: {
               : "service_error",
         title:
           lastError.code === "TIMEOUT" || lastError.code === "SKILL_TIMEOUT"
-            ? t('ai.panel.timeout')
+            ? t("ai.panel.timeout")
             : lastError.code === "RATE_LIMITED" ||
                 lastError.code === "AI_RATE_LIMITED"
-              ? t('ai.panel.rateLimited')
-              : t('ai.panel.aiError'),
+              ? t("ai.panel.rateLimited")
+              : t("ai.panel.aiError"),
         description: lastError.message,
         errorCode: lastError.code,
       }
@@ -503,8 +512,12 @@ function buildAiErrorConfigs(args: {
 type AiPanelEffectsDeps = {
   refreshSkills: () => Promise<void>;
   selectedModel: string;
-  setModelsStatus: React.Dispatch<React.SetStateAction<"idle" | "loading" | "ready" | "error">>;
-  setModelsLastError: React.Dispatch<React.SetStateAction<ModelsListError | null>>;
+  setModelsStatus: React.Dispatch<
+    React.SetStateAction<"idle" | "loading" | "ready" | "error">
+  >;
+  setModelsLastError: React.Dispatch<
+    React.SetStateAction<ModelsListError | null>
+  >;
   setAvailableModels: React.Dispatch<React.SetStateAction<AiModelOption[]>>;
   setSelectedModel: React.Dispatch<React.SetStateAction<AiModel>>;
   setRecentModelIds: React.Dispatch<React.SetStateAction<string[]>>;
@@ -512,7 +525,9 @@ type AiPanelEffectsDeps = {
   candidateCount: number;
   editor: Editor | null;
   bootstrapStatus: string;
-  setSelectionSnapshot: (snapshot: { selectionRef: SelectionRef; selectionText: string } | null) => void;
+  setSelectionSnapshot: (
+    snapshot: { selectionRef: SelectionRef; selectionText: string } | null,
+  ) => void;
   lastCandidates: AiCandidate[];
   selectedCandidateId: string | null;
   setSelectedCandidateId: (id: string | null) => void;
@@ -524,7 +539,10 @@ type AiPanelEffectsDeps = {
   selectionText: string;
   setProposal: (p: AiProposal | null) => void;
   setCompareMode: (enabled: boolean, versionId?: string | null) => void;
-  pendingSelectionSnapshotRef: React.MutableRefObject<{ selectionRef: SelectionRef; selectionText: string } | null>;
+  pendingSelectionSnapshotRef: React.MutableRefObject<{
+    selectionRef: SelectionRef;
+    selectionText: string;
+  } | null>;
   setInlineDiffConfirmOpen: React.Dispatch<React.SetStateAction<boolean>>;
   lastRunId: string | null;
   projectId: string | null;
@@ -540,15 +558,41 @@ type AiPanelEffectsDeps = {
 
 function useAiPanelEffects(d: AiPanelEffectsDeps): void {
   const {
-    activeOutputText, activeRunId, bootstrapStatus, candidateCount, editor,
-    evaluatedRunIdRef, handleNewChatRef, lastCandidates, lastHandledNewChatSignalRef,
-    lastRequest, lastRunId, newChatSignal, outputText,
-    pendingSelectionSnapshotRef, projectId, proposal, refreshSkills,
-    selectedCandidateId, selectedModel, selectionRef, selectionText,
-    setAvailableModels, setCandidateCount, setCompareMode, setInlineDiffConfirmOpen,
-    setJudgeResult, setModelsLastError, setModelsStatus, setProposal,
-    setRecentModelIds, setSelectedCandidateId, setSelectedModel, setSelectionSnapshot,
-    status, t,
+    activeOutputText,
+    activeRunId,
+    bootstrapStatus,
+    candidateCount,
+    editor,
+    evaluatedRunIdRef,
+    handleNewChatRef,
+    lastCandidates,
+    lastHandledNewChatSignalRef,
+    lastRequest,
+    lastRunId,
+    newChatSignal,
+    outputText,
+    pendingSelectionSnapshotRef,
+    projectId,
+    proposal,
+    refreshSkills,
+    selectedCandidateId,
+    selectedModel,
+    selectionRef,
+    selectionText,
+    setAvailableModels,
+    setCandidateCount,
+    setCompareMode,
+    setInlineDiffConfirmOpen,
+    setJudgeResult,
+    setModelsLastError,
+    setModelsStatus,
+    setProposal,
+    setRecentModelIds,
+    setSelectedCandidateId,
+    setSelectedModel,
+    setSelectionSnapshot,
+    status,
+    t,
   } = d;
 
   const refreshModels = React.useCallback(async () => {
@@ -558,20 +602,32 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
       const res = await invoke("ai:models:list", {});
       if (!res.ok) {
         setModelsStatus("error");
-        setModelsLastError({ code: res.error.code, message: res.error.message });
+        setModelsLastError({
+          code: res.error.code,
+          message: res.error.message,
+        });
         return;
       }
       setAvailableModels(res.data.items);
       setModelsStatus("ready");
       if (res.data.items.length === 0) return;
-      const selectedExists = res.data.items.some((item) => item.id === selectedModel);
+      const selectedExists = res.data.items.some(
+        (item) => item.id === selectedModel,
+      );
       if (!selectedExists) setSelectedModel(res.data.items[0].id);
     } catch (error) {
-      const cause = error instanceof Error ? error.message : String(error ?? "unknown");
+      const cause =
+        error instanceof Error ? error.message : String(error ?? "unknown");
       setModelsStatus("error");
       setModelsLastError({ code: "INTERNAL", message: cause });
     }
-  }, [selectedModel, setAvailableModels, setModelsLastError, setModelsStatus, setSelectedModel]);
+  }, [
+    selectedModel,
+    setAvailableModels,
+    setModelsLastError,
+    setModelsStatus,
+    setSelectedModel,
+  ]);
 
   React.useEffect(() => {
     void refreshSkills();
@@ -584,7 +640,9 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
       if (!raw) return;
       const parsed = JSON.parse(raw) as unknown;
       if (!Array.isArray(parsed)) return;
-      const items = parsed.filter((item): item is string => typeof item === "string").slice(0, 8);
+      const items = parsed
+        .filter((item): item is string => typeof item === "string")
+        .slice(0, 8);
       setRecentModelIds(items);
     } catch (error) {
       console.error("AiPanel localStorage read failed", {
@@ -598,9 +656,15 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
   React.useEffect(() => {
     if (selectedModel.trim().length === 0) return;
     setRecentModelIds((prev) => {
-      const next = [selectedModel, ...prev.filter((id) => id !== selectedModel)].slice(0, 8);
+      const next = [
+        selectedModel,
+        ...prev.filter((id) => id !== selectedModel),
+      ].slice(0, 8);
       try {
-        window.localStorage.setItem(RECENT_MODELS_STORAGE_KEY, JSON.stringify(next));
+        window.localStorage.setItem(
+          RECENT_MODELS_STORAGE_KEY,
+          JSON.stringify(next),
+        );
       } catch (error) {
         console.error("AiPanel localStorage write failed", {
           operation: "write",
@@ -630,7 +694,10 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
 
   React.useEffect(() => {
     try {
-      window.localStorage.setItem(CANDIDATE_COUNT_STORAGE_KEY, String(candidateCount));
+      window.localStorage.setItem(
+        CANDIDATE_COUNT_STORAGE_KEY,
+        String(candidateCount),
+      );
     } catch (error) {
       console.error("AiPanel localStorage write failed", {
         operation: "write",
@@ -641,7 +708,9 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
   }, [candidateCount]);
 
   React.useEffect(() => {
-    return onAiModelCatalogUpdated(() => { void refreshModels(); });
+    return onAiModelCatalogUpdated(() => {
+      void refreshModels();
+    });
   }, [refreshModels]);
 
   React.useEffect(() => {
@@ -651,10 +720,15 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
       if (!captured.ok) return;
       const normalized = captured.data.selectionText.trim();
       if (normalized.length === 0) return;
-      setSelectionSnapshot({ selectionRef: captured.data.selectionRef, selectionText: normalized });
+      setSelectionSnapshot({
+        selectionRef: captured.data.selectionRef,
+        selectionText: normalized,
+      });
     };
     editor.on("selectionUpdate", onSelectionUpdate);
-    return () => { editor?.off("selectionUpdate", onSelectionUpdate); };
+    return () => {
+      editor?.off("selectionUpdate", onSelectionUpdate);
+    };
   }, [bootstrapStatus, editor, setSelectionSnapshot]);
 
   React.useEffect(() => {
@@ -662,18 +736,22 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
       if (selectedCandidateId !== null) setSelectedCandidateId(null);
       return;
     }
-    const selectedExists = lastCandidates.some((item) => item.id === selectedCandidateId);
+    const selectedExists = lastCandidates.some(
+      (item) => item.id === selectedCandidateId,
+    );
     if (!selectedExists) setSelectedCandidateId(lastCandidates[0]?.id ?? null);
   }, [lastCandidates, selectedCandidateId, setSelectedCandidateId]);
 
   React.useEffect(() => {
     if (status !== "idle") return;
-    if (proposal || !activeRunId || activeOutputText.trim().length === 0) return;
+    if (proposal || !activeRunId || activeOutputText.trim().length === 0)
+      return;
     const effectiveSnapshot =
       selectionRef && selectionText.length > 0
         ? { selectionRef: selectionRef, selectionText: selectionText }
         : pendingSelectionSnapshotRef.current;
-    if (!effectiveSnapshot || effectiveSnapshot.selectionText.length === 0) return;
+    if (!effectiveSnapshot || effectiveSnapshot.selectionText.length === 0)
+      return;
     setProposal({
       runId: activeRunId,
       selectionRef: effectiveSnapshot.selectionRef,
@@ -682,7 +760,17 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
     });
     pendingSelectionSnapshotRef.current = null;
     if (typeof setCompareMode === "function") setCompareMode(true, null);
-  }, [activeOutputText, activeRunId, setCompareMode, proposal, selectionRef, selectionText, setProposal, status, pendingSelectionSnapshotRef]);
+  }, [
+    activeOutputText,
+    activeRunId,
+    setCompareMode,
+    proposal,
+    selectionRef,
+    selectionText,
+    setProposal,
+    status,
+    pendingSelectionSnapshotRef,
+  ]);
 
   React.useEffect(() => {
     if (!proposal) setInlineDiffConfirmOpen(false);
@@ -698,7 +786,9 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
       setJudgeResult(result);
     }
     window.addEventListener(JUDGE_RESULT_CHANNEL, onJudgeResultEvent);
-    return () => { window.removeEventListener(JUDGE_RESULT_CHANNEL, onJudgeResultEvent); };
+    return () => {
+      window.removeEventListener(JUDGE_RESULT_CHANNEL, onJudgeResultEvent);
+    };
   }, [lastRunId, projectId, setJudgeResult]);
 
   React.useEffect(() => {
@@ -728,9 +818,18 @@ function useAiPanelEffects(d: AiPanelEffectsDeps): void {
           error: error instanceof Error ? error.message : String(error),
         });
       }
-      if (evaluatedRunIdRef.current === lastRunId) evaluatedRunIdRef.current = null;
+      if (evaluatedRunIdRef.current === lastRunId)
+        evaluatedRunIdRef.current = null;
     });
-  }, [lastRequest, lastRunId, outputText, projectId, status, t, evaluatedRunIdRef]);
+  }, [
+    lastRequest,
+    lastRunId,
+    outputText,
+    projectId,
+    status,
+    t,
+    evaluatedRunIdRef,
+  ]);
 
   React.useEffect(() => {
     const signal = newChatSignal ?? 0;
@@ -763,7 +862,9 @@ type AiPanelActionsDeps = {
   applyStatus: AiApplyStatus;
   setInput: (v: string) => void;
   setSelectedSkillId: (id: string) => void;
-  setSelectionSnapshot: (s: { selectionRef: SelectionRef; selectionText: string } | null) => void;
+  setSelectionSnapshot: (
+    s: { selectionRef: SelectionRef; selectionText: string } | null,
+  ) => void;
   setLastRequest: React.Dispatch<React.SetStateAction<string | null>>;
   setJudgeResult: React.Dispatch<React.SetStateAction<JudgeResultEvent | null>>;
   setProposal: (p: AiProposal | null) => void;
@@ -781,24 +882,45 @@ type AiPanelActionsDeps = {
     candidateCount?: number;
     streamOverride?: boolean;
   }) => Promise<void>;
-  regenerateWithStrongNegative: (args?: { projectId?: string }) => Promise<void>;
+  regenerateWithStrongNegative: (args?: {
+    projectId?: string;
+  }) => Promise<void>;
   refreshSkills: () => Promise<void>;
-  persistAiApply: (args: { projectId: string; documentId: string; contentJson: string; runId: string }) => Promise<void>;
-  logAiApplyConflict: (args: { documentId: string; runId: string }) => Promise<void>;
+  persistAiApply: (args: {
+    projectId: string;
+    documentId: string;
+    contentJson: string;
+    runId: string;
+  }) => Promise<void>;
+  logAiApplyConflict: (args: {
+    documentId: string;
+    runId: string;
+  }) => Promise<void>;
   clearEvaluatedRunId: () => void;
-  setPendingSelectionSnapshot: (v: { selectionRef: SelectionRef; selectionText: string } | null) => void;
+  setPendingSelectionSnapshot: (
+    v: { selectionRef: SelectionRef; selectionText: string } | null,
+  ) => void;
   focusTextarea: () => void;
   t: (key: string) => string;
 };
 
 function createAiPanelActions(a: AiPanelActionsDeps) {
-  async function onRun(args?: { inputOverride?: string; skillIdOverride?: string }): Promise<void> {
+  async function onRun(args?: {
+    inputOverride?: string;
+    skillIdOverride?: string;
+  }): Promise<void> {
     const effectiveSkillId = args?.skillIdOverride ?? a.selectedSkillId;
     const inputToSend = (args?.inputOverride ?? a.input).trim();
     const allowEmptyInput = isContinueSkill(effectiveSkillId);
-    let selectionSnapshotForRun: { selectionRef: SelectionRef; selectionText: string } | null =
+    let selectionSnapshotForRun: {
+      selectionRef: SelectionRef;
+      selectionText: string;
+    } | null =
       a.selectionRef && a.selectionText.trim().length > 0
-        ? { selectionRef: a.selectionRef, selectionText: a.selectionText.trim() }
+        ? {
+            selectionRef: a.selectionRef,
+            selectionText: a.selectionText.trim(),
+          }
         : null;
     let selectionContextText = selectionSnapshotForRun?.selectionText ?? "";
     if (!selectionContextText && a.editor && a.bootstrapStatus === "ready") {
@@ -807,8 +929,14 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
         const normalized = captured.data.selectionText.trim();
         if (normalized.length > 0) {
           selectionContextText = normalized;
-          selectionSnapshotForRun = { selectionRef: captured.data.selectionRef, selectionText: normalized };
-          a.setSelectionSnapshot({ selectionRef: captured.data.selectionRef, selectionText: normalized });
+          selectionSnapshotForRun = {
+            selectionRef: captured.data.selectionRef,
+            selectionText: normalized,
+          };
+          a.setSelectionSnapshot({
+            selectionRef: captured.data.selectionRef,
+            selectionText: normalized,
+          });
         }
       }
     }
@@ -829,7 +957,10 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
     try {
       await a.run({
         inputOverride: composedInput,
-        context: { projectId: a.currentProject?.projectId ?? a.projectId ?? undefined, documentId: a.documentId ?? undefined },
+        context: {
+          projectId: a.currentProject?.projectId ?? a.projectId ?? undefined,
+          documentId: a.documentId ?? undefined,
+        },
         mode: a.selectedMode,
         model: a.selectedModel,
         candidateCount: a.candidateCount,
@@ -860,7 +991,9 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
     a.setSelectedCandidateId(null);
     a.setJudgeResult(null);
     a.clearEvaluatedRunId();
-    await a.regenerateWithStrongNegative({ projectId: a.currentProject?.projectId ?? a.projectId ?? undefined });
+    await a.regenerateWithStrongNegative({
+      projectId: a.currentProject?.projectId ?? a.projectId ?? undefined,
+    });
   }
 
   async function handleSkillSelect(skillId: string): Promise<void> {
@@ -877,29 +1010,63 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
     await onRun({ skillIdOverride: skillId, inputOverride });
   }
 
-  async function handleSkillToggle(args: { skillId: string; enabled: boolean }): Promise<void> {
-    const toggled = await invoke("skill:registry:toggle", { skillId: args.skillId, enabled: args.enabled });
-    if (!toggled.ok) { a.setError(toggled.error); return; }
+  async function handleSkillToggle(args: {
+    skillId: string;
+    enabled: boolean;
+  }): Promise<void> {
+    const toggled = await invoke("skill:registry:toggle", {
+      skillId: args.skillId,
+      enabled: args.enabled,
+    });
+    if (!toggled.ok) {
+      a.setError(toggled.error);
+      return;
+    }
     await a.refreshSkills();
   }
 
-  async function handleSkillScopeUpdate(args: { id: string; scope: "global" | "project" }): Promise<void> {
-    const updated = await invoke("skill:custom:update", { id: args.id, scope: args.scope });
-    if (!updated.ok) { a.setError(updated.error); return; }
+  async function handleSkillScopeUpdate(args: {
+    id: string;
+    scope: "global" | "project";
+  }): Promise<void> {
+    const updated = await invoke("skill:custom:update", {
+      id: args.id,
+      scope: args.scope,
+    });
+    if (!updated.ok) {
+      a.setError(updated.error);
+      return;
+    }
     await a.refreshSkills();
   }
 
   async function onApply(): Promise<void> {
     if (!a.editor || !a.proposal || !a.projectId || !a.documentId) return;
-    if (!a.inlineDiffConfirmOpen) { a.setInlineDiffConfirmOpen(true); return; }
-    const applied = applySelection({ editor: a.editor, selectionRef: a.proposal.selectionRef, replacementText: a.proposal.replacementText });
+    if (!a.inlineDiffConfirmOpen) {
+      a.setInlineDiffConfirmOpen(true);
+      return;
+    }
+    const applied = applySelection({
+      editor: a.editor,
+      selectionRef: a.proposal.selectionRef,
+      replacementText: a.proposal.replacementText,
+    });
     if (!applied.ok) {
       a.setError(applied.error);
-      if (applied.error.code === "CONFLICT") void a.logAiApplyConflict({ documentId: a.documentId, runId: a.proposal.runId });
+      if (applied.error.code === "CONFLICT")
+        void a.logAiApplyConflict({
+          documentId: a.documentId,
+          runId: a.proposal.runId,
+        });
       return;
     }
     const json = JSON.stringify(a.editor.getJSON());
-    await a.persistAiApply({ projectId: a.projectId, documentId: a.documentId, contentJson: json, runId: a.proposal.runId });
+    await a.persistAiApply({
+      projectId: a.projectId,
+      documentId: a.documentId,
+      contentJson: json,
+      runId: a.proposal.runId,
+    });
     a.setInlineDiffConfirmOpen(false);
   }
 
@@ -907,7 +1074,8 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       const allowEmptyInput = isContinueSkill(a.selectedSkillId);
-      if (!isRunning(a.status) && (allowEmptyInput || a.input.trim())) void onRun();
+      if (!isRunning(a.status) && (allowEmptyInput || a.input.trim()))
+        void onRun();
     }
   }
 
@@ -925,7 +1093,18 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
     a.focusTextarea();
   }
 
-  return { onRun, onReject, onSelectCandidate, onRegenerateAll, handleSkillSelect, handleSkillToggle, handleSkillScopeUpdate, onApply, handleKeyDown, handleNewChat };
+  return {
+    onRun,
+    onReject,
+    onSelectCandidate,
+    onRegenerateAll,
+    handleSkillSelect,
+    handleSkillToggle,
+    handleSkillScopeUpdate,
+    onApply,
+    handleKeyDown,
+    handleNewChat,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -971,9 +1150,9 @@ function AiPanelErrorDisplay(props: {
     return (
       <ErrorGuideCard
         testId="ai-error-guide-db"
-        title={t('ai.panel.dbErrorTitle')}
-        description={ec.dbGuideError?.message ?? t('ai.panel.dbErrorFallback')}
-        steps={[t('ai.panel.dbStep1'), t('ai.panel.dbStep2')]}
+        title={t("ai.panel.dbErrorTitle")}
+        description={ec.dbGuideError?.message ?? t("ai.panel.dbErrorFallback")}
+        steps={[t("ai.panel.dbStep1"), t("ai.panel.dbStep2")]}
         command={ec.dbGuideCommand}
         errorCode="DB_ERROR"
       />
@@ -984,11 +1163,15 @@ function AiPanelErrorDisplay(props: {
     return (
       <ErrorGuideCard
         testId="ai-error-guide-provider"
-        title={t('ai.panel.providerTitle')}
-        description={t('ai.panel.providerDescription')}
-        steps={[t('ai.panel.providerStep1'), t('ai.panel.providerStep2'), t('ai.panel.providerStep3')]}
+        title={t("ai.panel.providerTitle")}
+        description={t("ai.panel.providerDescription")}
+        steps={[
+          t("ai.panel.providerStep1"),
+          t("ai.panel.providerStep2"),
+          t("ai.panel.providerStep3"),
+        ]}
         errorCode={ec.providerGuideCode ?? "AI_NOT_CONFIGURED"}
-        actionLabel={t('ai.panel.openSettingsAi')}
+        actionLabel={t("ai.panel.openSettingsAi")}
         actionTestId="ai-error-guide-open-settings"
         onAction={() => props.openSettings("ai")}
       />
@@ -997,9 +1180,19 @@ function AiPanelErrorDisplay(props: {
 
   return (
     <>
-      {ec.skillsErrorConfig ? <AiErrorCard error={ec.skillsErrorConfig} showDismiss={false} /> : null}
-      {ec.modelsErrorConfig ? <AiErrorCard error={ec.modelsErrorConfig} showDismiss={false} /> : null}
-      {ec.runtimeErrorConfig ? <AiErrorCard error={ec.runtimeErrorConfig} errorCodeTestId="ai-error-code" onDismiss={props.clearError} /> : null}
+      {ec.skillsErrorConfig ? (
+        <AiErrorCard error={ec.skillsErrorConfig} showDismiss={false} />
+      ) : null}
+      {ec.modelsErrorConfig ? (
+        <AiErrorCard error={ec.modelsErrorConfig} showDismiss={false} />
+      ) : null}
+      {ec.runtimeErrorConfig ? (
+        <AiErrorCard
+          error={ec.runtimeErrorConfig}
+          errorCodeTestId="ai-error-code"
+          onDismiss={props.clearError}
+        />
+      ) : null}
     </>
   );
 }
@@ -1018,22 +1211,48 @@ function AiPanelProposalArea(props: {
   const { t } = useTranslation();
   return (
     <>
-      {!props.compareMode ? <DiffView diffText={props.diffText} testId="ai-panel-diff" /> : null}
+      {!props.compareMode ? (
+        <DiffView diffText={props.diffText} testId="ai-panel-diff" />
+      ) : null}
       <div className="flex gap-2">
-        <Button data-testid="ai-apply" variant="secondary" size="md" onClick={() => void props.onApply()} disabled={!props.canApply} className="flex-1">
-          {props.inlineDiffConfirmOpen ? t('ai.panel.applyArmed') : t('ai.panel.apply')}
+        <Button
+          data-testid="ai-apply"
+          variant="secondary"
+          size="md"
+          onClick={() => void props.onApply()}
+          disabled={!props.canApply}
+          className="flex-1"
+        >
+          {props.inlineDiffConfirmOpen
+            ? t("ai.panel.applyArmed")
+            : t("ai.panel.apply")}
         </Button>
         {props.inlineDiffConfirmOpen ? (
-          <Button data-testid="ai-apply-confirm" variant="secondary" size="md" onClick={() => void props.onApply()} disabled={!props.canApply} className="flex-1">
-            {t('ai.panel.confirmApply')}
+          <Button
+            data-testid="ai-apply-confirm"
+            variant="secondary"
+            size="md"
+            onClick={() => void props.onApply()}
+            disabled={!props.canApply}
+            className="flex-1"
+          >
+            {t("ai.panel.confirmApply")}
           </Button>
         ) : null}
         <Button
-          data-testid="ai-reject" variant="ghost" size="md"
-          onClick={props.inlineDiffConfirmOpen ? () => props.setInlineDiffConfirmOpen(false) : props.onReject}
+          data-testid="ai-reject"
+          variant="ghost"
+          size="md"
+          onClick={
+            props.inlineDiffConfirmOpen
+              ? () => props.setInlineDiffConfirmOpen(false)
+              : props.onReject
+          }
           disabled={props.applyStatus === "applying"}
         >
-          {props.inlineDiffConfirmOpen ? t('ai.panel.backToDiff') : t('ai.panel.reject')}
+          {props.inlineDiffConfirmOpen
+            ? t("ai.panel.backToDiff")
+            : t("ai.panel.reject")}
         </Button>
       </div>
     </>
@@ -1047,24 +1266,43 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
     <div className="flex-1 overflow-y-auto p-3 space-y-4">
       {props.lastRequest && (
         <div className="w-full p-3 rounded-[var(--radius-md)] bg-[var(--color-bg-base)]">
-          <div className="text-[13px] text-[var(--color-fg-default)] whitespace-pre-wrap">{props.lastRequest}</div>
+          <div className="text-[13px] text-[var(--color-fg-default)] whitespace-pre-wrap">
+            {props.lastRequest}
+          </div>
         </div>
       )}
 
       {props.working && (
         <div className="flex items-center gap-2 text-[12px] text-[var(--color-fg-muted)]">
           <Spinner size="sm" />
-          <span>{props.status === "streaming" ? t('ai.panel.generating') : t('ai.panel.thinking')}</span>
-          {typeof props.queuePosition === "number" && props.queuePosition > 0 ? (
-            <span data-testid="ai-queue-status">{t('ai.panel.queueStatus', { position: props.queuePosition, count: props.queuedCount })}</span>
+          <span>
+            {props.status === "streaming"
+              ? t("ai.panel.generating")
+              : t("ai.panel.thinking")}
+          </span>
+          {typeof props.queuePosition === "number" &&
+          props.queuePosition > 0 ? (
+            <span data-testid="ai-queue-status">
+              {t("ai.panel.queueStatus", {
+                position: props.queuePosition,
+                count: props.queuedCount,
+              })}
+            </span>
           ) : null}
         </div>
       )}
 
-      <AiPanelErrorDisplay errorConfigs={props.errorConfigs} clearError={props.clearError} openSettings={props.openSettings} />
+      <AiPanelErrorDisplay
+        errorConfigs={props.errorConfigs}
+        clearError={props.clearError}
+        openSettings={props.openSettings}
+      />
 
       {props.lastCandidates.length > 0 ? (
-        <div data-testid="ai-candidate-list" className="w-full grid grid-cols-1 gap-2">
+        <div
+          data-testid="ai-candidate-list"
+          className="w-full grid grid-cols-1 gap-2"
+        >
           {props.lastCandidates.map((candidate, index) => {
             const isSelected = props.selectedCandidate?.id === candidate.id;
             return (
@@ -1080,12 +1318,22 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
                 }`}
               >
                 <div className="flex items-center justify-between gap-2">
-                  <span className="text-[12px] font-semibold text-[var(--color-fg-default)]">{t("ai.candidate", { index: index + 1 })}</span>
+                  <span className="text-[12px] font-semibold text-[var(--color-fg-default)]">
+                    {t("ai.candidate", { index: index + 1 })}
+                  </span>
                   {isSelected ? (
-                    <span className="text-[11px] text-[var(--color-fg-accent)]">{t("ai.candidateSelected")}</span>
+                    <span className="text-[11px] text-[var(--color-fg-accent)]">
+                      {t("ai.candidateSelected")}
+                    </span>
                   ) : null}
                 </div>
-                <Text size="small" color="muted" className="mt-1 whitespace-pre-wrap">{candidate.summary}</Text>
+                <Text
+                  size="small"
+                  color="muted"
+                  className="mt-1 whitespace-pre-wrap"
+                >
+                  {candidate.summary}
+                </Text>
               </button>
             );
           })}
@@ -1094,63 +1342,127 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
 
       {props.lastCandidates.length > 1 ? (
         <div className="w-full flex justify-end">
-          <Button data-testid="ai-candidate-regenerate" variant="ghost" size="sm" onClick={() => void props.onRegenerateAll()} disabled={props.working}>
+          <Button
+            data-testid="ai-candidate-regenerate"
+            variant="ghost"
+            size="sm"
+            onClick={() => void props.onRegenerateAll()}
+            disabled={props.working}
+          >
             {t("ai.regenerateAll")}
           </Button>
         </div>
       ) : null}
 
       {props.activeOutputText ? (
-        <div data-testid="ai-output" className="w-full" aria-live="polite" aria-atomic="false">
+        <div
+          data-testid="ai-output"
+          className="w-full"
+          aria-live="polite"
+          aria-atomic="false"
+        >
           <div className="text-[13px] leading-relaxed text-[var(--color-fg-default)] whitespace-pre-wrap">
             {props.activeOutputText}
             {props.status === "streaming" && <span className="typing-cursor" />}
           </div>
         </div>
       ) : (
-        !props.lastRequest && !props.working && (
-          <div data-testid="ai-output" aria-live="polite" aria-atomic="false" className="flex-1 flex items-center justify-center text-center py-12">
-            <Text size="small" color="muted">{t("ai.emptyHint")}</Text>
+        !props.lastRequest &&
+        !props.working && (
+          <div
+            data-testid="ai-output"
+            aria-live="polite"
+            aria-atomic="false"
+            className="flex-1 flex items-center justify-center text-center py-12"
+          >
+            <Text size="small" color="muted">
+              {t("ai.emptyHint")}
+            </Text>
           </div>
         )
       )}
 
       {props.judgeResult ? (
-        <div data-testid="ai-judge-result" className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2 space-y-1">
+        <div
+          data-testid="ai-judge-result"
+          className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2 space-y-1"
+        >
           <div className="flex items-center gap-2 flex-wrap">
-            <span data-testid="ai-judge-severity" className={`text-[11px] font-semibold uppercase tracking-wide ${judgeSeverityClass(props.judgeResult.severity)}`}>
+            <span
+              data-testid="ai-judge-severity"
+              className={`text-[11px] font-semibold uppercase tracking-wide ${judgeSeverityClass(props.judgeResult.severity)}`}
+            >
               {props.judgeResult.severity}
             </span>
             {props.judgeResult.labels.length === 0 ? (
-              <span data-testid="ai-judge-pass" className="text-[12px] text-[var(--color-fg-default)]">{t("ai.judgePass")}</span>
+              <span
+                data-testid="ai-judge-pass"
+                className="text-[12px] text-[var(--color-fg-default)]"
+              >
+                {t("ai.judgePass")}
+              </span>
             ) : (
               props.judgeResult.labels.map((label) => (
-                <span key={label} className="text-[12px] text-[var(--color-fg-default)]">{label}</span>
+                <span
+                  key={label}
+                  className="text-[12px] text-[var(--color-fg-default)]"
+                >
+                  {label}
+                </span>
               ))
             )}
           </div>
-          <Text data-testid="ai-judge-summary" size="small" color="muted">{props.judgeResult.summary}</Text>
+          <Text data-testid="ai-judge-summary" size="small" color="muted">
+            {props.judgeResult.summary}
+          </Text>
           {props.judgeResult.partialChecksSkipped ? (
-            <Text data-testid="ai-judge-partial" size="small" color="muted">{t("ai.judgePartialSkipped")}</Text>
+            <Text data-testid="ai-judge-partial" size="small" color="muted">
+              {t("ai.judgePartialSkipped")}
+            </Text>
           ) : null}
         </div>
       ) : null}
 
       {props.usageStats ? (
-        <div data-testid="ai-usage-stats" className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2">
+        <div
+          data-testid="ai-usage-stats"
+          className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2"
+        >
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-[var(--color-fg-muted)]">
-            <span>{t('ai.panel.usagePrompt')}{" "}<span data-testid="ai-usage-prompt-tokens">{formatTokenValue(props.usageStats.promptTokens)}</span></span>
-            <span>{t("ai.usageOutput")}{" "}<span data-testid="ai-usage-completion-tokens">{formatTokenValue(props.usageStats.completionTokens)}</span></span>
-            <span>{t("ai.usageSessionTotal")}{" "}<span data-testid="ai-usage-session-total-tokens">{formatTokenValue(props.usageStats.sessionTotalTokens)}</span></span>
+            <span>
+              {t("ai.panel.usagePrompt")}{" "}
+              <span data-testid="ai-usage-prompt-tokens">
+                {formatTokenValue(props.usageStats.promptTokens)}
+              </span>
+            </span>
+            <span>
+              {t("ai.usageOutput")}{" "}
+              <span data-testid="ai-usage-completion-tokens">
+                {formatTokenValue(props.usageStats.completionTokens)}
+              </span>
+            </span>
+            <span>
+              {t("ai.usageSessionTotal")}{" "}
+              <span data-testid="ai-usage-session-total-tokens">
+                {formatTokenValue(props.usageStats.sessionTotalTokens)}
+              </span>
+            </span>
             {typeof props.usageStats.estimatedCostUsd === "number" ? (
-              <span>{t("ai.usageCostEstimate")}{" "}<span data-testid="ai-usage-estimated-cost">{formatUsd(props.usageStats.estimatedCostUsd)}</span></span>
+              <span>
+                {t("ai.usageCostEstimate")}{" "}
+                <span data-testid="ai-usage-estimated-cost">
+                  {formatUsd(props.usageStats.estimatedCostUsd)}
+                </span>
+              </span>
             ) : null}
           </div>
         </div>
       ) : null}
 
       {props.applyStatus === "applied" && (
-        <Text data-testid="ai-apply-status" size="small" color="muted">{t("ai.appliedSaved")}</Text>
+        <Text data-testid="ai-apply-status" size="small" color="muted">
+          {t("ai.appliedSaved")}
+        </Text>
       )}
 
       {props.proposal && (
@@ -1195,13 +1507,17 @@ type AiPanelInputAreaProps = {
   modelsStatus: string;
   selectedModel: AiModel;
   setSelectedModel: (model: AiModel) => void;
-  skillsStatus: string;  availableModels: AiModelOption[];
+  skillsStatus: string;
+  availableModels: AiModelOption[];
   recentModelIds: string[];
   selectedSkillId: string;
   skills: SkillListItem[];
   handleSkillSelect: (skillId: string) => void;
   handleSkillToggle: (args: { skillId: string; enabled: boolean }) => void;
-  handleSkillScopeUpdate: (args: { id: string; scope: "global" | "project" }) => void;
+  handleSkillScopeUpdate: (args: {
+    id: string;
+    scope: "global" | "project";
+  }) => void;
   openSettings: (section?: SettingsTab) => void;
   skillManagerOpen: boolean;
   setSkillManagerOpen: (open: boolean) => void;
@@ -1210,20 +1526,40 @@ type AiPanelInputAreaProps = {
   refreshSkills: () => Promise<void>;
 };
 
-const AiPanelInputArea = React.forwardRef<HTMLTextAreaElement, AiPanelInputAreaProps>(function AiPanelInputArea(props, ref) {
+const AiPanelInputArea = React.forwardRef<
+  HTMLTextAreaElement,
+  AiPanelInputAreaProps
+>(function AiPanelInputArea(props, ref) {
   const { t } = useTranslation();
   return (
     <div className="shrink-0 px-1.5 pb-1.5 pt-2 border-t border-[var(--color-separator)]">
       <div className="relative border border-[var(--color-border-default)] rounded-[var(--radius-md)] bg-[var(--color-bg-base)] focus-within:border-[var(--color-border-focus)]">
         {props.hasSelectionReference ? (
-          <div data-testid="ai-selection-reference-card" className="mx-2 mt-2 mb-1 rounded-[var(--radius-sm)] bg-[var(--color-bg-raised)] px-2 py-1.5">
+          <div
+            data-testid="ai-selection-reference-card"
+            className="mx-2 mt-2 mb-1 rounded-[var(--radius-sm)] bg-[var(--color-bg-raised)] px-2 py-1.5"
+          >
             <div className="flex items-start gap-2">
               <div className="min-w-0 flex-1">
-                <div className="text-[10px] uppercase tracking-wide text-[var(--color-fg-muted)]">{t('ai.panel.selectionFromEditor')}</div>
-                <div data-testid="ai-selection-reference-preview" className="text-[12px] text-[var(--color-fg-default)] whitespace-pre-wrap break-words">{props.selectionPreview}</div>
+                <div className="text-[10px] uppercase tracking-wide text-[var(--color-fg-muted)]">
+                  {t("ai.panel.selectionFromEditor")}
+                </div>
+                <div
+                  data-testid="ai-selection-reference-preview"
+                  className="text-[12px] text-[var(--color-fg-default)] whitespace-pre-wrap break-words"
+                >
+                  {props.selectionPreview}
+                </div>
               </div>
-              <Tooltip content={t('ai.panel.dismissSelection')}>
-                <button type="button" data-testid="ai-selection-reference-close" className="focus-ring h-5 w-5 shrink-0 rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]" onClick={() => props.setSelectionSnapshot(null)}>×</button>
+              <Tooltip content={t("ai.panel.dismissSelection")}>
+                <button
+                  type="button"
+                  data-testid="ai-selection-reference-close"
+                  className="focus-ring h-5 w-5 shrink-0 rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]"
+                  onClick={() => props.setSelectionSnapshot(null)}
+                >
+                  ×
+                </button>
               </Tooltip>
             </div>
           </div>
@@ -1234,41 +1570,104 @@ const AiPanelInputArea = React.forwardRef<HTMLTextAreaElement, AiPanelInputAreaP
           value={props.input}
           onChange={(e) => props.setInput(e.target.value)}
           onKeyDown={props.handleKeyDown}
-          placeholder={t('ai.panel.inputPlaceholder')}
+          placeholder={t("ai.panel.inputPlaceholder")}
           className="w-full min-h-[60px] max-h-[160px] px-3 py-2 bg-transparent border-none resize-none text-[13px] text-[var(--color-fg-default)] placeholder:text-[var(--color-fg-placeholder)] focus:outline-none"
         />
         <div className="flex items-center justify-between px-2 pb-2">
           <div className="flex items-center gap-1">
-            <ToolButton active={props.modeOpen} onClick={() => { props.setModeOpen((v) => !v); props.setModelOpen(false); props.setSkillsOpen(false); }}>
+            <ToolButton
+              active={props.modeOpen}
+              onClick={() => {
+                props.setModeOpen((v) => !v);
+                props.setModelOpen(false);
+                props.setSkillsOpen(false);
+              }}
+            >
               {getModeName(props.selectedMode, t)}
             </ToolButton>
-            <ToolButton active={props.modelOpen} onClick={() => { props.setModelOpen((v) => !v); props.setModeOpen(false); props.setSkillsOpen(false); }}>
-              {props.modelsStatus === "loading" ? t('ai.panel.loading') : getModelName(props.selectedModel, props.availableModels)}
+            <ToolButton
+              active={props.modelOpen}
+              onClick={() => {
+                props.setModelOpen((v) => !v);
+                props.setModeOpen(false);
+                props.setSkillsOpen(false);
+              }}
+            >
+              {props.modelsStatus === "loading"
+                ? t("ai.panel.loading")
+                : getModelName(props.selectedModel, props.availableModels)}
             </ToolButton>
-            <ToolButton active={props.skillsOpen} testId="ai-skills-toggle" onClick={() => { props.setSkillsOpen((v) => !v); props.setModeOpen(false); props.setModelOpen(false); }}>
-              {props.skillsStatus === "loading" ? t('ai.panel.loading') : t('ai.panel.skill')}
+            <ToolButton
+              active={props.skillsOpen}
+              testId="ai-skills-toggle"
+              onClick={() => {
+                props.setSkillsOpen((v) => !v);
+                props.setModeOpen(false);
+                props.setModelOpen(false);
+              }}
+            >
+              {props.skillsStatus === "loading"
+                ? t("ai.panel.loading")
+                : t("ai.panel.skill")}
             </ToolButton>
           </div>
-          <SendStopButton isWorking={props.working} disabled={!props.working && !props.input.trim()} onSend={() => void props.onRun()} onStop={() => void props.cancel()} />
+          <SendStopButton
+            isWorking={props.working}
+            disabled={!props.working && !props.input.trim()}
+            onSend={() => void props.onRun()}
+            onStop={() => void props.cancel()}
+          />
         </div>
-        <ModePicker open={props.modeOpen} selectedMode={props.selectedMode} onOpenChange={props.setModeOpen} onSelectMode={(mode) => { props.setSelectedMode(mode); props.setModeOpen(false); }} />
-        <ModelPicker open={props.modelOpen} models={props.availableModels} recentModelIds={props.recentModelIds} selectedModel={props.selectedModel} onOpenChange={props.setModelOpen} onSelectModel={(model) => { props.setSelectedModel(model); props.setModelOpen(false); }} />
+        <ModePicker
+          open={props.modeOpen}
+          selectedMode={props.selectedMode}
+          onOpenChange={props.setModeOpen}
+          onSelectMode={(mode) => {
+            props.setSelectedMode(mode);
+            props.setModeOpen(false);
+          }}
+        />
+        <ModelPicker
+          open={props.modelOpen}
+          models={props.availableModels}
+          recentModelIds={props.recentModelIds}
+          selectedModel={props.selectedModel}
+          onOpenChange={props.setModelOpen}
+          onSelectModel={(model) => {
+            props.setSelectedModel(model);
+            props.setModelOpen(false);
+          }}
+        />
         <SkillPicker
           open={props.skillsOpen}
           items={props.skills}
           selectedSkillId={props.selectedSkillId}
           onOpenChange={props.setSkillsOpen}
-          onSelectSkillId={(skillId) => { void props.handleSkillSelect(skillId); }}
-          onOpenSettings={() => { props.setSkillsOpen(false); props.openSettings(); }}
-          onCreateSkill={() => { props.setSkillsOpen(false); props.setSkillManagerOpen(true); }}
-          onToggleSkill={(skillId, enabled) => { void props.handleSkillToggle({ skillId, enabled }); }}
-          onUpdateScope={(id, scope) => { void props.handleSkillScopeUpdate({ id, scope }); }}
+          onSelectSkillId={(skillId) => {
+            void props.handleSkillSelect(skillId);
+          }}
+          onOpenSettings={() => {
+            props.setSkillsOpen(false);
+            props.openSettings();
+          }}
+          onCreateSkill={() => {
+            props.setSkillsOpen(false);
+            props.setSkillManagerOpen(true);
+          }}
+          onToggleSkill={(skillId, enabled) => {
+            void props.handleSkillToggle({ skillId, enabled });
+          }}
+          onUpdateScope={(id, scope) => {
+            void props.handleSkillScopeUpdate({ id, scope });
+          }}
         />
         <SkillManagerDialog
           open={props.skillManagerOpen}
           onOpenChange={props.setSkillManagerOpen}
           projectId={props.currentProject?.projectId ?? props.projectId ?? null}
-          onSaved={async () => { await props.refreshSkills(); }}
+          onSaved={async () => {
+            await props.refreshSkills();
+          }}
         />
       </div>
     </div>
@@ -1432,20 +1831,46 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
   const setPendingSelectionSnapshot = React.useCallback(
     (v: { selectionRef: SelectionRef; selectionText: string } | null) => {
       pendingSelectionSnapshotRef.current = v;
-    }, [],
+    },
+    [],
   );
 
   useAiPanelEffects({
-    refreshSkills, selectedModel, setModelsStatus, setModelsLastError,
-    setAvailableModels, setSelectedModel, setRecentModelIds, setCandidateCount,
-    candidateCount, editor, bootstrapStatus, setSelectionSnapshot, lastCandidates,
-    selectedCandidateId, setSelectedCandidateId, status, proposal,
-    activeRunId, activeOutputText, selectionRef, selectionText,
-    setProposal, setCompareMode, pendingSelectionSnapshotRef,
-    setInlineDiffConfirmOpen, lastRunId, projectId, outputText,
-    lastRequest, evaluatedRunIdRef, setJudgeResult,
-    handleNewChatRef, lastHandledNewChatSignalRef,
-    newChatSignal: props.newChatSignal, t,
+    refreshSkills,
+    selectedModel,
+    setModelsStatus,
+    setModelsLastError,
+    setAvailableModels,
+    setSelectedModel,
+    setRecentModelIds,
+    setCandidateCount,
+    candidateCount,
+    editor,
+    bootstrapStatus,
+    setSelectionSnapshot,
+    lastCandidates,
+    selectedCandidateId,
+    setSelectedCandidateId,
+    status,
+    proposal,
+    activeRunId,
+    activeOutputText,
+    selectionRef,
+    selectionText,
+    setProposal,
+    setCompareMode,
+    pendingSelectionSnapshotRef,
+    setInlineDiffConfirmOpen,
+    lastRunId,
+    projectId,
+    outputText,
+    lastRequest,
+    evaluatedRunIdRef,
+    setJudgeResult,
+    handleNewChatRef,
+    lastHandledNewChatSignalRef,
+    newChatSignal: props.newChatSignal,
+    t,
   });
 
   // createAiPanelActions receives callbacks that write to refs, which the React
@@ -1453,15 +1878,43 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
   // are only invoked from event handlers, never during render. Suppressed.
   // eslint-disable-next-line react-hooks/refs
   const actions = createAiPanelActions({
-    input, selectedSkillId, selectionRef, selectionText, editor, bootstrapStatus,
-    status, projectId, documentId, selectedMode, selectedModel, candidateCount,
-    currentProject, proposal, inlineDiffConfirmOpen, applyStatus,
-    setInput, setSelectedSkillId, setSelectionSnapshot, setLastRequest,
-    setJudgeResult, setProposal, setCompareMode, setInlineDiffConfirmOpen,
-    setSelectedCandidateId, setError, clearError, setSkillsOpen,
-    run, regenerateWithStrongNegative, refreshSkills, persistAiApply,
+    input,
+    selectedSkillId,
+    selectionRef,
+    selectionText,
+    editor,
+    bootstrapStatus,
+    status,
+    projectId,
+    documentId,
+    selectedMode,
+    selectedModel,
+    candidateCount,
+    currentProject,
+    proposal,
+    inlineDiffConfirmOpen,
+    applyStatus,
+    setInput,
+    setSelectedSkillId,
+    setSelectionSnapshot,
+    setLastRequest,
+    setJudgeResult,
+    setProposal,
+    setCompareMode,
+    setInlineDiffConfirmOpen,
+    setSelectedCandidateId,
+    setError,
+    clearError,
+    setSkillsOpen,
+    run,
+    regenerateWithStrongNegative,
+    refreshSkills,
+    persistAiApply,
     logAiApplyConflict,
-    clearEvaluatedRunId, setPendingSelectionSnapshot, focusTextarea, t,
+    clearEvaluatedRunId,
+    setPendingSelectionSnapshot,
+    focusTextarea,
+    t,
   });
 
   // Sync the latest handleNewChat callback into a ref so effects can call it
@@ -1479,7 +1932,12 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
   const selectionPreview = hasSelectionReference
     ? formatSelectionPreview(selectionText.trim())
     : "";
-  const errorConfigs = buildAiErrorConfigs({ skillsLastError, modelsLastError, lastError, t });
+  const errorConfigs = buildAiErrorConfigs({
+    skillsLastError,
+    modelsLastError,
+    lastError,
+    t,
+  });
   const diffText = proposal
     ? unifiedDiff({
         oldText: proposal.selectionText,
@@ -1496,71 +1954,75 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
   return (
     <PanelContainer data-testid="ai-panel" title="AI">
       <div className="flex flex-col h-full min-h-0">
-      <div className="flex-1 flex flex-col min-h-0">
-        <AiPanelChatArea
-          lastRequest={lastRequest}
-          working={working}
-          status={status}
-          queuePosition={queuePosition}
-          queuedCount={queuedCount}
-          errorConfigs={errorConfigs}
-          lastCandidates={lastCandidates}
-          selectedCandidate={selectedCandidate}
-          activeOutputText={activeOutputText}
-          judgeResult={judgeResult}
-          usageStats={usageStats}
-          applyStatus={applyStatus}
-          proposal={proposal}
-          compareMode={compareMode}
-          diffText={diffText}
-          canApply={canApply}
-          inlineDiffConfirmOpen={inlineDiffConfirmOpen}
-          clearError={clearError}
-          openSettings={openSettings}
-          onSelectCandidate={actions.onSelectCandidate}
-          onRegenerateAll={() => void actions.onRegenerateAll()}
-          onApply={() => void actions.onApply()}
-          onReject={actions.onReject}
-          setInlineDiffConfirmOpen={setInlineDiffConfirmOpen}
-        />
-        <AiPanelInputArea
-          ref={textareaRef}
-          hasSelectionReference={hasSelectionReference}
-          selectionPreview={selectionPreview}
-          setSelectionSnapshot={() => setSelectionSnapshot(null)}
-          input={input}
-          setInput={setInput}
-          handleKeyDown={actions.handleKeyDown}
-          working={working}
-          onRun={() => void actions.onRun()}
-          cancel={cancel}
-          modeOpen={modeOpen}
-          modelOpen={modelOpen}
-          skillsOpen={skillsOpen}
-          setModeOpen={setModeOpen}
-          setModelOpen={setModelOpen}
-          setSkillsOpen={setSkillsOpen}
-          selectedMode={selectedMode}
-          setSelectedMode={setSelectedMode}
-          modelsStatus={modelsStatus}
-          selectedModel={selectedModel}
-          setSelectedModel={setSelectedModel}
-          skillsStatus={skillsStatus}
-          availableModels={availableModels}
-          recentModelIds={recentModelIds}
-          selectedSkillId={selectedSkillId}
-          skills={skills}
-          handleSkillSelect={(skillId) => void actions.handleSkillSelect(skillId)}
-          handleSkillToggle={(args) => void actions.handleSkillToggle(args)}
-          handleSkillScopeUpdate={(args) => void actions.handleSkillScopeUpdate(args)}
-          openSettings={openSettings}
-          skillManagerOpen={skillManagerOpen}
-          setSkillManagerOpen={setSkillManagerOpen}
-          currentProject={currentProject}
-          projectId={projectId}
-          refreshSkills={refreshSkills}
-        />
-      </div>
+        <div className="flex-1 flex flex-col min-h-0">
+          <AiPanelChatArea
+            lastRequest={lastRequest}
+            working={working}
+            status={status}
+            queuePosition={queuePosition}
+            queuedCount={queuedCount}
+            errorConfigs={errorConfigs}
+            lastCandidates={lastCandidates}
+            selectedCandidate={selectedCandidate}
+            activeOutputText={activeOutputText}
+            judgeResult={judgeResult}
+            usageStats={usageStats}
+            applyStatus={applyStatus}
+            proposal={proposal}
+            compareMode={compareMode}
+            diffText={diffText}
+            canApply={canApply}
+            inlineDiffConfirmOpen={inlineDiffConfirmOpen}
+            clearError={clearError}
+            openSettings={openSettings}
+            onSelectCandidate={actions.onSelectCandidate}
+            onRegenerateAll={() => void actions.onRegenerateAll()}
+            onApply={() => void actions.onApply()}
+            onReject={actions.onReject}
+            setInlineDiffConfirmOpen={setInlineDiffConfirmOpen}
+          />
+          <AiPanelInputArea
+            ref={textareaRef}
+            hasSelectionReference={hasSelectionReference}
+            selectionPreview={selectionPreview}
+            setSelectionSnapshot={() => setSelectionSnapshot(null)}
+            input={input}
+            setInput={setInput}
+            handleKeyDown={actions.handleKeyDown}
+            working={working}
+            onRun={() => void actions.onRun()}
+            cancel={cancel}
+            modeOpen={modeOpen}
+            modelOpen={modelOpen}
+            skillsOpen={skillsOpen}
+            setModeOpen={setModeOpen}
+            setModelOpen={setModelOpen}
+            setSkillsOpen={setSkillsOpen}
+            selectedMode={selectedMode}
+            setSelectedMode={setSelectedMode}
+            modelsStatus={modelsStatus}
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
+            skillsStatus={skillsStatus}
+            availableModels={availableModels}
+            recentModelIds={recentModelIds}
+            selectedSkillId={selectedSkillId}
+            skills={skills}
+            handleSkillSelect={(skillId) =>
+              void actions.handleSkillSelect(skillId)
+            }
+            handleSkillToggle={(args) => void actions.handleSkillToggle(args)}
+            handleSkillScopeUpdate={(args) =>
+              void actions.handleSkillScopeUpdate(args)
+            }
+            openSettings={openSettings}
+            skillManagerOpen={skillManagerOpen}
+            setSkillManagerOpen={setSkillManagerOpen}
+            currentProject={currentProject}
+            projectId={projectId}
+            refreshSkills={refreshSkills}
+          />
+        </div>
       </div>
     </PanelContainer>
   );

--- a/apps/desktop/renderer/src/features/ai/SkillManagerDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillManagerDialog.test.tsx
@@ -198,7 +198,7 @@ describe("SkillManagerDialog", () => {
     await waitFor(() => {
       expect(
         screen.getByTestId("skill-form-error-promptTemplate"),
-      ).toHaveTextContent("promptTemplate 不能为空");
+      ).toHaveTextContent("Request parameters are invalid.");
     });
   });
 
@@ -260,7 +260,9 @@ describe("SkillManagerDialog", () => {
     await user.click(screen.getByTestId("skill-item-delete-skill-1"));
 
     await waitFor(() => {
-      expect(screen.getByText("This action cannot be undone")).toBeInTheDocument();
+      expect(
+        screen.getByText("This action cannot be undone"),
+      ).toBeInTheDocument();
     });
 
     const dialog = screen.getByRole("dialog");

--- a/apps/desktop/renderer/src/features/ai/SkillManagerDialog.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillManagerDialog.tsx
@@ -7,6 +7,7 @@ import { Dialog, Text } from "../../components/primitives";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { i18n } from "../../i18n";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 export type CustomSkillListItem =
   IpcResponseData<"skill:custom:list">["items"][number];
@@ -40,7 +41,8 @@ function buildSkillDraftFromDescription(
   "name" | "description" | "promptTemplate" | "inputType" | "contextRulesText"
 > {
   const normalized = description.trim();
-  const shortName = normalized.slice(0, 16) || i18n.t("ai.skillManager.aiGeneratedSkill");
+  const shortName =
+    normalized.slice(0, 16) || i18n.t("ai.skillManager.aiGeneratedSkill");
 
   return {
     name: shortName,
@@ -63,11 +65,17 @@ function parseContextRulesText(
       parsed === null ||
       Array.isArray(parsed)
     ) {
-      return { ok: false, message: i18n.t("ai.skillManager.contextRulesMustBeObject") };
+      return {
+        ok: false,
+        message: i18n.t("ai.skillManager.contextRulesMustBeObject"),
+      };
     }
     return { ok: true, data: parsed as CustomSkillContextRules };
   } catch {
-    return { ok: false, message: i18n.t("ai.skillManager.contextRulesInvalidJson") };
+    return {
+      ok: false,
+      message: i18n.t("ai.skillManager.contextRulesInvalidJson"),
+    };
   }
 }
 
@@ -105,12 +113,16 @@ function SkillFormFields(props: {
         {t("ai.skillManager.fieldName")}
         <input
           value={props.form.name}
-          onChange={(e) => props.onFormChange((prev) => ({ ...prev, name: e.target.value }))}
+          onChange={(e) =>
+            props.onFormChange((prev) => ({ ...prev, name: e.target.value }))
+          }
           className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
           data-testid="skill-form-name"
         />
         {props.fieldErrors.name && (
-          <span className="mt-1 block text-xs text-[var(--color-error)]">{props.fieldErrors.name}</span>
+          <span className="mt-1 block text-xs text-[var(--color-error)]">
+            {props.fieldErrors.name}
+          </span>
         )}
       </label>
 
@@ -118,12 +130,19 @@ function SkillFormFields(props: {
         {t("ai.skillManager.fieldDescription")}
         <input
           value={props.form.description}
-          onChange={(e) => props.onFormChange((prev) => ({ ...prev, description: e.target.value }))}
+          onChange={(e) =>
+            props.onFormChange((prev) => ({
+              ...prev,
+              description: e.target.value,
+            }))
+          }
           className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
           data-testid="skill-form-description"
         />
         {props.fieldErrors.description && (
-          <span className="mt-1 block text-xs text-[var(--color-error)]">{props.fieldErrors.description}</span>
+          <span className="mt-1 block text-xs text-[var(--color-error)]">
+            {props.fieldErrors.description}
+          </span>
         )}
       </label>
 
@@ -131,13 +150,21 @@ function SkillFormFields(props: {
         {t("ai.skillManager.fieldPromptTemplate")}
         <textarea
           value={props.form.promptTemplate}
-          onChange={(e) => props.onFormChange((prev) => ({ ...prev, promptTemplate: e.target.value }))}
+          onChange={(e) =>
+            props.onFormChange((prev) => ({
+              ...prev,
+              promptTemplate: e.target.value,
+            }))
+          }
           placeholder={t("ai.skillManager.promptPlaceholder")}
           className="mt-1 w-full min-h-20 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
           data-testid="skill-form-prompt-template"
         />
         {props.fieldErrors.promptTemplate && (
-          <span className="mt-1 block text-xs text-[var(--color-error)]" data-testid="skill-form-error-promptTemplate">
+          <span
+            className="mt-1 block text-xs text-[var(--color-error)]"
+            data-testid="skill-form-error-promptTemplate"
+          >
             {props.fieldErrors.promptTemplate}
           </span>
         )}
@@ -148,12 +175,21 @@ function SkillFormFields(props: {
           {t("ai.skillManager.fieldInputType")}
           <select
             value={props.form.inputType}
-            onChange={(e) => props.onFormChange((prev) => ({ ...prev, inputType: e.target.value as "selection" | "document" }))}
+            onChange={(e) =>
+              props.onFormChange((prev) => ({
+                ...prev,
+                inputType: e.target.value as "selection" | "document",
+              }))
+            }
             className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
             data-testid="skill-form-input-type"
           >
-            <option value="selection">{t("ai.skillManager.inputTypeSelection")}</option>
-            <option value="document">{t("ai.skillManager.inputTypeDocument")}</option>
+            <option value="selection">
+              {t("ai.skillManager.inputTypeSelection")}
+            </option>
+            <option value="document">
+              {t("ai.skillManager.inputTypeDocument")}
+            </option>
           </select>
         </label>
 
@@ -161,7 +197,12 @@ function SkillFormFields(props: {
           {t("ai.skillManager.fieldScope")}
           <select
             value={props.form.scope}
-            onChange={(e) => props.onFormChange((prev) => ({ ...prev, scope: e.target.value as "global" | "project" }))}
+            onChange={(e) =>
+              props.onFormChange((prev) => ({
+                ...prev,
+                scope: e.target.value as "global" | "project",
+              }))
+            }
             className="mt-1 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
             data-testid="skill-form-scope"
           >
@@ -175,12 +216,19 @@ function SkillFormFields(props: {
         {t("ai.skillManager.fieldContextRules")}
         <textarea
           value={props.form.contextRulesText}
-          onChange={(e) => props.onFormChange((prev) => ({ ...prev, contextRulesText: e.target.value }))}
+          onChange={(e) =>
+            props.onFormChange((prev) => ({
+              ...prev,
+              contextRulesText: e.target.value,
+            }))
+          }
           className="mt-1 w-full min-h-16 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2 text-sm"
           data-testid="skill-form-context-rules"
         />
         {props.fieldErrors.contextRules && (
-          <span className="mt-1 block text-xs text-[var(--color-error)]">{props.fieldErrors.contextRules}</span>
+          <span className="mt-1 block text-xs text-[var(--color-error)]">
+            {props.fieldErrors.contextRules}
+          </span>
         )}
       </label>
 
@@ -188,7 +236,12 @@ function SkillFormFields(props: {
         <input
           type="checkbox"
           checked={props.form.enabled}
-          onChange={(e) => props.onFormChange((prev) => ({ ...prev, enabled: e.target.checked }))}
+          onChange={(e) =>
+            props.onFormChange((prev) => ({
+              ...prev,
+              enabled: e.target.checked,
+            }))
+          }
           data-testid="skill-form-enabled"
         />
         {t("ai.skillManager.enableSkill")}
@@ -214,18 +267,30 @@ function SkillItemList(props: {
         {t("ai.skillManager.customSkillList")}
       </Text>
       {props.loading ? (
-        <Text size="small" color="muted">{t("ai.skillManager.loading")}</Text>
+        <Text size="small" color="muted">
+          {t("ai.skillManager.loading")}
+        </Text>
       ) : props.items.length === 0 ? (
-        <Text size="small" color="muted">{t("ai.skillManager.noCustomSkills")}</Text>
+        <Text size="small" color="muted">
+          {t("ai.skillManager.noCustomSkills")}
+        </Text>
       ) : (
         <div className="space-y-2" data-testid="skill-manager-list">
           {props.items.map((item) => (
-            <div key={item.id} className="rounded border border-[var(--color-border-default)] p-2">
+            <div
+              key={item.id}
+              className="rounded border border-[var(--color-border-default)] p-2"
+            >
               <div className="flex items-start justify-between gap-2">
                 <div>
-                  <Text size="small" weight="semibold">{item.name}</Text>
+                  <Text size="small" weight="semibold">
+                    {item.name}
+                  </Text>
                   <Text size="tiny" color="muted">
-                    {item.scope === "project" ? t("ai.skillManager.scopeProject") : t("ai.skillManager.scopeGlobal")} · {item.inputType}
+                    {item.scope === "project"
+                      ? t("ai.skillManager.scopeProject")
+                      : t("ai.skillManager.scopeGlobal")}{" "}
+                    · {item.inputType}
                   </Text>
                 </div>
                 <div className="flex items-center gap-2">
@@ -284,7 +349,10 @@ export function SkillManagerDialog(props: {
   const { t } = useTranslation();
 
   const title = useMemo(
-    () => (editingId ? t("ai.skillManager.editTitle") : t("ai.skillManager.createTitle")),
+    () =>
+      editingId
+        ? t("ai.skillManager.editTitle")
+        : t("ai.skillManager.createTitle"),
     [editingId, t],
   );
 
@@ -292,7 +360,7 @@ export function SkillManagerDialog(props: {
     setLoading(true);
     const listed = await invoke("skill:custom:list", {});
     if (!listed.ok) {
-      setFormError(listed.error.message);
+      setFormError(getHumanErrorMessage(listed.error));
       setLoading(false);
       return;
     }
@@ -331,7 +399,7 @@ export function SkillManagerDialog(props: {
       projectId: props.projectId ?? "skill-manager",
     });
     if (!generated.ok) {
-      setFormError(generated.error.message);
+      setFormError(getHumanErrorMessage(generated.error));
       return;
     }
 
@@ -357,7 +425,7 @@ export function SkillManagerDialog(props: {
 
     const deleted = await invoke("skill:custom:delete", { id: item.id });
     if (!deleted.ok) {
-      setFormError(deleted.error.message);
+      setFormError(getHumanErrorMessage(deleted.error));
       return;
     }
 
@@ -410,9 +478,9 @@ export function SkillManagerDialog(props: {
       if (!updated.ok) {
         const fieldName = readFieldName(updated.error);
         if (fieldName) {
-          setFieldErrors({ [fieldName]: updated.error.message });
+          setFieldErrors({ [fieldName]: getHumanErrorMessage(updated.error) });
         } else {
-          setFormError(updated.error.message);
+          setFormError(getHumanErrorMessage(updated.error));
         }
         setSubmitting(false);
         return;
@@ -430,9 +498,9 @@ export function SkillManagerDialog(props: {
       if (!created.ok) {
         const fieldName = readFieldName(created.error);
         if (fieldName) {
-          setFieldErrors({ [fieldName]: created.error.message });
+          setFieldErrors({ [fieldName]: getHumanErrorMessage(created.error) });
         } else {
-          setFormError(created.error.message);
+          setFormError(getHumanErrorMessage(created.error));
         }
         setSubmitting(false);
         return;
@@ -474,7 +542,11 @@ export function SkillManagerDialog(props: {
               disabled={submitting}
               data-testid="skill-manager-save"
             >
-              {submitting ? t("ai.skillManager.saving") : editingId ? t("ai.skillManager.saveChanges") : t("ai.skillManager.createSkill")}
+              {submitting
+                ? t("ai.skillManager.saving")
+                : editingId
+                  ? t("ai.skillManager.saveChanges")
+                  : t("ai.skillManager.createSkill")}
             </button>
           </>
         }

--- a/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
+++ b/apps/desktop/renderer/src/features/analytics/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import { Dialog } from "../../components/primitives/Dialog";
 import { Heading } from "../../components/primitives/Heading";
 import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 type StatsSummary = {
   wordsWritten: number;
@@ -86,7 +87,7 @@ export function AnalyticsPage(props: {
     <Dialog
       open={props.open}
       onOpenChange={props.onOpenChange}
-      title={t('analytics.title')}
+      title={t("analytics.title")}
     >
       <AnalyticsPageContent />
     </Dialog>
@@ -134,7 +135,7 @@ export function AnalyticsPageContent(): JSX.Element {
     <div data-testid="analytics-page" className="flex flex-col gap-3.5">
       <header className="flex items-baseline gap-2.5">
         <Heading level="h3" className="font-extrabold">
-          {t('analytics.statistics')}
+          {t("analytics.statistics")}
         </Heading>
         <Button
           variant="secondary"
@@ -142,44 +143,53 @@ export function AnalyticsPageContent(): JSX.Element {
           onClick={() => void refresh()}
           className="ml-auto"
         >
-          {t('analytics.refresh')}
+          {t("analytics.refresh")}
         </Button>
       </header>
 
       {error ? (
-        <Text data-testid="analytics-error" size="small" color="muted">
-          {error.code}: {error.message}
+        <Text
+          data-testid="analytics-error"
+          size="small"
+          color="muted"
+          role="alert"
+        >
+          {getHumanErrorMessage(error)}
         </Text>
       ) : null}
 
       <section className="grid grid-cols-4 gap-2.5">
         <StatCard
-          label={t('analytics.todayWords')}
+          label={t("analytics.todayWords")}
           value={today ? today.summary.wordsWritten : 0}
           testId="analytics-today-words"
         />
         <StatCard
-          label={t('analytics.todayTime')}
+          label={t("analytics.todayTime")}
           value={today ? formatSeconds(today.summary.writingSeconds) : "0s"}
         />
         <StatCard
-          label={t('analytics.todaySkills')}
+          label={t("analytics.todaySkills")}
           value={today ? today.summary.skillsUsed : 0}
           testId="analytics-today-skills"
         />
         <StatCard
-          label={t('analytics.todayDocs')}
+          label={t("analytics.todayDocs")}
           value={today ? today.summary.documentsCreated : 0}
         />
       </section>
 
       <Card className="p-3 rounded-[var(--radius-md)]">
         <Text size="small" color="muted">
-          {t('analytics.rangeLast7d')}
+          {t("analytics.rangeLast7d")}
         </Text>
         <div className="flex gap-3 mt-1.5">
-          <Text size="small">{t('analytics.words')}: {rangeSummary?.wordsWritten ?? 0}</Text>
-          <Text size="small">{t('analytics.skills')}: {rangeSummary?.skillsUsed ?? 0}</Text>
+          <Text size="small">
+            {t("analytics.words")}: {rangeSummary?.wordsWritten ?? 0}
+          </Text>
+          <Text size="small">
+            {t("analytics.skills")}: {rangeSummary?.skillsUsed ?? 0}
+          </Text>
         </div>
       </Card>
     </div>

--- a/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardListContainer.tsx
@@ -11,6 +11,7 @@ import {
 import { CharacterDetailDialog } from "./CharacterDetailDialog";
 import { characterToMetadataJson, kgToCharacters } from "./characterFromKg";
 import type { Character } from "./types";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 export interface CharacterCardListContainerProps {
   projectId: string;
@@ -23,27 +24,31 @@ function toSummary(
   const keyAttributes: string[] = [];
 
   if (typeof character.age === "number") {
-    keyAttributes.push(t('character.container.age', { value: character.age }));
+    keyAttributes.push(t("character.container.age", { value: character.age }));
   }
   if (character.role) {
-    keyAttributes.push(t('character.container.role', { value: character.role }));
+    keyAttributes.push(
+      t("character.container.role", { value: character.role }),
+    );
   }
   if (character.traits.length > 0) {
     keyAttributes.push(
-      t('character.container.traits', { value: character.traits.slice(0, 2).join(" / ") }),
+      t("character.container.traits", {
+        value: character.traits.slice(0, 2).join(" / "),
+      }),
     );
   }
   if (keyAttributes.length === 0) {
-    keyAttributes.push(t('character.container.noKeyAttributes'));
+    keyAttributes.push(t("character.container.noKeyAttributes"));
   }
 
   return {
     id: character.id,
     name: character.name,
-    typeLabel: t('character.container.typeLabel'),
+    typeLabel: t("character.container.typeLabel"),
     avatarUrl: character.avatarUrl,
     keyAttributes: keyAttributes.slice(0, 3),
-    relationSummary: t('character.container.relationSummary', {
+    relationSummary: t("character.container.relationSummary", {
       count: character.relationships.length,
     }),
   };
@@ -92,7 +97,7 @@ export function CharacterCardListContainer({
 
   const handleCreateCharacter = React.useCallback(async () => {
     const created = await entityCreate({
-      name: t('character.container.newCharacter'),
+      name: t("character.container.newCharacter"),
       type: "character",
       description: "",
     });
@@ -122,12 +127,14 @@ export function CharacterCardListContainer({
       const target = characters.find(
         (character) => character.id === characterId,
       );
-      const label = target?.name ?? t('character.container.thisCharacter');
+      const label = target?.name ?? t("character.container.thisCharacter");
       const confirmed = await confirm({
-        title: t('character.container.deleteTitle'),
-        description: t('character.container.deleteDescription', { name: label }),
-        primaryLabel: t('character.container.delete'),
-        secondaryLabel: t('character.container.cancel'),
+        title: t("character.container.deleteTitle"),
+        description: t("character.container.deleteDescription", {
+          name: label,
+        }),
+        primaryLabel: t("character.container.delete"),
+        secondaryLabel: t("character.container.cancel"),
       });
       if (!confirmed) {
         return;
@@ -151,12 +158,15 @@ export function CharacterCardListContainer({
 
   if (bootstrapStatus === "error" && lastError) {
     return (
-      <div className="h-full flex flex-col items-center justify-center gap-2 p-4">
+      <div
+        role="alert"
+        className="h-full flex flex-col items-center justify-center gap-2 p-4"
+      >
         <span className="text-sm text-[var(--color-error-default)]">
-          {t('character.panelContainer.loadError')}
+          {t("character.panelContainer.loadError")}
         </span>
         <span className="text-xs text-[var(--color-fg-muted)]">
-          {lastError.code}: {lastError.message}
+          {getHumanErrorMessage(lastError)}
         </span>
       </div>
     );

--- a/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelContainer.tsx
@@ -11,13 +11,11 @@ import { useTranslation } from "react-i18next";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { useDeferredLoading } from "../../lib/useDeferredLoading";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { useKgStore } from "../../stores/kgStore";
 import { CharacterPanelContent } from "./CharacterPanel";
 import { CharacterPanelSkeleton } from "./CharacterPanelSkeleton";
-import {
-  kgToCharacters,
-  characterToMetadataJson,
-} from "./characterFromKg";
+import { kgToCharacters, characterToMetadataJson } from "./characterFromKg";
 import type { Character } from "./types";
 
 export interface CharacterPanelContainerProps {
@@ -74,7 +72,7 @@ export function CharacterPanelContainer(
    */
   const handleCreate = React.useCallback(async () => {
     const res = await entityCreate({
-      name: t('character.panelContainer.newCharacter'),
+      name: t("character.panelContainer.newCharacter"),
       type: "character",
       description: "",
     });
@@ -108,13 +106,14 @@ export function CharacterPanelContainer(
   const handleDelete = React.useCallback(
     async (characterId: string) => {
       const character = characters.find((c) => c.id === characterId);
-      const name = character?.name ?? t('character.panelContainer.thisCharacter');
+      const name =
+        character?.name ?? t("character.panelContainer.thisCharacter");
 
       const confirmed = await confirm({
-        title: t('character.panelContainer.deleteTitle'),
-        description: t('character.panelContainer.deleteDescription', { name }),
-        primaryLabel: t('character.panelContainer.deleteLabel'),
-        secondaryLabel: t('character.panelContainer.cancelLabel'),
+        title: t("character.panelContainer.deleteTitle"),
+        description: t("character.panelContainer.deleteDescription", { name }),
+        primaryLabel: t("character.panelContainer.deleteLabel"),
+        secondaryLabel: t("character.panelContainer.cancelLabel"),
       });
 
       if (!confirmed) {
@@ -149,14 +148,15 @@ export function CharacterPanelContainer(
   if (bootstrapStatus === "error" && lastError) {
     return (
       <div
+        role="alert"
         className="flex flex-col items-center justify-center h-full gap-2 p-4"
         data-testid="character-panel-error"
       >
         <span className="text-sm text-[var(--color-error-default)]">
-          {t('character.panelContainer.loadError')}
+          {t("character.panelContainer.loadError")}
         </span>
         <span className="text-xs text-[var(--color-fg-muted)]">
-          {lastError.code}: {lastError.message}
+          {getHumanErrorMessage(lastError)}
         </span>
       </div>
     );
@@ -172,10 +172,10 @@ export function CharacterPanelContainer(
         >
           <div className="text-center space-y-2">
             <p className="text-sm text-[var(--color-fg-muted)]">
-              {t('character.panelContainer.emptyTitle')}
+              {t("character.panelContainer.emptyTitle")}
             </p>
             <p className="text-xs text-[var(--color-fg-placeholder)]">
-              {t('character.panelContainer.emptyDescription')}
+              {t("character.panelContainer.emptyDescription")}
             </p>
           </div>
           <button
@@ -183,7 +183,7 @@ export function CharacterPanelContainer(
             onClick={() => void handleCreate()}
             className="focus-ring px-4 py-2 text-sm font-medium bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] rounded-[var(--radius-md)] hover:opacity-90 transition-opacity"
           >
-            {t('character.panelContainer.createCharacter')}
+            {t("character.panelContainer.createCharacter")}
           </button>
         </div>
         <SystemDialog {...dialogProps} />

--- a/apps/desktop/renderer/src/features/dashboard/DashboardPage.test.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardPage.test.tsx
@@ -177,7 +177,9 @@ describe("DashboardPage", () => {
         expect(screen.getByTestId("dashboard-empty")).toBeInTheDocument();
       });
 
-      expect(screen.getByText("Create your first writing project")).toBeInTheDocument();
+      expect(
+        screen.getByText("Create your first writing project"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("dashboard-create-first")).toBeInTheDocument();
     });
 

--- a/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardPage.tsx
@@ -14,6 +14,7 @@ import {
 import { useDeferredLoading } from "../../lib/useDeferredLoading";
 import { DashboardSkeleton } from "./DashboardSkeleton";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
+import type { UseConfirmDialogReturn } from "../../hooks/useConfirmDialog";
 import { invoke } from "../../lib/ipcClient";
 import { CreateProjectDialog } from "../projects/CreateProjectDialog";
 import { DeleteProjectDialog } from "../projects/DeleteProjectDialog";
@@ -25,6 +26,7 @@ import {
 
 import { FilePlus, MoreHorizontal, PenTool, Search } from "lucide-react";
 import { i18n } from "../../i18n";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 // =============================================================================
 // Types
 // =============================================================================
@@ -47,7 +49,10 @@ function DashboardLoadingState(): JSX.Element {
 
   if (!showSkeleton) {
     return (
-      <div data-testid="dashboard-loading" className="flex-1 flex items-center justify-center" />
+      <div
+        data-testid="dashboard-loading"
+        className="flex-1 flex items-center justify-center"
+      />
     );
   }
 
@@ -118,7 +123,11 @@ function HeroCard(props: {
       </div>
       <div className="w-[35%] max-w-[280px] hidden lg:block bg-[var(--color-bg-surface)] border-l border-[var(--color-separator)] relative overflow-hidden">
         <div className="absolute inset-0 flex items-center justify-center text-[var(--color-fg-faint)]">
-          <PenTool className="w-16 h-16 opacity-20" size={24} strokeWidth={1.5} />
+          <PenTool
+            className="w-16 h-16 opacity-20"
+            size={24}
+            strokeWidth={1.5}
+          />
         </div>
       </div>
     </div>
@@ -129,9 +138,7 @@ function HeroCard(props: {
  * Three-dot menu icon for project actions.
  */
 function MoreIcon(): JSX.Element {
-  return (
-    <MoreHorizontal className="w-4 h-4" size={16} strokeWidth={1.5} />
-  );
+  return <MoreHorizontal className="w-4 h-4" size={16} strokeWidth={1.5} />;
 }
 
 /**
@@ -187,7 +194,9 @@ function ProjectCard(props: {
       if (onArchiveToggle) {
         items.push({
           key: "archive",
-          label: isArchived ? t("dashboard.menu.unarchive") : t("dashboard.menu.archive"),
+          label: isArchived
+            ? t("dashboard.menu.unarchive")
+            : t("dashboard.menu.archive"),
           onSelect: () => onArchiveToggle(project.projectId, !isArchived),
         });
       }
@@ -425,7 +434,7 @@ function useDashboardActions() {
       });
       setRenameSubmitting(false);
       if (!res.ok) {
-        setRenameErrorText(`${res.error.code}: ${res.error.message}`);
+        setRenameErrorText(getHumanErrorMessage(res.error));
         return;
       }
       setRenameDialogOpen(false);
@@ -532,6 +541,66 @@ function useDashboardActions() {
 }
 
 /**
+ * Renders the create / rename / delete / system dialog cluster.
+ */
+function DashboardDialogs(props: {
+  createDialogOpen: boolean;
+  setCreateDialogOpen: (v: boolean) => void;
+  renameDialogOpen: boolean;
+  renameTargetProject: ProjectListItem | null;
+  renameSubmitting: boolean;
+  renameErrorText: string | null;
+  setRenameDialogOpen: (v: boolean) => void;
+  setRenameTargetProject: (v: ProjectListItem | null) => void;
+  setRenameErrorText: (v: string | null) => void;
+  handleRenameSubmit: (name: string) => Promise<void>;
+  deleteDialogOpen: boolean;
+  deleteTargetProject: ProjectListItem | null;
+  deleteSubmitting: boolean;
+  setDeleteDialogOpen: (v: boolean) => void;
+  setDeleteTargetProject: (v: ProjectListItem | null) => void;
+  handleDeleteConfirm: () => Promise<void>;
+  dialogProps: UseConfirmDialogReturn["dialogProps"];
+}): JSX.Element {
+  return (
+    <>
+      <CreateProjectDialog
+        open={props.createDialogOpen}
+        onOpenChange={props.setCreateDialogOpen}
+      />
+      <RenameProjectDialog
+        open={props.renameDialogOpen}
+        initialName={props.renameTargetProject?.name ?? ""}
+        submitting={props.renameSubmitting}
+        errorText={props.renameErrorText}
+        onOpenChange={(open) => {
+          props.setRenameDialogOpen(open);
+          if (!open) {
+            props.setRenameTargetProject(null);
+            props.setRenameErrorText(null);
+          }
+        }}
+        onSubmit={props.handleRenameSubmit}
+      />
+      <DeleteProjectDialog
+        open={props.deleteDialogOpen}
+        projectName={props.deleteTargetProject?.name ?? ""}
+        documentCount={0}
+        submitting={props.deleteSubmitting}
+        onOpenChange={(open) => {
+          props.setDeleteDialogOpen(open);
+          if (!open) {
+            props.setDeleteTargetProject(null);
+          }
+        }}
+        onConfirm={props.handleDeleteConfirm}
+      />
+      <SystemDialog {...props.dialogProps} />
+    </>
+  );
+}
+
+/**
  * DashboardPage - Project overview and selection screen.
  *
  * Why: After onboarding, users need a central hub to see their projects,
@@ -606,8 +675,6 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
   // Remaining active projects for grid (exclude hero)
   const gridProjects = activeProjects.slice(1);
 
-
-
   // Loading state
   if (bootstrapStatus === "loading") {
     return <DashboardLoadingState />;
@@ -625,7 +692,7 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
             <div role="alert" className="w-full max-w-xl mb-8">
               <div className="p-3 border border-[var(--color-separator)] rounded-[var(--radius-md)] bg-[var(--color-bg-surface)]">
                 <Text size="small" className="mb-2 block">
-                  {lastError.code}: {lastError.message}
+                  {getHumanErrorMessage(lastError)}
                 </Text>
                 <Button
                   variant="secondary"
@@ -710,7 +777,7 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
             className="px-12 py-3 border-b border-[var(--color-separator)]"
           >
             <Text size="small" className="mb-2 block">
-              {lastError.code}: {lastError.message}
+              {getHumanErrorMessage(lastError)}
             </Text>
             <Button variant="secondary" size="sm" onClick={() => clearError()}>
               {t("dashboard.dismiss")}
@@ -723,16 +790,17 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
           {/* Continue Writing (Hero) */}
           {heroProject && (
             <>
-              <SectionTitle
-                className="animate-fade-in-up"
-              >
+              <SectionTitle className="animate-fade-in-up">
                 {t("dashboard.continueWriting")}
               </SectionTitle>
               <div className="mb-16">
                 <HeroCard
                   project={heroProject}
                   onClick={() =>
-                    void hookHandleProjectSelect(heroProject.projectId, props.onProjectSelect)
+                    void hookHandleProjectSelect(
+                      heroProject.projectId,
+                      props.onProjectSelect,
+                    )
                   }
                 />
               </div>
@@ -742,9 +810,7 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
           {/* Recent Projects Grid */}
           {(gridProjects.length > 0 || searchQuery) && (
             <>
-              <SectionTitle
-                className="mt-8 animate-fade-in-up animation-delay-200"
-              >
+              <SectionTitle className="mt-8 animate-fade-in-up animation-delay-200">
                 {t("dashboard.recentProjects")}
               </SectionTitle>
 
@@ -753,7 +819,12 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
                   <ProjectCard
                     key={project.projectId}
                     project={project}
-                    onClick={() => void hookHandleProjectSelect(project.projectId, props.onProjectSelect)}
+                    onClick={() =>
+                      void hookHandleProjectSelect(
+                        project.projectId,
+                        props.onProjectSelect,
+                      )
+                    }
                     onRename={handleRename}
                     onDuplicate={handleDuplicate}
                     onArchiveToggle={handleArchiveToggle}
@@ -796,7 +867,9 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
                     className="focus-ring text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                     onClick={() => setArchivedExpanded((prev) => !prev)}
                   >
-                    {archivedExpanded ? t("dashboard.collapse") : t("dashboard.expand")}
+                    {archivedExpanded
+                      ? t("dashboard.collapse")
+                      : t("dashboard.expand")}
                   </button>
                 }
                 className="animate-fade-in-up animation-delay-200"
@@ -810,7 +883,10 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
                       key={project.projectId}
                       project={project}
                       onClick={() =>
-                        void hookHandleProjectSelect(project.projectId, props.onProjectSelect)
+                        void hookHandleProjectSelect(
+                          project.projectId,
+                          props.onProjectSelect,
+                        )
                       }
                       onRename={handleRename}
                       onDuplicate={handleDuplicate}
@@ -825,38 +901,25 @@ export function DashboardPage(props: DashboardPageProps): JSX.Element {
         </div>
       </div>
 
-      <CreateProjectDialog
-        open={createDialogOpen}
-        onOpenChange={setCreateDialogOpen}
+      <DashboardDialogs
+        createDialogOpen={createDialogOpen}
+        setCreateDialogOpen={setCreateDialogOpen}
+        renameDialogOpen={renameDialogOpen}
+        renameTargetProject={renameTargetProject}
+        renameSubmitting={renameSubmitting}
+        renameErrorText={renameErrorText}
+        setRenameDialogOpen={setRenameDialogOpen}
+        setRenameTargetProject={setRenameTargetProject}
+        setRenameErrorText={setRenameErrorText}
+        handleRenameSubmit={handleRenameSubmit}
+        deleteDialogOpen={deleteDialogOpen}
+        deleteTargetProject={deleteTargetProject}
+        deleteSubmitting={deleteSubmitting}
+        setDeleteDialogOpen={setDeleteDialogOpen}
+        setDeleteTargetProject={setDeleteTargetProject}
+        handleDeleteConfirm={handleDeleteConfirm}
+        dialogProps={dialogProps}
       />
-      <RenameProjectDialog
-        open={renameDialogOpen}
-        initialName={renameTargetProject?.name ?? ""}
-        submitting={renameSubmitting}
-        errorText={renameErrorText}
-        onOpenChange={(open) => {
-          setRenameDialogOpen(open);
-          if (!open) {
-            setRenameTargetProject(null);
-            setRenameErrorText(null);
-          }
-        }}
-        onSubmit={handleRenameSubmit}
-      />
-      <DeleteProjectDialog
-        open={deleteDialogOpen}
-        projectName={deleteTargetProject?.name ?? ""}
-        documentCount={0}
-        submitting={deleteSubmitting}
-        onOpenChange={(open) => {
-          setDeleteDialogOpen(open);
-          if (!open) {
-            setDeleteTargetProject(null);
-          }
-        }}
-        onConfirm={handleDeleteConfirm}
-      />
-      <SystemDialog {...dialogProps} />
     </>
   );
 }

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -238,11 +238,9 @@ describe("ExportDialog", () => {
     );
 
     expect(screen.getByTestId("export-error")).toBeInTheDocument();
-    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
-      "IO_ERROR",
-    );
+    expect(screen.queryByTestId("export-error-code")).not.toBeInTheDocument();
     expect(screen.getByTestId("export-error-message")).toHaveTextContent(
-      "failed",
+      "Read/write operation failed. Please try again.",
     );
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
@@ -351,11 +349,9 @@ describe("ExportDialog", () => {
     await user.click(screen.getByTestId("export-submit"));
 
     expect(await screen.findByTestId("export-error")).toBeInTheDocument();
-    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
-      "IO_ERROR",
-    );
+    expect(screen.queryByTestId("export-error-code")).not.toBeInTheDocument();
     expect(screen.getByTestId("export-error-message")).toHaveTextContent(
-      "disk write permission denied",
+      "Read/write operation failed. Please try again.",
     );
     expect(screen.queryByTestId("export-success")).not.toBeInTheDocument();
   });
@@ -382,9 +378,7 @@ describe("ExportDialog", () => {
     await user.click(screen.getByTestId("export-submit"));
 
     expect(await screen.findByTestId("export-error")).toBeInTheDocument();
-    expect(screen.getByTestId("export-error-code")).toHaveTextContent(
-      "INVALID_ARGUMENT",
-    );
+    expect(screen.queryByTestId("export-error-code")).not.toBeInTheDocument();
     expect(screen.getByTestId("export-error-message")).toHaveTextContent(
       "This export format cannot write: doc.content.0:table",
     );

--- a/apps/desktop/renderer/src/features/export/ExportDialog.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.tsx
@@ -7,6 +7,7 @@ import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import { Button, Checkbox, Select, Tooltip } from "../../components/primitives";
 import { useAppToast } from "../../components/providers/AppToastProvider";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 import { Check, File, FileCode, FileOutput, FileText, X } from "lucide-react";
 /**
@@ -93,9 +94,9 @@ export const defaultExportOptions: ExportOptions = {
  */
 function getProgressSteps(t: TFunction): ProgressStep[] {
   return [
-    { label: t('export.progress.preparing'), threshold: 30 },
-    { label: t('export.progress.exporting'), threshold: 70 },
-    { label: t('export.progress.finalizing'), threshold: 100 },
+    { label: t("export.progress.preparing"), threshold: 30 },
+    { label: t("export.progress.exporting"), threshold: 70 },
+    { label: t("export.progress.finalizing"), threshold: 100 },
   ];
 }
 
@@ -129,25 +130,25 @@ function getFormatOptions(t: TFunction): FormatOption[] {
     {
       value: "pdf",
       label: "PDF",
-      description: t('export.format.pdfStructuredHint'),
+      description: t("export.format.pdfStructuredHint"),
       icon: <FileText size={20} strokeWidth={1.5} />,
     },
     {
       value: "markdown",
       label: "Markdown",
-      description: t('export.format.markdownStructuredHint'),
+      description: t("export.format.markdownStructuredHint"),
       icon: <FileCode size={20} strokeWidth={1.5} />,
     },
     {
       value: "docx",
       label: "Word",
-      description: t('export.format.docxStructuredHint'),
+      description: t("export.format.docxStructuredHint"),
       icon: <FileText size={20} strokeWidth={1.5} />,
     },
     {
       value: "txt",
-      label: t('export.format.plainText'),
-      description: t('export.format.txtBoundaryHint'),
+      label: t("export.format.plainText"),
+      description: t("export.format.txtBoundaryHint"),
       icon: <File size={20} strokeWidth={1.5} />,
     },
   ];
@@ -163,11 +164,21 @@ function formatExportError(t: TFunction, error: IpcError): IpcError {
     const details = error.message.slice(unsupportedPrefix.length).trim();
     return {
       code: "INVALID_ARGUMENT",
-      message: t('export.error.unsupportedStructure', { details }),
+      message: t("export.error.unsupportedStructure", { details }),
     };
   }
 
   return error;
+}
+
+/** Resolve the display message for an export error.
+ *  Domain-specific messages (unsupported-structure) take precedence;
+ *  all other codes are humanized via getHumanErrorMessage. */
+function formatExportErrorDisplay(t: TFunction, error: IpcError): string {
+  const formatted = formatExportError(t, error);
+  return formatted.message !== error.message
+    ? formatted.message
+    : getHumanErrorMessage(error);
 }
 
 /**
@@ -188,8 +199,8 @@ function getUnsupportedReason(format: ExportFormat): string | null {
 function getPageSizeOptions(t: TFunction) {
   return [
     { value: "a4", label: "A4" },
-    { value: "letter", label: t('export.pageSize.letter') },
-    { value: "legal", label: t('export.pageSize.legal') },
+    { value: "letter", label: t("export.pageSize.letter") },
+    { value: "legal", label: t("export.pageSize.legal") },
   ];
 }
 
@@ -320,7 +331,7 @@ function FormatCard({
     >
       {disabled ? (
         <div className="absolute top-3 left-3 text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">
-          {t('export.format.unsupported')}
+          {t("export.format.unsupported")}
         </div>
       ) : null}
 
@@ -384,7 +395,7 @@ function PreviewThumbnail({
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <span className={labelStyles}>{t('export.config.previewLabel')}</span>
+        <span className={labelStyles}>{t("export.config.previewLabel")}</span>
         <span className="text-[10px] text-[var(--color-fg-placeholder)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 rounded">
           {formatLabel} • {pageSizeLabel}
         </span>
@@ -429,6 +440,9 @@ function ConfigView({
 }) {
   const { t } = useTranslation();
   const isPdfFormat = options.format === "pdf";
+  // Errors stored internally are pre-humanized (via getHumanErrorMessage / formatExportError).
+  // External errors arriving via props are humanized here at render time.
+  const errorDisplayMessage = error ? formatExportErrorDisplay(t, error) : null;
 
   return (
     <>
@@ -440,11 +454,10 @@ function ConfigView({
             className="p-3 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
           >
             <div className="flex items-start gap-3">
-              <div className="flex-1 text-xs text-[var(--color-fg-muted)]">
-                <div data-testid="export-error-code" className="font-mono">
-                  {error.code}
+              <div className="flex-1 text-xs text-[var(--color-text-error)]">
+                <div data-testid="export-error-message">
+                  {errorDisplayMessage}
                 </div>
-                <div data-testid="export-error-message">{error.message}</div>
               </div>
               <Button
                 variant="ghost"
@@ -452,7 +465,7 @@ function ConfigView({
                 onClick={onDismissError}
                 className="shrink-0"
               >
-                {t('export.action.dismiss')}
+                {t("export.action.dismiss")}
               </Button>
             </div>
           </div>
@@ -460,7 +473,7 @@ function ConfigView({
 
         {/* Format Selection */}
         <div>
-          <span className={labelStyles}>{t('export.config.formatLabel')}</span>
+          <span className={labelStyles}>{t("export.config.formatLabel")}</span>
           <RadioGroupPrimitive.Root
             value={options.format}
             onValueChange={(value) =>
@@ -483,7 +496,9 @@ function ConfigView({
         <div className="grid grid-cols-2 gap-6">
           {/* Settings Column */}
           <div className="space-y-3">
-            <span className={labelStyles}>{t('export.config.settingsLabel')}</span>
+            <span className={labelStyles}>
+              {t("export.config.settingsLabel")}
+            </span>
 
             <Checkbox
               checked={options.includeMetadata}
@@ -493,7 +508,7 @@ function ConfigView({
                   includeMetadata: checked === true,
                 })
               }
-              label={t('export.config.includeMetadata')}
+              label={t("export.config.includeMetadata")}
             />
 
             <Checkbox
@@ -504,7 +519,7 @@ function ConfigView({
                   versionHistory: checked === true,
                 })
               }
-              label={t('export.config.versionHistory')}
+              label={t("export.config.versionHistory")}
             />
 
             <Checkbox
@@ -515,13 +530,15 @@ function ConfigView({
                   embedImages: checked === true,
                 })
               }
-              label={t('export.config.embedImages')}
+              label={t("export.config.embedImages")}
             />
           </div>
 
           {/* Page Size Column */}
           <div className="space-y-3">
-            <span className={labelStyles}>{t('export.config.pageSizeLabel')}</span>
+            <span className={labelStyles}>
+              {t("export.config.pageSizeLabel")}
+            </span>
             <Select
               value={options.pageSize}
               onValueChange={(value) =>
@@ -553,7 +570,7 @@ function ConfigView({
         <div className="flex-1" />
         <div className="flex gap-3">
           <Button variant="ghost" onClick={onCancel}>
-            {t('export.action.cancel')}
+            {t("export.action.cancel")}
           </Button>
           <Button
             variant="primary"
@@ -561,7 +578,7 @@ function ConfigView({
             data-testid="export-submit"
             disabled={exportDisabledReason !== null}
           >
-            {t('export.action.export')}
+            {t("export.action.export")}
           </Button>
         </div>
       </div>
@@ -596,10 +613,13 @@ function ProgressView({
       </div>
 
       <h3 className="text-xl font-medium text-[var(--color-fg-default)] mb-2">
-        {t('export.progress.title')}
+        {t("export.progress.title")}
       </h3>
       <p className="text-[var(--color-fg-muted)] text-sm mb-8">
-        {t('export.progress.converting', { title: documentTitle, format: formatLabel })}
+        {t("export.progress.converting", {
+          title: documentTitle,
+          format: formatLabel,
+        })}
       </p>
 
       {/* Progress bar */}
@@ -617,7 +637,7 @@ function ProgressView({
       </div>
 
       <Button variant="ghost" onClick={onCancel} className="mt-8">
-        {t('export.action.cancel')}
+        {t("export.action.cancel")}
       </Button>
     </div>
   );
@@ -642,19 +662,22 @@ function SuccessView(props: {
       </div>
 
       <h3 className="text-xl font-medium text-[var(--color-fg-default)] mb-2">
-        {t('export.success.title')}
+        {t("export.success.title")}
       </h3>
       <p className="text-[var(--color-fg-muted)] text-sm mb-8">
-        {t('export.success.description')}
+        {t("export.success.description")}
       </p>
 
       <div className="w-full max-w-sm mb-8 text-left">
         <div className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-[0.1em] mb-2">
-          {t('export.success.resultLabel')}
+          {t("export.success.resultLabel")}
         </div>
         <div className="p-3 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)] space-y-1">
           <div className="text-xs text-[var(--color-fg-muted)]">
-            <span className="font-mono">{t('workbench.export.fieldRelativePath')}</span>:{" "}
+            <span className="font-mono">
+              {t("workbench.export.fieldRelativePath")}
+            </span>
+            :{" "}
             <span
               data-testid="export-success-relative-path"
               className="font-mono"
@@ -663,7 +686,10 @@ function SuccessView(props: {
             </span>
           </div>
           <div className="text-xs text-[var(--color-fg-muted)]">
-            <span className="font-mono">{t('workbench.export.fieldBytesWritten')}</span>:{" "}
+            <span className="font-mono">
+              {t("workbench.export.fieldBytesWritten")}
+            </span>
+            :{" "}
             <span
               data-testid="export-success-bytes-written"
               className="font-mono"
@@ -680,7 +706,7 @@ function SuccessView(props: {
         onClick={props.onDone}
         className="!bg-[var(--color-bg-base)] !text-[var(--color-fg-default)] hover:!bg-[var(--color-bg-hover)]"
       >
-        {t('export.action.done')}
+        {t("export.action.done")}
       </Button>
     </div>
   );
@@ -732,7 +758,7 @@ export function ExportDialog({
 }: ExportDialogProps): JSX.Element {
   const { t } = useTranslation();
   const { showToast } = useAppToast();
-  const displayTitle = documentTitle ?? t('export.defaultDocumentTitle');
+  const displayTitle = documentTitle ?? t("export.defaultDocumentTitle");
   // Internal state for uncontrolled mode
   const [internalView, setInternalView] = React.useState<ExportView>("config");
   const [internalProgress, setInternalProgress] = React.useState(0);
@@ -751,7 +777,8 @@ export function ExportDialog({
   const view = controlledView ?? internalView;
   const progress = controlledProgress ?? internalProgress;
   const steps = getProgressSteps(t);
-  const progressStep = controlledProgressStep ?? getProgressStepLabel(progress, steps);
+  const progressStep =
+    controlledProgressStep ?? getProgressStepLabel(progress, steps);
   const error = controlledError ?? lastError;
   const exportResult = controlledResult ?? result;
 
@@ -785,7 +812,7 @@ export function ExportDialog({
   const exportDisabledReason = React.useMemo(() => {
     const trimmedProjectId = projectId?.trim() ?? "";
     if (trimmedProjectId.length === 0) {
-      return t('export.error.noProject');
+      return t("export.error.noProject");
     }
     const unsupported = getUnsupportedReason(options.format);
     if (unsupported) {
@@ -836,13 +863,12 @@ export function ExportDialog({
         return;
       }
 
-      setLastError({
-        code: "IO_ERROR",
+      const ioError = {
+        code: "IO_ERROR" as const,
         message:
-          error instanceof Error
-            ? error.message
-            : t('export.error.unknown'),
-      });
+          error instanceof Error ? error.message : t("export.error.unknown"),
+      };
+      setLastError(ioError);
       setInternalView("config");
       setInternalProgress(0);
       return;
@@ -853,7 +879,7 @@ export function ExportDialog({
     }
 
     if (!res.ok) {
-      setLastError(formatExportError(t, res.error));
+      setLastError(res.error);
       setInternalView("config");
       setInternalProgress(0);
       return;
@@ -902,7 +928,7 @@ export function ExportDialog({
               <div className="flex items-start justify-between p-6 pb-4 border-b border-[var(--color-separator)]">
                 <div>
                   <DialogPrimitive.Title className="text-lg font-medium text-[var(--color-fg-default)] mb-1">
-                    {t('export.dialog.title')}
+                    {t("export.dialog.title")}
                   </DialogPrimitive.Title>
                   <DialogPrimitive.Description className="text-sm text-[var(--color-fg-muted)]">
                     {displayTitle}
@@ -910,7 +936,7 @@ export function ExportDialog({
                 </div>
                 <DialogPrimitive.Close
                   className={closeButtonStyles}
-                  aria-label={t('export.dialog.close')}
+                  aria-label={t("export.dialog.close")}
                 >
                   <X size={20} strokeWidth={1.5} aria-hidden="true" />
                 </DialogPrimitive.Close>
@@ -932,10 +958,10 @@ export function ExportDialog({
           {view === "progress" && (
             <>
               <DialogPrimitive.Title className="sr-only">
-                {t('export.progress.title')}
+                {t("export.progress.title")}
               </DialogPrimitive.Title>
               <DialogPrimitive.Description className="sr-only">
-                {t('export.progress.description')}
+                {t("export.progress.description")}
               </DialogPrimitive.Description>
               <ProgressView
                 documentTitle={displayTitle}
@@ -950,10 +976,10 @@ export function ExportDialog({
           {view === "success" && (
             <>
               <DialogPrimitive.Title className="sr-only">
-                {t('export.success.title')}
+                {t("export.success.title")}
               </DialogPrimitive.Title>
               <DialogPrimitive.Description className="sr-only">
-                {t('export.success.srDescription')}
+                {t("export.success.srDescription")}
               </DialogPrimitive.Description>
               {exportResult ? (
                 <SuccessView result={exportResult} onDone={handleDone} />

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { FileTreePanel } from "./FileTreePanel";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 // Mock stores
 vi.mock("../../stores/fileStore", () => ({
@@ -73,9 +74,7 @@ describe("FileTreePanel", () => {
     it("当无Documents时应显示空状态提示", () => {
       render(<FileTreePanel projectId="test-project" />);
 
-      expect(
-        screen.getByText("No Files"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("No Files")).toBeInTheDocument();
       expect(
         screen.getByText("Start by creating your first file"),
       ).toBeInTheDocument();
@@ -147,7 +146,15 @@ describe("FileTreePanel", () => {
       render(<FileTreePanel projectId="test-project" />);
 
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          getHumanErrorMessage({
+            code: "IO_ERROR",
+            message: "Failed to load files",
+          }),
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/IO_ERROR/)).not.toBeInTheDocument();
       expect(screen.getByText("Dismiss")).toBeInTheDocument();
     });
   });

--- a/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreePanel.tsx
@@ -15,6 +15,7 @@ import { PanelContainer } from "../../components/composites/PanelContainer";
 import { EmptyState } from "../../components/composites/EmptyState";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
 import { useEditorStore } from "../../stores/editorStore";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import {
   useFileStore,
   type DocumentListItem,
@@ -281,7 +282,6 @@ function buildReorderedDocumentIds(args: {
  * Why: P1 requires sortable tree hierarchy with keyboard/context interactions.
  */
 
-
 interface TreeKeyDownDeps {
   editing: EditingState;
   tree: TreeSnapshot;
@@ -300,108 +300,120 @@ function handleTreeKeyDown(
   event: React.KeyboardEvent<HTMLDivElement>,
   deps: TreeKeyDownDeps,
 ): void {
-  const { editing, tree, visibleNodes, focusedDocumentId, currentDocumentId, expandedFolderIds, toggleFolderExpanded, setEditing, setFocusedDocumentId, onDelete, onSelect } = deps;
-    if (editing.mode === "rename") {
-      return;
-    }
-
-    if (visibleNodes.length === 0) {
-      return;
-    }
-
-    const activeId =
-      focusedDocumentId ??
-      currentDocumentId ??
-      visibleNodes[0]?.node.documentId ??
-      null;
-    if (!activeId) {
-      return;
-    }
-
-    const currentIndex = visibleNodes.findIndex(
-      (entry) => entry.node.documentId === activeId,
-    );
-    if (currentIndex < 0) {
-      return;
-    }
-
-    const activeNode = visibleNodes[currentIndex]?.node;
-    if (!activeNode) {
-      return;
-    }
-
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      const next =
-        visibleNodes[Math.min(currentIndex + 1, visibleNodes.length - 1)];
-      if (next) {
-        setFocusedDocumentId(next.node.documentId);
-      }
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      const next = visibleNodes[Math.max(currentIndex - 1, 0)];
-      if (next) {
-        setFocusedDocumentId(next.node.documentId);
-      }
-      return;
-    }
-
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      if (activeNode.children.length === 0) {
-        return;
-      }
-      if (!expandedFolderIds.has(activeNode.documentId)) {
-        toggleFolderExpanded(activeNode.documentId);
-        return;
-      }
-      const firstChild = activeNode.children[0];
-      if (firstChild) {
-        setFocusedDocumentId(firstChild.documentId);
-      }
-      return;
-    }
-
-    if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      if (
-        activeNode.children.length > 0 &&
-        expandedFolderIds.has(activeNode.documentId)
-      ) {
-        toggleFolderExpanded(activeNode.documentId);
-        return;
-      }
-      const parentId = tree.parentById.get(activeNode.documentId);
-      if (parentId) {
-        setFocusedDocumentId(parentId);
-      }
-      return;
-    }
-
-    if (event.key === "Enter") {
-      event.preventDefault();
-      void onSelect(activeNode.documentId);
-      return;
-    }
-
-    if (event.key === "F2") {
-      event.preventDefault();
-      setEditing({
-        mode: "rename",
-        documentId: activeNode.documentId,
-        title: activeNode.title,
-      });
-      return;
-    }
-
-    if (event.key === "Delete") {
-      event.preventDefault();
-      void onDelete(activeNode.documentId);
-    }
+  const {
+    editing,
+    tree,
+    visibleNodes,
+    focusedDocumentId,
+    currentDocumentId,
+    expandedFolderIds,
+    toggleFolderExpanded,
+    setEditing,
+    setFocusedDocumentId,
+    onDelete,
+    onSelect,
+  } = deps;
+  if (editing.mode === "rename") {
+    return;
   }
+
+  if (visibleNodes.length === 0) {
+    return;
+  }
+
+  const activeId =
+    focusedDocumentId ??
+    currentDocumentId ??
+    visibleNodes[0]?.node.documentId ??
+    null;
+  if (!activeId) {
+    return;
+  }
+
+  const currentIndex = visibleNodes.findIndex(
+    (entry) => entry.node.documentId === activeId,
+  );
+  if (currentIndex < 0) {
+    return;
+  }
+
+  const activeNode = visibleNodes[currentIndex]?.node;
+  if (!activeNode) {
+    return;
+  }
+
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    const next =
+      visibleNodes[Math.min(currentIndex + 1, visibleNodes.length - 1)];
+    if (next) {
+      setFocusedDocumentId(next.node.documentId);
+    }
+    return;
+  }
+
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    const next = visibleNodes[Math.max(currentIndex - 1, 0)];
+    if (next) {
+      setFocusedDocumentId(next.node.documentId);
+    }
+    return;
+  }
+
+  if (event.key === "ArrowRight") {
+    event.preventDefault();
+    if (activeNode.children.length === 0) {
+      return;
+    }
+    if (!expandedFolderIds.has(activeNode.documentId)) {
+      toggleFolderExpanded(activeNode.documentId);
+      return;
+    }
+    const firstChild = activeNode.children[0];
+    if (firstChild) {
+      setFocusedDocumentId(firstChild.documentId);
+    }
+    return;
+  }
+
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    if (
+      activeNode.children.length > 0 &&
+      expandedFolderIds.has(activeNode.documentId)
+    ) {
+      toggleFolderExpanded(activeNode.documentId);
+      return;
+    }
+    const parentId = tree.parentById.get(activeNode.documentId);
+    if (parentId) {
+      setFocusedDocumentId(parentId);
+    }
+    return;
+  }
+
+  if (event.key === "Enter") {
+    event.preventDefault();
+    void onSelect(activeNode.documentId);
+    return;
+  }
+
+  if (event.key === "F2") {
+    event.preventDefault();
+    setEditing({
+      mode: "rename",
+      documentId: activeNode.documentId,
+      title: activeNode.title,
+    });
+    return;
+  }
+
+  if (event.key === "Delete") {
+    event.preventDefault();
+    void onDelete(activeNode.documentId);
+  }
+}
 
 function buildNodeContextMenuItems(
   item: TreeNode,
@@ -411,8 +423,14 @@ function buildNodeContextMenuItems(
     setEditing: (state: EditingState) => void;
     onCopy: (item: TreeNode) => Promise<void>;
     onDelete: (documentId: string) => Promise<void>;
-    onToggleStatus: (args: { documentId: string; next: "draft" | "final" }) => Promise<void>;
-    onMoveDocumentToFolder: (args: { documentId: string; parentId: string }) => Promise<void>;
+    onToggleStatus: (args: {
+      documentId: string;
+      next: "draft" | "final";
+    }) => Promise<void>;
+    onMoveDocumentToFolder: (args: {
+      documentId: string;
+      parentId: string;
+    }) => Promise<void>;
     onOpenVersionHistory?: (documentId: string) => void;
   },
 ): ContextMenuItem[] {
@@ -420,7 +438,7 @@ function buildNodeContextMenuItems(
   return [
     {
       key: "rename",
-      label: deps.t('files.tree.rename'),
+      label: deps.t("files.tree.rename"),
       onSelect: () => {
         deps.setEditing({
           mode: "rename",
@@ -431,12 +449,12 @@ function buildNodeContextMenuItems(
     },
     {
       key: "copy",
-      label: deps.t('files.tree.copy'),
+      label: deps.t("files.tree.copy"),
       onSelect: () => void deps.onCopy(item),
     },
     {
       key: "move",
-      label: deps.t('files.tree.moveToFolder'),
+      label: deps.t("files.tree.moveToFolder"),
       disabled: moveToFolderDisabled,
       onSelect: () => {
         if (!moveTargetFolderId) {
@@ -450,13 +468,13 @@ function buildNodeContextMenuItems(
     },
     {
       key: "delete",
-      label: deps.t('files.tree.delete'),
+      label: deps.t("files.tree.delete"),
       onSelect: () => void deps.onDelete(item.documentId),
       destructive: true,
     },
     {
       key: "version-history",
-      label: deps.t('files.tree.versionHistory'),
+      label: deps.t("files.tree.versionHistory"),
       onSelect: () => {
         deps.onOpenVersionHistory?.(item.documentId);
       },
@@ -464,7 +482,9 @@ function buildNodeContextMenuItems(
     {
       key: "status",
       label:
-        item.status === "final" ? deps.t('files.tree.markAsDraft') : deps.t('files.tree.markAsFinal'),
+        item.status === "final"
+          ? deps.t("files.tree.markAsDraft")
+          : deps.t("files.tree.markAsFinal"),
       onSelect: () =>
         void deps.onToggleStatus({
           documentId: item.documentId,
@@ -474,14 +494,17 @@ function buildNodeContextMenuItems(
   ];
 }
 
-const FileTreeRenameRow = React.forwardRef<HTMLInputElement, {
-  item: TreeNode;
-  entry: VisibleTreeNode;
-  editing: { mode: "rename"; documentId: string; title: string };
-  dropBefore: boolean;
-  setEditing: (state: EditingState) => void;
-  onCommitRename: () => Promise<void>;
-}>(function FileTreeRenameRow(props, ref) {
+const FileTreeRenameRow = React.forwardRef<
+  HTMLInputElement,
+  {
+    item: TreeNode;
+    entry: VisibleTreeNode;
+    editing: { mode: "rename"; documentId: string; title: string };
+    dropBefore: boolean;
+    setEditing: (state: EditingState) => void;
+    onCommitRename: () => Promise<void>;
+  }
+>(function FileTreeRenameRow(props, ref) {
   const { t } = useTranslation();
   const { item, entry, editing, dropBefore, setEditing } = props;
   return (
@@ -534,7 +557,7 @@ const FileTreeRenameRow = React.forwardRef<HTMLInputElement, {
               void props.onCommitRename();
             }}
           >
-            {t('files.tree.ok')}
+            {t("files.tree.ok")}
           </Button>
           <Button
             variant="ghost"
@@ -544,7 +567,7 @@ const FileTreeRenameRow = React.forwardRef<HTMLInputElement, {
               setEditing({ mode: "idle" });
             }}
           >
-            {t('files.tree.closeSymbol')}
+            {t("files.tree.closeSymbol")}
           </Button>
         </div>
       </div>
@@ -557,16 +580,30 @@ interface DropOnDocumentDeps {
   dropTarget: DropTargetState | null;
   tree: TreeSnapshot;
   items: DocumentListItem[];
-  reorder: (args: { projectId: string; orderedDocumentIds: string[] }) => Promise<unknown>;
+  reorder: (args: {
+    projectId: string;
+    orderedDocumentIds: string[];
+  }) => Promise<unknown>;
   projectId: string;
-  onMoveDocumentToFolder: (args: { documentId: string; parentId: string }) => Promise<void>;
+  onMoveDocumentToFolder: (args: {
+    documentId: string;
+    parentId: string;
+  }) => Promise<void>;
 }
 
 async function performDropOnDocument(
   targetDocumentId: string,
   deps: DropOnDocumentDeps,
 ): Promise<void> {
-  const { draggingDocumentId, dropTarget, tree, items, reorder, projectId, onMoveDocumentToFolder } = deps;
+  const {
+    draggingDocumentId,
+    dropTarget,
+    tree,
+    items,
+    reorder,
+    projectId,
+    onMoveDocumentToFolder,
+  } = deps;
   if (!draggingDocumentId || draggingDocumentId === targetDocumentId) {
     return;
   }
@@ -602,6 +639,7 @@ async function performDropOnDocument(
   });
 }
 
+// eslint-disable-next-line max-lines-per-function
 function useFileTreeState(
   projectId: string,
   t: ReturnType<typeof useTranslation>["t"],
@@ -794,7 +832,7 @@ function useFileTreeState(
     const res = await createAndSetCurrent({
       projectId: projectId,
       type: item.type,
-      title: t('files.tree.copySuffix', { title: item.title }),
+      title: t("files.tree.copySuffix", { title: item.title }),
     });
     if (!res.ok) {
       return;
@@ -842,10 +880,10 @@ function useFileTreeState(
 
   async function onDelete(documentId: string): Promise<void> {
     const confirmed = await confirm({
-      title: t('files.tree.deleteTitle'),
-      description: t('files.tree.deleteDescription'),
-      primaryLabel: t('files.tree.deleteConfirm'),
-      secondaryLabel: t('files.tree.deleteCancel'),
+      title: t("files.tree.deleteTitle"),
+      description: t("files.tree.deleteDescription"),
+      primaryLabel: t("files.tree.deleteConfirm"),
+      secondaryLabel: t("files.tree.deleteCancel"),
     });
     if (!confirmed) {
       return;
@@ -919,55 +957,97 @@ function useFileTreeState(
 
   async function onDropOnDocument(targetDocumentId: string): Promise<void> {
     await performDropOnDocument(targetDocumentId, {
-      draggingDocumentId, dropTarget, tree, items, reorder, projectId, onMoveDocumentToFolder,
+      draggingDocumentId,
+      dropTarget,
+      tree,
+      items,
+      reorder,
+      projectId,
+      onMoveDocumentToFolder,
     });
   }
 
   function onTreeKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
     handleTreeKeyDown(event, {
-      editing, tree, visibleNodes, focusedDocumentId, currentDocumentId,
-      expandedFolderIds, toggleFolderExpanded, setEditing, setFocusedDocumentId,
-      onDelete, onSelect,
+      editing,
+      tree,
+      visibleNodes,
+      focusedDocumentId,
+      currentDocumentId,
+      expandedFolderIds,
+      toggleFolderExpanded,
+      setEditing,
+      setFocusedDocumentId,
+      onDelete,
+      onSelect,
     });
   }
 
   return {
-    items, currentDocumentId, bootstrapStatus, lastError, clearError,
-    editing, setEditing, expandedFolderIds,
-    focusedDocumentId, setFocusedDocumentId,
-    draggingDocumentId, setDraggingDocumentId,
-    dropTarget, setDropTarget,
-    inputRef, tree, visibleNodes, dialogProps,
-    toggleFolderExpanded, resolveMoveTargetFolder,
-    onCreate, onCopy, onSelect, onCommitRename,
-    onDelete, onToggleStatus, onMoveDocumentToFolder,
-    onDropOnDocument, onTreeKeyDown,
+    items,
+    currentDocumentId,
+    bootstrapStatus,
+    lastError,
+    clearError,
+    editing,
+    setEditing,
+    expandedFolderIds,
+    focusedDocumentId,
+    setFocusedDocumentId,
+    draggingDocumentId,
+    setDraggingDocumentId,
+    dropTarget,
+    setDropTarget,
+    inputRef,
+    tree,
+    visibleNodes,
+    dialogProps,
+    toggleFolderExpanded,
+    resolveMoveTargetFolder,
+    onCreate,
+    onCopy,
+    onSelect,
+    onCommitRename,
+    onDelete,
+    onToggleStatus,
+    onMoveDocumentToFolder,
+    onDropOnDocument,
+    onTreeKeyDown,
   };
 }
 
-const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
-  entry: VisibleTreeNode;
-  focusedDocumentId: string | null;
-  currentDocumentId: string | null;
-  editing: EditingState;
-  setEditing: (state: EditingState) => void;
-  draggingDocumentId: string | null;
-  setDraggingDocumentId: (id: string | null) => void;
-  dropTarget: DropTargetState | null;
-  setDropTarget: (target: DropTargetState | null) => void;
-  setFocusedDocumentId: (id: string | null) => void;
-  expandedFolderIds: Set<string>;
-  toggleFolderExpanded: (id: string) => void;
-  resolveMoveTargetFolder: (documentId: string) => string | null;
-  onSelect: (documentId: string) => Promise<void>;
-  onCopy: (item: TreeNode) => Promise<void>;
-  onDelete: (documentId: string) => Promise<void>;
-  onCommitRename: () => Promise<void>;
-  onToggleStatus: (args: { documentId: string; next: "draft" | "final" }) => Promise<void>;
-  onDropOnDocument: (targetId: string) => Promise<void>;
-  onMoveDocumentToFolder: (args: { documentId: string; parentId: string }) => Promise<void>;
-  onOpenVersionHistory?: (documentId: string) => void;
-}>(function FileTreeNodeRow(props, ref) {
+const FileTreeNodeRow = React.forwardRef<
+  HTMLInputElement,
+  {
+    entry: VisibleTreeNode;
+    focusedDocumentId: string | null;
+    currentDocumentId: string | null;
+    editing: EditingState;
+    setEditing: (state: EditingState) => void;
+    draggingDocumentId: string | null;
+    setDraggingDocumentId: (id: string | null) => void;
+    dropTarget: DropTargetState | null;
+    setDropTarget: (target: DropTargetState | null) => void;
+    setFocusedDocumentId: (id: string | null) => void;
+    expandedFolderIds: Set<string>;
+    toggleFolderExpanded: (id: string) => void;
+    resolveMoveTargetFolder: (documentId: string) => string | null;
+    onSelect: (documentId: string) => Promise<void>;
+    onCopy: (item: TreeNode) => Promise<void>;
+    onDelete: (documentId: string) => Promise<void>;
+    onCommitRename: () => Promise<void>;
+    onToggleStatus: (args: {
+      documentId: string;
+      next: "draft" | "final";
+    }) => Promise<void>;
+    onDropOnDocument: (targetId: string) => Promise<void>;
+    onMoveDocumentToFolder: (args: {
+      documentId: string;
+      parentId: string;
+    }) => Promise<void>;
+    onOpenVersionHistory?: (documentId: string) => void;
+  }
+>(function FileTreeNodeRow(props, ref) {
   const { t } = useTranslation();
   const { entry, editing, setEditing } = props;
   const item = entry.node;
@@ -975,8 +1055,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
   const selected =
     item.documentId === (props.focusedDocumentId ?? props.currentDocumentId);
   const isRenaming =
-    editing.mode === "rename" &&
-    editing.documentId === item.documentId;
+    editing.mode === "rename" && editing.documentId === item.documentId;
   const isDragging = props.draggingDocumentId === item.documentId;
   const dropBefore =
     props.dropTarget?.documentId === item.documentId &&
@@ -985,19 +1064,18 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
     props.dropTarget?.documentId === item.documentId &&
     props.dropTarget?.mode === "into";
 
-  const moveTargetFolderId = props.resolveMoveTargetFolder(
-    item.documentId,
-  );
+  const moveTargetFolderId = props.resolveMoveTargetFolder(item.documentId);
   const moveToFolderDisabled = !moveTargetFolderId;
 
-  const contextMenuItems = buildNodeContextMenuItems(
-    item, moveTargetFolderId, {
-      t: t, setEditing, onCopy: props.onCopy,
-      onDelete: props.onDelete, onToggleStatus: props.onToggleStatus,
-      onMoveDocumentToFolder: props.onMoveDocumentToFolder,
-      onOpenVersionHistory: props.onOpenVersionHistory,
-    },
-  );
+  const contextMenuItems = buildNodeContextMenuItems(item, moveTargetFolderId, {
+    t: t,
+    setEditing,
+    onCopy: props.onCopy,
+    onDelete: props.onDelete,
+    onToggleStatus: props.onToggleStatus,
+    onMoveDocumentToFolder: props.onMoveDocumentToFolder,
+    onOpenVersionHistory: props.onOpenVersionHistory,
+  });
 
   if (isRenaming) {
     return (
@@ -1078,8 +1156,8 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
               className="shrink-0 w-4 text-[10px] text-[var(--color-fg-muted)]"
               aria-label={
                 props.expandedFolderIds.has(item.documentId)
-                  ? t('files.tree.collapse')
-                  : t('files.tree.expand')
+                  ? t("files.tree.collapse")
+                  : t("files.tree.expand")
               }
             >
               {props.expandedFolderIds.has(item.documentId) ? "▾" : "▸"}
@@ -1115,7 +1193,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                 onClick={(e) => e.stopPropagation()}
                 className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shrink-0 w-6 h-6 p-0"
               >
-                {t('files.tree.moreActions')}
+                {t("files.tree.moreActions")}
               </Button>
             }
             side="bottom"
@@ -1136,7 +1214,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                   }}
                   className="justify-start w-full"
                 >
-                  {t('files.tree.rename')}
+                  {t("files.tree.rename")}
                 </Button>
               </PopoverClose>
               <PopoverClose asChild>
@@ -1147,7 +1225,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                   onClick={() => void props.onCopy(item)}
                   className="justify-start w-full"
                 >
-                  {t('files.tree.copy')}
+                  {t("files.tree.copy")}
                 </Button>
               </PopoverClose>
               <PopoverClose asChild>
@@ -1167,7 +1245,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                   }}
                   className="justify-start w-full"
                 >
-                  {t('files.tree.moveToFolder')}
+                  {t("files.tree.moveToFolder")}
                 </Button>
               </PopoverClose>
               <PopoverClose asChild>
@@ -1178,15 +1256,14 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                   onClick={() =>
                     void props.onToggleStatus({
                       documentId: item.documentId,
-                      next:
-                        item.status === "final" ? "draft" : "final",
+                      next: item.status === "final" ? "draft" : "final",
                     })
                   }
                   className="justify-start w-full"
                 >
                   {item.status === "final"
-                    ? t('files.tree.markAsDraft')
-                    : t('files.tree.markAsFinal')}
+                    ? t("files.tree.markAsDraft")
+                    : t("files.tree.markAsFinal")}
                 </Button>
               </PopoverClose>
               <PopoverClose asChild>
@@ -1197,7 +1274,7 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
                   onClick={() => void props.onDelete(item.documentId)}
                   className="justify-start w-full text-[var(--color-error)]"
                 >
-                  {t('files.tree.delete')}
+                  {t("files.tree.delete")}
                 </Button>
               </PopoverClose>
             </div>
@@ -1210,12 +1287,16 @@ const FileTreeNodeRow = React.forwardRef<HTMLInputElement, {
 
 export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
   const { t } = useTranslation();
-  const state = useFileTreeState(props.projectId, t, props.initialRenameDocumentId);
+  const state = useFileTreeState(
+    props.projectId,
+    t,
+    props.initialRenameDocumentId,
+  );
 
   return (
     <PanelContainer
       data-testid="sidebar-files"
-      title={t('files.tree.panelTitle')}
+      title={t("files.tree.panelTitle")}
       actions={
         <>
           <Button
@@ -1224,7 +1305,7 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             size="sm"
             onClick={() => void state.onCreate("chapter")}
           >
-            {t('files.tree.newButton')}
+            {t("files.tree.newButton")}
           </Button>
           <Button
             data-testid="file-create-note"
@@ -1232,22 +1313,25 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
             size="sm"
             onClick={() => void state.onCreate("note")}
           >
-            {t('files.tree.noteButton')}
+            {t("files.tree.noteButton")}
           </Button>
         </>
       }
     >
-
       {state.lastError ? (
         <div
           role="alert"
           className="p-3 border-b border-[var(--color-separator)]"
         >
           <Text size="small" className="mb-2 block">
-            {state.lastError.code}: {state.lastError.message}
+            {getHumanErrorMessage(state.lastError)}
           </Text>
-          <Button variant="secondary" size="sm" onClick={() => state.clearError()}>
-            {t('files.tree.dismiss')}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => state.clearError()}
+          >
+            {t("files.tree.dismiss")}
           </Button>
         </div>
       ) : null}
@@ -1261,12 +1345,12 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
       >
         {state.bootstrapStatus !== "ready" ? (
           <Text size="small" color="muted" className="p-3 block">
-            {t('files.tree.loading')}
+            {t("files.tree.loading")}
           </Text>
         ) : state.items.length === 0 ? (
           <EmptyState
-            title={t('files.tree.emptyTitle')}
-            description={t('files.tree.emptyDescription')}
+            title={t("files.tree.emptyTitle")}
+            description={t("files.tree.emptyDescription")}
             action={
               <Button
                 data-testid="file-create-empty"
@@ -1274,39 +1358,39 @@ export function FileTreePanel(props: FileTreePanelProps): JSX.Element {
                 size="sm"
                 onClick={() => void state.onCreate("chapter")}
               >
-                {t('files.tree.newFile')}
+                {t("files.tree.newFile")}
               </Button>
             }
           />
         ) : (
           <div className="flex flex-col gap-1 p-2">
-          {state.visibleNodes.map((entry) => (
-            <FileTreeNodeRow
-              key={entry.node.documentId}
-              ref={state.inputRef}
-              entry={entry}
-              focusedDocumentId={state.focusedDocumentId}
-              currentDocumentId={state.currentDocumentId}
-              editing={state.editing}
-              setEditing={state.setEditing}
-              draggingDocumentId={state.draggingDocumentId}
-              setDraggingDocumentId={state.setDraggingDocumentId}
-              dropTarget={state.dropTarget}
-              setDropTarget={state.setDropTarget}
-              setFocusedDocumentId={state.setFocusedDocumentId}
-              expandedFolderIds={state.expandedFolderIds}
-              toggleFolderExpanded={state.toggleFolderExpanded}
-              resolveMoveTargetFolder={state.resolveMoveTargetFolder}
-              onSelect={state.onSelect}
-              onCopy={state.onCopy}
-              onDelete={state.onDelete}
-              onCommitRename={state.onCommitRename}
-              onToggleStatus={state.onToggleStatus}
-              onDropOnDocument={state.onDropOnDocument}
-              onMoveDocumentToFolder={state.onMoveDocumentToFolder}
-              onOpenVersionHistory={props.onOpenVersionHistory}
-            />
-          ))}
+            {state.visibleNodes.map((entry) => (
+              <FileTreeNodeRow
+                key={entry.node.documentId}
+                ref={state.inputRef}
+                entry={entry}
+                focusedDocumentId={state.focusedDocumentId}
+                currentDocumentId={state.currentDocumentId}
+                editing={state.editing}
+                setEditing={state.setEditing}
+                draggingDocumentId={state.draggingDocumentId}
+                setDraggingDocumentId={state.setDraggingDocumentId}
+                dropTarget={state.dropTarget}
+                setDropTarget={state.setDropTarget}
+                setFocusedDocumentId={state.setFocusedDocumentId}
+                expandedFolderIds={state.expandedFolderIds}
+                toggleFolderExpanded={state.toggleFolderExpanded}
+                resolveMoveTargetFolder={state.resolveMoveTargetFolder}
+                onSelect={state.onSelect}
+                onCopy={state.onCopy}
+                onDelete={state.onDelete}
+                onCommitRename={state.onCommitRename}
+                onToggleStatus={state.onToggleStatus}
+                onDropOnDocument={state.onDropOnDocument}
+                onMoveDocumentToFolder={state.onMoveDocumentToFolder}
+                onOpenVersionHistory={props.onOpenVersionHistory}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
+++ b/apps/desktop/renderer/src/features/kg/KnowledgeGraphPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 import { Button, Card, Input, Select, Text } from "../../components/primitives";
 import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
@@ -10,7 +11,12 @@ import type {
   NodeType,
 } from "../../components/features/KnowledgeGraph/types";
 import { useConfirmDialog } from "../../hooks/useConfirmDialog";
-import { useKgStore, type KgEntity, type KgRelation, type KgActions } from "../../stores/kgStore";
+import {
+  useKgStore,
+  type KgEntity,
+  type KgRelation,
+  type KgActions,
+} from "../../stores/kgStore";
 import { TimelineView, type TimelineEventItem } from "./TimelineView";
 import { buildForceDirectedGraph } from "./graphRenderAdapter";
 import {
@@ -139,9 +145,9 @@ function ViewModeToggle(props: {
 }): JSX.Element {
   const { t } = useTranslation();
   const entries: Array<{ mode: ViewMode; label: string }> = [
-    { mode: "graph", label: t('kg.panel.viewGraph') },
-    { mode: "timeline", label: t('kg.panel.viewTimeline') },
-    { mode: "list", label: t('kg.panel.viewList') },
+    { mode: "graph", label: t("kg.panel.viewGraph") },
+    { mode: "timeline", label: t("kg.panel.viewTimeline") },
+    { mode: "list", label: t("kg.panel.viewList") },
   ];
   return (
     <div className="flex items-center gap-1">
@@ -211,7 +217,11 @@ function createKgGraphActions(deps: KgGraphActionsDeps) {
         patch: { metadataJson: updatedMetadata },
       });
       if (!res.ok) {
-        console.warn("[KnowledgeGraphPanel] deps.entityUpdate failed:", nodeId, res);
+        console.warn(
+          "[KnowledgeGraphPanel] deps.entityUpdate failed:",
+          nodeId,
+          res,
+        );
         return;
       }
       saveKgViewPreferences(deps.projectId, { lastDraggedNodeId: nodeId });
@@ -301,7 +311,7 @@ function createKgGraphActions(deps: KgGraphActionsDeps) {
     const position = { x: 300, y: 200 };
 
     const res = await deps.entityCreate({
-      name: deps.t('kg.panel.newEntity'),
+      name: deps.t("kg.panel.newEntity"),
       type: nodeTypeToEntityType(nodeType),
       description: "",
     });
@@ -373,12 +383,21 @@ function createKgGraphActions(deps: KgGraphActionsDeps) {
     deps.setSelectedNodeId(null);
   }
 
-  return { onNodeMove, onTimelineOrderChange, onAddNode, onNodeSave, onNodeDeleteFromGraph };
+  return {
+    onNodeMove,
+    onTimelineOrderChange,
+    onAddNode,
+    onNodeSave,
+    onNodeDeleteFromGraph,
+  };
 }
 
 // --- State hook (extracted for max-lines-per-function) ---
 
-function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>["t"]) {
+function useKgPanelState(
+  projectId: string,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
   const bootstrapStatus = useKgStore((s) => s.bootstrapStatus);
   const entities = useKgStore((s) => s.entities);
   const relations = useKgStore((s) => s.relations);
@@ -419,9 +438,7 @@ function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>
 
   const isReady = bootstrapStatus === "ready";
 
-
   React.useEffect(() => {
-
     void bootstrapForProject(projectId);
   }, [bootstrapForProject, projectId]);
 
@@ -463,10 +480,10 @@ function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>
 
   async function onDeleteEntity(entityId: string): Promise<void> {
     const confirmed = await confirm({
-      title: t('kg.panel.deleteEntityTitle'),
-      description: t('kg.panel.deleteEntityDescription'),
-      primaryLabel: t('kg.panel.delete'),
-      secondaryLabel: t('kg.panel.cancel'),
+      title: t("kg.panel.deleteEntityTitle"),
+      description: t("kg.panel.deleteEntityDescription"),
+      primaryLabel: t("kg.panel.delete"),
+      secondaryLabel: t("kg.panel.cancel"),
     });
     if (!confirmed) {
       return;
@@ -484,10 +501,10 @@ function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>
    */
   async function onDeleteRelation(relationId: string): Promise<void> {
     const confirmed = await confirm({
-      title: t('kg.panel.deleteRelationTitle'),
-      description: t('kg.panel.deleteRelationDescription'),
-      primaryLabel: t('kg.panel.delete'),
-      secondaryLabel: t('kg.panel.cancel'),
+      title: t("kg.panel.deleteRelationTitle"),
+      description: t("kg.panel.deleteRelationDescription"),
+      primaryLabel: t("kg.panel.delete"),
+      secondaryLabel: t("kg.panel.cancel"),
     });
     if (!confirmed) {
       return;
@@ -574,7 +591,6 @@ function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>
     return e ? e.name : entityId;
   }
 
-
   const baseGraphData = React.useMemo(
     () => kgToGraph(entities, relations),
     [entities, relations],
@@ -624,19 +640,55 @@ function useKgPanelState(projectId: string, t: ReturnType<typeof useTranslation>
   }
 
   const graphActions = createKgGraphActions({
-    entities, entityCreate, entityUpdate,
-    onDeleteEntity, setSelectedNodeId, t, projectId,
+    entities,
+    entityCreate,
+    entityUpdate,
+    onDeleteEntity,
+    setSelectedNodeId,
+    t,
+    projectId,
   });
 
   return {
-    t, isReady, bootstrapStatus, entities, relations, lastError, clearError,
-    editing, setEditing, viewMode, setViewMode,
-    selectedNodeId, setSelectedNodeId, graphTransform, graphData, timelineEvents,
-    dialogProps, onGraphTransformChange, ...graphActions,
-    onCreateEntity, onDeleteEntity, onDeleteRelation, onSaveEdit, onCreateRelation,
-    getEntityName, createName, setCreateName, createType, setCreateType,
-    createDescription, setCreateDescription, createAliasesInput, setCreateAliasesInput,
-    relFromId, setRelFromId, relToId, setRelToId, relType, setRelType,
+    t,
+    isReady,
+    bootstrapStatus,
+    entities,
+    relations,
+    lastError,
+    clearError,
+    editing,
+    setEditing,
+    viewMode,
+    setViewMode,
+    selectedNodeId,
+    setSelectedNodeId,
+    graphTransform,
+    graphData,
+    timelineEvents,
+    dialogProps,
+    onGraphTransformChange,
+    ...graphActions,
+    onCreateEntity,
+    onDeleteEntity,
+    onDeleteRelation,
+    onSaveEdit,
+    onCreateRelation,
+    getEntityName,
+    createName,
+    setCreateName,
+    createType,
+    setCreateType,
+    createDescription,
+    setCreateDescription,
+    createAliasesInput,
+    setCreateAliasesInput,
+    relFromId,
+    setRelFromId,
+    relToId,
+    setRelToId,
+    relType,
+    setRelType,
   };
 }
 
@@ -650,7 +702,14 @@ function KgEntityCard(props: {
   onDeleteEntity: (entityId: string) => Promise<void>;
   t: ReturnType<typeof useTranslation>["t"];
 }): JSX.Element {
-  const { entity: e, editing, setEditing, onSaveEdit, onDeleteEntity, t } = props;
+  const {
+    entity: e,
+    editing,
+    setEditing,
+    onSaveEdit,
+    onDeleteEntity,
+    t,
+  } = props;
   const isEditing = editing.mode === "entity" && editing.id === e.id;
   return (
     <Card
@@ -700,7 +759,7 @@ function KgEntityCard(props: {
                 lastSeenState: evt.target.value,
               })
             }
-            placeholder={t('kg.panel.lastSeenStatePlaceholder')}
+            placeholder={t("kg.panel.lastSeenStatePlaceholder")}
             fullWidth
           />
           <Input
@@ -750,14 +809,14 @@ function KgEntityCard(props: {
               size="sm"
               onClick={() => void onSaveEdit()}
             >
-              {t('kg.panel.save')}
+              {t("kg.panel.save")}
             </Button>
             <Button
               variant="ghost"
               size="sm"
               onClick={() => setEditing({ mode: "idle" })}
             >
-              {t('kg.panel.cancel')}
+              {t("kg.panel.cancel")}
             </Button>
           </>
         ) : (
@@ -778,7 +837,7 @@ function KgEntityCard(props: {
                 })
               }
             >
-              {t('kg.panel.edit')}
+              {t("kg.panel.edit")}
             </Button>
             <Button
               data-testid={`kg-entity-delete-${e.id}`}
@@ -786,7 +845,7 @@ function KgEntityCard(props: {
               size="sm"
               onClick={() => void onDeleteEntity(e.id)}
             >
-              {t('kg.panel.delete')}
+              {t("kg.panel.delete")}
             </Button>
           </>
         )}
@@ -806,7 +865,15 @@ function KgRelationCard(props: {
   getEntityName: (entityId: string) => string;
   t: ReturnType<typeof useTranslation>["t"];
 }): JSX.Element {
-  const { relation: r, editing, setEditing, onSaveEdit, onDeleteRelation, getEntityName, t } = props;
+  const {
+    relation: r,
+    editing,
+    setEditing,
+    onSaveEdit,
+    onDeleteRelation,
+    getEntityName,
+    t,
+  } = props;
   const isEditing = editing.mode === "relation" && editing.id === r.id;
   return (
     <Card
@@ -828,7 +895,11 @@ function KgRelationCard(props: {
         />
       ) : (
         <Text size="small">
-          {t('kg.panel.relationFormat', { source: getEntityName(r.sourceEntityId), type: r.relationType, target: getEntityName(r.targetEntityId) })}
+          {t("kg.panel.relationFormat", {
+            source: getEntityName(r.sourceEntityId),
+            type: r.relationType,
+            target: getEntityName(r.targetEntityId),
+          })}
         </Text>
       )}
 
@@ -840,14 +911,14 @@ function KgRelationCard(props: {
               size="sm"
               onClick={() => void onSaveEdit()}
             >
-              {t('kg.panel.save')}
+              {t("kg.panel.save")}
             </Button>
             <Button
               variant="ghost"
               size="sm"
               onClick={() => setEditing({ mode: "idle" })}
             >
-              {t('kg.panel.cancel')}
+              {t("kg.panel.cancel")}
             </Button>
           </>
         ) : (
@@ -856,24 +927,22 @@ function KgRelationCard(props: {
               variant="ghost"
               size="sm"
               onClick={() =>
-              setEditing({
-                mode: "relation",
-                id: r.id,
-                relationType: r.relationType,
-              })
+                setEditing({
+                  mode: "relation",
+                  id: r.id,
+                  relationType: r.relationType,
+                })
               }
             >
-              {t('kg.panel.edit')}
+              {t("kg.panel.edit")}
             </Button>
             <Button
               data-testid={`kg-relation-delete-${r.id}`}
               variant="ghost"
               size="sm"
-              onClick={() =>
-                void onDeleteRelation(r.id)
-              }
+              onClick={() => void onDeleteRelation(r.id)}
             >
-              {t('kg.panel.delete')}
+              {t("kg.panel.delete")}
             </Button>
           </>
         )}
@@ -888,22 +957,44 @@ function KgListView(props: {
   state: ReturnType<typeof useKgPanelState>;
 }): JSX.Element {
   const {
-    t, isReady, entities, relations, lastError, clearError,
-    editing, setEditing, viewMode, setViewMode, dialogProps,
-    onCreateEntity, onDeleteEntity, onDeleteRelation,
-    onSaveEdit, onCreateRelation, getEntityName,
-    createName, setCreateName, createType, setCreateType,
-    createDescription, setCreateDescription,
-    createAliasesInput, setCreateAliasesInput,
-    relFromId, setRelFromId, relToId, setRelToId,
-    relType, setRelType,
+    t,
+    isReady,
+    entities,
+    relations,
+    lastError,
+    clearError,
+    editing,
+    setEditing,
+    viewMode,
+    setViewMode,
+    dialogProps,
+    onCreateEntity,
+    onDeleteEntity,
+    onDeleteRelation,
+    onSaveEdit,
+    onCreateRelation,
+    getEntityName,
+    createName,
+    setCreateName,
+    createType,
+    setCreateType,
+    createDescription,
+    setCreateDescription,
+    createAliasesInput,
+    setCreateAliasesInput,
+    relFromId,
+    setRelFromId,
+    relToId,
+    setRelToId,
+    relType,
+    setRelType,
   } = props.state;
 
   return (
     <section data-testid="sidebar-kg" className="flex flex-col gap-3 min-h-0">
       <div className="flex items-center justify-between p-3 border-b border-[var(--color-separator)]">
         <Text size="small" color="muted">
-          {t('kg.panel.title')}
+          {t("kg.panel.title")}
         </Text>
         <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
       </div>
@@ -915,7 +1006,7 @@ function KgListView(props: {
         >
           <div className="flex gap-2 items-center">
             <Text data-testid="kg-error-code" size="code" color="muted">
-              {lastError.code}
+              {getHumanErrorMessage(lastError)}
             </Text>
             <Button
               variant="secondary"
@@ -923,11 +1014,11 @@ function KgListView(props: {
               onClick={clearError}
               className="ml-auto"
             >
-              {t('kg.panel.dismiss')}
+              {t("kg.panel.dismiss")}
             </Button>
           </div>
           <Text size="small" className="mt-1.5 block">
-            {lastError.message}
+            {getHumanErrorMessage(lastError)}
           </Text>
         </div>
       ) : null}
@@ -935,32 +1026,32 @@ function KgListView(props: {
       <div className="flex-1 overflow-auto min-h-0">
         <div className="p-3">
           <Text size="small" color="muted">
-            {t('kg.panel.entities')}
+            {t("kg.panel.entities")}
           </Text>
 
           <div className="flex flex-col gap-2 mt-2 pb-3 border-b border-[var(--color-separator)]">
             <Input
               data-testid="kg-entity-name"
-              placeholder={t('kg.panel.namePlaceholder')}
+              placeholder={t("kg.panel.namePlaceholder")}
               value={createName}
               onChange={(e) => setCreateName(e.target.value)}
               fullWidth
             />
             <Input
-              placeholder={t('kg.panel.typePlaceholder')}
+              placeholder={t("kg.panel.typePlaceholder")}
               value={createType}
               onChange={(e) => setCreateType(e.target.value)}
               fullWidth
             />
             <Input
-              placeholder={t('kg.panel.descriptionPlaceholder')}
+              placeholder={t("kg.panel.descriptionPlaceholder")}
               value={createDescription}
               onChange={(e) => setCreateDescription(e.target.value)}
               fullWidth
             />
             <Input
               data-testid="kg-entity-aliases"
-              placeholder={t('kg.panel.aliasesPlaceholder')}
+              placeholder={t("kg.panel.aliasesPlaceholder")}
               value={createAliasesInput}
               onChange={(e) => setCreateAliasesInput(e.target.value)}
               fullWidth
@@ -973,13 +1064,13 @@ function KgListView(props: {
               disabled={!isReady}
               className="self-start"
             >
-              {t('kg.panel.createEntity')}
+              {t("kg.panel.createEntity")}
             </Button>
           </div>
 
           {entities.length === 0 ? (
             <Text size="small" color="muted" className="mt-3 block">
-              {t('kg.panel.noEntities')}
+              {t("kg.panel.noEntities")}
             </Text>
           ) : (
             <div className="mt-3 flex flex-col gap-2">
@@ -999,7 +1090,7 @@ function KgListView(props: {
 
           <div className="mt-4">
             <Text size="small" color="muted">
-              {t('kg.panel.relations')}
+              {t("kg.panel.relations")}
             </Text>
 
             <div className="mt-2 flex flex-col gap-2 pb-3 border-b border-[var(--color-separator)]">
@@ -1014,7 +1105,7 @@ function KgListView(props: {
                     type: e.type,
                   }),
                 }))}
-                placeholder={t('kg.panel.selectEntityPlaceholder')}
+                placeholder={t("kg.panel.selectEntityPlaceholder")}
                 fullWidth
               />
 
@@ -1029,13 +1120,13 @@ function KgListView(props: {
                     type: e.type,
                   }),
                 }))}
-                placeholder={t('kg.panel.selectEntityPlaceholder')}
+                placeholder={t("kg.panel.selectEntityPlaceholder")}
                 fullWidth
               />
 
               <Input
                 data-testid="kg-relation-type"
-                placeholder={t('kg.panel.relationTypePlaceholder')}
+                placeholder={t("kg.panel.relationTypePlaceholder")}
                 value={relType}
                 onChange={(e) => setRelType(e.target.value)}
                 disabled={!isReady}
@@ -1050,13 +1141,13 @@ function KgListView(props: {
                 disabled={!isReady}
                 className="self-start"
               >
-                {t('kg.panel.createRelation')}
+                {t("kg.panel.createRelation")}
               </Button>
             </div>
 
             {relations.length === 0 ? (
               <Text size="small" color="muted" className="mt-3 block">
-                {t('kg.panel.noRelations')}
+                {t("kg.panel.noRelations")}
               </Text>
             ) : (
               <div className="mt-3 flex flex-col gap-2">
@@ -1092,12 +1183,24 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
   const { t } = useTranslation();
   const state = useKgPanelState(props.projectId, t);
   const {
-    entities, lastError, clearError,
-    setEditing, viewMode, setViewMode,
-    selectedNodeId, setSelectedNodeId,
-    graphTransform, graphData, timelineEvents, dialogProps,
-    onGraphTransformChange, onNodeMove, onAddNode, onNodeSave,
-    onNodeDeleteFromGraph, onTimelineOrderChange,
+    entities,
+    lastError,
+    clearError,
+    setEditing,
+    viewMode,
+    setViewMode,
+    selectedNodeId,
+    setSelectedNodeId,
+    graphTransform,
+    graphData,
+    timelineEvents,
+    dialogProps,
+    onGraphTransformChange,
+    onNodeMove,
+    onAddNode,
+    onNodeSave,
+    onNodeDeleteFromGraph,
+    onTimelineOrderChange,
   } = state;
 
   // Render Graph view
@@ -1110,7 +1213,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
         {/* Header with view toggle */}
         <div className="flex items-center justify-between p-3 border-b border-[var(--color-separator)] shrink-0">
           <Text size="small" color="muted">
-            {t('kg.panel.title')}
+            {t("kg.panel.title")}
           </Text>
           <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
         </div>
@@ -1123,7 +1226,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
           >
             <div className="flex gap-2 items-center">
               <Text data-testid="kg-error-code" size="code" color="muted">
-                {lastError.code}
+                {getHumanErrorMessage(lastError)}
               </Text>
               <Button
                 variant="secondary"
@@ -1131,11 +1234,11 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
                 onClick={clearError}
                 className="ml-auto"
               >
-                {t('kg.panel.dismiss')}
+                {t("kg.panel.dismiss")}
               </Button>
             </div>
             <Text size="small" className="mt-1.5 block">
-              {lastError.message}
+              {getHumanErrorMessage(lastError)}
             </Text>
           </div>
         ) : null}
@@ -1169,7 +1272,7 @@ export function KnowledgeGraphPanel(props: { projectId: string }): JSX.Element {
       >
         <div className="flex items-center justify-between p-3 border-b border-[var(--color-separator)] shrink-0">
           <Text size="small" color="muted">
-            {t('kg.panel.title')}
+            {t("kg.panel.title")}
           </Text>
           <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
         </div>

--- a/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/memory/MemoryPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { IpcError, IpcResponseData } from "@shared/types/ipc-generated";
 import { Button, Card, Text } from "../../components/primitives";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { useProjectStore } from "../../stores/projectStore";
 
 type PanelScope = "global" | "project";
@@ -24,7 +25,10 @@ const CATEGORY_GROUPS: CategoryGroup[] = [
   { category: "vocabulary", labelKey: "memory.panel.categoryVocabulary" },
 ];
 
-function normalizePanelLoadError(cause: unknown, fallbackMessage: string): IpcError {
+function normalizePanelLoadError(
+  cause: unknown,
+  fallbackMessage: string,
+): IpcError {
   if (
     typeof cause === "object" &&
     cause !== null &&
@@ -50,8 +54,10 @@ function formatUpdatedAt(ts: number | null): string {
   return new Date(ts).toLocaleString("zh-CN", { hour12: false });
 }
 
-
-function useMemoryState(projectId: string | null, t: (key: string, opts?: Record<string, unknown>) => string) {
+function useMemoryState(
+  projectId: string | null,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+) {
   const [status, setStatus] = React.useState<
     "idle" | "loading" | "ready" | "error"
   >("idle");
@@ -109,7 +115,7 @@ function useMemoryState(projectId: string | null, t: (key: string, opts?: Record
       setStatus("ready");
     } catch (cause) {
       setStatus("error");
-      setError(normalizePanelLoadError(cause, t('memory.panel.loadError')));
+      setError(normalizePanelLoadError(cause, t("memory.panel.loadError")));
     }
   }, [projectId, t]);
 
@@ -197,7 +203,10 @@ function useMemoryState(projectId: string | null, t: (key: string, opts?: Record
 
     const normalized = editingText.trim();
     if (normalized.length === 0) {
-      setError({ code: "INVALID_ARGUMENT", message: t('memory.panel.ruleTextRequired') });
+      setError({
+        code: "INVALID_ARGUMENT",
+        message: t("memory.panel.ruleTextRequired"),
+      });
       return;
     }
 
@@ -227,7 +236,7 @@ function useMemoryState(projectId: string | null, t: (key: string, opts?: Record
       return;
     }
 
-    const confirmed = window.confirm(t('memory.panel.confirmDeleteRule'));
+    const confirmed = window.confirm(t("memory.panel.confirmDeleteRule"));
     if (!confirmed) {
       return;
     }
@@ -248,7 +257,10 @@ function useMemoryState(projectId: string | null, t: (key: string, opts?: Record
 
     const normalized = draftRule.trim();
     if (normalized.length === 0) {
-      setError({ code: "INVALID_ARGUMENT", message: t('memory.panel.ruleTextRequired') });
+      setError({
+        code: "INVALID_ARGUMENT",
+        message: t("memory.panel.ruleTextRequired"),
+      });
       return;
     }
 
@@ -345,7 +357,6 @@ function useMemoryState(projectId: string | null, t: (key: string, opts?: Record
   };
 }
 
-
 function MemoryComposer(props: {
   t: (key: string) => string;
   draftRule: string;
@@ -365,11 +376,11 @@ function MemoryComposer(props: {
           className="text-xs text-[var(--color-fg-muted)]"
           htmlFor="memory-rule-create-input"
         >
-          {props.t('memory.panel.addRule')}
+          {props.t("memory.panel.addRule")}
         </label>
         <textarea
           id="memory-rule-create-input"
-          aria-label={props.t('memory.panel.addRule')}
+          aria-label={props.t("memory.panel.addRule")}
           value={props.draftRule}
           onChange={(event) => props.setDraftRule(event.target.value)}
           className="min-h-[72px] rounded-[var(--radius-sm)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5 text-sm"
@@ -378,7 +389,7 @@ function MemoryComposer(props: {
           className="text-xs text-[var(--color-fg-muted)]"
           htmlFor="memory-rule-category"
         >
-          {props.t('memory.panel.category')}
+          {props.t("memory.panel.category")}
         </label>
         <select
           id="memory-rule-category"
@@ -396,14 +407,10 @@ function MemoryComposer(props: {
         </select>
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={() => void props.handleCreateRule()}>
-            {props.t('memory.panel.saveRule')}
+            {props.t("memory.panel.saveRule")}
           </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={props.onClose}
-          >
-            {props.t('memory.panel.cancel')}
+          <Button size="sm" variant="ghost" onClick={props.onClose}>
+            {props.t("memory.panel.cancel")}
           </Button>
         </div>
       </div>
@@ -432,7 +439,7 @@ export function MemoryPanel(): JSX.Element {
     >
       <header className="shrink-0 flex items-center gap-2">
         <Text size="small" color="muted">
-          {t('memory.panel.title')}
+          {t("memory.panel.title")}
         </Text>
         <Text size="tiny" color="muted" className="ml-auto">
           {state.status}
@@ -450,7 +457,7 @@ export function MemoryPanel(): JSX.Element {
           }`}
           onClick={() => state.setActiveScope("global")}
         >
-          {t('memory.panel.globalTab')}
+          {t("memory.panel.globalTab")}
         </button>
         <button
           type="button"
@@ -463,7 +470,7 @@ export function MemoryPanel(): JSX.Element {
           } disabled:opacity-50 disabled:cursor-not-allowed`}
           onClick={() => state.setActiveScope("project")}
         >
-          {t('memory.panel.projectTab')}
+          {t("memory.panel.projectTab")}
         </button>
       </div>
 
@@ -474,7 +481,7 @@ export function MemoryPanel(): JSX.Element {
           className="shrink-0 px-2.5 py-2 border-[var(--color-warning)] text-[var(--color-warning)]"
         >
           <Text size="small" className="text-[var(--color-warning)]">
-            {t('memory.panel.learningPaused')}
+            {t("memory.panel.learningPaused")}
           </Text>
         </Card>
       ) : null}
@@ -486,7 +493,9 @@ export function MemoryPanel(): JSX.Element {
           className="shrink-0 px-2.5 py-2 border-[var(--color-warning)] text-[var(--color-warning)]"
         >
           <Text size="small" className="text-[var(--color-warning)]">
-            {t('memory.panel.conflictsDetected', { count: state.conflictCount })}
+            {t("memory.panel.conflictsDetected", {
+              count: state.conflictCount,
+            })}
           </Text>
         </Card>
       ) : null}
@@ -495,7 +504,7 @@ export function MemoryPanel(): JSX.Element {
         <Card noPadding className="shrink-0 p-2.5">
           <div className="flex items-center gap-2">
             <Text data-testid="memory-error-code" size="code" color="muted">
-              {state.error.code}
+              {getHumanErrorMessage(state.error)}
             </Text>
             <Button
               variant="ghost"
@@ -503,12 +512,9 @@ export function MemoryPanel(): JSX.Element {
               className="ml-auto"
               onClick={() => state.setError(null)}
             >
-              {t('memory.panel.dismissError')}
+              {t("memory.panel.dismissError")}
             </Button>
           </div>
-          <Text size="small" color="muted" className="mt-1.5 block">
-            {state.error.message}
-          </Text>
         </Card>
       ) : null}
 
@@ -519,19 +525,19 @@ export function MemoryPanel(): JSX.Element {
         {state.status === "loading" ? (
           <div className="h-full flex items-center justify-center">
             <Text size="small" color="muted">
-              {t('memory.panel.loading')}
+              {t("memory.panel.loading")}
             </Text>
           </div>
         ) : state.filteredRules.length === 0 ? (
           <div className="h-full min-h-[180px] flex flex-col items-center justify-center gap-3 text-center">
             <div className="w-9 h-9 rounded-[var(--radius-sm)] bg-[var(--color-bg-raised)] flex items-center justify-center text-[var(--color-fg-muted)]">
-              {t('memory.panel.emptyIcon')}
+              {t("memory.panel.emptyIcon")}
             </div>
             <Text size="small" color="muted">
-              {t('memory.panel.aiLearningHint')}
+              {t("memory.panel.aiLearningHint")}
             </Text>
             <Button size="sm" onClick={() => state.setComposerOpen(true)}>
-              {t('memory.panel.addRuleManually')}
+              {t("memory.panel.addRuleManually")}
             </Button>
           </div>
         ) : (
@@ -558,11 +564,11 @@ export function MemoryPanel(): JSX.Element {
                                 className="text-xs text-[var(--color-fg-muted)]"
                                 htmlFor={`memory-edit-${rule.id}`}
                               >
-                                {t('memory.panel.ruleText')}
+                                {t("memory.panel.ruleText")}
                               </label>
                               <textarea
                                 id={`memory-edit-${rule.id}`}
-                                aria-label={t('memory.panel.ruleText')}
+                                aria-label={t("memory.panel.ruleText")}
                                 value={state.editingText}
                                 onChange={(event) =>
                                   state.setEditingText(event.target.value)
@@ -572,9 +578,11 @@ export function MemoryPanel(): JSX.Element {
                               <div className="flex gap-2">
                                 <Button
                                   size="sm"
-                                  onClick={() => void state.handleSaveEdit(rule.id)}
+                                  onClick={() =>
+                                    void state.handleSaveEdit(rule.id)
+                                  }
                                 >
-                                  {t('memory.panel.saveChanges')}
+                                  {t("memory.panel.saveChanges")}
                                 </Button>
                                 <Button
                                   size="sm"
@@ -584,7 +592,7 @@ export function MemoryPanel(): JSX.Element {
                                     state.setEditingText("");
                                   }}
                                 >
-                                  {t('memory.panel.cancel')}
+                                  {t("memory.panel.cancel")}
                                 </Button>
                               </div>
                             </div>
@@ -598,12 +606,16 @@ export function MemoryPanel(): JSX.Element {
                               </Text>
                               <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-fg-muted)]">
                                 <span>
-                                  {t('memory.panel.confidence', { value: Math.round(rule.confidence * 100) })}
+                                  {t("memory.panel.confidence", {
+                                    value: Math.round(rule.confidence * 100),
+                                  })}
                                 </span>
                                 {rule.userConfirmed ? (
-                                  <span>{t('memory.panel.confirmed')}</span>
+                                  <span>{t("memory.panel.confirmed")}</span>
                                 ) : null}
-                                {rule.userModified ? <span>{t('memory.panel.modified')}</span> : null}
+                                {rule.userModified ? (
+                                  <span>{t("memory.panel.modified")}</span>
+                                ) : null}
                               </div>
                             </>
                           )}
@@ -615,23 +627,27 @@ export function MemoryPanel(): JSX.Element {
                               size="sm"
                               variant="secondary"
                               disabled={rule.userConfirmed}
-                              onClick={() => void state.handleConfirmRule(rule.id)}
+                              onClick={() =>
+                                void state.handleConfirmRule(rule.id)
+                              }
                             >
-                              {t('memory.panel.confirm')}
+                              {t("memory.panel.confirm")}
                             </Button>
                             <Button
                               size="sm"
                               variant="ghost"
                               onClick={() => state.startEdit(rule)}
                             >
-                              {t('memory.panel.modify')}
+                              {t("memory.panel.modify")}
                             </Button>
                             <Button
                               size="sm"
                               variant="danger"
-                              onClick={() => void state.handleDeleteRule(rule.id)}
+                              onClick={() =>
+                                void state.handleDeleteRule(rule.id)
+                              }
                             >
-                              {t('memory.panel.delete')}
+                              {t("memory.panel.delete")}
                             </Button>
                           </div>
                         ) : null}
@@ -650,14 +666,22 @@ export function MemoryPanel(): JSX.Element {
         className="shrink-0 p-2.5 bg-[var(--color-bg-raised)] rounded-[var(--radius-sm)]"
       >
         <div className="flex items-center justify-between text-xs text-[var(--color-fg-muted)]">
-          <span>{t('memory.panel.interactionCount', { count: state.interactionCount })}</span>
-          <span>{t('memory.panel.lastUpdate', { time: formatUpdatedAt(state.latestUpdateAt) })}</span>
+          <span>
+            {t("memory.panel.interactionCount", {
+              count: state.interactionCount,
+            })}
+          </span>
+          <span>
+            {t("memory.panel.lastUpdate", {
+              time: formatUpdatedAt(state.latestUpdateAt),
+            })}
+          </span>
         </div>
       </Card>
 
       <div className="shrink-0 flex items-center gap-2">
         <Button size="sm" onClick={() => state.setComposerOpen(true)}>
-          {t('memory.panel.addRuleManually')}
+          {t("memory.panel.addRuleManually")}
         </Button>
         <Button
           size="sm"
@@ -665,7 +689,7 @@ export function MemoryPanel(): JSX.Element {
           loading={state.distilling}
           onClick={() => void state.handleDistill()}
         >
-          {t('memory.panel.updatePreferences')}
+          {t("memory.panel.updatePreferences")}
         </Button>
         <Button
           size="sm"
@@ -673,8 +697,8 @@ export function MemoryPanel(): JSX.Element {
           onClick={() => void state.handleLearningToggle()}
         >
           {state.settings?.preferenceLearningEnabled === false
-            ? t('memory.panel.resumeLearning')
-            : t('memory.panel.pauseLearning')}
+            ? t("memory.panel.resumeLearning")
+            : t("memory.panel.pauseLearning")}
         </Button>
       </div>
 

--- a/apps/desktop/renderer/src/features/memory/__tests__/MemoryPanel.error.test.tsx
+++ b/apps/desktop/renderer/src/features/memory/__tests__/MemoryPanel.error.test.tsx
@@ -53,9 +53,8 @@ describe("MemoryPanel error handling", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("memory-error-code")).toHaveTextContent(
-        "INTERNAL_ERROR",
+        "Internal error. Please try again later.",
       );
     });
-    expect(screen.getByText("invoke exploded")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.test.tsx
@@ -419,8 +419,9 @@ describe("CreateProjectDialog — error and edge cases", () => {
 
       render(<CreateProjectDialog open={true} onOpenChange={vi.fn()} />);
 
-      expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
-      expect(screen.getByText(/Failed to create project/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Read\/write operation failed/),
+      ).toBeInTheDocument();
     });
 
     it("ProjectCreateGo back错误时应显示可见错误并记录诊断上下文", async () => {
@@ -457,8 +458,9 @@ describe("CreateProjectDialog — error and edge cases", () => {
         await user.click(screen.getByTestId("create-project-submit"));
 
         await waitFor(() => {
-          expect(screen.getByText(/NAME_CONFLICT/)).toBeInTheDocument();
-          expect(screen.getByText(/Project already exists/)).toBeInTheDocument();
+          expect(
+            screen.getByText(/Something unexpected happened/),
+          ).toBeInTheDocument();
         });
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -503,8 +505,9 @@ describe("CreateProjectDialog — error and edge cases", () => {
         await user.click(screen.getByTestId("create-project-submit"));
 
         await waitFor(() => {
-          expect(screen.getByText(/IO_ERROR/)).toBeInTheDocument();
-          expect(screen.getByText(/Disk full/)).toBeInTheDocument();
+          expect(
+            screen.getByText(/Read\/write operation failed/),
+          ).toBeInTheDocument();
         });
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -591,7 +594,9 @@ describe("CreateProjectDialog — error and edge cases", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("AI-assisted creation is temporarily unavailable. Please create manually or try again later"),
+          screen.getByText(
+            "AI-assisted creation is temporarily unavailable. Please create manually or try again later",
+          ),
         ).toBeInTheDocument();
       });
 

--- a/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
+++ b/apps/desktop/renderer/src/features/projects/CreateProjectDialog.tsx
@@ -18,6 +18,8 @@ import {
 import { useProjectStore } from "../../stores/projectStore";
 import { useTemplateStore } from "../../stores/templateStore";
 import { CreateTemplateDialog } from "./CreateTemplateDialog";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
 
 import { Plus } from "lucide-react";
 // =============================================================================
@@ -161,7 +163,15 @@ function FormContent({
         setSubmitting(false);
       }
     },
-    [coverImage, cropArea, description, initialType, name, onSubmit, templateId],
+    [
+      coverImage,
+      cropArea,
+      description,
+      initialType,
+      name,
+      onSubmit,
+      templateId,
+    ],
   );
 
   return (
@@ -175,7 +185,8 @@ function FormContent({
       <div>
         <label className="block mb-2">
           <Text size="small" color="muted">
-            {t('projects.create.projectNameLabel')} <span className="text-[var(--color-error)]">{'*'}</span>
+            {t("projects.create.projectNameLabel")}{" "}
+            <span className="text-[var(--color-error)]">{"*"}</span>
           </Text>
         </label>
         <Input
@@ -198,7 +209,7 @@ function FormContent({
             as="div"
             className="mt-1 text-[var(--color-error)]"
           >
-            {t('projects.create.nameRequired')}
+            {t("projects.create.nameRequired")}
           </Text>
         )}
       </div>
@@ -207,7 +218,7 @@ function FormContent({
       <div>
         <label className="block mb-2">
           <Text size="small" color="muted">
-            {t('projects.create.templateLabel')}
+            {t("projects.create.templateLabel")}
           </Text>
         </label>
 
@@ -230,7 +241,7 @@ function FormContent({
         {hasCustomTemplates && (
           <div className="mt-4">
             <Text size="small" color="muted" as="div" className="mb-2">
-              {t('projects.create.yourTemplates')}
+              {t("projects.create.yourTemplates")}
             </Text>
             <RadioGroupRoot
               value={templateId}
@@ -256,7 +267,7 @@ function FormContent({
             className="h-10 px-3 w-full flex items-center justify-center gap-2 border-2 border-dashed border-[var(--color-border-default)] rounded-[var(--radius-sm)] text-sm text-[var(--color-fg-muted)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-fg-default)] transition-colors"
           >
             <Plus size={16} strokeWidth={1.5} />
-            {t('projects.create.createTemplateButton')}
+            {t("projects.create.createTemplateButton")}
           </button>
         </div>
       </div>
@@ -265,14 +276,17 @@ function FormContent({
       <div>
         <label className="block mb-2">
           <Text size="small" color="muted">
-            {t('projects.create.descriptionLabel')} <span className="opacity-50 text-xs">{t('projects.create.optionalHint')}</span>
+            {t("projects.create.descriptionLabel")}{" "}
+            <span className="opacity-50 text-xs">
+              {t("projects.create.optionalHint")}
+            </span>
           </Text>
         </label>
         <Textarea
           data-testid="create-project-description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          placeholder={t('projects.create.descriptionPlaceholder')}
+          placeholder={t("projects.create.descriptionPlaceholder")}
           fullWidth
           rows={2}
         />
@@ -282,21 +296,21 @@ function FormContent({
       <div>
         <label className="block mb-2">
           <Text size="small" color="muted">
-            {t('projects.create.coverImageLabel')} <span className="opacity-50 text-xs">{t('projects.create.optionalHint')}</span>
+            {t("projects.create.coverImageLabel")}{" "}
+            <span className="opacity-50 text-xs">
+              {t("projects.create.optionalHint")}
+            </span>
           </Text>
         </label>
         <ImageUpload
           value={coverImage}
           onChange={setCoverImage}
           onError={setImageError}
-          placeholder={t('projects.create.imagePlaceholder')}
+          placeholder={t("projects.create.imagePlaceholder")}
           hint="PNG, JPG up to 5MB"
         />
         {coverImage && (
-          <ImageCropper
-            file={coverImage}
-            onCropChange={setCropArea}
-          />
+          <ImageCropper file={coverImage} onCropChange={setCropArea} />
         )}
         {imageError && (
           <Text
@@ -316,15 +330,96 @@ function FormContent({
           size="small"
           color="muted"
           as="div"
-          className="text-[var(--color-error)]"
+          role="alert"
+          className="text-[var(--color-text-error)]"
         >
-          {lastError.code}: {lastError.message}
+          {getHumanErrorMessage(
+            lastError as { code: IpcErrorCode; message: string },
+          )}
         </Text>
       )}
 
       {/* Submit button state indicator (hidden, used by parent) */}
       <input type="hidden" data-submitting={submitting} />
     </form>
+  );
+}
+
+// =============================================================================
+// AI Assist Section
+// =============================================================================
+
+type AiDraft = {
+  name: string;
+  type: "novel" | "screenplay" | "media";
+  description: string;
+  chapterOutlines: string[];
+  characters: string[];
+};
+
+function AiAssistSection(props: {
+  aiPrompt: string;
+  setAiPrompt: (v: string) => void;
+  aiGenerating: boolean;
+  aiErrorMessage: string | null;
+  aiDraft: AiDraft | null;
+  onGenerate: () => void;
+  onUseDraft: () => void;
+}): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-4">
+      <Textarea
+        data-testid="create-project-ai-prompt"
+        value={props.aiPrompt}
+        onChange={(e) => props.setAiPrompt(e.target.value)}
+        placeholder={t("projects.create.aiPlaceholder")}
+        rows={4}
+        fullWidth
+      />
+      <Button
+        data-testid="create-project-ai-generate"
+        variant="secondary"
+        size="sm"
+        loading={props.aiGenerating}
+        onClick={props.onGenerate}
+      >
+        {props.aiGenerating
+          ? t("projects.create.generating")
+          : t("projects.create.generateDraft")}
+      </Button>
+
+      {props.aiErrorMessage ? (
+        <Text
+          size="small"
+          color="muted"
+          as="div"
+          className="text-[var(--color-error)]"
+        >
+          {props.aiErrorMessage}
+        </Text>
+      ) : null}
+
+      {props.aiDraft ? (
+        <div className="space-y-2 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] p-3">
+          <Text size="small" color="default">
+            {t("projects.create.draftInfo", {
+              name: props.aiDraft.name,
+              type: props.aiDraft.type,
+            })}
+          </Text>
+          <Text size="small" color="muted">
+            {t("projects.create.draftStats", {
+              chapters: props.aiDraft.chapterOutlines.length,
+              characters: props.aiDraft.characters.length,
+            })}
+          </Text>
+          <Button size="sm" variant="ghost" onClick={props.onUseDraft}>
+            {t("projects.create.useDraft")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -370,13 +465,7 @@ export function CreateProjectDialog({
   const [aiPrompt, setAiPrompt] = useState("");
   const [aiGenerating, setAiGenerating] = useState(false);
   const [aiErrorMessage, setAiErrorMessage] = useState<string | null>(null);
-  const [aiDraft, setAiDraft] = useState<{
-    name: string;
-    type: "novel" | "screenplay" | "media";
-    description: string;
-    chapterOutlines: string[];
-    characters: string[];
-  } | null>(null);
+  const [aiDraft, setAiDraft] = useState<AiDraft | null>(null);
 
   const formId = "create-project-form";
 
@@ -493,7 +582,7 @@ export function CreateProjectDialog({
         const message =
           error instanceof Error && error.message.length > 0
             ? error.message
-            : t('projects.create.createFailed');
+            : t("projects.create.createFailed");
         setSubmitError({ code, message });
         console.error("[CreateProjectDialog] createProject failed:", {
           operation: "createAndSetCurrent",
@@ -509,7 +598,7 @@ export function CreateProjectDialog({
 
   const handleAiGenerate = useCallback(async () => {
     if (aiPrompt.trim().length === 0) {
-      setAiErrorMessage(t('projects.create.enterIntentFirst'));
+      setAiErrorMessage(t("projects.create.enterIntentFirst"));
       return;
     }
 
@@ -518,7 +607,7 @@ export function CreateProjectDialog({
     try {
       const res = await createAiAssistDraft({ prompt: aiPrompt });
       if (!res.ok) {
-        setAiErrorMessage(t('projects.create.aiUnavailable'));
+        setAiErrorMessage(t("projects.create.aiUnavailable"));
         return;
       }
 
@@ -542,8 +631,8 @@ export function CreateProjectDialog({
       <Dialog
         open={open}
         onOpenChange={onOpenChange}
-        title={t('projects.create.dialogTitle')}
-        description={t('projects.create.dialogDescription')}
+        title={t("projects.create.dialogTitle")}
+        description={t("projects.create.dialogDescription")}
         footer={
           <>
             <Button
@@ -552,7 +641,7 @@ export function CreateProjectDialog({
               onClick={() => onOpenChange(false)}
               disabled={submitting}
             >
-              {t('projects.create.cancel')}
+              {t("projects.create.cancel")}
             </Button>
             <Button
               data-testid="create-project-submit"
@@ -569,7 +658,11 @@ export function CreateProjectDialog({
       >
         {open ? (
           <div className="space-y-4">
-            <div role="tablist" aria-label={t('projects.create.modeLabel')} className="flex gap-2">
+            <div
+              role="tablist"
+              aria-label={t("projects.create.modeLabel")}
+              className="flex gap-2"
+            >
               <button
                 type="button"
                 role="tab"
@@ -577,7 +670,7 @@ export function CreateProjectDialog({
                 onClick={() => setMode("manual")}
                 className="h-8 px-3 text-xs rounded-[var(--radius-sm)] border border-[var(--color-border-default)]"
               >
-                {t('projects.create.manualCreate')}
+                {t("projects.create.manualCreate")}
               </button>
               <button
                 type="button"
@@ -586,7 +679,7 @@ export function CreateProjectDialog({
                 onClick={() => setMode("ai-assist")}
                 className="h-8 px-3 text-xs rounded-[var(--radius-sm)] border border-[var(--color-border-default)]"
               >
-                {t('projects.create.aiAssisted')}
+                {t("projects.create.aiAssisted")}
               </button>
             </div>
 
@@ -605,54 +698,15 @@ export function CreateProjectDialog({
                 onOpenCreateTemplate={() => setCreateTemplateOpen(true)}
               />
             ) : (
-              <div className="space-y-4">
-                <Textarea
-                  data-testid="create-project-ai-prompt"
-                  value={aiPrompt}
-                  onChange={(e) => setAiPrompt(e.target.value)}
-                  placeholder={t('projects.create.aiPlaceholder')}
-                  rows={4}
-                  fullWidth
-                />
-                <Button
-                  data-testid="create-project-ai-generate"
-                  variant="secondary"
-                  size="sm"
-                  loading={aiGenerating}
-                  onClick={() => void handleAiGenerate()}
-                >
-                  {aiGenerating ? t('projects.create.generating') : t('projects.create.generateDraft')}
-                </Button>
-
-                {aiErrorMessage ? (
-                  <Text
-                    size="small"
-                    color="muted"
-                    as="div"
-                    className="text-[var(--color-error)]"
-                  >
-                    {aiErrorMessage}
-                  </Text>
-                ) : null}
-
-                {aiDraft ? (
-                  <div className="space-y-2 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] p-3">
-                    <Text size="small" color="default">
-                      {t('projects.create.draftInfo', { name: aiDraft.name, type: aiDraft.type })}
-                    </Text>
-                    <Text size="small" color="muted">
-                      {t('projects.create.draftStats', { chapters: aiDraft.chapterOutlines.length, characters: aiDraft.characters.length })}
-                    </Text>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setMode("manual")}
-                    >
-                      {t('projects.create.useDraft')}
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
+              <AiAssistSection
+                aiPrompt={aiPrompt}
+                setAiPrompt={setAiPrompt}
+                aiGenerating={aiGenerating}
+                aiErrorMessage={aiErrorMessage}
+                aiDraft={aiDraft}
+                onGenerate={() => void handleAiGenerate()}
+                onUseDraft={() => setMode("manual")}
+              />
             )}
           </div>
         ) : null}

--- a/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/InfoPanel.tsx
@@ -6,6 +6,7 @@ import { Card } from "../../components/primitives/Card";
 import { Heading } from "../../components/primitives/Heading";
 import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { useFileStore, type DocumentListItem } from "../../stores/fileStore";
 import "../../i18n";
 
@@ -82,7 +83,7 @@ function DocumentInfoSection(props: {
           color="muted"
           className="text-center"
         >
-          {t('rightPanel.info.noDocumentSelected')}
+          {t("rightPanel.info.noDocumentSelected")}
         </Text>
       </Card>
     );
@@ -91,16 +92,16 @@ function DocumentInfoSection(props: {
   return (
     <section>
       <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-        {t('rightPanel.info.currentDocument')}
+        {t("rightPanel.info.currentDocument")}
       </Heading>
       <Card className="p-3 rounded-[var(--radius-md)]">
         <StatItem
-          label={t('rightPanel.info.title')}
-          value={document.title || t('rightPanel.info.untitled')}
+          label={t("rightPanel.info.title")}
+          value={document.title || t("rightPanel.info.untitled")}
           testId="info-panel-doc-title"
         />
         <StatItem
-          label={t('rightPanel.info.updated')}
+          label={t("rightPanel.info.updated")}
           value={formatDate(document.updatedAt)}
           testId="info-panel-doc-updated"
         />
@@ -124,11 +125,11 @@ function TodayStatsSection(props: {
     return (
       <section>
         <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-          {t('rightPanel.info.todaysProgress')}
+          {t("rightPanel.info.todaysProgress")}
         </Heading>
         <Card className="p-3 rounded-[var(--radius-md)]">
           <Text size="small" color="muted" className="text-center">
-            {t('rightPanel.info.loading')}
+            {t("rightPanel.info.loading")}
           </Text>
         </Card>
       </section>
@@ -139,7 +140,7 @@ function TodayStatsSection(props: {
     return (
       <section>
         <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-          {t('rightPanel.info.todaysProgress')}
+          {t("rightPanel.info.todaysProgress")}
         </Heading>
         <Card className="p-3 rounded-[var(--radius-md)] border-[var(--color-error)]/20">
           <Text
@@ -148,8 +149,7 @@ function TodayStatsSection(props: {
             color="muted"
             className="text-center"
           >
-            <span data-testid="info-panel-stats-error-code">{error.code}</span>:{" "}
-            {error.message}
+            {getHumanErrorMessage(error)}
           </Text>
         </Card>
       </section>
@@ -160,11 +160,11 @@ function TodayStatsSection(props: {
     return (
       <section>
         <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-          {t('rightPanel.info.todaysProgress')}
+          {t("rightPanel.info.todaysProgress")}
         </Heading>
         <Card className="p-3 rounded-[var(--radius-md)]">
           <Text size="small" color="muted" className="text-center">
-            {t('rightPanel.info.noStatsAvailable')}
+            {t("rightPanel.info.noStatsAvailable")}
           </Text>
         </Card>
       </section>
@@ -174,26 +174,26 @@ function TodayStatsSection(props: {
   return (
     <section>
       <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-        {t('rightPanel.info.todaysProgress')}
+        {t("rightPanel.info.todaysProgress")}
       </Heading>
       <Card className="p-3 rounded-[var(--radius-md)]">
         <StatItem
-          label={t('rightPanel.info.wordsWritten')}
+          label={t("rightPanel.info.wordsWritten")}
           value={stats.wordsWritten.toLocaleString()}
           testId="info-panel-words-written"
         />
         <StatItem
-          label={t('rightPanel.info.writingTime')}
+          label={t("rightPanel.info.writingTime")}
           value={formatDuration(stats.writingSeconds)}
           testId="info-panel-writing-time"
         />
         <StatItem
-          label={t('rightPanel.info.skillsUsed')}
+          label={t("rightPanel.info.skillsUsed")}
           value={stats.skillsUsed}
           testId="info-panel-skills-used"
         />
         <StatItem
-          label={t('rightPanel.info.documentsCreated')}
+          label={t("rightPanel.info.documentsCreated")}
           value={stats.documentsCreated}
           testId="info-panel-docs-created"
         />
@@ -276,7 +276,7 @@ export function InfoPanel(props: InfoPanelProps = {}): JSX.Element {
       className="flex flex-col gap-4 p-4 h-full overflow-auto"
     >
       <Heading level="h3" className="font-bold text-[15px]">
-        {t('rightPanel.info.panelTitle')}
+        {t("rightPanel.info.panelTitle")}
       </Heading>
 
       <DocumentInfoSection document={currentDocument} />

--- a/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
@@ -7,6 +7,7 @@ import { Card } from "../../components/primitives/Card";
 import { Button } from "../../components/primitives/Button";
 import { Heading } from "../../components/primitives/Heading";
 import { Text } from "../../components/primitives/Text";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { useJudgeEnsure } from "../../hooks/useJudgeEnsure";
 import { invoke } from "../../lib/ipcClient";
 import { useProjectStore } from "../../stores/projectStore";
@@ -115,9 +116,8 @@ function JudgeStatusSection(props: {
               color="muted"
             >
               <span data-testid="quality-panel-judge-error-code">
-                {error.code}
+                {getHumanErrorMessage(error)}
               </span>
-              : {error.message}
             </Text>
           </div>
         </div>
@@ -202,9 +202,8 @@ function ConstraintsSection(props: {
           color="muted"
         >
           <span data-testid="quality-panel-constraints-error-code">
-            {error.code}
+            {getHumanErrorMessage(error)}
           </span>
-          : {error.message}
         </Text>
       </Card>
     );

--- a/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/AiSettingsSection.tsx
@@ -7,6 +7,7 @@ import { Card } from "../../components/primitives/Card";
 import { Input } from "../../components/primitives/Input";
 import { Text } from "../../components/primitives/Text";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { emitAiModelCatalogUpdated } from "../ai/modelCatalogEvents";
 
 type AiSettings = IpcResponseData<"ai:config:get">;
@@ -39,7 +40,7 @@ export function AiSettingsSection(): JSX.Element {
     const res = await invoke("ai:config:get", {});
     if (!res.ok) {
       setStatus("idle");
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getHumanErrorMessage(res.error));
       return;
     }
 
@@ -62,15 +63,21 @@ export function AiSettingsSection(): JSX.Element {
 
   function resolveApiKeyPlaceholder(): string {
     if (!settings) {
-      return t('settings.ai.notConfigured');
+      return t("settings.ai.notConfigured");
     }
     if (providerMode === "anthropic-byok") {
-      return settings.anthropicByokApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
+      return settings.anthropicByokApiKeyConfigured
+        ? t("settings.ai.configured")
+        : t("settings.ai.notConfigured");
     }
     if (providerMode === "openai-byok") {
-      return settings.openAiByokApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
+      return settings.openAiByokApiKeyConfigured
+        ? t("settings.ai.configured")
+        : t("settings.ai.notConfigured");
     }
-    return settings.openAiCompatibleApiKeyConfigured ? t('settings.ai.configured') : t('settings.ai.notConfigured');
+    return settings.openAiCompatibleApiKeyConfigured
+      ? t("settings.ai.configured")
+      : t("settings.ai.notConfigured");
   }
 
   async function onSave(): Promise<void> {
@@ -101,7 +108,7 @@ export function AiSettingsSection(): JSX.Element {
 
     const res = await invoke("ai:config:update", { patch });
     if (!res.ok) {
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getHumanErrorMessage(res.error));
       return;
     }
 
@@ -118,12 +125,14 @@ export function AiSettingsSection(): JSX.Element {
 
     const res = await invoke("ai:config:test", {});
     if (!res.ok) {
-      setErrorText(`${res.error.code}: ${res.error.message}`);
+      setErrorText(getHumanErrorMessage(res.error));
       return;
     }
 
     if (res.data.ok) {
-      setTestResult(t('settings.ai.connectionSuccess', { latency: res.data.latencyMs }));
+      setTestResult(
+        t("settings.ai.connectionSuccess", { latency: res.data.latencyMs }),
+      );
       return;
     }
 
@@ -139,12 +148,12 @@ export function AiSettingsSection(): JSX.Element {
       className="flex flex-col gap-2.5 p-3 rounded-[var(--radius-lg)]"
     >
       <Text size="body" weight="bold">
-        {t('settings.ai.title')}
+        {t("settings.ai.title")}
       </Text>
 
       <div className="flex flex-col gap-1.5">
         <Text size="small" color="muted">
-          {t('settings.aiSection.provider')}
+          {t("settings.aiSection.provider")}
         </Text>
         <select
           data-testid="ai-provider-mode"
@@ -159,15 +168,21 @@ export function AiSettingsSection(): JSX.Element {
           }
           className="h-10 w-full px-3 bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded-[var(--radius-sm)] text-[13px] text-[var(--color-fg-default)]"
         >
-          <option value="openai-compatible">{t('settings.aiSection.providerOpenAiProxy')}</option>
-          <option value="openai-byok">{t('settings.aiSection.providerOpenAiByok')}</option>
-          <option value="anthropic-byok">{t('settings.aiSection.providerAnthropicByok')}</option>
+          <option value="openai-compatible">
+            {t("settings.aiSection.providerOpenAiProxy")}
+          </option>
+          <option value="openai-byok">
+            {t("settings.aiSection.providerOpenAiByok")}
+          </option>
+          <option value="anthropic-byok">
+            {t("settings.aiSection.providerAnthropicByok")}
+          </option>
         </select>
       </div>
 
       <div className="flex flex-col gap-1.5">
         <Text size="small" color="muted">
-          {t('settings.aiSection.baseUrl')}
+          {t("settings.aiSection.baseUrl")}
         </Text>
         <Input
           data-testid="ai-base-url"
@@ -180,7 +195,7 @@ export function AiSettingsSection(): JSX.Element {
 
       <div className="flex flex-col gap-1.5">
         <Text size="small" color="muted">
-          {t('settings.aiSection.apiKey')}
+          {t("settings.aiSection.apiKey")}
         </Text>
         <Input
           data-testid="ai-api-key"
@@ -212,7 +227,7 @@ export function AiSettingsSection(): JSX.Element {
           onClick={() => void onSave()}
           disabled={status === "loading"}
         >
-          {t('settings.ai.save')}
+          {t("settings.ai.save")}
         </Button>
         <Button
           data-testid="ai-test-btn"
@@ -221,7 +236,7 @@ export function AiSettingsSection(): JSX.Element {
           onClick={() => void onTest()}
           disabled={status === "loading"}
         >
-          {t('settings.ai.testConnection')}
+          {t("settings.ai.testConnection")}
         </Button>
       </div>
     </Card>

--- a/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
+++ b/apps/desktop/renderer/src/features/settings/JudgeSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type { IpcChannelSpec } from "@shared/types/ipc-generated";
 import { invoke } from "../../lib/ipcClient";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 import { runFireAndForget } from "../../lib/fireAndForget";
 import { Button, Heading, Text } from "../../components/primitives";
 import { useJudgeEnsure } from "../../hooks/useJudgeEnsure";
@@ -15,7 +16,7 @@ type JudgeModelState =
  */
 function formatState(state: JudgeModelState): string {
   if (state.status === "error") {
-    return `error (${state.error.code})`;
+    return `error (${getHumanErrorMessage(state.error)})`;
   }
   return state.status;
 }
@@ -51,7 +52,7 @@ export function JudgeSection(): JSX.Element {
           clearError();
           return;
         }
-        setErrorText(`${res.error.code}: ${res.error.message}`);
+        setErrorText(getHumanErrorMessage(res.error));
       },
       (error) => {
         if (canceled) {
@@ -59,7 +60,7 @@ export function JudgeSection(): JSX.Element {
         }
         const message =
           error instanceof Error ? error.message : String(error ?? "unknown");
-        setErrorText(`INTERNAL: ${message}`);
+        setErrorText(message);
       },
     );
     return () => {
@@ -79,7 +80,7 @@ export function JudgeSection(): JSX.Element {
       return;
     }
 
-    setErrorText(`${result.error.code}: ${result.error.message}`);
+    setErrorText(getHumanErrorMessage(result.error));
     setState({
       status: "error",
       error: { code: result.error.code, message: result.error.message },
@@ -90,7 +91,7 @@ export function JudgeSection(): JSX.Element {
     ? { status: "downloading" }
     : state;
   const displayError = ensureError
-    ? `${ensureError.code}: ${ensureError.message}`
+    ? getHumanErrorMessage(ensureError)
     : errorText;
 
   return (
@@ -99,12 +100,12 @@ export function JudgeSection(): JSX.Element {
       className="p-3 rounded-[var(--radius-lg)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)]"
     >
       <Heading level="h4" className="mb-1.5 font-bold">
-        {t('settings.judge.title')}
+        {t("settings.judge.title")}
       </Heading>
       <Text size="small" color="muted" as="div" className="mb-2.5">
-        {t('settings.judge.status')}{" "}
+        {t("settings.judge.status")}{" "}
         <Text data-testid="judge-status" size="small" color="default" as="span">
-          {viewState ? formatState(viewState) : t('settings.judge.loading')}
+          {viewState ? formatState(viewState) : t("settings.judge.loading")}
         </Text>
       </Text>
 
@@ -118,7 +119,7 @@ export function JudgeSection(): JSX.Element {
           loading={ensureBusy}
           className="bg-[var(--color-bg-selected)]"
         >
-          {t('settings.judge.ensure')}
+          {t("settings.judge.ensure")}
         </Button>
 
         {displayError ? (

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.test.tsx
@@ -8,6 +8,7 @@ import {
   createVersionStore,
   type UseVersionStore,
 } from "../../stores/versionStore";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 const invokeMock = vi.hoisted(() => vi.fn());
 const startCompareMock = vi.hoisted(() => vi.fn());
@@ -244,7 +245,7 @@ describe("VersionHistoryContainer", () => {
     expect(versionStore.getState().previewContentJson).not.toBeNull();
   });
 
-  it("shows IPC error code/message when preview read fails", async () => {
+  it("shows humanized preview error when preview read fails", async () => {
     const user = userEvent.setup();
     const versionStore = createVersionStore({ invoke: invokeMock as never });
     installInvokeMock({
@@ -265,7 +266,10 @@ describe("VersionHistoryContainer", () => {
     await user.click(screen.getByTestId("version-preview-trigger"));
 
     const error = await screen.findByTestId("version-preview-error");
-    expect(error).toHaveTextContent("NOT_FOUND: Version not found");
+    expect(error).toHaveTextContent(
+      getHumanErrorMessage({ code: "NOT_FOUND", message: "Version not found" }),
+    );
+    expect(error).not.toHaveTextContent("NOT_FOUND");
   });
 
   it("restore requires confirmation and refreshes editor only after confirm", async () => {

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -20,6 +20,7 @@ import { SystemDialog } from "../../components/features/AiDialogs/SystemDialog";
 import { RESTORE_VERSION_CONFIRM_COPY } from "./restoreConfirmCopy";
 import { useVersionPreferencesStore } from "../../stores/versionPreferencesStore";
 import { i18n } from "../../i18n";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 /**
  * Map backend actor to UI author type.
@@ -678,8 +679,8 @@ export function VersionHistoryContainer(
           </div>
         ) : null}
         {branchMergeStatus === "error" && branchMergeError ? (
-          <div className="text-[11px] text-[var(--color-error)]">
-            {branchMergeError.code}: {branchMergeError.message}
+          <div role="alert" className="text-[11px] text-[var(--color-error)]">
+            {getHumanErrorMessage(branchMergeError)}
           </div>
         ) : null}
       </div>
@@ -730,9 +731,12 @@ export function VersionHistoryContainer(
         </div>
       ) : null}
       {previewStatus === "error" && previewError ? (
-        <div className="px-3 py-2 text-xs text-[var(--color-error)]">
+        <div
+          role="alert"
+          className="px-3 py-2 text-xs text-[var(--color-error)]"
+        >
           <span data-testid="version-preview-error">
-            {previewError.code}: {previewError.message}
+            {getHumanErrorMessage(previewError)}
           </span>
         </div>
       ) : null}

--- a/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionPreviewDialog.tsx
@@ -3,6 +3,8 @@ import { Dialog } from "../../components/primitives/Dialog";
 import { Button } from "../../components/primitives/Button";
 import { Textarea } from "../../components/primitives/Textarea";
 import { Text } from "../../components/primitives/Text";
+import type { IpcErrorCode } from "@shared/types/ipc-generated";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 type PreviewVersion = {
   versionId: string;
@@ -16,7 +18,7 @@ type VersionPreviewDialogProps = {
   open: boolean;
   loading: boolean;
   data: PreviewVersion | null;
-  error: { code: string; message: string } | null;
+  error: { code: IpcErrorCode; message: string } | null;
   onOpenChange: (open: boolean) => void;
 };
 
@@ -26,9 +28,9 @@ type TFunction = (key: string, options?: Record<string, unknown>) => string;
  * Convert actor value into dialog display text.
  */
 function formatActor(actor: "user" | "auto" | "ai", t: TFunction): string {
-  if (actor === "user") return t('versionHistory.preview.actorUser');
-  if (actor === "ai") return t('versionHistory.preview.actorAi');
-  return t('versionHistory.preview.actorAutoSave');
+  if (actor === "user") return t("versionHistory.preview.actorUser");
+  if (actor === "ai") return t("versionHistory.preview.actorAi");
+  return t("versionHistory.preview.actorAutoSave");
 }
 
 /**
@@ -47,7 +49,7 @@ export function VersionPreviewDialog(
       size="sm"
       onClick={() => props.onOpenChange(false)}
     >
-      {t('versionHistory.preview.close')}
+      {t("versionHistory.preview.close")}
     </Button>
   );
 
@@ -55,8 +57,8 @@ export function VersionPreviewDialog(
     <Dialog
       open={props.open}
       onOpenChange={props.onOpenChange}
-      title={t('versionHistory.preview.title')}
-      description={t('versionHistory.preview.description')}
+      title={t("versionHistory.preview.title")}
+      description={t("versionHistory.preview.description")}
       footer={footer}
     >
       <div data-testid="version-preview-dialog" className="space-y-3">
@@ -66,7 +68,7 @@ export function VersionPreviewDialog(
             size="small"
             color="muted"
           >
-            {t('versionHistory.preview.loading')}
+            {t("versionHistory.preview.loading")}
           </Text>
         ) : null}
 
@@ -75,8 +77,8 @@ export function VersionPreviewDialog(
             data-testid="version-preview-error"
             className="rounded-[var(--radius-sm)] border border-[var(--color-error)] bg-[var(--color-error-subtle)] p-3"
           >
-            <Text size="small" className="text-[var(--color-error)]">
-              {props.error.code}: {props.error.message}
+            <Text size="small" className="text-[var(--color-text-error)]">
+              {getHumanErrorMessage(props.error)}
             </Text>
           </div>
         ) : null}
@@ -86,19 +88,19 @@ export function VersionPreviewDialog(
             <div className="grid grid-cols-2 gap-2 text-xs text-[var(--color-fg-muted)]">
               <div>
                 <span className="font-medium text-[var(--color-fg-default)]">
-                  {t('versionHistory.preview.actorLabel')}
+                  {t("versionHistory.preview.actorLabel")}
                 </span>{" "}
                 {formatActor(props.data.actor, t)}
               </div>
               <div>
                 <span className="font-medium text-[var(--color-fg-default)]">
-                  {t('versionHistory.preview.timestampLabel')}
+                  {t("versionHistory.preview.timestampLabel")}
                 </span>{" "}
                 {new Date(props.data.createdAt).toLocaleString()}
               </div>
               <div className="col-span-2">
                 <span className="font-medium text-[var(--color-fg-default)]">
-                  {t('versionHistory.preview.reasonLabel')}
+                  {t("versionHistory.preview.reasonLabel")}
                 </span>{" "}
                 {props.data.reason}
               </div>

--- a/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
+++ b/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
@@ -6,6 +6,7 @@ import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { invoke } from "../../lib/ipcClient";
 import { i18n } from "../../i18n";
+import { getHumanErrorMessage } from "../../lib/errorMessages";
 
 export type CompareState = {
   status: "idle" | "loading" | "ready" | "error";
@@ -63,7 +64,7 @@ export function useVersionCompare() {
           setCompareState({
             status: "error",
             diffText: "",
-            error: `${res.error.code}: ${res.error.message}`,
+            error: getHumanErrorMessage(res.error),
           });
           return;
         }

--- a/apps/desktop/renderer/src/lib/__tests__/error-surface-closure.guard.test.ts
+++ b/apps/desktop/renderer/src/lib/__tests__/error-surface-closure.guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Guard: Error Surface Closure — A0-21
+ *
+ * Scans all .tsx/.ts source files (excluding errorMessages.ts and test files)
+ * for patterns that leak raw IPC error codes into the UI.
+ *
+ * Scenario: S-A0-21-GUARD — no technical error code rendered to user
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const SRC_ROOT = join(__dirname, "../..");
+
+/** Patterns that indicate raw IPC error code/message leaking into UI */
+const LEAK_PATTERNS = [
+  /\{(?:\w+\.)*\w*error\w*\.(?:code|message|errorCode)\}/i,
+  /\$\{[^}]*?(?:\w+\.)*\w*error\w*\.(?:code|message|errorCode)[^}]*\}/i,
+  /"ACTION_FAILED:/,
+  /"NO_PROJECT:/,
+];
+
+/** Files/patterns excluded from scanning */
+const EXCLUDE_PATTERNS = [
+  /errorMessages\.ts$/,
+  /\.test\./,
+  /\.spec\./,
+  /\.guard\.test\./,
+  /\.stories\./,
+  /__tests__\//,
+  /node_modules/,
+  /ErrorBoundary\.tsx$/,
+];
+
+function collectFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...collectFiles(full));
+    } else if (/\.tsx?$/.test(entry)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function collectViolations(content: string): string[] {
+  const lines = content.split("\n");
+  const violations: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    for (const pattern of LEAK_PATTERNS) {
+      if (pattern.test(line)) {
+        violations.push(`${i + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  return violations;
+}
+
+describe("A0-21: error surface closure guard", () => {
+  it("flags raw error variants and ignores localized pass fixtures", () => {
+    const failFixtures = [
+      "{lastError.code}: {lastError.message}",
+      "{state.lastError.code}: {state.lastError.message}",
+      "{branchMergeError.code}: {branchMergeError.message}",
+      "{previewError.code}: {previewError.message}",
+      "{error.errorCode}",
+      'ctx.setErrorText("ACTION_FAILED: Settings dialog not available")',
+    ];
+    const passFixtures = [
+      "{getHumanErrorMessage(lastError)}",
+      "{getHumanErrorMessage(branchMergeError)}",
+      "{getHumanErrorMessage(previewError)}",
+      "{localizedErrorCode}",
+      'ctx.setErrorText(t("commandPalette.error.settingsUnavailable"))',
+    ];
+
+    for (const fixture of failFixtures) {
+      expect(collectViolations(fixture), fixture).not.toEqual([]);
+    }
+    for (const fixture of passFixtures) {
+      expect(collectViolations(fixture), fixture).toEqual([]);
+    }
+  });
+
+  it("should not have raw error.code/error.message rendered in UI components", () => {
+    const files = collectFiles(SRC_ROOT);
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file);
+      if (EXCLUDE_PATTERNS.some((p) => p.test(rel))) continue;
+
+      const content = readFileSync(file, "utf-8");
+      const fileViolations = collectViolations(content).map(
+        (line) => `${rel}:${line}`,
+      );
+      violations.push(...fileViolations);
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/desktop/tests/e2e/ai-runtime.spec.ts
+++ b/apps/desktop/tests/e2e/ai-runtime.spec.ts
@@ -120,7 +120,7 @@ test("ai runtime: timeout maps to SKILL_TIMEOUT", async () => {
   await runInput(page, "E2E_TIMEOUT");
 
   await expect(page.getByTestId("ai-error-code")).toContainText(
-    "SKILL_TIMEOUT",
+    /技能执行超时|Operation timed out/i,
   );
 
   await electronApp.close();
@@ -134,7 +134,7 @@ test("ai runtime: upstream error maps to LLM_API_ERROR", async () => {
   await runInput(page, "E2E_UPSTREAM_ERROR");
 
   await expect(page.getByTestId("ai-error-code")).toContainText(
-    "LLM_API_ERROR",
+    /AI 服务响应异常，请稍后重试|Upstream service error/i,
   );
 
   await electronApp.close();

--- a/apps/desktop/tests/e2e/settings-dialog.spec.ts
+++ b/apps/desktop/tests/e2e/settings-dialog.spec.ts
@@ -48,7 +48,7 @@ test("settings-dialog: shortcut opens + theme persists + ai settings errors obse
   await first.page.keyboard.press("Control+,");
   await expect(first.page.getByTestId("settings-dialog")).toBeVisible();
 
-  // AI settings: invalid empty baseUrl should show INVALID_ARGUMENT (observable failure)
+  // AI settings: invalid empty baseUrl should show human-readable error (observable failure)
   await first.page.getByTestId("settings-nav-ai").click();
   await expect(first.page.getByTestId("ai-save-btn")).toBeVisible();
   await first.page
@@ -57,7 +57,7 @@ test("settings-dialog: shortcut opens + theme persists + ai settings errors obse
   await first.page.getByTestId("ai-base-url").fill("");
   await first.page.getByTestId("ai-save-btn").click();
   await expect(first.page.getByTestId("ai-error")).toContainText(
-    "INVALID_ARGUMENT",
+    /Invalid parameter format|参数格式不正确/,
   );
 
   // Theme: switch to light and persist across restart


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

A0-21 错误展示组件收口：将 15+ 组件中直接渲染 `error.code` / `error.message` 的技术错误码替换为 `getHumanErrorMessage()` 人话化错误消息。

## 关联 Issue

- Closes #988

## 用户影响

- 用户在所有错误场景中看到的是人话化提示（如「读写操作失败，请重试。」），不再看到技术错误码（如 `IO_ERROR: ENOENT`）
- 错误区域增加 `role="alert"` 无障碍属性
- 错误文本统一使用 `var(--color-text-error)` Design Token
- CommandPalette 硬编码错误字符串全部收口到 i18n

## 不修最坏后果

- 用户在导出、项目创建、AI 设置、技能管理等 15+ 场景中看到技术错误码，体验割裂

## 验证证据

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors, 690 warnings (全部为已有 warning)
- [x] `pnpm -C apps/desktop vitest run` — 271 files, 1854 tests passed
- [x] Guard test `error-surface-closure.guard.test.ts` — 扫描全部 .tsx/.ts 源文件，确保无 raw error code 泄漏
- [x] `pnpm exec prettier --write` — 已格式化所有变更文件

## 回滚点

- 回滚 commit: `066fe449`
- 回滚后无数据影响，仅 UI 文案回退

## 非自动化检查（Tier 3）

- [x] **品牌调性**：错误文本使用 `var(--color-text-error)` Design Token，无硬编码色值
- [x] **无障碍**：错误区域增加 `role="alert"` 属性
- [ ] **字体渲染**：N/A — 本次无新增字体/样式组件
- [ ] **CJK 场景**：i18n 同时维护 en.json 和 zh-CN.json

### 变更清单

| 文件 | 改动 |
|------|------|
| ExportDialog | `formatExportErrorDisplay()` 统一渲染入口 |
| QualityPanel | Judge 错误 + 约束错误 → `getHumanErrorMessage` |
| VersionPreviewDialog | 错误文本人话化 + 类型收窄 |
| useVersionCompare | 错误字符串人话化 |
| InfoPanel | 移除 error-code testid，单一人话消息 |
| MemoryPanel | 合并 code/message 为单一人话消息 |
| AnalyticsPage | 增加 `role="alert"` + 人话化 |
| CreateProjectDialog | 类型 cast + `role="alert"` + 人话化 |
| DashboardPage | 重命名错误字符串 |
| AiSettingsSection | 3 处 setErrorText 人话化 |
| JudgeSection | 5 处错误路径人话化 |
| AiPanel | modelsLastError 描述人话化 |
| SkillManagerDialog | 6 处 error.message → getHumanErrorMessage |
| CommandPalette | 9 处硬编码字符串 → `t()` i18n |
| AppShell | throw 人话化消息 |
| en.json / zh-CN.json | 新增 commandPalette.error.* 8 keys + 修正 export.error.noProject |
| error-surface-closure.guard.test.ts | 新增 guard 防回归 |