### PR TITLE
fix(i18n): A0-22 i18n 错误文案修正 (#989)

### DIFF
--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -26,7 +26,17 @@ import { Text } from "../../components/primitives/Text";
 import { CommandItem as CommandItemComposite } from "../../components/composites/CommandItem";
 import { useProjectStore } from "../../stores/projectStore";
 import "../../i18n";
-import { Download, FolderPlus, History, Maximize, PanelLeft, PanelRight, Search, Settings, SquarePen } from "lucide-react";
+import {
+  Download,
+  FolderPlus,
+  History,
+  Maximize,
+  PanelLeft,
+  PanelRight,
+  Search,
+  Settings,
+  SquarePen,
+} from "lucide-react";
 import { fuzzyFilter } from "./fuzzyMatch";
 
 // =============================================================================
@@ -308,148 +318,166 @@ function buildDefaultCommands(ctx: {
   documentActions: CommandPaletteProps["documentActions"];
 }): CommandItem[] {
   return [
-      // === Settings ===
-      {
-        id: "open-settings",
-        label: "Open Settings",
-        icon: <SettingsIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: `${ctx.modKey},`,
-        group: GROUP_IDS.suggestions,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.dialogActions?.onOpenSettings) {
-            ctx.dialogActions.onOpenSettings();
+    // === Settings ===
+    {
+      id: "open-settings",
+      label: "Open Settings",
+      icon: <SettingsIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: `${ctx.modKey},`,
+      group: GROUP_IDS.suggestions,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.dialogActions?.onOpenSettings) {
+          ctx.dialogActions.onOpenSettings();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.settingsUnavailable"),
+          );
+        }
+      },
+    },
+    // === Export ===
+    {
+      id: "export",
+      label: "Export…",
+      icon: <DownloadIcon className="text-[var(--color-fg-muted)]" />,
+      group: GROUP_IDS.suggestions,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        // Always open ExportDialog; it handles NO_PROJECT error internally
+        if (ctx.dialogActions?.onOpenExport) {
+          ctx.dialogActions.onOpenExport();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.exportUnavailable"),
+          );
+        }
+      },
+    },
+    // === Layout: Toggle Sidebar ===
+    {
+      id: "toggle-sidebar",
+      label: "Toggle Sidebar",
+      icon: <SidebarIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: `${ctx.modKey}\\`,
+      group: GROUP_IDS.layout,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.layoutActions?.onToggleSidebar) {
+          ctx.layoutActions.onToggleSidebar();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.layoutUnavailable"),
+          );
+        }
+      },
+    },
+    // === Layout: Toggle Right Panel ===
+    {
+      id: "toggle-right-panel",
+      label: "Toggle Right Panel",
+      icon: <PanelRightIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: `${ctx.modKey}L`,
+      group: GROUP_IDS.layout,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.layoutActions?.onToggleRightPanel) {
+          ctx.layoutActions.onToggleRightPanel();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.layoutUnavailable"),
+          );
+        }
+      },
+    },
+    // === Layout: Zen Mode ===
+    {
+      id: "toggle-zen-mode",
+      label: "Toggle Zen Mode",
+      icon: <MaximizeIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: "F11",
+      group: GROUP_IDS.layout,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.layoutActions?.onToggleZenMode) {
+          ctx.layoutActions.onToggleZenMode();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.layoutUnavailable"),
+          );
+        }
+      },
+    },
+    // === Document: Create New Document ===
+    {
+      id: "create-new-document",
+      label: "Create New Document",
+      icon: <EditIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: `${ctx.modKey}N`,
+      group: GROUP_IDS.document,
+      onSelect: async () => {
+        ctx.setErrorText(null);
+        if (!ctx.currentProjectId) {
+          ctx.setErrorText(ctx.t("workbench.commandPalette.errors.noProject"));
+          return;
+        }
+        if (ctx.documentActions?.onCreateDocument) {
+          try {
+            await ctx.documentActions.onCreateDocument();
             ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.settingsUnavailable"));
+          } catch {
+            ctx.setErrorText(
+              ctx.t("workbench.commandPalette.errors.createDocumentFailed"),
+            );
           }
-        },
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.documentUnavailable"),
+          );
+        }
       },
-      // === Export ===
-      {
-        id: "export",
-        label: "Export…",
-        icon: <DownloadIcon className="text-[var(--color-fg-muted)]" />,
-        group: GROUP_IDS.suggestions,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          // Always open ExportDialog; it handles NO_PROJECT error internally
-          if (ctx.dialogActions?.onOpenExport) {
-            ctx.dialogActions.onOpenExport();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.exportUnavailable"));
-          }
-        },
+    },
+    {
+      id: "open-version-history",
+      label: "Open Version History",
+      icon: <HistoryIcon className="text-[var(--color-fg-muted)]" />,
+      group: GROUP_IDS.document,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.layoutActions?.onOpenVersionHistory) {
+          ctx.layoutActions.onOpenVersionHistory();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.versionHistoryUnavailable"),
+          );
+        }
       },
-      // === Layout: Toggle Sidebar ===
-      {
-        id: "toggle-sidebar",
-        label: "Toggle Sidebar",
-        icon: <SidebarIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: `${ctx.modKey}\\`,
-        group: GROUP_IDS.layout,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.layoutActions?.onToggleSidebar) {
-            ctx.layoutActions.onToggleSidebar();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
-          }
-        },
+    },
+    // === Project: Create New Project ===
+    {
+      id: "create-new-project",
+      label: "Create New Project",
+      icon: <FolderPlusIcon className="text-[var(--color-fg-muted)]" />,
+      shortcut: `${ctx.modKey}⇧N`,
+      group: GROUP_IDS.project,
+      onSelect: () => {
+        ctx.setErrorText(null);
+        if (ctx.dialogActions?.onOpenCreateProject) {
+          ctx.dialogActions.onOpenCreateProject();
+          ctx.onOpenChange(false);
+        } else {
+          ctx.setErrorText(
+            ctx.t("workbench.commandPalette.errors.createProjectUnavailable"),
+          );
+        }
       },
-      // === Layout: Toggle Right Panel ===
-      {
-        id: "toggle-right-panel",
-        label: "Toggle Right Panel",
-        icon: <PanelRightIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: `${ctx.modKey}L`,
-        group: GROUP_IDS.layout,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.layoutActions?.onToggleRightPanel) {
-            ctx.layoutActions.onToggleRightPanel();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
-          }
-        },
-      },
-      // === Layout: Zen Mode ===
-      {
-        id: "toggle-zen-mode",
-        label: "Toggle Zen Mode",
-        icon: <MaximizeIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: "F11",
-        group: GROUP_IDS.layout,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.layoutActions?.onToggleZenMode) {
-            ctx.layoutActions.onToggleZenMode();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
-          }
-        },
-      },
-      // === Document: Create New Document ===
-      {
-        id: "create-new-document",
-        label: "Create New Document",
-        icon: <EditIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: `${ctx.modKey}N`,
-        group: GROUP_IDS.document,
-        onSelect: async () => {
-          ctx.setErrorText(null);
-          if (!ctx.currentProjectId) {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.noProject"));
-            return;
-          }
-          if (ctx.documentActions?.onCreateDocument) {
-            try {
-              await ctx.documentActions.onCreateDocument();
-              ctx.onOpenChange(false);
-            } catch {
-              ctx.setErrorText(ctx.t("workbench.commandPalette.errors.createDocumentFailed"));
-            }
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.documentUnavailable"));
-          }
-        },
-      },
-      {
-        id: "open-version-history",
-        label: "Open Version History",
-        icon: <HistoryIcon className="text-[var(--color-fg-muted)]" />,
-        group: GROUP_IDS.document,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.layoutActions?.onOpenVersionHistory) {
-            ctx.layoutActions.onOpenVersionHistory();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.versionHistoryUnavailable"));
-          }
-        },
-      },
-      // === Project: Create New Project ===
-      {
-        id: "create-new-project",
-        label: "Create New Project",
-        icon: <FolderPlusIcon className="text-[var(--color-fg-muted)]" />,
-        shortcut: `${ctx.modKey}⇧N`,
-        group: GROUP_IDS.project,
-        onSelect: () => {
-          ctx.setErrorText(null);
-          if (ctx.dialogActions?.onOpenCreateProject) {
-            ctx.dialogActions.onOpenCreateProject();
-            ctx.onOpenChange(false);
-          } else {
-            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.createProjectUnavailable"));
-          }
-        },
-      },
+    },
   ];
 }
 
@@ -619,7 +647,7 @@ export function CommandPalette({
         data-testid="command-palette"
         role="dialog"
         aria-modal="true"
-        aria-label={t('workbench.commandPalette.ariaLabel')}
+        aria-label={t("workbench.commandPalette.ariaLabel")}
         onClick={(e) => e.stopPropagation()}
         className="w-[600px] max-w-[90vw] flex flex-col bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[var(--shadow-xl)] overflow-hidden"
       >
@@ -641,7 +669,7 @@ export function CommandPalette({
             onKeyDown={handleKeyDown}
             placeholder={t("workbench.commandPalette.searchPlaceholder")}
             className="flex-1 bg-transparent border-none text-[15px] text-[var(--color-fg-default)] placeholder:text-[var(--color-fg-placeholder)] outline-none"
-            aria-label={t('workbench.commandPalette.searchAriaLabel')}
+            aria-label={t("workbench.commandPalette.searchAriaLabel")}
           />
         </div>
 

--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -321,7 +321,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenSettings();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Settings dialog not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.settingsUnavailable"));
           }
         },
       },
@@ -338,7 +338,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenExport();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Export dialog not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.exportUnavailable"));
           }
         },
       },
@@ -355,7 +355,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleSidebar();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
           }
         },
       },
@@ -372,7 +372,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleRightPanel();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
           }
         },
       },
@@ -389,7 +389,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onToggleZenMode();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Layout actions not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.layoutUnavailable"));
           }
         },
       },
@@ -403,7 +403,7 @@ function buildDefaultCommands(ctx: {
         onSelect: async () => {
           ctx.setErrorText(null);
           if (!ctx.currentProjectId) {
-            ctx.setErrorText("NO_PROJECT: Please open a project first");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.noProject"));
             return;
           }
           if (ctx.documentActions?.onCreateDocument) {
@@ -411,10 +411,10 @@ function buildDefaultCommands(ctx: {
               await ctx.documentActions.onCreateDocument();
               ctx.onOpenChange(false);
             } catch {
-              ctx.setErrorText("ACTION_FAILED: Failed to create document");
+              ctx.setErrorText(ctx.t("workbench.commandPalette.errors.createDocumentFailed"));
             }
           } else {
-            ctx.setErrorText("ACTION_FAILED: Document actions not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.documentUnavailable"));
           }
         },
       },
@@ -429,7 +429,7 @@ function buildDefaultCommands(ctx: {
             ctx.layoutActions.onOpenVersionHistory();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Version history action not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.versionHistoryUnavailable"));
           }
         },
       },
@@ -446,7 +446,7 @@ function buildDefaultCommands(ctx: {
             ctx.dialogActions.onOpenCreateProject();
             ctx.onOpenChange(false);
           } else {
-            ctx.setErrorText("ACTION_FAILED: Create project dialog not available");
+            ctx.setErrorText(ctx.t("workbench.commandPalette.errors.createProjectUnavailable"));
           }
         },
       },

--- a/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportDialog.test.tsx
@@ -1,11 +1,7 @@
 import { afterEach, beforeAll, describe, it, expect, vi } from "vitest";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type {
-  ButtonHTMLAttributes,
-  HTMLAttributes,
-  ReactNode,
-} from "react";
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
 
 import type { IpcError } from "@shared/types/ipc-generated";
 import { AppToastProvider } from "../../components/providers/AppToastProvider";
@@ -29,10 +25,14 @@ vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
     Title: ({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h2 {...props}>{children}</h2>
     ),
-    Description: ({ children, ...props }: HTMLAttributes<HTMLParagraphElement>) => (
-      <p {...props}>{children}</p>
-    ),
-    Close: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    Description: ({
+      children,
+      ...props
+    }: HTMLAttributes<HTMLParagraphElement>) => <p {...props}>{children}</p>,
+    Close: ({
+      children,
+      ...props
+    }: ButtonHTMLAttributes<HTMLButtonElement>) => (
       <button type="button" {...props}>
         {children}
       </button>
@@ -185,7 +185,7 @@ describe("ExportDialog", () => {
     );
 
     expect(screen.getByTestId("export-submit")).toBeDisabled();
-    expect(screen.getByText(/NO_PROJECT:/)).toBeInTheDocument();
+    expect(screen.getByText("Please open a project first")).toBeInTheDocument();
   });
 
   it("renders controlled progress view", () => {
@@ -291,7 +291,9 @@ describe("ExportDialog", () => {
     });
 
     it("shows Chinese structured hints after switching to zh-CN locale", async () => {
-      await act(async () => { await i18n.changeLanguage("zh-CN"); });
+      await act(async () => {
+        await i18n.changeLanguage("zh-CN");
+      });
       renderWithToastProvider(
         <ExportDialog open={true} onOpenChange={() => {}} projectId="test" />,
       );
@@ -300,15 +302,21 @@ describe("ExportDialog", () => {
       expect(pdfCard).toHaveTextContent("结构化分页 · 保留标题、列表、图片");
 
       const docxCard = screen.getByTestId("export-format-docx");
-      expect(docxCard).toHaveTextContent("结构化 Word 导出 · 保留标题、链接、图片");
+      expect(docxCard).toHaveTextContent(
+        "结构化 Word 导出 · 保留标题、链接、图片",
+      );
 
       const markdownCard = screen.getByTestId("export-format-markdown");
-      expect(markdownCard).toHaveTextContent("结构化 Markdown · 保留标题、列表、链接");
+      expect(markdownCard).toHaveTextContent(
+        "结构化 Markdown · 保留标题、列表、链接",
+      );
 
       const txtCard = screen.getByTestId("export-format-txt");
       expect(txtCard).toHaveTextContent("纯文本导出 · 自动移除格式");
 
-      await act(async () => { await i18n.changeLanguage("en"); });
+      await act(async () => {
+        await i18n.changeLanguage("en");
+      });
     });
 
     it("does not show the old plain-text-only copy for PDF or DOCX", () => {
@@ -382,4 +390,3 @@ describe("ExportDialog", () => {
     );
   });
 });
-

--- a/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
+++ b/apps/desktop/renderer/src/features/rightpanel/QualityPanel.tsx
@@ -26,19 +26,25 @@ type ConstraintsData =
 /**
  * Format judge state into a human-readable label with status indicator.
  */
-function formatJudgeState(state: JudgeModelState, t: TFunction): {
+function formatJudgeState(
+  state: JudgeModelState,
+  t: TFunction,
+): {
   label: string;
   status: "ready" | "downloading" | "error" | "not_ready";
 } {
   switch (state.status) {
     case "ready":
-      return { label: t('rightPanel.quality.ready'), status: "ready" };
+      return { label: t("rightPanel.quality.ready"), status: "ready" };
     case "downloading":
-      return { label: t('rightPanel.quality.downloading'), status: "downloading" };
+      return {
+        label: t("rightPanel.quality.downloading"),
+        status: "downloading",
+      };
     case "not_ready":
-      return { label: t('rightPanel.quality.notReady'), status: "not_ready" };
+      return { label: t("rightPanel.quality.notReady"), status: "not_ready" };
     case "error":
-      return { label: t('rightPanel.quality.errorWithCode', { code: state.error.code }), status: "error" };
+      return { label: t("rightPanel.quality.errorWithCode"), status: "error" };
   }
 }
 
@@ -89,7 +95,7 @@ function JudgeStatusSection(props: {
           <div className="flex items-center gap-2">
             <StatusDot status="loading" />
             <Text size="small" color="muted">
-              {t('rightPanel.quality.loadingJudgeStatus')}
+              {t("rightPanel.quality.loadingJudgeStatus")}
             </Text>
           </div>
         </div>
@@ -123,7 +129,7 @@ function JudgeStatusSection(props: {
     return (
       <Card className="p-3 rounded-[var(--radius-md)]">
         <Text size="small" color="muted">
-          {t('rightPanel.quality.judgeStatusUnavailable')}
+          {t("rightPanel.quality.judgeStatusUnavailable")}
         </Text>
       </Card>
     );
@@ -137,7 +143,7 @@ function JudgeStatusSection(props: {
         <div className="flex items-center gap-2">
           <StatusDot status={status} />
           <Text size="small" color="default">
-            {t('rightPanel.quality.judgeModelLabel')}{" "}
+            {t("rightPanel.quality.judgeModelLabel")}{" "}
             <span
               data-testid="quality-panel-judge-status"
               data-status={status}
@@ -156,7 +162,9 @@ function JudgeStatusSection(props: {
             disabled={ensureBusy}
             loading={ensureBusy}
           >
-            {status === "not_ready" ? t('rightPanel.quality.initialize') : t('rightPanel.quality.retry')}
+            {status === "not_ready"
+              ? t("rightPanel.quality.initialize")
+              : t("rightPanel.quality.retry")}
           </Button>
         )}
       </div>
@@ -179,7 +187,7 @@ function ConstraintsSection(props: {
     return (
       <Card className="p-3 rounded-[var(--radius-md)]">
         <Text size="small" color="muted">
-          {t('rightPanel.quality.loadingConstraints')}
+          {t("rightPanel.quality.loadingConstraints")}
         </Text>
       </Card>
     );
@@ -208,12 +216,12 @@ function ConstraintsSection(props: {
     <Card className="p-3 rounded-[var(--radius-md)]">
       <div className="flex items-center justify-between">
         <Text size="small" color="default">
-          {t('rightPanel.quality.constraintsLabel')}{" "}
+          {t("rightPanel.quality.constraintsLabel")}{" "}
           <span
             data-testid="quality-panel-constraints-count"
             className="font-medium"
           >
-            {t('rightPanel.quality.rulesCount', { count })}
+            {t("rightPanel.quality.rulesCount", { count })}
           </span>
         </Text>
       </div>
@@ -229,7 +237,7 @@ function ConstraintsSection(props: {
           ))}
           {count > 5 && (
             <span className="inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]">
-              {t('rightPanel.quality.moreCount', { count: count - 5 })}
+              {t("rightPanel.quality.moreCount", { count: count - 5 })}
             </span>
           )}
         </div>
@@ -264,14 +272,17 @@ function buildCheckGroups(
 
     groups.push({
       id: "system",
-      name: t('rightPanel.quality.systemGroup'),
+      name: t("rightPanel.quality.systemGroup"),
       checks: [
         {
           id: "judge-model",
-          name: t('rightPanel.quality.judgeModelCheck'),
-          description: t('rightPanel.quality.judgeModelDescription'),
+          name: t("rightPanel.quality.judgeModelCheck"),
+          description: t("rightPanel.quality.judgeModelDescription"),
           status: judgeStatus,
-          resultValue: judgeState.status === "ready" ? t('rightPanel.quality.available') : undefined,
+          resultValue:
+            judgeState.status === "ready"
+              ? t("rightPanel.quality.available")
+              : undefined,
         },
       ],
     });
@@ -282,14 +293,16 @@ function buildCheckGroups(
     const constraintCount = constraints.items.length;
     groups.push({
       id: "constraints",
-      name: t('rightPanel.quality.writingConstraints'),
+      name: t("rightPanel.quality.writingConstraints"),
       checks: [
         {
           id: "active-constraints",
-          name: t('rightPanel.quality.activeConstraints'),
-          description: t('rightPanel.quality.activeConstraintsDescription'),
+          name: t("rightPanel.quality.activeConstraints"),
+          description: t("rightPanel.quality.activeConstraintsDescription"),
           status: constraintCount > 0 ? "passed" : "warning",
-          resultValue: t('rightPanel.quality.rulesDefinedCount', { count: constraintCount }),
+          resultValue: t("rightPanel.quality.rulesDefinedCount", {
+            count: constraintCount,
+          }),
         },
       ],
     });
@@ -481,7 +494,7 @@ export function QualityPanel(): JSX.Element {
         className="flex flex-col gap-4 p-4 h-full overflow-auto"
       >
         <Heading level="h3" className="font-bold text-[15px]">
-          {t('rightPanel.quality.panelTitle')}
+          {t("rightPanel.quality.panelTitle")}
         </Heading>
 
         <Card className="p-4 rounded-[var(--radius-md)]">
@@ -491,13 +504,13 @@ export function QualityPanel(): JSX.Element {
             color="muted"
             className="text-center"
           >
-            {t('rightPanel.quality.noProjectSelected')}
+            {t("rightPanel.quality.noProjectSelected")}
           </Text>
         </Card>
 
         <section>
           <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-            {t('rightPanel.quality.judgeModelHeading')}
+            {t("rightPanel.quality.judgeModelHeading")}
           </Heading>
           <JudgeStatusSection
             state={effectiveJudgeState}
@@ -517,7 +530,7 @@ export function QualityPanel(): JSX.Element {
       <div className="p-4 space-y-4 border-b border-[var(--color-separator)]">
         <section>
           <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-            {t('rightPanel.quality.judgeModelHeading')}
+            {t("rightPanel.quality.judgeModelHeading")}
           </Heading>
           <JudgeStatusSection
             state={effectiveJudgeState}
@@ -530,7 +543,7 @@ export function QualityPanel(): JSX.Element {
 
         <section>
           <Heading level="h4" className="mb-2 font-semibold text-[13px]">
-            {t('rightPanel.quality.projectConstraints')}
+            {t("rightPanel.quality.projectConstraints")}
           </Heading>
           <ConstraintsSection
             constraints={constraints}

--- a/apps/desktop/renderer/src/i18n/__tests__/i18n-error-copy-cleanup.guard.test.ts
+++ b/apps/desktop/renderer/src/i18n/__tests__/i18n-error-copy-cleanup.guard.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import en from "../locales/en.json";
+import zhCN from "../locales/zh-CN.json";
+
+// ─── helpers ───
+
+interface LocaleNode {
+  [key: string]: LocaleNode | string;
+}
+
+function flattenEntries(
+  node: LocaleNode,
+  prefix = "",
+): Array<[string, string]> {
+  return Object.entries(node).flatMap(([key, value]) => {
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") return [[p, value] as [string, string]];
+    return flattenEntries(value as LocaleNode, p);
+  });
+}
+
+// ─── tests ───
+
+describe("A0-22: i18n error copy cleanup", () => {
+  // ── export.error.noProject ──
+
+  it("zh-CN export.error.noProject has no technical prefix", () => {
+    expect((zhCN as LocaleNode).export).toBeDefined();
+    const val = ((zhCN as LocaleNode).export as LocaleNode).error as LocaleNode;
+    expect(val.noProject).toBe("请先打开一个项目");
+  });
+
+  it("en export.error.noProject has no technical prefix", () => {
+    const val = ((en as LocaleNode).export as LocaleNode).error as LocaleNode;
+    expect(val.noProject).toBe("Please open a project first");
+  });
+
+  // ── rightPanel.quality.errorWithCode ──
+
+  it("zh-CN rightPanel.quality.errorWithCode has no {{code}} interpolation", () => {
+    const val = ((zhCN as LocaleNode).rightPanel as LocaleNode)
+      .quality as LocaleNode;
+    expect(val.errorWithCode).toBe("质量检测遇到问题");
+  });
+
+  it("en rightPanel.quality.errorWithCode has no {{code}} interpolation", () => {
+    const val = ((en as LocaleNode).rightPanel as LocaleNode)
+      .quality as LocaleNode;
+    expect(val.errorWithCode).toBe("Quality check encountered an issue");
+  });
+
+  // ── full scan: no technical error code prefixes ──
+
+  it("no locale value starts with UPPER_SNAKE_CASE: prefix", () => {
+    const pattern = /^[A-Z][A-Z_]{2,}:\s/;
+    const violations: string[] = [];
+
+    for (const [label, entries] of [
+      ["en", flattenEntries(en as LocaleNode)],
+      ["zh-CN", flattenEntries(zhCN as LocaleNode)],
+    ] as const) {
+      for (const [key, value] of entries) {
+        if (pattern.test(value)) {
+          violations.push(`[${label}] ${key} = ${value}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  // ── full scan: no {{code}} / {{errorCode}} in error contexts ──
+
+  it("no locale value contains {{code}} or {{errorCode}}", () => {
+    const violations: string[] = [];
+
+    for (const [label, entries] of [
+      ["en", flattenEntries(en as LocaleNode)],
+      ["zh-CN", flattenEntries(zhCN as LocaleNode)],
+    ] as const) {
+      for (const [key, value] of entries) {
+        if (value.includes("{{code}}") || value.includes("{{errorCode}}")) {
+          violations.push(`[${label}] ${key} = ${value}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  // ── no call site passes { code: ... } to errorWithCode ──
+
+  it("no source file passes { code: ... } to t('rightPanel.quality.errorWithCode')", () => {
+    const srcDir = path.resolve(__dirname, "../../");
+    const violations: string[] = [];
+
+    function scanDir(dir: string): void {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory() && entry.name !== "node_modules") {
+          scanDir(full);
+        } else if (
+          /\.(ts|tsx)$/.test(entry.name) &&
+          !entry.name.endsWith(".test.ts") &&
+          !entry.name.endsWith(".test.tsx")
+        ) {
+          const content = fs.readFileSync(full, "utf-8");
+          if (
+            content.includes("errorWithCode") &&
+            /errorWithCode['"]?\s*,\s*\{/.test(content)
+          ) {
+            violations.push(path.relative(srcDir, full));
+          }
+        }
+      }
+    }
+
+    scanDir(srcDir);
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/desktop/renderer/src/i18n/__tests__/i18n-error-copy-cleanup.guard.test.ts
+++ b/apps/desktop/renderer/src/i18n/__tests__/i18n-error-copy-cleanup.guard.test.ts
@@ -121,4 +121,14 @@ describe("A0-22: i18n error copy cleanup", () => {
     scanDir(srcDir);
     expect(violations).toEqual([]);
   });
+
+  it("CommandPalette source no longer contains ACTION_FAILED / NO_PROJECT raw codes", () => {
+    const commandPalettePath = path.resolve(
+      __dirname,
+      "../../features/commandPalette/CommandPalette.tsx",
+    );
+    const content = fs.readFileSync(commandPalettePath, "utf-8");
+    expect(content).not.toContain("ACTION_FAILED:");
+    expect(content).not.toContain("NO_PROJECT:");
+  });
 });

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -27,6 +27,16 @@
         "command": "Command",
         "file": "File",
         "recent": "Recent"
+      },
+      "errors": {
+        "settingsUnavailable": "Settings dialog is unavailable right now.",
+        "exportUnavailable": "Export dialog is unavailable right now.",
+        "layoutUnavailable": "Layout actions are unavailable right now.",
+        "noProject": "Please open a project first.",
+        "createDocumentFailed": "Failed to create a new document. Please try again.",
+        "documentUnavailable": "Document actions are unavailable right now.",
+        "versionHistoryUnavailable": "Version history is unavailable right now.",
+        "createProjectUnavailable": "Create Project dialog is unavailable right now."
       }
     },
     "statusBar": {

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1175,7 +1175,7 @@
     },
     "defaultDocumentTitle": "Untitled Document",
     "error": {
-      "noProject": "NO_PROJECT: Please open a project first",
+      "noProject": "Please open a project first",
       "unsupportedStructure": "This export format cannot write: {{details}}",
       "unknown": "Export failed due to unknown error"
     }
@@ -1337,7 +1337,7 @@
       "ready": "Ready",
       "downloading": "Downloading...",
       "notReady": "Not ready",
-      "errorWithCode": "Error ({{code}})",
+      "errorWithCode": "Quality check encountered an issue",
       "loadingJudgeStatus": "Loading quality check status...",
       "judgeStatusUnavailable": "Quality check unavailable",
       "judgeModelLabel": "Quality Check:",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -27,6 +27,16 @@
         "command": "命令",
         "file": "文件",
         "recent": "最近使用"
+      },
+      "errors": {
+        "settingsUnavailable": "当前无法打开设置对话框。",
+        "exportUnavailable": "当前无法打开导出对话框。",
+        "layoutUnavailable": "当前无法执行布局操作。",
+        "noProject": "请先打开一个项目。",
+        "createDocumentFailed": "新建文档失败，请重试。",
+        "documentUnavailable": "当前无法执行文档操作。",
+        "versionHistoryUnavailable": "当前无法打开版本历史。",
+        "createProjectUnavailable": "当前无法打开新建项目对话框。"
       }
     },
     "statusBar": {

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1175,7 +1175,7 @@
     },
     "defaultDocumentTitle": "未命名文档",
     "error": {
-      "noProject": "NO_PROJECT: 请先打开一个项目",
+      "noProject": "请先打开一个项目",
       "unsupportedStructure": "当前导出格式暂不支持写出：{{details}}",
       "unknown": "由于未知错误导出失败"
     }
@@ -1337,7 +1337,7 @@
       "ready": "就绪",
       "downloading": "下载中...",
       "notReady": "未就绪",
-      "errorWithCode": "错误 ({{code}})",
+      "errorWithCode": "质量检测遇到问题",
       "loadingJudgeStatus": "加载质量检查状态...",
       "judgeStatusUnavailable": "质量检查不可用",
       "judgeModelLabel": "质量检查：",

--- a/apps/desktop/tests/e2e/command-palette.spec.ts
+++ b/apps/desktop/tests/e2e/command-palette.spec.ts
@@ -253,8 +253,10 @@ test.describe("Command Palette + Shortcuts", () => {
     // Export button should be disabled (no project)
     await expect(page.getByTestId("export-submit")).toBeDisabled();
 
-    // Should show NO_PROJECT message
-    await expect(page.getByText(/NO_PROJECT/)).toBeVisible();
+    // Should show "no project" message (i18n: export.error.noProject)
+    await expect(
+      page.getByText(/Please open a project first|请先打开一个项目/),
+    ).toBeVisible();
 
     // Close dialog
     await page.keyboard.press("Escape");


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

A0-22 i18n 错误文案修正：清理 locale 文件中残留的技术错误码模式。

## 关联 Issue

- Closes #989

## 用户影响

- `export.error.noProject`：移除 `NO_PROJECT:` 前缀，用户看到人话（"请先打开一个项目" / "Please open a project first"）
- `rightPanel.quality.errorWithCode`：移除 `{{code}}` 插值，显示 "质量检测遇到问题" / "Quality check encountered an issue"
- QualityPanel 调用点同步移除 `{ code: ... }` 参数

## 不修最坏后果

- 用户在导出和质量面板中仍看到技术错误码（如 `NO_PROJECT:` / `Error (JUDGE_TIMEOUT)`）

## 验证证据

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors, 691 warnings（全部为已有 warning）
- [x] `pnpm exec vitest run` — 271 files, 1860 tests passed
- [x] Guard test `i18n-error-copy-cleanup.guard.test.ts` — 7 tests:
  - en/zh-CN export.error.noProject 无前缀
  - en/zh-CN rightPanel.quality.errorWithCode 无 {{code}}
  - 全量扫描无 UPPER_SNAKE: 前缀
  - 全量扫描无 {{code}}/{{errorCode}} 插值
  - 无调用点传递 { code: ... } 给 errorWithCode
- [x] `pnpm exec prettier --write` — 已格式化

## 回滚点

- 回滚 commit: `c915d165`（main HEAD）
- 回滚后无数据影响，仅 UI 文案回退

## 非自动化检查（Tier 3）

- [x] **品牌调性**：错误文案使用人话化措辞
- [ ] **字体渲染**：N/A — 无新增字体/样式组件
- [ ] **CJK 场景**：i18n 同时维护 en.json 和 zh-CN.json

### 变更清单

| 文件 | 改动 |
|------|------|
| en.json | `export.error.noProject` 去除 `NO_PROJECT:` 前缀；`rightPanel.quality.errorWithCode` 改为人话 |
| zh-CN.json | 同上 |
| QualityPanel.tsx | 移除 `{ code: state.error.code }` 插值参数 |
| ExportDialog.test.tsx | 断言从 `/NO_PROJECT:/` 改为人话文本 |
| i18n-error-copy-cleanup.guard.test.ts | 新增 guard 测试（7 tests） |