### PR TITLE
fix(i18n): A0-16 编辑器/版本/Slash i18n 收口 (#991)

### DIFF
--- a/apps/desktop/renderer/src/features/editor/EditorContextMenu.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorContextMenu.tsx
@@ -22,8 +22,16 @@ import { useOptionalAiStore } from "../../stores/aiStore";
 /* ------------------------------------------------------------------ */
 
 const AI_CONTEXT_ACTIONS = [
-  { id: "builtin:polish", labelKey: "editor.contextMenu.aiPolish", testId: "ctx-ai-polish" },
-  { id: "builtin:rewrite", labelKey: "editor.contextMenu.aiRewrite", testId: "ctx-ai-rewrite" },
+  {
+    id: "builtin:polish",
+    labelKey: "editor.contextMenu.aiPolish",
+    testId: "ctx-ai-polish",
+  },
+  {
+    id: "builtin:rewrite",
+    labelKey: "editor.contextMenu.aiRewrite",
+    testId: "ctx-ai-rewrite",
+  },
 ] as const;
 
 /* ------------------------------------------------------------------ */
@@ -69,14 +77,12 @@ const menuItemClass = [
   "data-[disabled]:pointer-events-none",
 ].join(" ");
 
-const separatorClass =
-  "my-1 h-px bg-[var(--color-border-default)]";
+const separatorClass = "my-1 h-px bg-[var(--color-border-default)]";
 
 const labelClass =
   "px-2 py-1 text-xs font-medium text-[var(--color-fg-muted)] select-none";
 
-const shortcutClass =
-  "ml-auto text-xs text-[var(--color-fg-muted)]";
+const shortcutClass = "ml-auto text-xs text-[var(--color-fg-muted)]";
 
 /* ------------------------------------------------------------------ */
 /* Component                                                           */
@@ -111,9 +117,7 @@ export function EditorContextMenu({
   /* ---- Handlers ---- */
 
   const handleCopy = React.useCallback(() => {
-    void navigator.clipboard.writeText(
-      window.getSelection()?.toString() ?? "",
-    );
+    void navigator.clipboard.writeText(window.getSelection()?.toString() ?? "");
   }, []);
 
   const handlePaste = React.useCallback(async () => {
@@ -173,7 +177,10 @@ export function EditorContextMenu({
             <ClipboardCopy size={16} strokeWidth={1.5} />
             {t("editor.contextMenu.copy")}
             <span className={shortcutClass}>
-              {EDITOR_SHORTCUTS.bold.display().replace("B", "C").replace("⌘C", "⌘C")}
+              {EDITOR_SHORTCUTS.bold
+                .display()
+                .replace("B", "C")
+                .replace("⌘C", "⌘C")}
             </span>
           </ContextMenu.Item>
 
@@ -218,7 +225,9 @@ export function EditorContextMenu({
           <ContextMenu.Separator className={separatorClass} />
 
           {/* ---- Formatting ---- */}
-          <ContextMenu.Label className={labelClass}>{t("editor.contextMenu.format")}</ContextMenu.Label>
+          <ContextMenu.Label className={labelClass}>
+            {t("editor.contextMenu.format")}
+          </ContextMenu.Label>
 
           <ContextMenu.Item
             data-testid="ctx-bold"
@@ -262,7 +271,9 @@ export function EditorContextMenu({
           <ContextMenu.Separator className={separatorClass} />
 
           {/* ---- AI actions ---- */}
-          <ContextMenu.Label className={labelClass}>AI</ContextMenu.Label>
+          <ContextMenu.Label className={labelClass}>
+            {t("editor.contextMenu.ai")}
+          </ContextMenu.Label>
 
           {AI_CONTEXT_ACTIONS.map((action) => (
             <ContextMenu.Item

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -8,7 +8,10 @@ import BubbleMenuExtension from "@tiptap/extension-bubble-menu";
 import type { IpcResponseData } from "@shared/types/ipc-generated";
 
 import { useOptionalAiStore } from "../../stores/aiStore";
-import { useEditorStore, type EntityCompletionSession } from "../../stores/editorStore";
+import {
+  useEditorStore,
+  type EntityCompletionSession,
+} from "../../stores/editorStore";
 import { useVersionStore } from "../../stores/versionStore";
 import { useAutosave } from "./useAutosave";
 import { useHotkey } from "../../lib/hotkeys/useHotkey";
@@ -28,7 +31,7 @@ import { SlashCommandPanel } from "./SlashCommandPanel";
 import { EntityCompletionPanel } from "./EntityCompletionPanel";
 import {
   routeSlashCommandExecution,
-  SLASH_COMMAND_REGISTRY,
+  getSlashCommandRegistry,
   type SlashCommandExecutors,
   type SlashCommandId,
 } from "./slashCommands";
@@ -346,13 +349,25 @@ function useEntityCompletion(deps: {
   entityCompletionSession: EntityCompletionSession;
   setEntityCompletionSession: (patch: Partial<EntityCompletionSession>) => void;
   clearEntityCompletionSession: () => void;
-  listKnowledgeEntities: (args: { projectId: string }) => Promise<{ ok: true; data: { items: EntityListItem[] } } | { ok: false }>;
+  listKnowledgeEntities: (args: {
+    projectId: string;
+  }) => Promise<
+    { ok: true; data: { items: EntityListItem[] } } | { ok: false }
+  >;
   projectId: string;
 }) {
   const {
-    bootstrapStatus, clearEntityCompletionSession, contentReady, documentId,
-    documentStatus, editor, entityCompletionSession, isPreviewMode,
-    listKnowledgeEntities, projectId, setEntityCompletionSession,
+    bootstrapStatus,
+    clearEntityCompletionSession,
+    contentReady,
+    documentId,
+    documentStatus,
+    editor,
+    entityCompletionSession,
+    isPreviewMode,
+    listKnowledgeEntities,
+    projectId,
+    setEntityCompletionSession,
   } = deps;
 
   const entityCompletionSessionRef = React.useRef(entityCompletionSession);
@@ -397,7 +412,7 @@ function useEntityCompletion(deps: {
           status: "error",
           candidates: [],
           selectedIndex: 0,
-          message: "Entity suggestions unavailable.",
+          message: null,
         });
         return;
       }
@@ -579,31 +594,54 @@ function useEntityCompletion(deps: {
     setEntityCompletionSession,
   ]);
 
-
   return { applyEntityCompletionCandidate };
 }
 
 function useEditorCommands(deps: {
   editor: ReturnType<typeof useEditor>;
   aiSetSelectedSkillId: ((id: string) => void) | null;
-  aiRun: ((args?: { inputOverride?: string; context?: { projectId?: string; documentId?: string } }) => Promise<void>) | null;
+  aiRun:
+    | ((args?: {
+        inputOverride?: string;
+        context?: { projectId?: string; documentId?: string };
+      }) => Promise<void>)
+    | null;
   aiStatus: string;
   documentId: string | null;
   projectId: string;
   isPreviewMode: boolean;
   documentStatus: string | null;
-  save: (args: { projectId: string; documentId: string; contentJson: string; actor: "user" | "auto"; reason: "manual-save" | "autosave" }) => Promise<void>;
+  save: (args: {
+    projectId: string;
+    documentId: string;
+    contentJson: string;
+    actor: "user" | "auto";
+    reason: "manual-save" | "autosave";
+  }) => Promise<void>;
   closeSlashPanel: () => void;
   contentReady: boolean;
   bootstrapStatus: string;
-  downgradeFinalStatusForEdit: (args: { projectId: string; documentId: string }) => Promise<boolean>;
+  downgradeFinalStatusForEdit: (args: {
+    projectId: string;
+    documentId: string;
+  }) => Promise<boolean>;
   t: (key: string) => string;
 }) {
   const {
-    aiRun, aiSetSelectedSkillId, aiStatus, bootstrapStatus,
-    closeSlashPanel, contentReady, documentId, documentStatus,
-    downgradeFinalStatusForEdit, editor, isPreviewMode, projectId,
+    aiRun,
+    aiSetSelectedSkillId,
+    aiStatus,
+    bootstrapStatus,
+    closeSlashPanel,
+    contentReady,
+    documentId,
+    documentStatus,
+    downgradeFinalStatusForEdit,
+    editor,
+    isPreviewMode,
+    projectId,
     save,
+    t,
   } = deps;
 
   const aiStreamCheckpointRef = React.useRef<AiStreamCheckpoint | null>(null);
@@ -612,9 +650,7 @@ function useEditorCommands(deps: {
     if (!documentId || documentStatus !== "final") {
       return;
     }
-    const confirmed = window.confirm(
-      "This document is final. Editing will switch it back to draft. Continue?",
-    );
+    const confirmed = window.confirm(t("editor.confirmSwitchToDraft"));
     const decision = resolveFinalDocumentEditDecision({
       status: documentStatus,
       confirmed,
@@ -660,14 +696,7 @@ function useEditorCommands(deps: {
       // Next Ctrl+Z will revert the entire AI round via undoAiStream.
       // Checkpoint is cleared on manual user edit (see onUpdate handler).
     },
-    [
-      aiRun,
-      aiSetSelectedSkillId,
-      aiStatus,
-      documentId,
-      editor,
-      projectId,
-    ],
+    [aiRun, aiSetSelectedSkillId, aiStatus, documentId, editor, projectId],
   );
 
   /**
@@ -689,10 +718,7 @@ function useEditorCommands(deps: {
   // (Replaces the former useEffect + window.addEventListener("keydown"))
 
   const editorReady =
-    !!editor &&
-    bootstrapStatus === "ready" &&
-    !!documentId &&
-    contentReady;
+    !!editor && bootstrapStatus === "ready" && !!documentId && contentReady;
 
   // Cmd/Ctrl+Enter: Continue Writing (AI skill)
   useHotkey(
@@ -783,9 +809,12 @@ function useEditorCommands(deps: {
     [closeSlashPanel, onWriteClick, runSlashAiSkill],
   );
 
-
-
-  return { handleSlashCommandSelect, onWriteClick, requestEditFromFinal, aiStreamCheckpointRef };
+  return {
+    handleSlashCommandSelect,
+    onWriteClick,
+    requestEditFromFinal,
+    aiStreamCheckpointRef,
+  };
 }
 
 function useEditorPaneCore(projectId: string) {
@@ -837,7 +866,9 @@ function useEditorPaneCore(projectId: string) {
     (nextCount: number) => {
       setDocumentCharacterCount(nextCount);
       setCapacityWarning(
-        shouldWarnDocumentCapacity(nextCount) ? t('editor.pane.charLimitReached') : null,
+        shouldWarnDocumentCapacity(nextCount)
+          ? t("editor.pane.charLimitReached")
+          : null,
       );
     },
     [setCapacityWarning, setDocumentCharacterCount, t],
@@ -846,7 +877,6 @@ function useEditorPaneCore(projectId: string) {
   React.useEffect(() => {
     slashPanelOpenRef.current = isSlashPanelOpen;
   }, [isSlashPanelOpen]);
-
 
   const openSlashPanel = React.useCallback(() => {
     setIsSlashPanelOpen(true);
@@ -902,10 +932,7 @@ function useEditorPaneCore(projectId: string) {
           pasteLength: clipboardText.length,
         });
         const shouldContinueOverflow =
-          !overflow ||
-          window.confirm(
-            t('editor.pane.pasteLimitExceeded'),
-          );
+          !overflow || window.confirm(t("editor.pane.pasteLimitExceeded"));
 
         const allowedLength = shouldContinueOverflow
           ? clipboardText.length
@@ -965,7 +992,9 @@ function useEditorPaneCore(projectId: string) {
     try {
       setContentReady(false);
       suppressAutosaveRef.current = true;
-      editor.commands.setContent(parseEditorContentJsonSafely(activeContentJson));
+      editor.commands.setContent(
+        parseEditorContentJsonSafely(activeContentJson),
+      );
     } finally {
       window.setTimeout(() => {
         suppressAutosaveRef.current = false;
@@ -1007,10 +1036,7 @@ function useEditorPaneCore(projectId: string) {
 
       // Clear AI undo checkpoint on any manual edit — the user has
       // implicitly accepted the AI output by continuing to type.
-      if (
-        aiStreamCheckpointRef.current &&
-        !isAiRunning(aiStatus)
-      ) {
+      if (aiStreamCheckpointRef.current && !isAiRunning(aiStatus)) {
         aiStreamCheckpointRef.current = null;
       }
     };
@@ -1036,7 +1062,6 @@ function useEditorPaneCore(projectId: string) {
     projectId,
   });
 
-
   useAutosave({
     enabled:
       bootstrapStatus === "ready" &&
@@ -1049,7 +1074,6 @@ function useEditorPaneCore(projectId: string) {
     editor,
     suppressRef: suppressAutosaveRef,
   });
-
 
   return {
     t,
@@ -1087,7 +1111,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
   if (core.bootstrapStatus !== "ready") {
     return (
       <Text as="div" size="body" color="muted" className="p-4">
-        {core.t('editor.pane.loadingEditor')}
+        {core.t("editor.pane.loadingEditor")}
       </Text>
     );
   }
@@ -1095,7 +1119,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
   if (!core.documentId) {
     return (
       <Text as="div" size="body" color="muted" className="p-4">
-        {core.t('editor.pane.noDocumentSelected')}
+        {core.t("editor.pane.noDocumentSelected")}
       </Text>
     );
   }
@@ -1103,7 +1127,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
   if (!core.contentReady) {
     return (
       <Text as="div" size="body" color="muted" className="p-4">
-        {core.t('editor.pane.loadingDocument')}
+        {core.t("editor.pane.loadingDocument")}
       </Text>
     );
   }
@@ -1136,17 +1160,19 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
           className="flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-raised)] px-4 py-2"
         >
           <Text size="small" color="muted">
-            {core.t('editor.pane.previewingVersion', { timestamp: core.previewTimestamp ?? core.t('editor.pane.history') })}
+            {core.t("editor.pane.previewingVersion", {
+              timestamp: core.previewTimestamp ?? core.t("editor.pane.history"),
+            })}
           </Text>
           <div className="flex items-center gap-2">
-            <Tooltip content={core.t('editor.pane.restoreTooltip')}>
+            <Tooltip content={core.t("editor.pane.restoreTooltip")}>
               <Button
                 data-testid="preview-restore-placeholder"
                 variant="secondary"
                 size="sm"
                 disabled={true}
               >
-                {core.t('editor.pane.restoreVersion')}
+                {core.t("editor.pane.restoreVersion")}
               </Button>
             </Tooltip>
             <Button
@@ -1155,7 +1181,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
               size="sm"
               onClick={core.exitPreview}
             >
-              {core.t('editor.pane.backToCurrent')}
+              {core.t("editor.pane.backToCurrent")}
             </Button>
           </div>
         </div>
@@ -1167,7 +1193,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
           className="flex items-center justify-between gap-3 border-b border-[var(--color-separator)] bg-[var(--color-bg-surface)] px-4 py-2"
         >
           <Text size="small" color="muted">
-            {core.t('editor.pane.finalDocumentHint')}
+            {core.t("editor.pane.finalDocumentHint")}
           </Text>
           <Button
             data-testid="final-document-edit-trigger"
@@ -1175,7 +1201,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
             size="sm"
             onClick={() => void core.requestEditFromFinal()}
           >
-            {core.t('editor.pane.editAnyway')}
+            {core.t("editor.pane.editAnyway")}
           </Button>
         </div>
       ) : null}
@@ -1184,7 +1210,7 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
       <SlashCommandPanel
         open={core.isSlashPanelOpen}
         query={core.slashSearchQuery}
-        candidates={SLASH_COMMAND_REGISTRY}
+        candidates={getSlashCommandRegistry()}
         onQueryChange={core.setSlashSearchQuery}
         onSelectCommand={core.handleSlashCommandSelect}
         onRequestClose={core.closeSlashPanel}
@@ -1219,7 +1245,11 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
             core.editor.isEditable &&
             core.editor.state.selection.empty
           }
-          disabled={!core.aiSetSelectedSkillId || !core.aiRun || isAiRunning(core.aiStatus)}
+          disabled={
+            !core.aiSetSelectedSkillId ||
+            !core.aiRun ||
+            isAiRunning(core.aiStatus)
+          }
           running={isAiRunning(core.aiStatus)}
           onClick={() => void core.onWriteClick()}
         />

--- a/apps/desktop/renderer/src/features/editor/slashCommands.test.ts
+++ b/apps/desktop/renderer/src/features/editor/slashCommands.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  SLASH_COMMAND_REGISTRY,
+  getSlashCommandRegistry,
   filterSlashCommands,
   routeSlashCommandExecution,
   type SlashCommandId,
@@ -9,30 +9,28 @@ import {
 
 describe("s2 slash commands", () => {
   it("[SCN-S2-CMD-1] should register exactly six roadmap commands with unique ids", () => {
-    const labels = SLASH_COMMAND_REGISTRY.map((command) => command.label);
+    const registry = getSlashCommandRegistry();
+    const labels = registry.map((command) => command.label);
     expect(labels).toEqual([
-      "/续写",
-      "/描写",
-      "/对白",
-      "/角色",
-      "/大纲",
-      "/搜索",
+      "/Continue",
+      "/Describe",
+      "/Dialogue",
+      "/Character",
+      "/Outline",
+      "/Search",
     ]);
 
-    const uniqueIds = new Set(
-      SLASH_COMMAND_REGISTRY.map((command) => command.id),
-    );
-    expect(uniqueIds.size).toBe(SLASH_COMMAND_REGISTRY.length);
+    const uniqueIds = new Set(registry.map((command) => command.id));
+    expect(uniqueIds.size).toBe(registry.length);
   });
 
   it("[SCN-S2-CMD-2] should filter by keyword and recover full list for empty query", () => {
-    expect(filterSlashCommands(SLASH_COMMAND_REGISTRY, "描写")).toEqual([
+    const registry = getSlashCommandRegistry();
+    expect(filterSlashCommands(registry, "describe")).toEqual([
       expect.objectContaining({ id: "describe" }),
     ]);
 
-    expect(filterSlashCommands(SLASH_COMMAND_REGISTRY, "  ")).toEqual(
-      SLASH_COMMAND_REGISTRY,
-    );
+    expect(filterSlashCommands(registry, "  ")).toEqual(registry);
   });
 
   it("[SCN-S2-CMD-3] should route execution by command id without triggering non-target executors", () => {

--- a/apps/desktop/renderer/src/features/editor/slashCommands.ts
+++ b/apps/desktop/renderer/src/features/editor/slashCommands.ts
@@ -1,3 +1,5 @@
+import { i18n } from "../../i18n";
+
 export type SlashCommandId =
   | "continueWriting"
   | "describe"
@@ -13,44 +15,60 @@ export interface SlashCommandDefinition {
   keywords: string[];
 }
 
-export const SLASH_COMMAND_REGISTRY: SlashCommandDefinition[] = [
+export function getSlashCommandRegistry(): SlashCommandDefinition[] {
+  return [
+    {
+      id: "continueWriting",
+      label: i18n.t("editor.slash.continue.label"),
+      description: i18n.t("editor.slash.continue.description"),
+      keywords: ["续写", "continue", "write"],
+    },
+    {
+      id: "describe",
+      label: i18n.t("editor.slash.describe.label"),
+      description: i18n.t("editor.slash.describe.description"),
+      keywords: ["描写", "description", "describe"],
+    },
+    {
+      id: "dialogue",
+      label: i18n.t("editor.slash.dialogue.label"),
+      description: i18n.t("editor.slash.dialogue.description"),
+      keywords: ["对白", "dialogue", "conversation"],
+    },
+    {
+      id: "character",
+      label: i18n.t("editor.slash.character.label"),
+      description: i18n.t("editor.slash.character.description"),
+      keywords: ["角色", "character", "persona"],
+    },
+    {
+      id: "outline",
+      label: i18n.t("editor.slash.outline.label"),
+      description: i18n.t("editor.slash.outline.description"),
+      keywords: ["大纲", "outline", "structure"],
+    },
+    {
+      id: "search",
+      label: i18n.t("editor.slash.search.label"),
+      description: i18n.t("editor.slash.search.description"),
+      keywords: ["搜索", "search", "find"],
+    },
+  ];
+}
+
+/**
+ * @deprecated Use getSlashCommandRegistry() for i18n-aware labels.
+ * Kept as a lazy alias for callers that still reference SLASH_COMMAND_REGISTRY.
+ */
+export const SLASH_COMMAND_REGISTRY: SlashCommandDefinition[] = new Proxy(
+  [] as SlashCommandDefinition[],
   {
-    id: "continueWriting",
-    label: "/续写",
-    description: "基于当前光标附近上下文继续创作。",
-    keywords: ["续写", "continue", "write"],
+    get(_target, prop, receiver) {
+      const live = getSlashCommandRegistry();
+      return Reflect.get(live, prop, receiver);
+    },
   },
-  {
-    id: "describe",
-    label: "/描写",
-    description: "扩展场景细节与氛围描写。",
-    keywords: ["描写", "description", "describe"],
-  },
-  {
-    id: "dialogue",
-    label: "/对白",
-    description: "生成角色间自然对话。",
-    keywords: ["对白", "dialogue", "conversation"],
-  },
-  {
-    id: "character",
-    label: "/角色",
-    description: "补充角色设定与人物动机。",
-    keywords: ["角色", "character", "persona"],
-  },
-  {
-    id: "outline",
-    label: "/大纲",
-    description: "整理章节结构与叙事节奏。",
-    keywords: ["大纲", "outline", "structure"],
-  },
-  {
-    id: "search",
-    label: "/搜索",
-    description: "检索项目中的相关信息。",
-    keywords: ["搜索", "search", "find"],
-  },
-];
+);
 
 export function filterSlashCommands(
   commands: SlashCommandDefinition[],

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryContainer.tsx
@@ -45,13 +45,13 @@ function mapActorToAuthorType(
 function getAuthorName(actor: "user" | "auto" | "ai"): string {
   switch (actor) {
     case "user":
-      return "You";
+      return i18n.t("versionHistory.container.author.you");
     case "ai":
-      return "AI";
+      return i18n.t("versionHistory.container.author.ai");
     case "auto":
-      return "Auto";
+      return i18n.t("versionHistory.container.author.auto");
     default:
-      return "Unknown";
+      return i18n.t("versionHistory.container.author.unknown");
   }
 }
 
@@ -67,10 +67,10 @@ export function formatTimestamp(
   const hours = Math.floor(diff / 3600000);
 
   if (minutes < 1) {
-    return "Just now";
+    return i18n.t("versionHistory.container.timeGroup.justNow");
   }
   if (minutes < 60) {
-    return `${minutes}m ago`;
+    return i18n.t("versionHistory.container.timeGroup.minutesAgo", { minutes });
   }
   if (hours < 24) {
     const date = new Date(createdAt);
@@ -101,12 +101,12 @@ function getTimeGroupLabel(createdAt: number): string {
     date.getFullYear() === yesterday.getFullYear();
 
   if (isToday) {
-    return "Today";
+    return "today";
   }
   if (isYesterday) {
-    return "Yesterday";
+    return "yesterday";
   }
-  return "Earlier";
+  return "earlier";
 }
 
 /**
@@ -168,19 +168,23 @@ function convertToTimeGroups(
   }
 
   // Sort groups: Today first, then Yesterday, then Earlier
-  const order = ["Today", "Yesterday", "Earlier"];
+  const TIME_GROUP_KEY_TO_I18N: Record<string, string> = {
+    today: "versionHistory.container.timeGroup.today",
+    yesterday: "versionHistory.container.timeGroup.yesterday",
+    earlier: "versionHistory.container.timeGroup.earlier",
+  };
+  const order = ["today", "yesterday", "earlier"];
   const groups: TimeGroup[] = [];
 
-  for (const label of order) {
-    const versions = groupMap.get(label);
+  for (const key of order) {
+    const versions = groupMap.get(key);
     if (versions && versions.length > 0) {
-      groups.push({ label, versions });
+      groups.push({ label: i18n.t(TIME_GROUP_KEY_TO_I18N[key]), versions });
     }
   }
 
   return groups;
 }
-
 
 type ConflictFormEntry = {
   resolution: "ours" | "theirs" | "manual";
@@ -190,11 +194,15 @@ type ConflictFormEntry = {
 function BranchConflictItem(props: {
   conflict: BranchMergeConflict;
   selected: ConflictFormEntry;
-  onResolutionChange: (conflictId: string, resolution: "ours" | "theirs" | "manual") => void;
+  onResolutionChange: (
+    conflictId: string,
+    resolution: "ours" | "theirs" | "manual",
+  ) => void;
   onManualTextChange: (conflictId: string, manualText: string) => void;
   t: ReturnType<typeof useTranslation>["t"];
 }): JSX.Element {
-  const { conflict, selected, onResolutionChange, onManualTextChange, t } = props;
+  const { conflict, selected, onResolutionChange, onManualTextChange, t } =
+    props;
   return (
     <div
       key={conflict.conflictId}
@@ -202,12 +210,14 @@ function BranchConflictItem(props: {
       className="space-y-2 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-2"
     >
       <div className="text-[11px] text-[var(--color-fg-muted)]">
-        {t('versionHistory.container.conflictNumber', { number: conflict.index + 1 })}
+        {t("versionHistory.container.conflictNumber", {
+          number: conflict.index + 1,
+        })}
       </div>
       <div className="grid grid-cols-1 gap-2 text-xs text-[var(--color-fg-default)]">
         <div>
           <div className="text-[11px] text-[var(--color-fg-muted)]">
-            {t('versionHistory.container.base')}
+            {t("versionHistory.container.base")}
           </div>
           <pre className="whitespace-pre-wrap font-mono text-xs">
             {conflict.baseText}
@@ -215,7 +225,7 @@ function BranchConflictItem(props: {
         </div>
         <div>
           <div className="text-[11px] text-[var(--color-fg-muted)]">
-            {t('versionHistory.container.ours')}
+            {t("versionHistory.container.ours")}
           </div>
           <pre className="whitespace-pre-wrap font-mono text-xs">
             {conflict.oursText}
@@ -223,7 +233,7 @@ function BranchConflictItem(props: {
         </div>
         <div>
           <div className="text-[11px] text-[var(--color-fg-muted)]">
-            {t('versionHistory.container.theirs')}
+            {t("versionHistory.container.theirs")}
           </div>
           <pre className="whitespace-pre-wrap font-mono text-xs">
             {conflict.theirsText}
@@ -237,22 +247,18 @@ function BranchConflictItem(props: {
             type="radio"
             name={`resolution-${conflict.conflictId}`}
             checked={selected.resolution === "ours"}
-            onChange={() =>
-              onResolutionChange(conflict.conflictId, "ours")
-            }
+            onChange={() => onResolutionChange(conflict.conflictId, "ours")}
           />
-          {t('versionHistory.container.useOurs')}
+          {t("versionHistory.container.useOurs")}
         </label>
         <label className="inline-flex items-center gap-1">
           <input
             type="radio"
             name={`resolution-${conflict.conflictId}`}
             checked={selected.resolution === "theirs"}
-            onChange={() =>
-              onResolutionChange(conflict.conflictId, "theirs")
-            }
+            onChange={() => onResolutionChange(conflict.conflictId, "theirs")}
           />
-          {t('versionHistory.container.useTheirs')}
+          {t("versionHistory.container.useTheirs")}
         </label>
         <label className="inline-flex items-center gap-1">
           <input
@@ -260,11 +266,9 @@ function BranchConflictItem(props: {
             type="radio"
             name={`resolution-${conflict.conflictId}`}
             checked={selected.resolution === "manual"}
-            onChange={() =>
-              onResolutionChange(conflict.conflictId, "manual")
-            }
+            onChange={() => onResolutionChange(conflict.conflictId, "manual")}
           />
-          {t('versionHistory.container.useManual')}
+          {t("versionHistory.container.useManual")}
         </label>
       </div>
       {selected.resolution === "manual" ? (
@@ -273,10 +277,7 @@ function BranchConflictItem(props: {
           className="h-20 w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-raised)] p-2 font-mono text-xs text-[var(--color-fg-default)]"
           value={selected.manualText}
           onChange={(event) =>
-            onManualTextChange(
-              conflict.conflictId,
-              event.target.value,
-            )
+            onManualTextChange(conflict.conflictId, event.target.value)
           }
         />
       ) : null}
@@ -291,7 +292,10 @@ function useConflictResolution(
   resolveBranchConflict: VersionStoreActions["resolveBranchConflict"],
 ): {
   conflictForm: Record<string, ConflictFormEntry>;
-  handleResolutionChange: (conflictId: string, resolution: "ours" | "theirs" | "manual") => void;
+  handleResolutionChange: (
+    conflictId: string,
+    resolution: "ours" | "theirs" | "manual",
+  ) => void;
   handleManualTextChange: (conflictId: string, manualText: string) => void;
   hasInvalidManualResolution: boolean;
   handleResolveConflicts: () => Promise<void>;
@@ -460,14 +464,18 @@ export function VersionHistoryContainer(
   const [currentHash, setCurrentHash] = React.useState<string | null>(null);
   const [sourceBranchName, setSourceBranchName] = React.useState("alt-ending");
   const [targetBranchName, setTargetBranchName] = React.useState("main");
-const {
-  conflictForm,
-  handleResolutionChange,
-  handleManualTextChange,
-  hasInvalidManualResolution,
-  handleResolveConflicts,
-} = useConflictResolution(mergeConflicts, documentId, mergeSessionId, resolveBranchConflict);
-
+  const {
+    conflictForm,
+    handleResolutionChange,
+    handleManualTextChange,
+    hasInvalidManualResolution,
+    handleResolveConflicts,
+  } = useConflictResolution(
+    mergeConflicts,
+    documentId,
+    mergeSessionId,
+    resolveBranchConflict,
+  );
 
   // Fetch version list when documentId changes
   React.useEffect(() => {
@@ -556,12 +564,13 @@ const {
       if (!documentId) return;
 
       const item = items.find((candidate) => candidate.versionId === versionId);
-      const timestamp = item ? formatTimestamp(item.createdAt) : t("versionHistory.container.history");
+      const timestamp = item
+        ? formatTimestamp(item.createdAt)
+        : t("versionHistory.container.history");
       void startPreview(documentId, { versionId, timestamp });
     },
     [documentId, items, startPreview, t],
   );
-
 
   const handleMergeBranches = React.useCallback(async () => {
     if (!documentId) {
@@ -580,14 +589,10 @@ const {
     });
   }, [documentId, mergeBranch, sourceBranchName, targetBranchName]);
 
-
-
-
-
   if (!documentId) {
     return (
       <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-        {t('versionHistory.container.openDocumentToViewHistory')}
+        {t("versionHistory.container.openDocumentToViewHistory")}
       </div>
     );
   }
@@ -595,7 +600,7 @@ const {
   if (status === "loading") {
     return (
       <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-        Loading versions...
+        {t("versionHistory.container.loadingVersions")}
       </div>
     );
   }
@@ -603,7 +608,7 @@ const {
   if (status === "error") {
     return (
       <div className="p-3 text-xs text-[var(--color-error)]">
-        {t('versionHistory.container.failedToLoadHistory')}
+        {t("versionHistory.container.failedToLoadHistory")}
       </div>
     );
   }
@@ -611,7 +616,7 @@ const {
   if (items.length === 0) {
     return (
       <div className="p-3 text-xs text-[var(--color-fg-muted)]">
-        {t('versionHistory.container.noVersionsYet')}
+        {t("versionHistory.container.noVersionsYet")}
       </div>
     );
   }
@@ -630,11 +635,11 @@ const {
       />
       <div className="mx-3 mt-3 space-y-2 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-raised)] p-3">
         <div className="text-xs font-semibold text-[var(--color-fg-default)]">
-          {t('versionHistory.container.branchMerge')}
+          {t("versionHistory.container.branchMerge")}
         </div>
         <div className="grid grid-cols-1 gap-2">
           <label className="flex flex-col gap-1 text-[11px] text-[var(--color-fg-muted)]">
-            {t('versionHistory.container.sourceBranch')}
+            {t("versionHistory.container.sourceBranch")}
             <input
               data-testid="branch-merge-source-input"
               className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2 py-1 text-xs text-[var(--color-fg-default)]"
@@ -643,7 +648,7 @@ const {
             />
           </label>
           <label className="flex flex-col gap-1 text-[11px] text-[var(--color-fg-muted)]">
-            {t('versionHistory.container.targetBranch')}
+            {t("versionHistory.container.targetBranch")}
             <input
               data-testid="branch-merge-target-input"
               className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2 py-1 text-xs text-[var(--color-fg-default)]"
@@ -663,11 +668,13 @@ const {
             targetBranchName.trim().length === 0
           }
         >
-          {branchMergeStatus === "loading" ? t('versionHistory.container.merging') : t('versionHistory.container.mergeBranches')}
+          {branchMergeStatus === "loading"
+            ? t("versionHistory.container.merging")
+            : t("versionHistory.container.mergeBranches")}
         </button>
         {branchMergeStatus === "ready" ? (
           <div className="text-[11px] text-[var(--color-success)]">
-            {t('versionHistory.container.branchMergeCompleted')}
+            {t("versionHistory.container.branchMergeCompleted")}
           </div>
         ) : null}
         {branchMergeStatus === "error" && branchMergeError ? (
@@ -683,33 +690,33 @@ const {
         >
           <div className="flex items-center justify-between gap-2">
             <div className="text-xs font-semibold text-[var(--color-fg-default)]">
-              {t('versionHistory.container.mergeConflictDiff')}
+              {t("versionHistory.container.mergeConflictDiff")}
             </div>
             <button
               type="button"
               className="focus-ring rounded border border-[var(--color-border-default)] px-2 py-1 text-[11px] text-[var(--color-fg-muted)]"
               onClick={clearBranchMergeState}
             >
-              {t('versionHistory.container.dismiss')}
+              {t("versionHistory.container.dismiss")}
             </button>
           </div>
 
-{mergeConflicts.map((conflict) => {
-  const selected = conflictForm[conflict.conflictId] ?? {
-    resolution: "ours" as const,
-    manualText: "",
-  };
-  return (
-    <BranchConflictItem
-      key={conflict.conflictId}
-      conflict={conflict}
-      selected={selected}
-      onResolutionChange={handleResolutionChange}
-      onManualTextChange={handleManualTextChange}
-      t={t}
-    />
-  );
-})}
+          {mergeConflicts.map((conflict) => {
+            const selected = conflictForm[conflict.conflictId] ?? {
+              resolution: "ours" as const,
+              manualText: "",
+            };
+            return (
+              <BranchConflictItem
+                key={conflict.conflictId}
+                conflict={conflict}
+                selected={selected}
+                onResolutionChange={handleResolutionChange}
+                onManualTextChange={handleManualTextChange}
+                t={t}
+              />
+            );
+          })}
 
           <button
             type="button"
@@ -718,7 +725,7 @@ const {
             onClick={() => void handleResolveConflicts()}
             disabled={hasInvalidManualResolution}
           >
-            {t('versionHistory.container.submitConflictResolution')}
+            {t("versionHistory.container.submitConflictResolution")}
           </button>
         </div>
       ) : null}

--- a/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
+++ b/apps/desktop/renderer/src/features/version-history/VersionHistoryPanel.tsx
@@ -284,7 +284,11 @@ function VersionMeta({
       {affectedParagraphs !== undefined && affectedParagraphs > 0 && (
         <>
           {reason && <span className="opacity-40">·</span>}
-          <span>{t("versionHistory.panel.affectedParagraphs", { count: affectedParagraphs })}</span>
+          <span>
+            {t("versionHistory.panel.affectedParagraphs", {
+              count: affectedParagraphs,
+            })}
+          </span>
         </>
       )}
     </div>
@@ -348,6 +352,7 @@ function HoverActions({
   onCompare?: (id: string) => void;
   onPreview?: (id: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       className={[
@@ -369,7 +374,7 @@ function HoverActions({
         "duration-[var(--duration-fast)]",
       ].join(" ")}
     >
-      <Tooltip content="Restore">
+      <Tooltip content={t("versionHistory.panel.restore")}>
         <button
           type="button"
           onClick={() => onRestore?.(versionId)}
@@ -378,7 +383,7 @@ function HoverActions({
           <RestoreIcon />
         </button>
       </Tooltip>
-      <Tooltip content="Compare">
+      <Tooltip content={t("versionHistory.panel.compare")}>
         <button
           type="button"
           onClick={() => onCompare?.(versionId)}
@@ -387,7 +392,7 @@ function HoverActions({
           <CompareIcon />
         </button>
       </Tooltip>
-      <Tooltip content="Preview">
+      <Tooltip content={t("versionHistory.panel.preview")}>
         <button
           type="button"
           onClick={() => onPreview?.(versionId)}
@@ -527,7 +532,9 @@ function VersionCard({
           <span className="text-[var(--color-fg-placeholder)] font-medium">
             {version.wordChange.count === 0
               ? t("versionHistory.panel.wordsChanged", { value: "0" })
-              : t("versionHistory.panel.wordsChanged", { value: `${version.wordChange.type === "added" ? "+" : "-"}${version.wordChange.count}` })}
+              : t("versionHistory.panel.wordsChanged", {
+                  value: `${version.wordChange.type === "added" ? "+" : "-"}${version.wordChange.count}`,
+                })}
           </span>
         </div>
       </div>
@@ -558,7 +565,9 @@ function VersionCard({
       {version.affectedParagraphs !== undefined &&
         version.affectedParagraphs > 0 && (
           <div className="text-[10px] text-[var(--color-fg-placeholder)] mt-1 mb-1">
-            {t("versionHistory.panel.affectedParagraphs", { count: version.affectedParagraphs })}
+            {t("versionHistory.panel.affectedParagraphs", {
+              count: version.affectedParagraphs,
+            })}
           </div>
         )}
 
@@ -726,7 +735,7 @@ export function VersionHistoryPanelContent({
             type="button"
             onClick={onClose}
             className={`focus-ring ${closeButtonStyles}`}
-            aria-label={t('versionHistory.panel.closeAriaLabel')}
+            aria-label={t("versionHistory.panel.closeAriaLabel")}
           >
             <CloseIcon />
           </button>

--- a/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
+++ b/apps/desktop/renderer/src/features/version-history/useVersionCompare.ts
@@ -5,6 +5,7 @@
 import { useCallback, useState } from "react";
 import { useEditorStore } from "../../stores/editorStore";
 import { invoke } from "../../lib/ipcClient";
+import { i18n } from "../../i18n";
 
 export type CompareState = {
   status: "idle" | "loading" | "ready" | "error";
@@ -69,11 +70,15 @@ export function useVersionCompare() {
 
         setCompareState({
           status: "ready",
-          diffText: res.data.diffText || "No differences found.",
+          diffText:
+            res.data.diffText || i18n.t("versionHistory.compare.noDifferences"),
           aiMarked: res.data.aiMarked,
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Unknown error";
+        const message =
+          err instanceof Error
+            ? err.message
+            : i18n.t("versionHistory.compare.unknownError");
         setCompareState({
           status: "error",
           diffText: "",

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -118,7 +118,8 @@
       "italic": "Italic",
       "underline": "Underline",
       "aiPolish": "Polish",
-      "aiRewrite": "Rewrite"
+      "aiRewrite": "Rewrite",
+      "ai": "AI"
     },
     "bubbleMenu": {
       "link": "Link",
@@ -165,6 +166,33 @@
     "slashCommand": {
       "searchPlaceholder": "Search slash commands...",
       "noCommandsFound": "No commands found."
+    },
+    "confirmSwitchToDraft": "This document is final. Editing will switch it back to draft. Continue?",
+    "slash": {
+      "continue": {
+        "label": "/Continue",
+        "description": "Continue writing from cursor context."
+      },
+      "describe": {
+        "label": "/Describe",
+        "description": "Expand scene details and atmosphere."
+      },
+      "dialogue": {
+        "label": "/Dialogue",
+        "description": "Generate natural character dialogue."
+      },
+      "character": {
+        "label": "/Character",
+        "description": "Supplement character traits and motivations."
+      },
+      "outline": {
+        "label": "/Outline",
+        "description": "Organize chapter structure and narrative rhythm."
+      },
+      "search": {
+        "label": "/Search",
+        "description": "Search for relevant information in the project."
+      }
     }
   },
   "dashboard": {
@@ -782,7 +810,21 @@
       "useOurs": "ours",
       "useTheirs": "theirs",
       "useManual": "manual",
-      "submitConflictResolution": "Submit Conflict Resolution"
+      "submitConflictResolution": "Submit Conflict Resolution",
+      "author": {
+        "you": "You",
+        "ai": "AI",
+        "auto": "Auto",
+        "unknown": "Unknown"
+      },
+      "timeGroup": {
+        "justNow": "Just now",
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "earlier": "Earlier",
+        "minutesAgo": "{{minutes}}m ago"
+      },
+      "loadingVersions": "Loading versions..."
     },
     "panel": {
       "closeAriaLabel": "Close version history",
@@ -816,6 +858,10 @@
       "actorLabel": "Actor:",
       "timestampLabel": "Timestamp:",
       "reasonLabel": "Reason:"
+    },
+    "compare": {
+      "noDifferences": "No differences found.",
+      "unknownError": "Unknown error"
     }
   },
   "settings": {

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -118,7 +118,8 @@
       "italic": "斜体",
       "underline": "下划线",
       "aiPolish": "润色",
-      "aiRewrite": "改写"
+      "aiRewrite": "改写",
+      "ai": "AI"
     },
     "bubbleMenu": {
       "link": "链接",
@@ -165,6 +166,33 @@
     "slashCommand": {
       "searchPlaceholder": "搜索斜杠命令...",
       "noCommandsFound": "未找到命令。"
+    },
+    "confirmSwitchToDraft": "此文档已定稿。继续编辑将切换回草稿状态，确定继续？",
+    "slash": {
+      "continue": {
+        "label": "/续写",
+        "description": "基于当前光标附近上下文继续创作。"
+      },
+      "describe": {
+        "label": "/描写",
+        "description": "扩展场景细节与氛围描写。"
+      },
+      "dialogue": {
+        "label": "/对白",
+        "description": "生成角色间自然对话。"
+      },
+      "character": {
+        "label": "/角色",
+        "description": "补充角色设定与人物动机。"
+      },
+      "outline": {
+        "label": "/大纲",
+        "description": "整理章节结构与叙事节奏。"
+      },
+      "search": {
+        "label": "/搜索",
+        "description": "检索项目中的相关信息。"
+      }
     }
   },
   "dashboard": {
@@ -782,7 +810,21 @@
       "useOurs": "我方",
       "useTheirs": "对方",
       "useManual": "手动",
-      "submitConflictResolution": "提交冲突解决"
+      "submitConflictResolution": "提交冲突解决",
+      "author": {
+        "you": "你",
+        "ai": "AI",
+        "auto": "自动",
+        "unknown": "未知"
+      },
+      "timeGroup": {
+        "justNow": "刚刚",
+        "today": "今天",
+        "yesterday": "昨天",
+        "earlier": "更早",
+        "minutesAgo": "{{minutes}}分钟前"
+      },
+      "loadingVersions": "加载版本中..."
     },
     "panel": {
       "closeAriaLabel": "关闭版本历史",
@@ -816,6 +858,10 @@
       "actorLabel": "操作者：",
       "timestampLabel": "时间戳：",
       "reasonLabel": "原因："
+    },
+    "compare": {
+      "noDifferences": "未发现差异。",
+      "unknownError": "未知错误"
     }
   },
   "settings": {

--- a/apps/desktop/tests/i18n/a0-16-editor-version-slash-i18n.guard.test.ts
+++ b/apps/desktop/tests/i18n/a0-16-editor-version-slash-i18n.guard.test.ts
@@ -1,0 +1,162 @@
+/**
+ * A0-16 Guard: editor / version-history / slash-command i18n 收口
+ *
+ * 「巧妇难为无米之炊」—— 但有了 i18n 键，便不再有硬编码裸字符串。
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const RENDERER_SRC = resolve(CURRENT_DIR, "..", "..", "renderer", "src");
+const LOCALES_DIR = resolve(RENDERER_SRC, "i18n", "locales");
+
+function src(relativePath: string): string {
+  return readFileSync(resolve(RENDERER_SRC, relativePath), "utf8");
+}
+
+function locale(lang: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(LOCALES_DIR, `${lang}.json`), "utf8"));
+}
+
+function deepGet(obj: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((cur, key) => {
+    if (cur && typeof cur === "object")
+      return (cur as Record<string, unknown>)[key];
+    return undefined;
+  }, obj);
+}
+
+// ─── New keys introduced by A0-16 ──────────────────────────────────
+const A016_KEYS = [
+  // editor
+  "editor.contextMenu.ai",
+  "editor.confirmSwitchToDraft",
+  // slash commands (6 × 2)
+  "editor.slash.continue.label",
+  "editor.slash.continue.description",
+  "editor.slash.describe.label",
+  "editor.slash.describe.description",
+  "editor.slash.dialogue.label",
+  "editor.slash.dialogue.description",
+  "editor.slash.character.label",
+  "editor.slash.character.description",
+  "editor.slash.outline.label",
+  "editor.slash.outline.description",
+  "editor.slash.search.label",
+  "editor.slash.search.description",
+  // version history container
+  "versionHistory.container.author.you",
+  "versionHistory.container.author.ai",
+  "versionHistory.container.author.auto",
+  "versionHistory.container.author.unknown",
+  "versionHistory.container.timeGroup.justNow",
+  "versionHistory.container.timeGroup.today",
+  "versionHistory.container.timeGroup.yesterday",
+  "versionHistory.container.timeGroup.earlier",
+  "versionHistory.container.timeGroup.minutesAgo",
+  "versionHistory.container.loadingVersions",
+  // useVersionCompare
+  "versionHistory.compare.noDifferences",
+  "versionHistory.compare.unknownError",
+];
+
+// ─── 1. i18n key completeness ──────────────────────────────────────
+describe("A0-16: i18n key completeness", () => {
+  const en = locale("en");
+  const zhCN = locale("zh-CN");
+
+  for (const key of A016_KEYS) {
+    it(`en.json has key "${key}"`, () => {
+      expect(deepGet(en, key)).toBeDefined();
+      expect(typeof deepGet(en, key)).toBe("string");
+    });
+
+    it(`zh-CN.json has key "${key}"`, () => {
+      expect(deepGet(zhCN, key)).toBeDefined();
+      expect(typeof deepGet(zhCN, key)).toBe("string");
+    });
+  }
+
+  it("en and zh-CN have the same set of A0-16 keys", () => {
+    const enPresent = A016_KEYS.filter((k) => deepGet(en, k) !== undefined);
+    const zhPresent = A016_KEYS.filter((k) => deepGet(zhCN, k) !== undefined);
+    expect(enPresent).toEqual(zhPresent);
+  });
+});
+
+// ─── 2. Source scan: no hardcoded English in target files ──────────
+describe("A0-16: no hardcoded English strings remain", () => {
+  it("EditorPane.tsx: no bare 'Entity suggestions unavailable.'", () => {
+    const code = src("features/editor/EditorPane.tsx");
+    expect(code).not.toContain('"Entity suggestions unavailable."');
+  });
+
+  it("EditorPane.tsx: no bare 'This document is final. Editing will switch'", () => {
+    const code = src("features/editor/EditorPane.tsx");
+    expect(code).not.toContain(
+      "This document is final. Editing will switch it back to draft. Continue?",
+    );
+  });
+
+  it("EditorContextMenu.tsx: AI label uses t()", () => {
+    const code = src("features/editor/EditorContextMenu.tsx");
+    // Should not have bare "AI" as a ContextMenu.Label child
+    expect(code).not.toMatch(/>AI</);
+    expect(code).toMatch(/t\(["']editor\.contextMenu\.ai["']\)/);
+  });
+
+  it("slashCommands.ts: all labels and descriptions use t()", () => {
+    const code = src("features/editor/slashCommands.ts");
+    // No hardcoded Chinese slash labels
+    expect(code).not.toContain('"/续写"');
+    expect(code).not.toContain('"/描写"');
+    expect(code).not.toContain('"/对白"');
+    expect(code).not.toContain('"/角色"');
+    expect(code).not.toContain('"/大纲"');
+    expect(code).not.toContain('"/搜索"');
+    // No hardcoded Chinese descriptions
+    expect(code).not.toContain("基于当前光标附近上下文继续创作");
+    expect(code).not.toContain("扩展场景细节与氛围描写");
+    // Should reference i18n keys
+    expect(code).toMatch(/editor\.slash\.continue\.label/);
+    expect(code).toMatch(/editor\.slash\.search\.description/);
+  });
+
+  it("VersionHistoryContainer.tsx: author names use i18n", () => {
+    const code = src("features/version-history/VersionHistoryContainer.tsx");
+    // getAuthorName should not return bare English
+    expect(code).not.toMatch(/return\s+["']You["']/);
+    expect(code).not.toMatch(/return\s+["']Auto["']/);
+    expect(code).not.toMatch(/return\s+["']Unknown["']/);
+  });
+
+  it("VersionHistoryContainer.tsx: time group labels use i18n", () => {
+    const code = src("features/version-history/VersionHistoryContainer.tsx");
+    // getTimeGroupLabel should not return bare English
+    expect(code).not.toMatch(/return\s+["']Today["']/);
+    expect(code).not.toMatch(/return\s+["']Yesterday["']/);
+    expect(code).not.toMatch(/return\s+["']Earlier["']/);
+    expect(code).not.toMatch(/return\s+["']Just now["']/);
+  });
+
+  it("VersionHistoryContainer.tsx: 'Loading versions...' uses t()", () => {
+    const code = src("features/version-history/VersionHistoryContainer.tsx");
+    expect(code).not.toContain("Loading versions...");
+  });
+
+  it("VersionHistoryPanel.tsx: tooltip strings use t()", () => {
+    const code = src("features/version-history/VersionHistoryPanel.tsx");
+    // Tooltip content should not be bare English
+    expect(code).not.toMatch(/content="Restore"/);
+    expect(code).not.toMatch(/content="Compare"/);
+    expect(code).not.toMatch(/content="Preview"/);
+  });
+
+  it("useVersionCompare.ts: fallback strings use i18n", () => {
+    const code = src("features/version-history/useVersionCompare.ts");
+    expect(code).not.toMatch(/["']No differences found\.["']/);
+    expect(code).not.toMatch(/["']Unknown error["']/);
+  });
+});


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

A0-16 编辑器/版本/Slash i18n 核查：清理 editor、version history、slash command 区域的硬编码英文/中文字符串。

## 关联 Issue

- Closes #991

## 用户影响

- 编辑器确认对话框、右键菜单 AI 标签、Slash 命令、版本历史作者名/时间分组/加载提示、版本对比面板 — 全部走 i18n，用户切换语言后即刻生效。

## 不修最坏后果

- 用户切换语言后，编辑器区域仍显示硬编码的英文/中文字符串，体验割裂。

## 验证证据

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors, 691 warnings（全部为已有 warning）
- [x] `vitest run` — 270 files, 1853 tests passed
- [x] Guard test `a0-16-editor-version-slash-i18n.guard.test.ts` — 62 tests:
  - en/zh-CN 各 28 新键完整性
  - en/zh-CN 键对称
  - EditorPane 无裸字符串
  - EditorContextMenu AI label 走 t()
  - slashCommands 无硬编码中文
  - VersionHistoryContainer author/timeGroup/loading 走 i18n
  - VersionHistoryPanel tooltip 走 t()
  - useVersionCompare fallback 走 i18n

## 回滚点

- 回滚 commit: `c915d165`（main HEAD）
- 回滚后无数据影响，仅 UI 文案回退

## 非自动化检查（Tier 3）

- [x] **品牌调性**：slash 命令和版本历史文案保持简洁人话风格
- [ ] **字体渲染**：N/A — 无新增字体/样式组件
- [x] **CJK 场景**：i18n 同时维护 en.json 和 zh-CN.json

### 变更清单

| 文件 | 改动 |
|------|------|
| en.json | 新增 28+ 键（editor.contextMenu.ai, editor.confirmSwitchToDraft, editor.slash.\*, versionHistory.container.author.\*, versionHistory.container.timeGroup.\*, versionHistory.container.loadingVersions, versionHistory.compare.\*） |
| zh-CN.json | 同上对应中文 |
| EditorContextMenu.tsx | `AI` label → `t("editor.contextMenu.ai")` |
| EditorPane.tsx | entity unavailable message 改 null 兜底; confirm 对话框走 `t()` |
| slashCommands.ts | 6 命令 label/description 走 `i18n.t()`，`SLASH_COMMAND_REGISTRY` 改为 Proxy 向后兼容 |
| slashCommands.test.ts | 更新 label 期望值为英文 i18n 值 |
| VersionHistoryContainer.tsx | author names / time groups / loading 走 `i18n.t()` |
| VersionHistoryPanel.tsx | HoverActions tooltip 走 `t()` |
| useVersionCompare.ts | fallback strings 走 `i18n.t()` |
| a0-16-editor-version-slash-i18n.guard.test.ts | 新增 guard test（62 tests） |