### PR TITLE
fix(export): A0-19 导出能力标注对齐 (#998)

### DIFF
--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -1142,10 +1142,7 @@
       "markdownStructuredHint": "Structured Markdown · headings, lists, links",
       "txtBoundaryHint": "Plain text only · formatting removed",
       "plainText": "Plain Text",
-      "unsupported": "UNSUPPORTED",
-      "pdfPlainTextHint": "Plain text export · no formatting",
-      "docxPlainTextHint": "Plain text export · no formatting",
-      "plainTextOnly": "Plain text only"
+      "unsupported": "UNSUPPORTED"
     },
     "pageSize": {
       "letter": "Letter",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -1142,10 +1142,7 @@
       "markdownStructuredHint": "结构化 Markdown · 保留标题、列表、链接",
       "txtBoundaryHint": "纯文本导出 · 自动移除格式",
       "plainText": "纯文本",
-      "unsupported": "不支持",
-      "pdfPlainTextHint": "纯文本导出 · 不含格式",
-      "docxPlainTextHint": "纯文本导出 · 不含格式",
-      "plainTextOnly": "纯文本导出"
+      "unsupported": "不支持"
     },
     "pageSize": {
       "letter": "Letter",

--- a/apps/desktop/tests/unit/export-i18n-keys.test.ts
+++ b/apps/desktop/tests/unit/export-i18n-keys.test.ts
@@ -2,7 +2,17 @@ import { describe, it, expect } from "vitest";
 import en from "../../renderer/src/i18n/locales/en.json";
 import zhCN from "../../renderer/src/i18n/locales/zh-CN.json";
 
+/** Keys that ExportDialog actually uses for structured format hints */
 const REQUIRED_KEYS = [
+  "pdfStructuredHint",
+  "docxStructuredHint",
+  "markdownStructuredHint",
+  "txtBoundaryHint",
+  "plainText",
+] as const;
+
+/** Dead keys removed after A0-04 structured export replaced plain-text fallback */
+const REMOVED_KEYS = [
   "pdfPlainTextHint",
   "docxPlainTextHint",
   "plainTextOnly",
@@ -18,6 +28,16 @@ describe("export format i18n key completeness", () => {
     it(`zh-CN.json contains export.format.${key}`, () => {
       expect(zhCN.export.format).toHaveProperty(key);
       expect((zhCN.export.format as Record<string, string>)[key]).toBeTruthy();
+    });
+  }
+
+  for (const key of REMOVED_KEYS) {
+    it(`en.json no longer contains stale export.format.${key}`, () => {
+      expect(en.export.format).not.toHaveProperty(key);
+    });
+
+    it(`zh-CN.json no longer contains stale export.format.${key}`, () => {
+      expect(zhCN.export.format).not.toHaveProperty(key);
     });
   }
 


### PR DESCRIPTION
## Summary

A0-04（结构化导出）已合并后，ExportDialog 的格式标注已正确使用 `pdfStructuredHint` / `docxStructuredHint` / `markdownStructuredHint` / `txtBoundaryHint` 等 i18n key。

但旧的纯文本标注 key（`pdfPlainTextHint`、`docxPlainTextHint`、`plainTextOnly`）仍残留在 en.json 和 zh-CN.json 中，且 `tests/unit/export-i18n-keys.test.ts` 仍在断言这些已废弃 key 存在。

### Changes

1. **移除死 key**：从 en.json / zh-CN.json 删除 `pdfPlainTextHint`、`docxPlainTextHint`、`plainTextOnly`
2. **更新测试**：`export-i18n-keys.test.ts` 改为验证正确的结构化 key 存在，并断言旧 key 已不存在

### Validation

- `pnpm vitest run`: 1853 tests passed (270 files)
- `pnpm typecheck`: clean
- `pnpm lint`: 0 errors

Closes #998