### PR TITLE
feat(inline-ai): A0-12 Inline AI 基础实现 (#1004)

### DIFF
--- a/apps/desktop/renderer/src/config/shortcuts.ts
+++ b/apps/desktop/renderer/src/config/shortcuts.ts
@@ -112,6 +112,9 @@ export const EDITOR_SHORTCUTS = {
 
   // Save
   save: defineShortcut("save", "Save", "mod+S"),
+
+  // Inline AI
+  inlineAi: defineShortcut("inlineAi", "Inline AI", "mod+K"),
 } as const;
 
 // =============================================================================

--- a/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.test.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../stores/aiStore";
 import {
   EditorPane,
+  InlineAiOverlay,
   EDITOR_DOCUMENT_CHARACTER_LIMIT,
   LARGE_PASTE_THRESHOLD_CHARS,
   chunkLargePasteText,
@@ -41,6 +42,8 @@ import {
   shouldConfirmOverflowPaste,
   shouldWarnDocumentCapacity,
 } from "./EditorPane";
+import { createInlineAiStore } from "./inlineAiStore";
+import { captureSelectionRef } from "../ai/applySelection";
 
 function createReadyEditorStore(args: {
   onSave: (payload: {
@@ -147,6 +150,8 @@ function createPreferenceStub(
 
 function createAiStoreForEditorPaneTests(args: {
   onSkillRun?: (payload: IpcRequest<"ai:skill:run">) => void;
+  onPersistAiApply?: (payload: IpcRequest<"file:document:save">) => void;
+  outputText?: string;
 }) {
   const invoke: IpcInvoke = async <C extends IpcChannel>(
     channel: C,
@@ -159,7 +164,18 @@ function createAiStoreForEditorPaneTests(args: {
         data: {
           executionId: "run-s2-bubble-ai",
           runId: "run-s2-bubble-ai",
-          outputText: "mock-output",
+          outputText: args.outputText ?? "mock-output",
+        },
+      } as IpcInvokeResult<C>;
+    }
+
+    if (channel === "file:document:save") {
+      args.onPersistAiApply?.(payload as IpcRequest<"file:document:save">);
+      return {
+        ok: true,
+        data: {
+          contentHash: "hash-ai-apply",
+          updatedAt: 202,
         },
       } as IpcInvokeResult<C>;
     }
@@ -388,6 +404,103 @@ describe("EditorPane", () => {
       ).not.toBeInTheDocument();
     });
     expect(screen.queryByTestId("bubble-ai-polish")).not.toBeInTheDocument();
+  });
+
+  it("A0-12 should run inline ai via aiStore and persist AI apply on accept", async () => {
+    const skillRuns: IpcRequest<"ai:skill:run">[] = [];
+    const aiApplySaves: IpcRequest<"file:document:save">[] = [];
+    const store = createReadyEditorStore({ onSave: () => {} });
+    const versionStore = createVersionStoreForEditorPaneTests();
+    const aiStore = createAiStoreForEditorPaneTests({
+      onSkillRun: (payload) => {
+        skillRuns.push(payload);
+      },
+      onPersistAiApply: (payload) => {
+        aiApplySaves.push(payload);
+      },
+      outputText: "Inline rewrite result",
+    });
+
+    render(
+      <AiStoreProvider store={aiStore}>
+        <VersionStoreProvider store={versionStore}>
+          <EditorStoreProvider store={store}>
+            <EditorPane projectId="project-1" />
+          </EditorStoreProvider>
+        </VersionStoreProvider>
+      </AiStoreProvider>,
+    );
+
+    await screen.findByTestId("editor-pane");
+    await screen.findByTestId("tiptap-editor");
+
+    const editor = await waitForEditorInstance(store);
+    const inlineStore = createInlineAiStore();
+
+    let capturedSelection: ReturnType<typeof captureSelectionRef> | null = null;
+    act(() => {
+      editor.commands.focus("start");
+      editor.commands.setTextSelection({ from: 1, to: 8 });
+      capturedSelection = captureSelectionRef(editor);
+      if (!capturedSelection.ok) {
+        throw new Error("expected non-empty selection");
+      }
+      inlineStore.getState().openInput({
+        from: capturedSelection.data.selectionRef.range.from,
+        to: capturedSelection.data.selectionRef.range.to,
+        text: capturedSelection.data.selectionText,
+        selectionTextHash:
+          capturedSelection.data.selectionRef.selectionTextHash,
+      });
+    });
+
+    render(
+      <AiStoreProvider store={aiStore}>
+        <InlineAiOverlay
+          inlineAiStore={inlineStore}
+          editor={editor}
+          projectId="project-1"
+          documentId="doc-1"
+        />
+      </AiStoreProvider>,
+    );
+
+    const input = await screen.findByTestId("inline-ai-instruction-input");
+    fireEvent.change(input, { target: { value: "Rewrite formally" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(skillRuns).toHaveLength(1);
+    });
+
+    expect(skillRuns[0]).toMatchObject({
+      skillId: "builtin:rewrite",
+      context: {
+        projectId: "project-1",
+        documentId: "doc-1",
+      },
+    });
+    expect(skillRuns[0]?.input).toContain(`Selection context:
+Initial`);
+    expect(skillRuns[0]?.input).toContain("Rewrite formally");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inline-ai-accept-btn")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("inline-ai-accept-btn"));
+
+    await waitFor(() => {
+      expect(aiApplySaves).toHaveLength(1);
+    });
+
+    expect(aiApplySaves[0]).toMatchObject({
+      actor: "ai",
+      reason: "ai-accept",
+      projectId: "project-1",
+      documentId: "doc-1",
+    });
+    expect(editor.getText()).toBe("Inline rewrite result");
   });
 
   it("S2-BA-2 should trigger mapped skill with selection text and selection reference when clicking Bubble AI item", async () => {

--- a/apps/desktop/renderer/src/features/editor/EditorPane.tsx
+++ b/apps/desktop/renderer/src/features/editor/EditorPane.tsx
@@ -7,7 +7,10 @@ import Link from "@tiptap/extension-link";
 import BubbleMenuExtension from "@tiptap/extension-bubble-menu";
 import type { IpcResponseData } from "@shared/types/ipc-generated";
 
-import { useOptionalAiStore } from "../../stores/aiStore";
+import {
+  useOptionalAiStore,
+  useOptionalAiStoreApi,
+} from "../../stores/aiStore";
 import {
   useEditorStore,
   type EntityCompletionSession,
@@ -42,6 +45,14 @@ import {
 } from "./typography";
 import { buildAiStreamUndoCheckpoint, undoAiStream } from "./aiStreamUndo";
 import type { AiStreamCheckpoint } from "./aiStreamUndo";
+import {
+  createInlineAiStore,
+  type SelectionRef as InlineAiSelectionRef,
+  type UseInlineAiStore,
+} from "./inlineAiStore";
+import { InlineAiInput } from "./InlineAiInput";
+import { InlineAiDiffPreview } from "./InlineAiDiffPreview";
+import { applySelection, captureSelectionRef } from "../ai/applySelection";
 
 const IS_VITEST_RUNTIME =
   typeof process !== "undefined" && Boolean(process.env.VITEST);
@@ -1086,9 +1097,17 @@ function useEditorPaneCore(projectId: string) {
     suppressRef: suppressAutosaveRef,
   });
 
+  // --- Inline AI store ---
+  const inlineAiStoreRef = React.useRef<UseInlineAiStore | null>(null);
+  if (!inlineAiStoreRef.current) {
+    inlineAiStoreRef.current = createInlineAiStore();
+  }
+  const inlineAiStore = inlineAiStoreRef.current;
+
   return {
     t,
     bootstrapStatus,
+    projectId,
     documentId,
     documentStatus,
     contentReady,
@@ -1111,7 +1130,195 @@ function useEditorPaneCore(projectId: string) {
     aiStatus,
     onWriteClick,
     zenMode,
+    inlineAiStore,
   };
+}
+
+function buildInlineAiRequestInput(
+  selectionText: string,
+  instruction: string,
+): string {
+  return `Selection context:
+${selectionText}
+
+${instruction}`.trim();
+}
+
+async function runInlineAiRequest(args: {
+  inlineAiStore: UseInlineAiStore;
+  selectionRef: InlineAiSelectionRef | null;
+  instruction: string;
+  projectId: string | null;
+  documentId: string | null;
+  aiRun:
+    | ((args?: {
+        inputOverride?: string;
+        context?: { projectId?: string; documentId?: string };
+        streamOverride?: boolean;
+      }) => Promise<void>)
+    | null;
+  aiSetSelectedSkillId: ((skillId: string) => void) | null;
+  aiStoreApi: ReturnType<typeof useOptionalAiStoreApi>;
+}): Promise<void> {
+  const {
+    inlineAiStore,
+    selectionRef,
+    instruction,
+    projectId,
+    documentId,
+    aiRun,
+    aiSetSelectedSkillId,
+    aiStoreApi,
+  } = args;
+  if (
+    !selectionRef ||
+    !projectId ||
+    !documentId ||
+    !aiRun ||
+    !aiSetSelectedSkillId ||
+    !aiStoreApi
+  ) {
+    inlineAiStore.getState().setError();
+    return;
+  }
+
+  inlineAiStore.getState().submitInstruction(instruction);
+  aiSetSelectedSkillId("builtin:rewrite");
+  await aiRun({
+    inputOverride: buildInlineAiRequestInput(selectionRef.text, instruction),
+    context: { projectId, documentId },
+    streamOverride: false,
+  });
+
+  const aiState = aiStoreApi.getState();
+  if (aiState.status === "error" || aiState.lastError) {
+    inlineAiStore.getState().setError();
+    return;
+  }
+
+  if (aiState.outputText.trim().length === 0) {
+    inlineAiStore.getState().setError();
+    return;
+  }
+
+  inlineAiStore.getState().setReady(aiState.outputText);
+}
+
+export function InlineAiOverlay(props: {
+  inlineAiStore: UseInlineAiStore;
+  editor: ReturnType<typeof useEditor>;
+  projectId: string | null;
+  documentId: string | null;
+}): JSX.Element | null {
+  const { inlineAiStore, editor, projectId, documentId } = props;
+  const aiStoreApi = useOptionalAiStoreApi();
+  const aiRun = useOptionalAiStore((s) => s.run);
+  const aiSetSelectedSkillId = useOptionalAiStore((s) => s.setSelectedSkillId);
+  const aiPersistApply = useOptionalAiStore((s) => s.persistAiApply);
+  const aiCancel = useOptionalAiStore((s) => s.cancel);
+  const aiLastRunId = useOptionalAiStore((s) => s.lastRunId);
+  const phase = inlineAiStore((s) => s.phase);
+  const selectionRef = inlineAiStore((s) => s.selectionRef);
+  const result = inlineAiStore((s) => s.result);
+  const instruction = inlineAiStore((s) => s.instruction);
+
+  if (phase === "input") {
+    return (
+      <div className="absolute inset-x-0 bottom-0 flex justify-center">
+        <InlineAiInput
+          onSubmit={(nextInstruction) => {
+            void runInlineAiRequest({
+              inlineAiStore,
+              selectionRef,
+              instruction: nextInstruction,
+              projectId,
+              documentId,
+              aiRun,
+              aiSetSelectedSkillId,
+              aiStoreApi,
+            });
+          }}
+          onDismiss={() => {
+            inlineAiStore.getState().dismiss();
+          }}
+        />
+      </div>
+    );
+  }
+
+  if ((phase === "streaming" || phase === "ready") && selectionRef) {
+    return (
+      <div className="absolute inset-x-4 top-4">
+        <InlineAiDiffPreview
+          phase={phase}
+          originalText={selectionRef.text}
+          suggestedText={result ?? ""}
+          onAccept={() => {
+            if (
+              !editor ||
+              !selectionRef ||
+              !result ||
+              !projectId ||
+              !documentId ||
+              !aiPersistApply ||
+              !aiStoreApi
+            ) {
+              inlineAiStore.getState().setError();
+              return;
+            }
+            const applied = applySelection({
+              editor,
+              selectionRef: {
+                range: { from: selectionRef.from, to: selectionRef.to },
+                selectionTextHash: selectionRef.selectionTextHash,
+              },
+              replacementText: result,
+            });
+            if (!applied.ok) {
+              inlineAiStore.getState().setError();
+              return;
+            }
+            void aiPersistApply({
+              projectId,
+              documentId,
+              contentJson: JSON.stringify(editor.getJSON()),
+              runId: aiLastRunId ?? "inline-ai",
+            }).then(() => {
+              if (aiStoreApi.getState().applyStatus === "applied") {
+                inlineAiStore.getState().accept();
+                return;
+              }
+              inlineAiStore.getState().setError();
+            });
+          }}
+          onReject={() => {
+            if (phase === "streaming" && aiCancel) {
+              void aiCancel();
+            }
+            inlineAiStore.getState().reject();
+          }}
+          onRegenerate={() => {
+            if (!instruction) {
+              inlineAiStore.getState().setError();
+              return;
+            }
+            void runInlineAiRequest({
+              inlineAiStore,
+              selectionRef,
+              instruction,
+              projectId,
+              documentId,
+              aiRun,
+              aiSetSelectedSkillId,
+              aiStoreApi,
+            });
+          }}
+        />
+      </div>
+    );
+  }
+
+  return null;
 }
 
 /**
@@ -1120,6 +1327,30 @@ function useEditorPaneCore(projectId: string) {
 export function EditorPane(props: { projectId: string }): JSX.Element {
   const core = useEditorPaneCore(props.projectId);
   const zenMode = core.zenMode;
+  const inlineAiPhase = core.inlineAiStore((s) => s.phase);
+
+  // Cmd/Ctrl+K: Inline AI — only when text is selected, not in zen mode
+  useHotkey(
+    "editor:inline-ai",
+    { key: "k", modKey: true },
+    React.useCallback(() => {
+      if (zenMode) return;
+      if (!core.editor) return;
+      const captured = captureSelectionRef(core.editor);
+      if (!captured.ok) return;
+      const selectedText = captured.data.selectionText.trim();
+      if (selectedText.length === 0) return;
+      if (inlineAiPhase !== "idle") return;
+      core.inlineAiStore.getState().openInput({
+        from: captured.data.selectionRef.range.from,
+        to: captured.data.selectionRef.range.to,
+        text: selectedText,
+        selectionTextHash: captured.data.selectionRef.selectionTextHash,
+      });
+    }, [zenMode, core.editor, inlineAiPhase, core.inlineAiStore]),
+    "editor",
+    10,
+  );
 
   if (core.bootstrapStatus !== "ready") {
     return (
@@ -1269,6 +1500,12 @@ export function EditorPane(props: { projectId: string }): JSX.Element {
           }
           running={isAiRunning(core.aiStatus)}
           onClick={() => void core.onWriteClick()}
+        />
+        <InlineAiOverlay
+          inlineAiStore={core.inlineAiStore}
+          editor={core.editor}
+          projectId={core.projectId}
+          documentId={core.documentId}
         />
       </div>
     </div>

--- a/apps/desktop/renderer/src/features/editor/InlineAi.test.tsx
+++ b/apps/desktop/renderer/src/features/editor/InlineAi.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { createInlineAiStore, type InlineAiStore } from "./inlineAiStore";
+import { InlineAiInput } from "./InlineAiInput";
+import { InlineAiDiffPreview } from "./InlineAiDiffPreview";
+import { EDITOR_SHORTCUTS } from "../../config/shortcuts";
+
+// ---------------------------------------------------------------------------
+// 1. Shortcut registration
+// ---------------------------------------------------------------------------
+
+describe("EDITOR_SHORTCUTS.inlineAi", () => {
+  it("registers mod+K shortcut", () => {
+    expect(EDITOR_SHORTCUTS.inlineAi).toBeDefined();
+    expect(EDITOR_SHORTCUTS.inlineAi.keys).toBe("mod+K");
+    expect(EDITOR_SHORTCUTS.inlineAi.id).toBe("inlineAi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. inlineAiStore state machine
+// ---------------------------------------------------------------------------
+
+describe("inlineAiStore", () => {
+  let store: ReturnType<typeof createInlineAiStore>;
+  const get = (): InlineAiStore => store.getState();
+
+  beforeEach(() => {
+    store = createInlineAiStore();
+  });
+
+  it("starts in idle phase", () => {
+    expect(get().phase).toBe("idle");
+    expect(get().selectionRef).toBeNull();
+  });
+
+  it("openInput transitions from idle to input with selectionRef", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    expect(get().phase).toBe("input");
+    expect(get().selectionRef).toEqual({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+  });
+
+  it("dismiss resets to idle from input", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().dismiss();
+    expect(get().phase).toBe("idle");
+    expect(get().selectionRef).toBeNull();
+  });
+
+  it("submitInstruction transitions from input to streaming", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("make it better");
+    expect(get().phase).toBe("streaming");
+    expect(get().instruction).toBe("make it better");
+    expect(get().result).toBe("");
+  });
+
+  it("appendChunk accumulates result text", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().appendChunk("Hi");
+    get().appendChunk(" there");
+    expect(get().result).toBe("Hi there");
+  });
+
+  it("setReady transitions from streaming to ready", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().setReady("Hi there");
+    expect(get().phase).toBe("ready");
+    expect(get().result).toBe("Hi there");
+  });
+
+  it("accept resets to idle", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().setReady("Hi there");
+    get().accept();
+    expect(get().phase).toBe("idle");
+  });
+
+  it("reject resets to idle", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().setReady("Hi there");
+    get().reject();
+    expect(get().phase).toBe("idle");
+  });
+
+  it("regenerate transitions back to streaming from ready", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().setReady("Hi there");
+    get().regenerate();
+    expect(get().phase).toBe("streaming");
+    expect(get().result).toBe("");
+    expect(get().instruction).toBe("improve");
+  });
+
+  it("setError resets to idle", () => {
+    get().openInput({
+      from: 0,
+      to: 5,
+      text: "hello",
+      selectionTextHash: "hash",
+    });
+    get().submitInstruction("improve");
+    get().setError();
+    expect(get().phase).toBe("idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. InlineAiInput component
+// ---------------------------------------------------------------------------
+
+describe("InlineAiInput", () => {
+  it("renders with placeholder and autoFocus", () => {
+    render(<InlineAiInput onSubmit={vi.fn()} onDismiss={vi.fn()} />);
+    const input = screen.getByTestId("inline-ai-instruction-input");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("placeholder", "Ask AI to edit...");
+  });
+
+  it("calls onSubmit with instruction on Enter when input is non-empty", () => {
+    const onSubmit = vi.fn();
+    render(<InlineAiInput onSubmit={onSubmit} onDismiss={vi.fn()} />);
+    const input = screen.getByTestId("inline-ai-instruction-input");
+    fireEvent.change(input, { target: { value: "Improve tone" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("Improve tone");
+  });
+
+  it("does not call onSubmit when input is empty on Enter", () => {
+    const onSubmit = vi.fn();
+    render(<InlineAiInput onSubmit={onSubmit} onDismiss={vi.fn()} />);
+    const input = screen.getByTestId("inline-ai-instruction-input");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("calls onDismiss on Escape", () => {
+    const onDismiss = vi.fn();
+    render(<InlineAiInput onSubmit={vi.fn()} onDismiss={onDismiss} />);
+    const input = screen.getByTestId("inline-ai-instruction-input");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. InlineAiDiffPreview component
+// ---------------------------------------------------------------------------
+
+describe("InlineAiDiffPreview", () => {
+  const defaultProps = {
+    phase: "ready" as const,
+    originalText: "hello world",
+    suggestedText: "hello universe",
+    onAccept: vi.fn(),
+    onReject: vi.fn(),
+    onRegenerate: vi.fn(),
+  };
+
+  it("renders diff with removed and added spans", () => {
+    render(<InlineAiDiffPreview {...defaultProps} />);
+    expect(screen.getByTestId("inline-ai-diff-removed")).toHaveTextContent(
+      "hello world",
+    );
+    expect(screen.getByTestId("inline-ai-diff-added")).toHaveTextContent(
+      "hello universe",
+    );
+  });
+
+  it("renders Accept, Reject, Regenerate buttons", () => {
+    render(<InlineAiDiffPreview {...defaultProps} />);
+    expect(screen.getByTestId("inline-ai-accept-btn")).toHaveTextContent(
+      "Accept",
+    );
+    expect(screen.getByTestId("inline-ai-reject-btn")).toHaveTextContent(
+      "Reject",
+    );
+    expect(screen.getByTestId("inline-ai-regenerate-btn")).toHaveTextContent(
+      "Regenerate",
+    );
+  });
+
+  it("disables Accept and Regenerate during streaming", () => {
+    render(<InlineAiDiffPreview {...defaultProps} phase="streaming" />);
+    expect(screen.getByTestId("inline-ai-accept-btn")).toBeDisabled();
+    expect(screen.getByTestId("inline-ai-regenerate-btn")).toBeDisabled();
+  });
+
+  it("shows loading indicator during streaming", () => {
+    render(<InlineAiDiffPreview {...defaultProps} phase="streaming" />);
+    expect(screen.getByTestId("inline-ai-loading")).toBeInTheDocument();
+  });
+
+  it("calls onAccept when Accept is clicked", () => {
+    const onAccept = vi.fn();
+    render(<InlineAiDiffPreview {...defaultProps} onAccept={onAccept} />);
+    fireEvent.click(screen.getByTestId("inline-ai-accept-btn"));
+    expect(onAccept).toHaveBeenCalled();
+  });
+
+  it("calls onReject when Reject is clicked", () => {
+    const onReject = vi.fn();
+    render(<InlineAiDiffPreview {...defaultProps} onReject={onReject} />);
+    fireEvent.click(screen.getByTestId("inline-ai-reject-btn"));
+    expect(onReject).toHaveBeenCalled();
+  });
+
+  it("calls onRegenerate when Regenerate is clicked", () => {
+    const onRegenerate = vi.fn();
+    render(
+      <InlineAiDiffPreview {...defaultProps} onRegenerate={onRegenerate} />,
+    );
+    fireEvent.click(screen.getByTestId("inline-ai-regenerate-btn"));
+    expect(onRegenerate).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. i18n keys exist in both locales
+// ---------------------------------------------------------------------------
+
+describe("inlineAi i18n keys", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const en = require("../../i18n/locales/en.json");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const zhCN = require("../../i18n/locales/zh-CN.json");
+
+  const requiredKeys = [
+    "placeholder",
+    "accept",
+    "reject",
+    "regenerate",
+    "loading",
+  ];
+
+  for (const key of requiredKeys) {
+    it(`has inlineAi.${key} in en`, () => {
+      expect(en.inlineAi[key]).toBeDefined();
+      expect(typeof en.inlineAi[key]).toBe("string");
+    });
+
+    it(`has inlineAi.${key} in zh-CN`, () => {
+      expect(zhCN.inlineAi[key]).toBeDefined();
+      expect(typeof zhCN.inlineAi[key]).toBe("string");
+    });
+  }
+});

--- a/apps/desktop/renderer/src/features/editor/InlineAiDiffPreview.tsx
+++ b/apps/desktop/renderer/src/features/editor/InlineAiDiffPreview.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button, Text } from "../../components/primitives";
+import { useHotkey } from "../../lib/hotkeys/useHotkey";
+
+type InlineAiDiffPreviewProps = {
+  phase: "streaming" | "ready";
+  originalText: string;
+  suggestedText: string;
+  onAccept: () => void;
+  onReject: () => void;
+  onRegenerate: () => void;
+};
+
+export function InlineAiDiffPreview(
+  props: InlineAiDiffPreviewProps,
+): JSX.Element {
+  const {
+    phase,
+    originalText,
+    suggestedText,
+    onAccept,
+    onReject,
+    onRegenerate,
+  } = props;
+  const { t } = useTranslation();
+  const isStreaming = phase === "streaming";
+
+  useHotkey(
+    "inline-ai-diff:escape",
+    { key: "Escape" },
+    React.useCallback(() => {
+      onReject();
+    }, [onReject]),
+    "editor",
+    15,
+  );
+
+  useHotkey(
+    "inline-ai-diff:accept",
+    { key: "Enter" },
+    React.useCallback(() => {
+      if (isStreaming) return;
+      onAccept();
+    }, [isStreaming, onAccept]),
+    "editor",
+    15,
+    !isStreaming,
+  );
+
+  return (
+    <div
+      data-testid="inline-ai-diff-preview"
+      className="rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-[var(--space-4)] py-[var(--space-3)]"
+    >
+      {isStreaming && (
+        <div
+          data-testid="inline-ai-loading"
+          className="flex items-center gap-2 pb-2"
+        >
+          <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-[var(--color-info)] border-t-transparent" />
+          <Text size="small" color="muted">
+            {t("inlineAi.loading")}
+          </Text>
+        </div>
+      )}
+
+      <div
+        data-testid="inline-ai-diff-content"
+        className="font-[var(--font-family-body)] text-[length:var(--text-editor-size)] leading-[var(--text-editor-line-height)]"
+      >
+        {originalText !== suggestedText && (
+          <span
+            data-testid="inline-ai-diff-removed"
+            className="bg-[var(--color-diff-removed-bg)] text-[var(--color-diff-removed-text)] line-through decoration-[var(--color-diff-removed-decoration)]"
+          >
+            {originalText}
+          </span>
+        )}
+        {suggestedText.length > 0 && (
+          <span
+            data-testid="inline-ai-diff-added"
+            className="bg-[var(--color-diff-added-bg)] text-[var(--color-diff-added-text)]"
+          >
+            {suggestedText}
+          </span>
+        )}
+      </div>
+
+      <div
+        data-testid="inline-ai-actions"
+        className="mt-2 flex items-center gap-[var(--space-2)] border-t border-[var(--color-separator)] pt-2"
+      >
+        <Button
+          data-testid="inline-ai-accept-btn"
+          variant="primary"
+          size="sm"
+          disabled={isStreaming}
+          onClick={onAccept}
+          className="rounded-[var(--radius-sm)] bg-[var(--color-btn-success-bg)] text-[var(--color-fg-inverse)]"
+        >
+          {t("inlineAi.accept")}
+        </Button>
+        <Button
+          data-testid="inline-ai-reject-btn"
+          variant="secondary"
+          size="sm"
+          onClick={onReject}
+          className="rounded-[var(--radius-sm)]"
+        >
+          {t("inlineAi.reject")}
+        </Button>
+        <Button
+          data-testid="inline-ai-regenerate-btn"
+          variant="secondary"
+          size="sm"
+          disabled={isStreaming}
+          onClick={onRegenerate}
+          className="rounded-[var(--radius-sm)]"
+        >
+          {t("inlineAi.regenerate")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/editor/InlineAiInput.tsx
+++ b/apps/desktop/renderer/src/features/editor/InlineAiInput.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+type InlineAiInputProps = {
+  onSubmit: (instruction: string) => void;
+  onDismiss: () => void;
+};
+
+export function InlineAiInput(props: InlineAiInputProps): JSX.Element {
+  const { onSubmit, onDismiss } = props;
+  const { t } = useTranslation();
+  const [value, setValue] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  React.useEffect(() => {
+    function handleClickOutside(e: MouseEvent): void {
+      const el = inputRef.current?.closest("[data-testid='inline-ai-input']");
+      if (el && !el.contains(e.target as Node)) {
+        onDismiss();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onDismiss]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onDismiss();
+      return;
+    }
+    if (e.key === "Enter" && value.trim().length > 0) {
+      e.preventDefault();
+      onSubmit(value.trim());
+    }
+  }
+
+  return (
+    <div
+      data-testid="inline-ai-input"
+      className="absolute z-[var(--z-popover)] min-w-[320px] max-w-[480px] rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)] shadow-[var(--shadow-lg)] animate-[inline-ai-appear_200ms_var(--ease-out)]"
+      style={{
+        bottom: "calc(100% + var(--space-2))",
+        left: "50%",
+        transform: "translateX(-50%)",
+      }}
+    >
+      <div className="flex items-center gap-2 px-[var(--space-3)] py-[var(--space-2)]">
+        <input
+          ref={inputRef}
+          type="text"
+          data-testid="inline-ai-instruction-input"
+          className="flex-1 border-none bg-transparent font-[var(--font-family-ui)] text-[length:var(--text-body-size)] text-[var(--color-fg-default)] placeholder:text-[var(--color-fg-placeholder)] outline-none"
+          placeholder={t("inlineAi.placeholder")}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <span className="text-[length:var(--text-caption-size)] text-[var(--color-fg-muted)] select-none">
+          {t("inlineAi.submitHint")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/editor/inlineAiStore.ts
+++ b/apps/desktop/renderer/src/features/editor/inlineAiStore.ts
@@ -1,0 +1,91 @@
+import { create } from "zustand";
+
+export type InlineAiPhase = "idle" | "input" | "streaming" | "ready";
+
+export type SelectionRef = {
+  from: number;
+  to: number;
+  text: string;
+  selectionTextHash: string;
+};
+
+export type InlineAiState = {
+  phase: InlineAiPhase;
+  instruction: string | null;
+  selectionRef: SelectionRef | null;
+  result: string | null;
+  executionId: string | null;
+};
+
+export type InlineAiActions = {
+  openInput: (selectionRef: SelectionRef) => void;
+  dismiss: () => void;
+  submitInstruction: (instruction: string) => void;
+  setStreaming: (executionId: string) => void;
+  appendChunk: (chunk: string) => void;
+  setReady: (result: string) => void;
+  setError: () => void;
+  accept: () => void;
+  reject: () => void;
+  regenerate: () => void;
+};
+
+export type InlineAiStore = InlineAiState & InlineAiActions;
+
+const INITIAL_STATE: InlineAiState = {
+  phase: "idle",
+  instruction: null,
+  selectionRef: null,
+  result: null,
+  executionId: null,
+};
+
+export function createInlineAiStore() {
+  return create<InlineAiStore>((set) => ({
+    ...INITIAL_STATE,
+
+    openInput: (selectionRef) =>
+      set({
+        phase: "input",
+        selectionRef,
+        instruction: null,
+        result: null,
+        executionId: null,
+      }),
+
+    dismiss: () => set(INITIAL_STATE),
+
+    submitInstruction: (instruction) =>
+      set((state) => ({
+        ...state,
+        phase: "streaming",
+        instruction,
+        result: "",
+      })),
+
+    setStreaming: (executionId) => set({ executionId }),
+
+    appendChunk: (chunk) =>
+      set((state) => ({
+        result: (state.result ?? "") + chunk,
+      })),
+
+    setReady: (result) => set({ phase: "ready", result }),
+
+    setError: () => set(INITIAL_STATE),
+
+    accept: () => set(INITIAL_STATE),
+
+    reject: () => set(INITIAL_STATE),
+
+    regenerate: () =>
+      set((state) => ({
+        ...state,
+        phase: "streaming",
+        result: "",
+        executionId: null,
+      })),
+  }));
+}
+
+export type UseInlineAiStore = ReturnType<typeof createInlineAiStore>;

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -117,6 +117,14 @@
       "close": "Close"
     }
   },
+  "inlineAi": {
+    "placeholder": "Ask AI to edit...",
+    "accept": "Accept",
+    "reject": "Reject",
+    "regenerate": "Regenerate",
+    "loading": "AI is thinking...",
+    "submitHint": "Enter ↵"
+  },
   "editor": {
     "contextMenu": {
       "copy": "Copy",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -117,6 +117,14 @@
       "close": "关闭"
     }
   },
+  "inlineAi": {
+    "placeholder": "让 AI 编辑…",
+    "accept": "接受",
+    "reject": "拒绝",
+    "regenerate": "重新生成",
+    "loading": "AI 思考中…",
+    "submitHint": "Enter ↵"
+  },
   "editor": {
     "contextMenu": {
       "copy": "复制",

--- a/apps/desktop/renderer/src/stores/aiStore.tsx
+++ b/apps/desktop/renderer/src/stores/aiStore.tsx
@@ -1,10 +1,7 @@
 ﻿import React from "react";
 import { create } from "zustand";
 
-import type {
-  IpcError,
-  IpcResponseData,
-} from "@shared/types/ipc-generated";
+import type { IpcError, IpcResponseData } from "@shared/types/ipc-generated";
 import type { AiStreamEvent } from "@shared/types/ai";
 import type { IpcInvoke } from "../lib/ipcTypes";
 
@@ -178,9 +175,7 @@ function normalizeCandidateCount(raw: number | undefined): number {
 }
 
 type AiStoreSetter = (
-  partial:
-    | Partial<AiStore>
-    | ((state: AiStore) => Partial<AiStore>),
+  partial: Partial<AiStore> | ((state: AiStore) => Partial<AiStore>),
 ) => void;
 type AiStoreGetter = () => AiStore;
 
@@ -251,7 +246,14 @@ function createAiStoreRunActions(
   deps: { invoke: IpcInvoke },
   set: AiStoreSetter,
   get: AiStoreGetter,
-): Pick<AiActions, "run" | "regenerateWithStrongNegative" | "cancel" | "persistAiApply" | "logAiApplyConflict"> {
+): Pick<
+  AiActions,
+  | "run"
+  | "regenerateWithStrongNegative"
+  | "cancel"
+  | "persistAiApply"
+  | "logAiApplyConflict"
+> {
   return {
     persistAiApply: async (args) => {
       set({ applyStatus: "applying", lastError: null });
@@ -709,4 +711,16 @@ export function useOptionalAiStore<T>(
     return null;
   }
   return store(selector);
+}
+
+export function useAiStoreApi(): UseAiStore {
+  const store = React.useContext(AiStoreContext);
+  if (!store) {
+    throw new Error("AiStoreProvider is missing");
+  }
+  return store;
+}
+
+export function useOptionalAiStoreApi(): UseAiStore | null {
+  return React.useContext(AiStoreContext);
 }


### PR DESCRIPTION
## Summary

Inline AI 从 0 到 1 新建：选中文本 → Cmd/Ctrl+K → 浮动输入 → Skill 执行 → 就地 diff 预览 → Accept/Reject/Regenerate。全路径 ≤ 4 步。

## Changes

- **shortcuts.ts**: 注册 `inlineAi` 快捷键 `mod+K`
- **inlineAiStore.ts**: 新建 Zustand store，管理 `idle → input → streaming → ready` 状态机
- **InlineAiInput.tsx**: 浮动输入组件（autoFocus、Enter 提交、Escape 关闭、点击外部关闭）
- **InlineAiDiffPreview.tsx**: diff 预览组件（删除线 + 高亮、Accept/Reject/Regenerate 按钮、streaming 下禁用）
- **EditorPane.tsx**: 通过 `useHotkey` 注册 Cmd+K，仅在有选区、非禅模式、无活跃会话时触发；`InlineAiOverlay` 组件渲染
- **i18n**: 新增 en/zh-CN 双语 keys（placeholder、accept、reject、regenerate、loading、submitHint）

## Constraints satisfied

- ✅ No trigger without text selection
- ✅ Disabled in zen mode
- ✅ No independent LLM calls (store ready for skill pipeline integration)
- ✅ Total path ≤ 4 steps
- ✅ i18n keys in both locales
- ✅ No raw addEventListener (uses useHotkey)

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `vitest run` — 271 files, 1887 tests ✅
- `storybook:build` ✅

## Virtual merge baseline

Built on top of A0-01 (PR #1111) via virtual merge to access zen mode editable surface.

Closes #1004