### PR TITLE
feat(ai): persist chat sessions and messages to SQLite (#1124)

### DIFF
--- a/apps/desktop/main/src/db/init.ts
+++ b/apps/desktop/main/src/db/init.ts
@@ -38,6 +38,7 @@ import kgLastSeenStateSql from "./migrations/0020_kg_last_seen_state.sql?raw";
 import tracePersistenceSql from "./migrations/0021_s3_trace_persistence.sql?raw";
 import synopsisInjectionSql from "./migrations/0022_s3_synopsis_injection.sql?raw";
 import kgTypeOtherToFactionSql from "./migrations/0023_kg_type_other_to_faction.sql?raw";
+import chatHistoryPersistenceSql from "./migrations/0024_chat_history_persistence.sql?raw";
 
 export type DbInitOk = {
   ok: true;
@@ -140,6 +141,11 @@ const MIGRATIONS_BASE: readonly Migration[] = [
     version: 23,
     name: "0023_kg_type_other_to_faction",
     sql: kgTypeOtherToFactionSql,
+  },
+  {
+    version: 24,
+    name: "0024_chat_history_persistence",
+    sql: chatHistoryPersistenceSql,
   },
 ];
 

--- a/apps/desktop/main/src/db/migrations/0024_chat_history_persistence.sql
+++ b/apps/desktop/main/src/db/migrations/0024_chat_history_persistence.sql
@@ -1,0 +1,30 @@
+-- a1-01: chat history persistence — sessions + messages per project.
+-- Why: in-memory Map loses history on restart; SQLite provides durable storage.
+
+CREATE TABLE IF NOT EXISTS chat_sessions (
+  id         TEXT    PRIMARY KEY,
+  project_id TEXT    NOT NULL,
+  title      TEXT    NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_project
+  ON chat_sessions (project_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id         TEXT    PRIMARY KEY,
+  session_id TEXT    NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+  project_id TEXT    NOT NULL,
+  role       TEXT    NOT NULL CHECK (role IN ('user', 'assistant')),
+  content    TEXT    NOT NULL,
+  skill_id   TEXT,
+  timestamp  INTEGER NOT NULL,
+  trace_id   TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_session
+  ON chat_messages (session_id, timestamp ASC);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_project
+  ON chat_messages (project_id);

--- a/apps/desktop/main/src/ipc/__tests__/ai-chat-project-isolation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-chat-project-isolation.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
+import Database from "better-sqlite3";
 import type { IpcMain } from "electron";
 
 import type { Logger } from "../../logging/logger";
@@ -7,6 +11,11 @@ import { registerAiIpcHandlers } from "../ai";
 import { createProjectSessionBindingRegistry } from "../projectSessionBinding";
 
 type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../db/migrations",
+);
 
 function createLogger(): Logger {
   return {
@@ -16,10 +25,25 @@ function createLogger(): Logger {
   };
 }
 
-function createHarness(args?: { useProjectSessionBinding?: boolean }): {
+function applyAllMigrations(db: Database.Database): void {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql") && !f.includes("vec"))
+    .sort();
+  for (const file of files) {
+    db.exec(fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8"));
+  }
+}
+
+function createHarness(args?: {
+  useProjectSessionBinding?: boolean;
+  db?: Database.Database;
+}): {
   chatSend: Handler;
   chatList: Handler;
   chatClear: Handler;
+  chatSessions: Handler;
+  chatSessionDelete: Handler;
   binding: ReturnType<typeof createProjectSessionBindingRegistry> | null;
 } {
   const handlers = new Map<string, Handler>();
@@ -33,9 +57,18 @@ function createHarness(args?: { useProjectSessionBinding?: boolean }): {
     ? createProjectSessionBindingRegistry()
     : null;
 
+  const db =
+    args?.db ??
+    (() => {
+      const memDb = new Database(":memory:");
+      memDb.pragma("foreign_keys = ON");
+      applyAllMigrations(memDb);
+      return memDb;
+    })();
+
   registerAiIpcHandlers({
     ipcMain,
-    db: null,
+    db,
     userDataDir: "<test-user-data>",
     builtinSkillsDir: "<test-skills>",
     logger: createLogger(),
@@ -46,15 +79,24 @@ function createHarness(args?: { useProjectSessionBinding?: boolean }): {
   const chatSend = handlers.get("ai:chat:send");
   const chatList = handlers.get("ai:chat:list");
   const chatClear = handlers.get("ai:chat:clear");
+  const chatSessions = handlers.get("ai:chat:sessions");
+  const chatSessionDelete = handlers.get("ai:chatsession:delete");
 
   assert.ok(chatSend, "expected ai:chat:send handler to be registered");
   assert.ok(chatList, "expected ai:chat:list handler to be registered");
   assert.ok(chatClear, "expected ai:chat:clear handler to be registered");
+  assert.ok(chatSessions, "expected ai:chat:sessions handler to be registered");
+  assert.ok(
+    chatSessionDelete,
+    "expected ai:chatsession:delete handler to be registered",
+  );
 
   return {
     chatSend: chatSend as Handler,
     chatList: chatList as Handler,
     chatClear: chatClear as Handler,
+    chatSessions: chatSessions as Handler,
+    chatSessionDelete: chatSessionDelete as Handler,
     binding,
   };
 }
@@ -176,4 +218,149 @@ function createEvent(webContentsId: number): { sender: { id: number } } {
   assert.equal(boundList.data?.items.length, 1);
   assert.equal(boundList.data?.items[0]?.projectId, "project-bound");
   assert.equal(boundList.data?.items[0]?.content, "uses bound project");
+}
+
+// Scenario: chat history survives handler re-instantiation (SQLite persistence) [ADDED]
+{
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyAllMigrations(db);
+
+  const h1 = createHarness({ db });
+  const projectId = "project-persist";
+
+  const sendRes = (await h1.chatSend(createEvent(1), {
+    projectId,
+    message: "hello persistence",
+  })) as {
+    ok: boolean;
+    data?: { sessionId: string };
+  };
+  assert.equal(sendRes.ok, true);
+  assert.ok(sendRes.data?.sessionId, "send should return a sessionId");
+
+  // Re-instantiate handlers with the same DB (simulates restart)
+  const h2 = createHarness({ db });
+  const listRes = (await h2.chatList(createEvent(1), {
+    projectId,
+  })) as {
+    ok: boolean;
+    data?: { items: Array<{ content: string }> };
+  };
+  assert.equal(listRes.ok, true);
+  assert.equal(
+    listRes.data?.items.length,
+    1,
+    "message must survive handler re-instantiation",
+  );
+  assert.equal(listRes.data?.items[0]?.content, "hello persistence");
+}
+
+// Scenario: sessions listing and search [ADDED]
+{
+  const { chatSend, chatSessions } = createHarness();
+  const projectId = "project-sessions";
+
+  await chatSend(createEvent(1), {
+    projectId,
+    message: "first topic about cats",
+  });
+  await chatSend(createEvent(1), {
+    projectId,
+    message: "second topic about dogs",
+  });
+
+  const allSessions = (await chatSessions(createEvent(1), { projectId })) as {
+    ok: boolean;
+    data?: { sessions: Array<{ sessionId: string; title: string }> };
+  };
+  assert.equal(allSessions.ok, true);
+  assert.equal(allSessions.data?.sessions.length, 2, "should have 2 sessions");
+
+  // Search should filter
+  const searchRes = (await chatSessions(createEvent(1), {
+    projectId,
+    query: "cats",
+  })) as {
+    ok: boolean;
+    data?: { sessions: Array<{ sessionId: string; title: string }> };
+  };
+  assert.equal(searchRes.ok, true);
+  assert.equal(
+    searchRes.data?.sessions.length,
+    1,
+    "search should find 1 session",
+  );
+}
+
+// Scenario: session delete cascades messages [ADDED]
+{
+  const { chatSend, chatList, chatSessionDelete, chatSessions } =
+    createHarness();
+  const projectId = "project-delete";
+
+  const sendRes = (await chatSend(createEvent(1), {
+    projectId,
+    message: "to be deleted",
+  })) as {
+    ok: boolean;
+    data?: { sessionId: string };
+  };
+  assert.equal(sendRes.ok, true);
+  const sessionId = sendRes.data?.sessionId;
+  assert.ok(sessionId);
+
+  await chatSessionDelete(createEvent(1), { projectId, sessionId });
+
+  const listRes = (await chatList(createEvent(1), { projectId })) as {
+    ok: boolean;
+    data?: { items: unknown[] };
+  };
+  assert.equal(listRes.ok, true);
+  assert.equal(
+    listRes.data?.items.length,
+    0,
+    "messages removed after session delete",
+  );
+
+  const sessionsRes = (await chatSessions(createEvent(1), { projectId })) as {
+    ok: boolean;
+    data?: { sessions: unknown[] };
+  };
+  assert.equal(sessionsRes.ok, true);
+  assert.equal(sessionsRes.data?.sessions.length, 0, "session removed");
+}
+
+// Scenario: list messages filtered by session [ADDED]
+{
+  const { chatSend, chatList } = createHarness();
+  const projectId = "project-filter";
+
+  const s1 = (await chatSend(createEvent(1), {
+    projectId,
+    message: "session A msg",
+  })) as { ok: boolean; data?: { sessionId: string } };
+  assert.equal(s1.ok, true);
+  const sessionA = s1.data?.sessionId;
+  assert.ok(sessionA);
+
+  await chatSend(createEvent(1), { projectId, message: "session B msg" });
+
+  // List all
+  const allMsgs = (await chatList(createEvent(1), { projectId })) as {
+    ok: boolean;
+    data?: { items: unknown[] };
+  };
+  assert.equal(allMsgs.data?.items.length, 2, "should have 2 messages total");
+
+  // List by session
+  const sessionMsgs = (await chatList(createEvent(1), {
+    projectId,
+    sessionId: sessionA,
+  })) as {
+    ok: boolean;
+    data?: { items: Array<{ content: string }> };
+  };
+  assert.equal(sessionMsgs.data?.items.length, 1, "should filter by session");
+  assert.equal(sessionMsgs.data?.items[0]?.content, "session A msg");
 }

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -97,17 +97,20 @@ type SkillFeedbackResponse = {
 type ChatSendPayload = {
   message: string;
   projectId?: string;
+  sessionId?: string;
   documentId?: string;
 };
 
 type ChatSendResponse = {
   accepted: true;
   messageId: string;
+  sessionId: string;
   echoed: string;
 };
 
 type ChatListPayload = {
   projectId?: string;
+  sessionId?: string;
 };
 
 type ChatMessageRole = "user" | "assistant";
@@ -128,11 +131,38 @@ type ChatListResponse = {
 
 type ChatClearPayload = {
   projectId?: string;
+  sessionId?: string;
 };
 
 type ChatClearResponse = {
   cleared: true;
   removed: number;
+};
+
+type ChatSession = {
+  sessionId: string;
+  projectId: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type ChatSessionsPayload = {
+  projectId?: string;
+  query?: string;
+};
+
+type ChatSessionsResponse = {
+  sessions: ChatSession[];
+};
+
+type ChatSessionDeletePayload = {
+  projectId?: string;
+  sessionId: string;
+};
+
+type ChatSessionDeleteResponse = {
+  deleted: true;
 };
 
 const AI_CANDIDATE_COUNT_MIN = 1;
@@ -283,6 +313,15 @@ function parseModelPricingMap(
  *
  * Why: chat history must be isolated by project to prevent cross-project leakage.
  */
+
+function validateChatPayload(
+  payload: unknown,
+): asserts payload is Record<string, unknown> {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("payload must be an object");
+  }
+}
+
 function resolveChatProjectId(args: {
   projectId?: string;
   boundProjectId?: string | null;
@@ -368,7 +407,6 @@ type AiIpcContext = {
     string,
     { startedAt: number; context?: SkillRunPayload["context"] }
   >;
-  chatHistoryByProject: Map<string, ChatHistoryMessage[]>;
   sessionTokenTotalsByContext: Map<string, number>;
   modelPricingByModel: Map<string, ModelPricing>;
   pushBackpressureByRenderer: Map<
@@ -417,9 +455,7 @@ function rememberRunInRegistry(
   }
 }
 
-function resolveUsageContextKey(
-  context?: SkillRunPayload["context"],
-): string {
+function resolveUsageContextKey(context?: SkillRunPayload["context"]): string {
   const projectId = context?.projectId?.trim() ?? "";
   if (projectId.length > 0) {
     return `project:${projectId}`;
@@ -508,7 +544,6 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     string,
     { startedAt: number; context?: SkillRunPayload["context"] }
   >();
-  const chatHistoryByProject = new Map<string, ChatHistoryMessage[]>();
   const sessionTokenTotalsByContext = new Map<string, number>();
   const modelPricingByModel = parseModelPricingMap(deps.env);
   const degradationCounter = new DegradationCounter();
@@ -632,7 +667,6 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     aiService,
     skillExecutor,
     runRegistry,
-    chatHistoryByProject,
     sessionTokenTotalsByContext,
     modelPricingByModel,
     pushBackpressureByRenderer,
@@ -733,7 +767,10 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
         });
       };
 
-      const stats = createStatsService({ db: ctx.deps.db, logger: ctx.deps.logger });
+      const stats = createStatsService({
+        db: ctx.deps.db,
+        logger: ctx.deps.logger,
+      });
       const inc = stats.increment({
         ts: nowTs(),
         delta: { skillsUsed: 1 },
@@ -761,7 +798,10 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
             return { ok: false, error: res.error };
           }
 
-          rememberRunInRegistry(ctx, { runId: res.data.runId, context: payload.context });
+          rememberRunInRegistry(ctx, {
+            runId: res.data.runId,
+            context: payload.context,
+          });
 
           const outputText = res.data.outputText;
           if (typeof outputText === "string") {
@@ -823,7 +863,10 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
           if (!res.ok) {
             return { ok: false, error: res.error };
           }
-          rememberRunInRegistry(ctx, { runId: res.data.runId, context: payload.context });
+          rememberRunInRegistry(ctx, {
+            runId: res.data.runId,
+            context: payload.context,
+          });
           runs.push({
             executionId: res.data.executionId,
             runId: res.data.runId,
@@ -1044,9 +1087,49 @@ function registerAiChatHandlers(ctx: AiIpcContext): void {
         };
       }
 
+      const db = ctx.deps.db;
+      if (!db) {
+        return { ok: false, error: createDbNotReadyError() };
+      }
+
       const timestamp = nowTs();
-      const projectMessages = ctx.chatHistoryByProject.get(projectId.data) ?? [];
-      if (projectMessages.length >= ctx.runtimeGovernance.ai.chatMessageCapacity) {
+
+      // Resolve or create session
+      const sessionId = payload.sessionId?.trim() || null;
+      let resolvedSessionId: string;
+
+      if (sessionId) {
+        const existing = db
+          .prepare(
+            "SELECT id FROM chat_sessions WHERE id = ? AND project_id = ?",
+          )
+          .get(sessionId, projectId.data) as { id: string } | undefined;
+        if (!existing) {
+          return {
+            ok: false,
+            error: {
+              code: "NOT_FOUND",
+              message: "session not found",
+            },
+          };
+        }
+        resolvedSessionId = sessionId;
+      } else {
+        resolvedSessionId = `session-${timestamp}-${Math.random().toString(36).slice(2, 8)}`;
+        db.prepare(
+          "INSERT INTO chat_sessions (id, project_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        ).run(resolvedSessionId, projectId.data, "", timestamp, timestamp);
+      }
+
+      // Check capacity
+      const msgCount = (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS cnt FROM chat_messages WHERE project_id = ?",
+          )
+          .get(projectId.data) as { cnt: number }
+      ).cnt;
+      if (msgCount >= ctx.runtimeGovernance.ai.chatMessageCapacity) {
         return {
           ok: false,
           error: {
@@ -1055,23 +1138,40 @@ function registerAiChatHandlers(ctx: AiIpcContext): void {
           },
         };
       }
-      const messageId = `chat-${timestamp}`;
-      const nextMessage: ChatHistoryMessage = {
+
+      const messageId = `chat-${timestamp}-${Math.random().toString(36).slice(2, 8)}`;
+      const traceId = `trace-${messageId}`;
+
+      db.prepare(
+        "INSERT INTO chat_messages (id, session_id, project_id, role, content, skill_id, timestamp, trace_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
         messageId,
-        projectId: projectId.data,
-        role: "user",
-        content: message,
+        resolvedSessionId,
+        projectId.data,
+        "user",
+        message,
+        payload.documentId ?? null,
         timestamp,
-        traceId: `trace-${messageId}`,
-      };
-      const nextMessages = [...projectMessages, nextMessage];
-      ctx.chatHistoryByProject.set(projectId.data, nextMessages);
+        traceId,
+      );
+
+      // Update session title from first message if empty
+      db.prepare(
+        "UPDATE chat_sessions SET title = ?, updated_at = ? WHERE id = ? AND title = ''",
+      ).run(message.slice(0, 100), timestamp, resolvedSessionId);
+
+      // Always update session timestamp
+      db.prepare("UPDATE chat_sessions SET updated_at = ? WHERE id = ?").run(
+        timestamp,
+        resolvedSessionId,
+      );
 
       return {
         ok: true,
         data: {
           accepted: true,
           messageId,
+          sessionId: resolvedSessionId,
           echoed: message,
         },
       };
@@ -1097,10 +1197,28 @@ function registerAiChatHandlers(ctx: AiIpcContext): void {
         };
       }
 
-      const messages = ctx.chatHistoryByProject.get(projectId.data) ?? [];
+      const db = ctx.deps.db;
+      if (!db) {
+        return { ok: false, error: createDbNotReadyError() };
+      }
+
+      const sessionId = payload.sessionId?.trim() || null;
+
+      const rows = sessionId
+        ? (db
+            .prepare(
+              "SELECT id AS messageId, project_id AS projectId, role, content, skill_id AS skillId, timestamp, trace_id AS traceId FROM chat_messages WHERE project_id = ? AND session_id = ? ORDER BY timestamp ASC",
+            )
+            .all(projectId.data, sessionId) as ChatHistoryMessage[])
+        : (db
+            .prepare(
+              "SELECT id AS messageId, project_id AS projectId, role, content, skill_id AS skillId, timestamp, trace_id AS traceId FROM chat_messages WHERE project_id = ? ORDER BY timestamp ASC",
+            )
+            .all(projectId.data) as ChatHistoryMessage[]);
+
       return {
         ok: true,
-        data: { items: [...messages] },
+        data: { items: rows },
       };
     },
   );
@@ -1124,8 +1242,31 @@ function registerAiChatHandlers(ctx: AiIpcContext): void {
         };
       }
 
-      const removed = ctx.chatHistoryByProject.get(projectId.data)?.length ?? 0;
-      ctx.chatHistoryByProject.delete(projectId.data);
+      const db = ctx.deps.db;
+      if (!db) {
+        return { ok: false, error: createDbNotReadyError() };
+      }
+
+      const sessionId = payload.sessionId?.trim() || null;
+      let removed: number;
+
+      if (sessionId) {
+        removed = db
+          .prepare(
+            "DELETE FROM chat_messages WHERE project_id = ? AND session_id = ?",
+          )
+          .run(projectId.data, sessionId).changes;
+        db.prepare(
+          "DELETE FROM chat_sessions WHERE id = ? AND project_id = ?",
+        ).run(sessionId, projectId.data);
+      } else {
+        removed = db
+          .prepare("DELETE FROM chat_messages WHERE project_id = ?")
+          .run(projectId.data).changes;
+        db.prepare("DELETE FROM chat_sessions WHERE project_id = ?").run(
+          projectId.data,
+        );
+      }
 
       return {
         ok: true,
@@ -1133,6 +1274,88 @@ function registerAiChatHandlers(ctx: AiIpcContext): void {
           cleared: true,
           removed,
         },
+      };
+    },
+  );
+
+  ctx.deps.ipcMain.handle(
+    "ai:chat:sessions",
+    async (
+      event,
+      payload: ChatSessionsPayload,
+    ): Promise<IpcResponse<ChatSessionsResponse>> => {
+      validateChatPayload(payload);
+      const projectId = resolveChatProjectId({
+        projectId: payload.projectId,
+        boundProjectId: ctx.deps.projectSessionBinding?.resolveProjectId({
+          webContentsId: event.sender.id,
+        }),
+      });
+      if (!projectId.ok) {
+        return {
+          ok: false,
+          error: projectId.error,
+        };
+      }
+
+      const db = ctx.deps.db;
+      if (!db) {
+        return { ok: false, error: createDbNotReadyError() };
+      }
+
+      const query = payload.query?.trim() || null;
+      const sessions = query
+        ? (db
+            .prepare(
+              "SELECT s.id AS sessionId, s.project_id AS projectId, s.title, s.created_at AS createdAt, s.updated_at AS updatedAt FROM chat_sessions s WHERE s.project_id = ? AND (s.title LIKE ? OR EXISTS (SELECT 1 FROM chat_messages m WHERE m.session_id = s.id AND m.content LIKE ?)) ORDER BY s.updated_at DESC",
+            )
+            .all(projectId.data, `%${query}%`, `%${query}%`) as ChatSession[])
+        : (db
+            .prepare(
+              "SELECT id AS sessionId, project_id AS projectId, title, created_at AS createdAt, updated_at AS updatedAt FROM chat_sessions WHERE project_id = ? ORDER BY updated_at DESC",
+            )
+            .all(projectId.data) as ChatSession[]);
+
+      return {
+        ok: true,
+        data: { sessions },
+      };
+    },
+  );
+
+  ctx.deps.ipcMain.handle(
+    "ai:chatsession:delete",
+    async (
+      event,
+      payload: ChatSessionDeletePayload,
+    ): Promise<IpcResponse<ChatSessionDeleteResponse>> => {
+      validateChatPayload(payload);
+      const projectId = resolveChatProjectId({
+        projectId: payload.projectId,
+        boundProjectId: ctx.deps.projectSessionBinding?.resolveProjectId({
+          webContentsId: event.sender.id,
+        }),
+      });
+      if (!projectId.ok) {
+        return {
+          ok: false,
+          error: projectId.error,
+        };
+      }
+
+      const db = ctx.deps.db;
+      if (!db) {
+        return { ok: false, error: createDbNotReadyError() };
+      }
+
+      // CASCADE delete handles messages
+      db.prepare(
+        "DELETE FROM chat_sessions WHERE id = ? AND project_id = ?",
+      ).run(payload.sessionId, projectId.data);
+
+      return {
+        ok: true,
+        data: { deleted: true },
       };
     },
   );

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -841,6 +841,14 @@ const AI_CHAT_HISTORY_ITEM_SCHEMA = s.object({
   traceId: s.string(),
 });
 
+const AI_CHAT_SESSION_SCHEMA = s.object({
+  sessionId: s.string(),
+  projectId: s.string(),
+  title: s.string(),
+  createdAt: s.number(),
+  updatedAt: s.number(),
+});
+
 const APP_WINDOW_STATE_SCHEMA = s.object({
   controlsEnabled: s.boolean(),
   isMaximized: s.boolean(),
@@ -927,17 +935,20 @@ export const ipcContract = {
       request: s.object({
         message: s.string(),
         projectId: s.string(),
+        sessionId: s.optional(s.string()),
         documentId: s.optional(s.string()),
       }),
       response: s.object({
         accepted: s.literal(true),
         messageId: s.string(),
+        sessionId: s.string(),
         echoed: s.string(),
       }),
     },
     "ai:chat:list": {
       request: s.object({
         projectId: s.string(),
+        sessionId: s.optional(s.string()),
       }),
       response: s.object({
         items: s.array(AI_CHAT_HISTORY_ITEM_SCHEMA),
@@ -946,10 +957,29 @@ export const ipcContract = {
     "ai:chat:clear": {
       request: s.object({
         projectId: s.string(),
+        sessionId: s.optional(s.string()),
       }),
       response: s.object({
         cleared: s.literal(true),
         removed: s.number(),
+      }),
+    },
+    "ai:chat:sessions": {
+      request: s.object({
+        projectId: s.string(),
+        query: s.optional(s.string()),
+      }),
+      response: s.object({
+        sessions: s.array(AI_CHAT_SESSION_SCHEMA),
+      }),
+    },
+    "ai:chatsession:delete": {
+      request: s.object({
+        projectId: s.string(),
+        sessionId: s.string(),
+      }),
+      response: s.object({
+        deleted: s.literal(true),
       }),
     },
     "ai:skill:run": {

--- a/apps/desktop/renderer/src/components/layout/RightPanel.tsx
+++ b/apps/desktop/renderer/src/components/layout/RightPanel.tsx
@@ -13,6 +13,8 @@ import {
   type OpenSettingsTarget,
 } from "../../contexts/OpenSettingsContext";
 import { ScrollArea } from "../primitives";
+import { useProjectStore } from "../../stores/projectStore";
+import { useAiStore } from "../../stores/aiStore";
 
 export { useOpenSettings } from "../../contexts/OpenSettingsContext";
 
@@ -91,6 +93,9 @@ export function RightPanel(props: {
   const setActiveRightPanel = useLayoutStore((s) => s.setActiveRightPanel);
   const [aiHistoryOpen, setAiHistoryOpen] = React.useState(false);
   const [aiNewChatSignal, setAiNewChatSignal] = React.useState(0);
+  const currentProjectId = useProjectStore((s) => s.current?.projectId ?? "");
+  const selectChatSession = useAiStore((s) => s.selectChatSession);
+  const clearActiveChatSession = useAiStore((s) => s.clearActiveChatSession);
 
   React.useEffect(() => {
     if (activeRightPanel !== "ai") {
@@ -188,7 +193,10 @@ export function RightPanel(props: {
               <button
                 type="button"
                 data-testid="right-panel-ai-new-chat-action"
-                onClick={() => setAiNewChatSignal((prev) => prev + 1)}
+                onClick={() => {
+                  setAiNewChatSignal((prev) => prev + 1);
+                  clearActiveChatSession();
+                }}
                 title={t("workbench.rightPanel.newChatTitle")}
                 className="w-6 h-6 flex items-center justify-center rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
               >
@@ -207,8 +215,15 @@ export function RightPanel(props: {
               <ChatHistory
                 open={aiHistoryOpen}
                 onOpenChange={setAiHistoryOpen}
-                onSelectChat={() => {
+                projectId={currentProjectId}
+                onSelectChat={(sessionId) => {
                   setAiHistoryOpen(false);
+                  if (currentProjectId) {
+                    void selectChatSession({
+                      projectId: currentProjectId,
+                      sessionId,
+                    });
+                  }
                 }}
               />
             </div>

--- a/apps/desktop/renderer/src/features/ai/AiPanel.history-replay.test.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.history-replay.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AiPanel } from "./AiPanel";
+import type { AiStore } from "../../stores/aiStore";
+
+vi.mock("../../stores/aiStore", () => ({
+  useAiStore: vi.fn((selector) => {
+    const state = {
+      status: "idle" as const,
+      stream: false,
+      selectedSkillId: "default",
+      skills: [
+        {
+          id: "default",
+          name: "Default Skill",
+          enabled: true,
+          valid: true,
+          scope: "global",
+        },
+      ],
+      skillsStatus: "ready" as const,
+      skillsLastError: null,
+      input: "",
+      outputText: "",
+      lastRunId: null,
+      activeRunId: null,
+      activeChunkSeq: 0,
+      lastError: null,
+      selectionRef: null,
+      selectionText: "",
+      proposal: null,
+      applyStatus: "idle" as const,
+      lastCandidates: [],
+      usageStats: null,
+      selectedCandidateId: null,
+      lastRunRequest: null,
+      queuePosition: null,
+      queuedCount: 0,
+      globalRunningCount: 0,
+      chatSessions: [],
+      chatSessionsStatus: "ready" as const,
+      activeChatSessionId: "session-1",
+      activeChatMessages: [
+        {
+          messageId: "m1",
+          projectId: "project-1",
+          role: "user" as const,
+          content: "第一条历史问题",
+          timestamp: 1,
+          traceId: "trace-1",
+        },
+        {
+          messageId: "m2",
+          projectId: "project-1",
+          role: "assistant" as const,
+          content: "第一条历史回答",
+          timestamp: 2,
+          traceId: "trace-1",
+        },
+      ],
+      setInput: vi.fn(),
+      setStream: vi.fn(),
+      setSelectedSkillId: vi.fn(),
+      refreshSkills: vi.fn().mockResolvedValue(undefined),
+      clearError: vi.fn(),
+      setError: vi.fn(),
+      setSelectionSnapshot: vi.fn(),
+      setProposal: vi.fn(),
+      setSelectedCandidateId: vi.fn(),
+      persistAiApply: vi.fn(),
+      logAiApplyConflict: vi.fn(),
+      run: vi.fn().mockResolvedValue({ ok: true }),
+      regenerateWithStrongNegative: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    return selector(state as unknown as AiStore);
+  }),
+}));
+
+vi.mock("../../stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector) => {
+    const state = {
+      editor: null,
+      bootstrapStatus: "ready",
+      compareMode: false,
+      setCompareMode: vi.fn(),
+      projectId: null,
+      documentId: null,
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("../../stores/projectStore", () => ({
+  useProjectStore: vi.fn((selector) => {
+    const state = {
+      current: null,
+    };
+    return selector(state);
+  }),
+}));
+
+vi.mock("./useAiStream", () => ({
+  useAiStream: vi.fn(),
+}));
+
+describe("AiPanel history replay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("选择历史会话后应展示历史消息回放", () => {
+    render(<AiPanel />);
+
+    expect(screen.getByTestId("ai-history-replay-list")).toBeInTheDocument();
+    expect(screen.getByText("第一条历史问题")).toBeInTheDocument();
+    expect(screen.getByText("第一条历史回答")).toBeInTheDocument();
+    expect(screen.queryByTestId("ai-output")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/renderer/src/features/ai/AiPanel.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiPanel.tsx
@@ -19,6 +19,7 @@ import {
   useAiStore,
   type AiApplyStatus,
   type AiCandidate,
+  type ChatMessageItem,
   type AiProposal,
   type AiStatus,
   type AiUsageStats,
@@ -1112,6 +1113,7 @@ function createAiPanelActions(a: AiPanelActionsDeps) {
 // ---------------------------------------------------------------------------
 
 type AiPanelChatAreaProps = {
+  historyMessages: ChatMessageItem[];
   lastRequest: string | null;
   working: boolean;
   status: AiStatus;
@@ -1261,16 +1263,35 @@ function AiPanelProposalArea(props: {
 
 function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
   const { t } = useTranslation();
+  const hasHistoryReplay = props.historyMessages.length > 0;
 
   return (
     <div className="flex-1 overflow-y-auto p-3 space-y-4">
-      {props.lastRequest && (
+      {hasHistoryReplay ? (
+        <div data-testid="ai-history-replay-list" className="w-full space-y-2">
+          {props.historyMessages.map((message) => (
+            <div
+              key={message.messageId}
+              data-testid={`ai-history-message-${message.role}`}
+              className={`w-full rounded-[var(--radius-md)] p-3 text-[13px] whitespace-pre-wrap ${
+                message.role === "user"
+                  ? "bg-[var(--color-bg-base)] text-[var(--color-fg-default)]"
+                  : "bg-[var(--color-bg-selected)] text-[var(--color-fg-default)]"
+              }`}
+            >
+              {message.content}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {!hasHistoryReplay && props.lastRequest ? (
         <div className="w-full p-3 rounded-[var(--radius-md)] bg-[var(--color-bg-base)]">
           <div className="text-[13px] text-[var(--color-fg-default)] whitespace-pre-wrap">
             {props.lastRequest}
           </div>
         </div>
-      )}
+      ) : null}
 
       {props.working && (
         <div className="flex items-center gap-2 text-[12px] text-[var(--color-fg-muted)]">
@@ -1354,7 +1375,7 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
         </div>
       ) : null}
 
-      {props.activeOutputText ? (
+      {!hasHistoryReplay && props.activeOutputText ? (
         <div
           data-testid="ai-output"
           className="w-full"
@@ -1366,7 +1387,7 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
             {props.status === "streaming" && <span className="typing-cursor" />}
           </div>
         </div>
-      ) : (
+      ) : !hasHistoryReplay ? (
         !props.lastRequest &&
         !props.working && (
           <div
@@ -1380,7 +1401,7 @@ function AiPanelChatArea(props: AiPanelChatAreaProps): JSX.Element {
             </Text>
           </div>
         )
-      )}
+      ) : null}
 
       {props.judgeResult ? (
         <div
@@ -1726,6 +1747,8 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
   const usageStats = useAiStore((s) => s.usageStats);
   const queuePosition = useAiStore((s) => s.queuePosition);
   const queuedCount = useAiStore((s) => s.queuedCount);
+  const activeChatSessionId = useAiStore((s) => s.activeChatSessionId);
+  const activeChatMessages = useAiStore((s) => s.activeChatMessages);
 
   const selectedCandidateId = useAiStore((s) => s.selectedCandidateId);
 
@@ -1816,6 +1839,7 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
     lastCandidates[0] ??
     null;
   const activeOutputText = selectedCandidate?.text ?? outputText;
+  const historyMessages = activeChatSessionId ? activeChatMessages : [];
   const activeRunId = selectedCandidate?.runId ?? lastRunId;
 
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -1956,6 +1980,7 @@ export function AiPanel(props: AiPanelProps = {}): JSX.Element {
       <div className="flex flex-col h-full min-h-0">
         <div className="flex-1 flex flex-col min-h-0">
           <AiPanelChatArea
+            historyMessages={historyMessages}
             lastRequest={lastRequest}
             working={working}
             status={status}

--- a/apps/desktop/renderer/src/features/ai/ChatHistory.tsx
+++ b/apps/desktop/renderer/src/features/ai/ChatHistory.tsx
@@ -1,32 +1,67 @@
+import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { Button } from "../../components/primitives/Button";
+import { Input } from "../../components/primitives/Input";
 import { Text } from "../../components/primitives";
+import { useAiStore } from "../../stores/aiStore";
 
 type ChatHistoryProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectChat: (chatId: string) => void;
+  projectId: string;
 };
 
 /**
  * ChatHistory renders a dropdown list of past conversations.
  *
- * Currently shows an empty state because chat persistence is not yet
- * implemented (P1 scope). When a chat store / IPC source becomes available,
- * this component will render grouped history items via ChatHistoryItemRow.
+ * Fetches sessions from IPC when opened and supports search filtering.
  */
 export function ChatHistory(props: ChatHistoryProps): JSX.Element | null {
+  const { open, onOpenChange, onSelectChat, projectId } = props;
   const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState("");
 
-  if (!props.open) {
+  const chatSessions = useAiStore((s) => s.chatSessions);
+  const chatSessionsStatus = useAiStore((s) => s.chatSessionsStatus);
+  const loadChatSessions = useAiStore((s) => s.loadChatSessions);
+  const deleteChatSession = useAiStore((s) => s.deleteChatSession);
+
+  useEffect(() => {
+    if (open && projectId) {
+      void loadChatSessions({
+        projectId,
+        ...(searchQuery.trim() ? { query: searchQuery.trim() } : {}),
+      });
+    }
+  }, [open, projectId, searchQuery, loadChatSessions]);
+
+  const handleSelect = useCallback(
+    (sessionId: string) => {
+      onSelectChat(sessionId);
+    },
+    [onSelectChat],
+  );
+
+  const handleDelete = useCallback(
+    (sessionId: string) => {
+      void deleteChatSession({ projectId, sessionId });
+    },
+    [deleteChatSession, projectId],
+  );
+
+  if (!open) {
     return null;
   }
+
+  const isEmpty = chatSessions.length === 0 && chatSessionsStatus === "ready";
 
   return (
     <>
       {/* Backdrop to close on click outside */}
       <div
         role="presentation"
-        onClick={() => props.onOpenChange(false)}
+        onClick={() => onOpenChange(false)}
         className="fixed inset-0 z-[var(--z-dropdown)]"
       />
 
@@ -37,14 +72,58 @@ export function ChatHistory(props: ChatHistoryProps): JSX.Element | null {
         onClick={(e) => e.stopPropagation()}
         className="absolute top-full right-0 mt-1 w-64 z-[var(--z-popover)] bg-[var(--color-bg-raised)] border border-[var(--color-border-default)] rounded-[var(--radius-lg)] shadow-[var(--shadow-xl)] overflow-hidden"
       >
-        {/* Empty state — chat persistence not yet available */}
-        <div className="px-4 py-8 text-center">
-          <Text size="tiny" color="muted">
-            {t("ai.chatHistory.emptyTitle")}
-          </Text>
-          <Text size="tiny" color="muted" className="mt-1 block">
-            {t("ai.chatHistory.emptyDescription")}
-          </Text>
+        {/* Search input */}
+        <div className="px-3 py-2 border-b border-[var(--color-separator)]">
+          <Input
+            type="search"
+            placeholder={t("ai.chatHistory.searchPlaceholder")}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full text-xs"
+            aria-label={t("ai.chatHistory.searchPlaceholder")}
+            fullWidth
+          />
+        </div>
+
+        {/* Session list */}
+        <div className="max-h-64 overflow-y-auto">
+          {isEmpty ? (
+            <div className="px-4 py-8 text-center">
+              <Text size="tiny" color="muted">
+                {t("ai.chatHistory.emptyTitle")}
+              </Text>
+              <Text size="tiny" color="muted" className="mt-1 block">
+                {t("ai.chatHistory.emptyDescription")}
+              </Text>
+            </div>
+          ) : (
+            chatSessions.map((session) => (
+              <div
+                key={session.sessionId}
+                className="group flex items-center gap-1 px-3 py-2 hover:bg-[var(--color-bg-hover)] cursor-pointer"
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="flex-1 text-left truncate text-xs"
+                  onClick={() => handleSelect(session.sessionId)}
+                >
+                  {session.title || t("ai.chatHistory.untitledSession")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label={t("ai.chatHistory.deleteSession")}
+                  className="opacity-0 group-hover:opacity-100 shrink-0 text-[var(--color-text-muted)] hover:text-[var(--color-text-danger)] text-xs focus-visible:opacity-100"
+                  onClick={() => handleDelete(session.sessionId)}
+                >
+                  <span aria-hidden="true">{"\u2715"}</span>
+                </Button>
+              </div>
+            ))
+          )}
         </div>
       </div>
     </>

--- a/apps/desktop/renderer/src/features/placeholder-ui-closure.test.tsx
+++ b/apps/desktop/renderer/src/features/placeholder-ui-closure.test.tsx
@@ -53,6 +53,18 @@ vi.mock("../lib/hotkeys/useHotkey", () => ({
   useHotkey: vi.fn(),
 }));
 
+vi.mock("../stores/aiStore", () => ({
+  useAiStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      chatSessions: [],
+      chatSessionsStatus: "ready" as const,
+      loadChatSessions: vi.fn(),
+      deleteChatSession: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+
 /* ------------------------------------------------------------------ */
 /* Fixtures                                                            */
 /* ------------------------------------------------------------------ */
@@ -254,10 +266,20 @@ describe("SearchPanel placeholder UI closure", () => {
 /* ================================================================== */
 
 describe("ChatHistory placeholder UI closure", () => {
-  it("does not render a disabled fake search input", () => {
-    render(<ChatHistory open onOpenChange={vi.fn()} onSelectChat={vi.fn()} />);
+  it("renders a functional search input (not a disabled fake)", () => {
+    render(
+      <ChatHistory
+        open
+        onOpenChange={vi.fn()}
+        onSelectChat={vi.fn()}
+        projectId="test-project"
+      />,
+    );
 
-    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    const searchInput = screen.queryByRole("searchbox");
+    if (searchInput) {
+      expect(searchInput).not.toBeDisabled();
+    }
   });
 
   it("click does nothing and does not call console.info", () => {
@@ -265,7 +287,12 @@ describe("ChatHistory placeholder UI closure", () => {
     const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
 
     render(
-      <ChatHistory open onOpenChange={vi.fn()} onSelectChat={onSelectChat} />,
+      <ChatHistory
+        open
+        onOpenChange={vi.fn()}
+        onSelectChat={onSelectChat}
+        projectId="test-project"
+      />,
     );
 
     // ChatHistory shows empty state — no clickable chat items

--- a/apps/desktop/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/renderer/src/i18n/locales/en.json
@@ -486,7 +486,9 @@
       "ariaLabel": "Chat History",
       "searchPlaceholder": "Search...",
       "emptyTitle": "No conversation history yet.",
-      "emptyDescription": "Chat history will appear here once chat persistence is available."
+      "emptyDescription": "Start a conversation to see it here.",
+      "untitledSession": "Untitled conversation",
+      "deleteSession": "Delete conversation"
     },
     "modePicker": {
       "modeAgent": "Agent",

--- a/apps/desktop/renderer/src/i18n/locales/zh-CN.json
+++ b/apps/desktop/renderer/src/i18n/locales/zh-CN.json
@@ -486,7 +486,9 @@
       "ariaLabel": "聊天历史",
       "searchPlaceholder": "搜索...",
       "emptyTitle": "暂无对话记录。",
-      "emptyDescription": "聊天持久化功能上线后，历史记录将显示在此处。"
+      "emptyDescription": "开始对话后，记录将显示在此处。",
+      "untitledSession": "未命名对话",
+      "deleteSession": "删除对话"
     },
     "modePicker": {
       "modeAgent": "智能体",

--- a/apps/desktop/renderer/src/stores/aiStore.tsx
+++ b/apps/desktop/renderer/src/stores/aiStore.tsx
@@ -59,6 +59,24 @@ export type AiRunRequestSnapshot = {
 
 export type { IpcInvoke };
 
+export type ChatSessionItem = {
+  sessionId: string;
+  projectId: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ChatMessageItem = {
+  messageId: string;
+  projectId: string;
+  role: "user" | "assistant";
+  content: string;
+  skillId?: string;
+  timestamp: number;
+  traceId: string;
+};
+
 export type AiState = {
   status: AiStatus;
   stream: boolean;
@@ -83,6 +101,10 @@ export type AiState = {
   queuePosition: number | null;
   queuedCount: number;
   globalRunningCount: number;
+  chatSessions: ChatSessionItem[];
+  chatSessionsStatus: "idle" | "loading" | "ready";
+  activeChatSessionId: string | null;
+  activeChatMessages: ChatMessageItem[];
 };
 
 export type AiActions = {
@@ -124,6 +146,19 @@ export type AiActions = {
   }) => Promise<void>;
   cancel: () => Promise<void>;
   onStreamEvent: (event: AiStreamEvent) => void;
+  loadChatSessions: (args: {
+    projectId: string;
+    query?: string;
+  }) => Promise<void>;
+  selectChatSession: (args: {
+    projectId: string;
+    sessionId: string;
+  }) => Promise<void>;
+  deleteChatSession: (args: {
+    projectId: string;
+    sessionId: string;
+  }) => Promise<void>;
+  clearActiveChatSession: () => void;
 };
 
 export type AiStore = AiState & AiActions;
@@ -617,6 +652,65 @@ function createAiStoreStreamHandler(
  * Why: UI must support stream/cancel/timeout/upstream-error with deterministic
  * state transitions for Windows E2E.
  */
+function createAiStoreChatActions(
+  deps: { invoke: IpcInvoke },
+  set: AiStoreSetter,
+): Pick<
+  AiActions,
+  | "loadChatSessions"
+  | "selectChatSession"
+  | "deleteChatSession"
+  | "clearActiveChatSession"
+> {
+  return {
+    loadChatSessions: async (args) => {
+      set({ chatSessionsStatus: "loading" });
+      const res = await deps.invoke("ai:chat:sessions", {
+        projectId: args.projectId,
+        ...(args.query ? { query: args.query } : {}),
+      });
+      if (res.ok) {
+        set({
+          chatSessions: res.data.sessions,
+          chatSessionsStatus: "ready",
+        });
+      } else {
+        set({ chatSessionsStatus: "ready" });
+      }
+    },
+    selectChatSession: async (args) => {
+      set({ activeChatSessionId: args.sessionId });
+      const res = await deps.invoke("ai:chat:list", {
+        projectId: args.projectId,
+        sessionId: args.sessionId,
+      });
+      if (res.ok) {
+        set({ activeChatMessages: res.data.items });
+      }
+    },
+    deleteChatSession: async (args) => {
+      await deps.invoke("ai:chatsession:delete", {
+        projectId: args.projectId,
+        sessionId: args.sessionId,
+      });
+      set((state) => ({
+        chatSessions: state.chatSessions.filter(
+          (s) => s.sessionId !== args.sessionId,
+        ),
+        ...(state.activeChatSessionId === args.sessionId
+          ? { activeChatSessionId: null, activeChatMessages: [] }
+          : {}),
+      }));
+    },
+    clearActiveChatSession: () => {
+      set({
+        activeChatSessionId: null,
+        activeChatMessages: [],
+      });
+    },
+  };
+}
+
 export function createAiStore(deps: { invoke: IpcInvoke }) {
   return create<AiStore>((set, get) => ({
     status: "idle",
@@ -642,6 +736,10 @@ export function createAiStore(deps: { invoke: IpcInvoke }) {
     queuePosition: null,
     queuedCount: 0,
     globalRunningCount: 0,
+    chatSessions: [],
+    chatSessionsStatus: "idle",
+    activeChatSessionId: null,
+    activeChatMessages: [],
 
     setStream: (enabled) => set({ stream: enabled }),
     setSelectedSkillId: (skillId) => set({ selectedSkillId: skillId }),
@@ -670,6 +768,7 @@ export function createAiStore(deps: { invoke: IpcInvoke }) {
     ...createAiStoreSkillActions(deps, set, get),
     ...createAiStoreRunActions(deps, set, get),
     ...createAiStoreStreamHandler(set, get),
+    ...createAiStoreChatActions(deps, set),
   }));
 }
 

--- a/apps/desktop/tests/integration/ai-chat-capacity-guard.test.ts
+++ b/apps/desktop/tests/integration/ai-chat-capacity-guard.test.ts
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
+import Database from "better-sqlite3";
 import type { IpcMain } from "electron";
 
 import type { Logger } from "../../main/src/logging/logger";
 import { registerAiIpcHandlers } from "../../main/src/ipc/ai";
 
 type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../main/src/db/migrations",
+);
 
 function createLogger(): Logger {
   return {
@@ -14,6 +23,20 @@ function createLogger(): Logger {
     error: () => {},
   };
 }
+
+function applyAllMigrations(db: Database.Database): void {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql") && !f.includes("vec"))
+    .sort();
+  for (const file of files) {
+    db.exec(fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8"));
+  }
+}
+
+const db = new Database(":memory:");
+db.pragma("foreign_keys = ON");
+applyAllMigrations(db);
 
 const handlers = new Map<string, Handler>();
 const ipcMain = {
@@ -24,7 +47,7 @@ const ipcMain = {
 
 registerAiIpcHandlers({
   ipcMain,
-  db: null,
+  db,
   userDataDir: "<test-user-data>",
   builtinSkillsDir: "<test-skills>",
   logger: createLogger(),
@@ -39,10 +62,22 @@ assert.ok(chatList, "expected ai:chat:list handler");
 
 const projectId = "project-chat-capacity";
 
-for (let i = 1; i <= 2000; i += 1) {
+// Send first message to create a session, then reuse it for remaining
+const firstSend = (await chatSend?.(
+  {},
+  { projectId, message: "message-1" },
+)) as {
+  ok: boolean;
+  data?: { sessionId: string };
+};
+assert.equal(firstSend.ok, true);
+const sessionId = firstSend.data?.sessionId;
+assert.ok(sessionId);
+
+for (let i = 2; i <= 2000; i += 1) {
   const response = (await chatSend?.(
     {},
-    { projectId, message: `message-${i}` },
+    { projectId, sessionId, message: `message-${i}` },
   )) as {
     ok: boolean;
   };

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -123,6 +123,8 @@ export const IPC_CHANNELS = [
   "ai:chat:clear",
   "ai:chat:list",
   "ai:chat:send",
+  "ai:chat:sessions",
+  "ai:chatsession:delete",
   "ai:config:get",
   "ai:config:test",
   "ai:config:update",
@@ -272,6 +274,7 @@ export type IpcChannelSpec = {
   "ai:chat:clear": {
     request: {
       projectId: string;
+      sessionId?: string;
     };
     response: {
       cleared: true;
@@ -281,6 +284,7 @@ export type IpcChannelSpec = {
   "ai:chat:list": {
     request: {
       projectId: string;
+      sessionId?: string;
     };
     response: {
       items: Array<{
@@ -299,11 +303,37 @@ export type IpcChannelSpec = {
       documentId?: string;
       message: string;
       projectId: string;
+      sessionId?: string;
     };
     response: {
       accepted: true;
       echoed: string;
       messageId: string;
+      sessionId: string;
+    };
+  };
+  "ai:chat:sessions": {
+    request: {
+      projectId: string;
+      query?: string;
+    };
+    response: {
+      sessions: Array<{
+        createdAt: number;
+        projectId: string;
+        sessionId: string;
+        title: string;
+        updatedAt: number;
+      }>;
+    };
+  };
+  "ai:chatsession:delete": {
+    request: {
+      projectId: string;
+      sessionId: string;
+    };
+    response: {
+      deleted: true;
     };
   };
   "ai:config:get": {

--- a/scripts/lint-baseline.json
+++ b/scripts/lint-baseline.json
@@ -1,19 +1,19 @@
 {
-  "version": "2026-03-11",
-  "generatedAt": "2026-03-11T20:00:00.000Z",
+  "version": "2026-03-16",
+  "generatedAt": "2026-03-16T14:39:51.689Z",
   "source": "eslint-json",
   "governance": {
-    "issue": "#1072",
-    "reason": "G0.5-01: require-describe-in-tests rule added as warn for legacy files; baseline updated to include initial debt"
+    "issue": "#1124",
+    "reason": "chat-history-persistence-using-design-system-components"
   },
   "snapshot": {
-    "totalViolations": 702,
+    "totalViolations": 690,
     "byRule": {
-      "creonow/no-hardcoded-dimension": 63,
-      "creonow/no-native-html-element": 222,
-      "creonow/no-raw-error-code-in-ui": 8,
+      "creonow/no-hardcoded-dimension": 59,
+      "creonow/no-native-html-element": 221,
+      "creonow/no-raw-error-code-in-ui": 5,
       "creonow/no-raw-tailwind-tokens": 4,
-      "creonow/require-describe-in-tests": 405
+      "creonow/require-describe-in-tests": 401
     }
   }
 }


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

将 AI 聊天记录从内存 Map 迁移至 SQLite 持久化存储。实现会话级管理（创建/列表/搜索/删除），支持按项目隔离、按会话筛选消息。

## 关联 Issue

- Closes #1124

## 用户影响

- 聊天记录不再因应用重启丢失，会话历史可浏览、搜索、删除
- ChatHistory 面板从占位 UI 升级为功能完整的会话列表

## 不修最坏后果

- 聊天记录仅存内存，应用重启即失；ChatHistory 面板无法展示真实会话

## 验证证据

- [x] pnpm typecheck — 0 errors
- [x] pnpm lint — 0 errors (693 pre-existing warnings)
- [x] pnpm vitest run — 281 test files, 1971 tests all passing

## 回滚点

- 回滚 commit: aecf84f3
- 回滚后 migration 0024 不会被应用，聊天回退至内存模式

## 非自动化检查（Tier 3）

- [x] 字体渲染：使用 Design Token
- [x] 品牌调性：全部 Design Token
- [x] 无障碍：aria-label + focus-visible
- [x] CJK 场景：i18n 双语 + truncate