### PR TITLE
feat(design-system): v1-01 Design Token 补完 — Typography Scale / 语义间距 / Animation Token

### DIFF
--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -21,14 +21,69 @@
 
   /* 动效 */
   --ease-default: cubic-bezier(0.2, 0, 0.2, 1);
+  --duration-instant: 50ms;
   --duration-fast: 100ms;
   --duration-normal: 200ms;
   --duration-slow: 300ms;
+  --duration-slower: 500ms;
 
   /* 字体 */
   --font-family-ui: "Inter", system-ui, sans-serif;
   --font-family-body: "Lora", "Crimson Pro", Georgia, serif;
   --font-family-mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
+}
+
+/*
+ * Tailwind v4 桥接层 — 引用 tokens.css 中的 CSS 变量
+ *
+ * @theme inline 保留 var() 引用，运行时解析；
+ * 命名遵循 Tailwind v4 namespace（见 node_modules/tailwindcss/theme.css）：
+ *   字体尺寸: --text-<name> / --text-<name>--line-height / --text-<name>--letter-spacing / --text-<name>--font-weight
+ *   字重:     --font-weight-<name>
+ *   字间距:   --tracking-<name>
+ *   行高:     --leading-<name>
+ */
+@theme inline {
+  /* Typography — 展示级标题 → utility: text-display */
+  --text-display: var(--text-display-size);
+  --text-display--line-height: var(--text-display-line-height);
+  --text-display--letter-spacing: var(--text-display-letter-spacing);
+  --text-display--font-weight: var(--text-display-weight);
+
+  /* Typography — 区块标题 → utility: text-heading */
+  --text-heading: var(--text-heading-size);
+  --text-heading--line-height: var(--text-heading-line-height);
+  --text-heading--letter-spacing: var(--text-heading-letter-spacing);
+  --text-heading--font-weight: var(--text-heading-weight);
+
+  /* Typography — 导航 → utility: text-nav */
+  --text-nav: var(--text-nav-size);
+  --text-nav--line-height: var(--text-nav-line-height);
+  --text-nav--letter-spacing: var(--text-nav-letter-spacing);
+  --text-nav--font-weight: var(--text-nav-weight);
+
+  /* Typography — 元数据 → utility: text-metadata */
+  --text-metadata: var(--text-metadata-size);
+  --text-metadata--line-height: var(--text-metadata-line-height);
+  --text-metadata--letter-spacing: var(--text-metadata-letter-spacing);
+  --text-metadata--font-weight: var(--text-metadata-weight);
+
+  /* 独立字重 → utility: font-light / font-normal / font-medium / font-semibold */
+  --font-weight-light: var(--weight-light);
+  --font-weight-normal: var(--weight-normal);
+  --font-weight-medium: var(--weight-medium);
+  --font-weight-semibold: var(--weight-semibold);
+
+  /* 独立字间距 → utility: tracking-tight / tracking-normal / tracking-wide / tracking-wider */
+  --tracking-tight: var(--tracking-tight);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+
+  /* 独立行高 → utility: leading-tight / leading-normal / leading-relaxed */
+  --leading-tight: var(--leading-tight);
+  --leading-normal: var(--leading-normal);
+  --leading-relaxed: var(--leading-relaxed);
 }
 
 /* === 全局基础样式 === */

--- a/apps/desktop/renderer/src/styles/tokens.css
+++ b/apps/desktop/renderer/src/styles/tokens.css
@@ -17,6 +17,12 @@
   --space-16: 64px;
   --space-20: 80px; /* 页面间距 */
 
+  /* 语义间距 — 给布局组件使用的别名 */
+  --space-panel-padding: var(--space-4); /* 面板内边距 */
+  --space-section-gap: var(--space-6); /* 区块间距 */
+  --space-item-gap: var(--space-2); /* 列表项间距 */
+  --space-inline-gap: var(--space-1); /* 行内元素间距 */
+
   /* Radius */
   --radius-none: 0px;
   --radius-sm: 4px;
@@ -102,6 +108,47 @@
   --text-mono-size: 13px;
   --text-mono-weight: 400;
   --text-mono-line-height: 1.5;
+
+  /* 页面大标题（展示级） */
+  --text-display-size: 48px;
+  --text-display-weight: 300;
+  --text-display-line-height: 1.1;
+  --text-display-letter-spacing: -0.03em;
+
+  /* 区块标题 — 与 --text-page-title-* 同值，语义别名 */
+  --text-heading-size: 24px;
+  --text-heading-weight: 600;
+  --text-heading-line-height: 1.2;
+  --text-heading-letter-spacing: -0.02em;
+
+  /* 导航元素 */
+  --text-nav-size: 13px;
+  --text-nav-weight: 500;
+  --text-nav-line-height: 1.4;
+  --text-nav-letter-spacing: 0;
+
+  /* 元数据（时间戳、字数统计等） */
+  --text-metadata-size: 12px;
+  --text-metadata-weight: 400;
+  --text-metadata-line-height: 1.4;
+  --text-metadata-letter-spacing: 0.02em;
+
+  /* 独立字重 */
+  --weight-light: 300; /* 展示级标题 */
+  --weight-normal: 400; /* 正文 */
+  --weight-medium: 500; /* 小标题、导航 */
+  --weight-semibold: 600; /* 标题 */
+
+  /* 独立字间距（Tracking） */
+  --tracking-tight: -0.03em; /* 大号展示文字 */
+  --tracking-normal: 0; /* 正文默认 */
+  --tracking-wide: 0.05em; /* 宽松间距 */
+  --tracking-wider: 0.1em; /* 大写标签 */
+
+  /* 独立行高（Leading） */
+  --leading-tight: 1.1; /* 标题紧凑 */
+  --leading-normal: 1.5; /* 正文默认 */
+  --leading-relaxed: 1.8; /* 编辑器长文 */
 
   /* z-index 层级 §5.1 */
   --z-base: 0; /* 默认层 */

--- a/apps/desktop/tests/lint/design-token-completeness.test.ts
+++ b/apps/desktop/tests/lint/design-token-completeness.test.ts
@@ -1,0 +1,267 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const DESIGN_TOKENS = path.join(REPO_ROOT, "design/system/01-tokens.css");
+const RENDERER_TOKENS = path.join(
+  REPO_ROOT,
+  "apps/desktop/renderer/src/styles/tokens.css",
+);
+const MAIN_CSS = path.join(
+  REPO_ROOT,
+  "apps/desktop/renderer/src/styles/main.css",
+);
+
+function readCSS(filePath: string): string {
+  return readFileSync(filePath, "utf8");
+}
+
+describe("v1-01 Design Token 完整性 guard", () => {
+  const designTokens = readCSS(DESIGN_TOKENS);
+  const rendererTokens = readCSS(RENDERER_TOKENS);
+  const mainCSS = readCSS(MAIN_CSS);
+
+  describe("typography scale token（design/system/01-tokens.css）", () => {
+    const typographyGroups = [
+      {
+        prefix: "--text-display",
+        size: "48px",
+        weight: "300",
+        lineHeight: "1.1",
+        letterSpacing: "-0.03em",
+      },
+      {
+        prefix: "--text-heading",
+        size: "24px",
+        weight: "600",
+        lineHeight: "1.2",
+        letterSpacing: "-0.02em",
+      },
+      {
+        prefix: "--text-nav",
+        size: "13px",
+        weight: "500",
+        lineHeight: "1.4",
+        letterSpacing: "0",
+      },
+      {
+        prefix: "--text-metadata",
+        size: "12px",
+        weight: "400",
+        lineHeight: "1.4",
+        letterSpacing: "0.02em",
+      },
+    ] as const;
+
+    for (const group of typographyGroups) {
+      it(`包含 ${group.prefix} 四件组`, () => {
+        expect(designTokens).toContain(`${group.prefix}-size: ${group.size}`);
+        expect(designTokens).toContain(
+          `${group.prefix}-weight: ${group.weight}`,
+        );
+        expect(designTokens).toContain(
+          `${group.prefix}-line-height: ${group.lineHeight}`,
+        );
+        expect(designTokens).toContain(
+          `${group.prefix}-letter-spacing: ${group.letterSpacing}`,
+        );
+      });
+    }
+  });
+
+  describe("独立 weight / tracking / leading token（design/system/01-tokens.css）", () => {
+    it("包含独立字重 token", () => {
+      expect(designTokens).toContain("--weight-light: 300");
+      expect(designTokens).toContain("--weight-normal: 400");
+      expect(designTokens).toContain("--weight-medium: 500");
+      expect(designTokens).toContain("--weight-semibold: 600");
+    });
+
+    it("包含独立字间距 token", () => {
+      expect(designTokens).toContain("--tracking-tight: -0.03em");
+      expect(designTokens).toContain("--tracking-normal: 0");
+      expect(designTokens).toContain("--tracking-wide: 0.05em");
+      expect(designTokens).toContain("--tracking-wider: 0.1em");
+    });
+
+    it("包含独立行高 token", () => {
+      expect(designTokens).toContain("--leading-tight: 1.1");
+      expect(designTokens).toContain("--leading-normal: 1.5");
+      expect(designTokens).toContain("--leading-relaxed: 1.8");
+    });
+  });
+
+  describe("语义间距 token（design/system/01-tokens.css）", () => {
+    it("包含语义间距别名", () => {
+      expect(designTokens).toContain("--space-panel-padding: var(--space-4)");
+      expect(designTokens).toContain("--space-section-gap: var(--space-6)");
+      expect(designTokens).toContain("--space-item-gap: var(--space-2)");
+      expect(designTokens).toContain("--space-inline-gap: var(--space-1)");
+    });
+  });
+
+  describe("@theme 块 duration 补全", () => {
+    it("包含 --duration-instant 和 --duration-slower", () => {
+      expect(mainCSS).toContain("--duration-instant: 50ms");
+      expect(mainCSS).toContain("--duration-slower: 500ms");
+    });
+  });
+
+  describe("@theme inline — Tailwind v4 namespace 正确性", () => {
+    function extractThemeInlineBlock(css: string): string {
+      const match = css.match(/@theme\s+inline\s*\{([\s\S]*?)\n\}/);
+      expect(match, "main.css 缺少 @theme inline 块").not.toBeNull();
+      return match![1];
+    }
+
+    it("存在 @theme inline 块", () => {
+      expect(mainCSS).toMatch(/@theme\s+inline\s*\{/);
+    });
+
+    it("typography 使用 Tailwind v4 text namespace（--text-<name> + 双横线子属性）", () => {
+      const themeInline = extractThemeInlineBlock(mainCSS);
+      const textGroups = ["display", "heading", "nav", "metadata"];
+      for (const name of textGroups) {
+        expect(themeInline, `缺少 --text-${name} 主尺寸映射`).toMatch(
+          new RegExp(`--text-${name}:\\s*var\\(--text-${name}-size\\)`),
+        );
+        expect(themeInline, `缺少 --text-${name}--line-height`).toMatch(
+          new RegExp(
+            `--text-${name}--line-height:\\s*var\\(--text-${name}-line-height\\)`,
+          ),
+        );
+        expect(themeInline, `缺少 --text-${name}--letter-spacing`).toMatch(
+          new RegExp(
+            `--text-${name}--letter-spacing:\\s*var\\(--text-${name}-letter-spacing\\)`,
+          ),
+        );
+        expect(themeInline, `缺少 --text-${name}--font-weight`).toMatch(
+          new RegExp(
+            `--text-${name}--font-weight:\\s*var\\(--text-${name}-weight\\)`,
+          ),
+        );
+      }
+    });
+
+    it("字重使用 Tailwind v4 --font-weight-* namespace", () => {
+      const themeInline = extractThemeInlineBlock(mainCSS);
+      expect(themeInline).toMatch(
+        /--font-weight-light:\s*var\(--weight-light\)/,
+      );
+      expect(themeInline).toMatch(
+        /--font-weight-normal:\s*var\(--weight-normal\)/,
+      );
+      expect(themeInline).toMatch(
+        /--font-weight-medium:\s*var\(--weight-medium\)/,
+      );
+      expect(themeInline).toMatch(
+        /--font-weight-semibold:\s*var\(--weight-semibold\)/,
+      );
+    });
+
+    it("字间距使用 --tracking-* namespace 并引用内部 token", () => {
+      const themeInline = extractThemeInlineBlock(mainCSS);
+      expect(themeInline).toMatch(
+        /--tracking-tight:\s*var\(--tracking-tight\)/,
+      );
+      expect(themeInline).toMatch(
+        /--tracking-normal:\s*var\(--tracking-normal\)/,
+      );
+      expect(themeInline).toMatch(/--tracking-wide:\s*var\(--tracking-wide\)/);
+      expect(themeInline).toMatch(
+        /--tracking-wider:\s*var\(--tracking-wider\)/,
+      );
+    });
+
+    it("行高使用 --leading-* namespace 并引用内部 token", () => {
+      const themeInline = extractThemeInlineBlock(mainCSS);
+      expect(themeInline).toMatch(/--leading-tight:\s*var\(--leading-tight\)/);
+      expect(themeInline).toMatch(
+        /--leading-normal:\s*var\(--leading-normal\)/,
+      );
+      expect(themeInline).toMatch(
+        /--leading-relaxed:\s*var\(--leading-relaxed\)/,
+      );
+    });
+
+    it("@theme inline 中不包含内部命名 --text-*-size / --weight-* / --text-*-weight", () => {
+      const themeInline = extractThemeInlineBlock(mainCSS);
+      // 确保没有把内部 token 名直接当 @theme 变量名
+      expect(themeInline).not.toMatch(/^\s*--text-\w+-size:/m);
+      expect(themeInline).not.toMatch(/^\s*--text-\w+-weight:/m);
+      expect(themeInline).not.toMatch(/^\s*--weight-\w+:/m);
+    });
+  });
+
+  describe("renderer/src/styles/tokens.css 同步一致性", () => {
+    const syncedTokens = [
+      "--text-display-size",
+      "--text-display-weight",
+      "--text-display-line-height",
+      "--text-display-letter-spacing",
+      "--text-heading-size",
+      "--text-heading-weight",
+      "--text-heading-line-height",
+      "--text-heading-letter-spacing",
+      "--text-nav-size",
+      "--text-nav-weight",
+      "--text-nav-line-height",
+      "--text-nav-letter-spacing",
+      "--text-metadata-size",
+      "--text-metadata-weight",
+      "--text-metadata-line-height",
+      "--text-metadata-letter-spacing",
+      "--weight-light",
+      "--weight-normal",
+      "--weight-medium",
+      "--weight-semibold",
+      "--tracking-tight",
+      "--tracking-normal",
+      "--tracking-wide",
+      "--tracking-wider",
+      "--leading-tight",
+      "--leading-normal",
+      "--leading-relaxed",
+      "--space-panel-padding",
+      "--space-section-gap",
+      "--space-item-gap",
+      "--space-inline-gap",
+    ] as const;
+
+    it("renderer tokens.css 包含所有新增 token", () => {
+      for (const token of syncedTokens) {
+        expect(rendererTokens, `renderer tokens.css 缺少 ${token}`).toContain(
+          token,
+        );
+      }
+    });
+
+    it("design 与 renderer 的 token 值一致", () => {
+      for (const token of syncedTokens) {
+        const designMatch = designTokens.match(
+          new RegExp(
+            `${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:\\s*([^;]+);`,
+          ),
+        );
+        const rendererMatch = rendererTokens.match(
+          new RegExp(
+            `${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:\\s*([^;]+);`,
+          ),
+        );
+
+        expect(
+          designMatch,
+          `design 01-tokens.css 缺少 ${token}`,
+        ).not.toBeNull();
+        expect(
+          rendererMatch,
+          `renderer tokens.css 缺少 ${token}`,
+        ).not.toBeNull();
+        expect(rendererMatch![1].trim(), `${token} 值不一致`).toBe(
+          designMatch![1].trim(),
+        );
+      }
+    });
+  });
+});

--- a/design/system/01-tokens.css
+++ b/design/system/01-tokens.css
@@ -187,6 +187,12 @@
   --space-12: 48px; /* 模块间距 */
   --space-16: 64px;
   --space-20: 80px; /* 页面间距 */
+
+  /* 语义间距 — 给布局组件使用的别名 */
+  --space-panel-padding: var(--space-4); /* 面板内边距 */
+  --space-section-gap: var(--space-6); /* 区块间距 */
+  --space-item-gap: var(--space-2); /* 列表项间距 */
+  --space-inline-gap: var(--space-1); /* 行内元素间距 */
 }
 
 /* ============================================
@@ -320,6 +326,59 @@
   --text-mono-size: 13px;
   --text-mono-weight: 400;
   --text-mono-line-height: 1.5;
+
+  /* 页面大标题（展示级） */
+  --text-display-size: 48px;
+  --text-display-weight: 300;
+  --text-display-line-height: 1.1;
+  --text-display-letter-spacing: -0.03em;
+
+  /* 区块标题 — 与 --text-page-title-* 同值，语义别名 */
+  --text-heading-size: 24px;
+  --text-heading-weight: 600;
+  --text-heading-line-height: 1.2;
+  --text-heading-letter-spacing: -0.02em;
+
+  /* 导航元素 */
+  --text-nav-size: 13px;
+  --text-nav-weight: 500;
+  --text-nav-line-height: 1.4;
+  --text-nav-letter-spacing: 0;
+
+  /* 元数据（时间戳、字数统计等） */
+  --text-metadata-size: 12px;
+  --text-metadata-weight: 400;
+  --text-metadata-line-height: 1.4;
+  --text-metadata-letter-spacing: 0.02em;
+}
+
+/* ============================================
+   独立字重 Token
+   ============================================ */
+:root {
+  --weight-light: 300; /* 展示级标题 */
+  --weight-normal: 400; /* 正文 */
+  --weight-medium: 500; /* 小标题、导航 */
+  --weight-semibold: 600; /* 标题 */
+}
+
+/* ============================================
+   独立字间距 Token（Tracking）
+   ============================================ */
+:root {
+  --tracking-tight: -0.03em; /* 大号展示文字 */
+  --tracking-normal: 0; /* 正文默认 */
+  --tracking-wide: 0.05em; /* 宽松间距 */
+  --tracking-wider: 0.1em; /* 大写标签 */
+}
+
+/* ============================================
+   独立行高 Token（Leading）
+   ============================================ */
+:root {
+  --leading-tight: 1.1; /* 标题紧凑 */
+  --leading-normal: 1.5; /* 正文默认 */
+  --leading-relaxed: 1.8; /* 编辑器长文 */
 }
 
 /* ============================================

--- a/openspec/specs/design-system/spec.md
+++ b/openspec/specs/design-system/spec.md
@@ -1,0 +1,208 @@
+# Design System Specification
+
+## Purpose
+
+定义 CreoNow 视觉设计系统的 Token 体系、命名规范、Tailwind 映射契约与模块间消费关系。
+
+### Scope
+
+| Layer  | Path                                                                           |
+| ------ | ------------------------------------------------------------------------------ |
+| 设计源 | `design/system/01-tokens.css`                                                  |
+| 运行时 | `apps/desktop/renderer/src/styles/tokens.css`                                  |
+| 主题桥 | `apps/desktop/renderer/src/styles/main.css`（`@theme` 块）                     |
+| 组件层 | `apps/desktop/renderer/src/components/primitives/`                             |
+| 参考   | `design/DESIGN_DECISIONS.md` §3-4、`docs/references/design-ui-architecture.md` |
+
+---
+
+## Requirements
+
+### Requirement: Token 分层架构
+
+设计系统**必须**采用三层 Token 架构：
+
+1. **源文件层**（`design/system/01-tokens.css`）：Token 的权威定义，由设计决策驱动。
+2. **运行时层**（`renderer/src/styles/tokens.css`）：与源文件层保持完全同步，供 Electron 渲染进程使用。
+3. **Tailwind 桥接层**（`renderer/src/styles/main.css` 的 `@theme` 块）：将 Token 映射到 Tailwind v4 namespace，使 utility class 可用。
+
+Token 值的变更**必须**先更新源文件层，再同步到运行时层和桥接层。
+
+---
+
+### Requirement: Token 命名规范
+
+#### 内部 Token（源文件层 + 运行时层）
+
+内部 Token 使用 CreoNow 自有命名体系，反映语义用途：
+
+| 类别            | 命名模式                   | 示例                    |
+| --------------- | -------------------------- | ----------------------- |
+| 颜色            | `--color-<role>-<variant>` | `--color-bg-base`       |
+| 间距            | `--space-<N>`              | `--space-4`（16px）     |
+| 语义间距        | `--space-<context>`        | `--space-panel-padding` |
+| 圆角            | `--radius-<size>`          | `--radius-md`           |
+| 阴影            | `--shadow-<size>`          | `--shadow-lg`           |
+| 动效时长        | `--duration-<speed>`       | `--duration-fast`       |
+| 动效曲线        | `--ease-<type>`            | `--ease-default`        |
+| 预设 Typography | `--text-<role>-<property>` | `--text-display-size`   |
+| 独立字重        | `--weight-<name>`          | `--weight-semibold`     |
+| 独立字间距      | `--tracking-<name>`        | `--tracking-tight`      |
+| 独立行高        | `--leading-<name>`         | `--leading-relaxed`     |
+| 字体族          | `--font-family-<name>`     | `--font-family-ui`      |
+| 布局尺寸        | `--size-<context>`         | `--size-icon-bar`       |
+| z-index         | `--z-<level>`              | `--z-modal`             |
+
+#### Typography 预设 Token 完整清单
+
+| Token 族              | 用途                      | size | weight | line-height | letter-spacing |
+| --------------------- | ------------------------- | ---- | ------ | ----------- | -------------- |
+| `--text-display-*`    | 页面大标题（展示级）      | 48px | 300    | 1.1         | -0.03em        |
+| `--text-page-title-*` | 页面标题                  | 24px | 600    | 1.2         | -0.02em        |
+| `--text-heading-*`    | 区块标题（同 page-title） | 24px | 600    | 1.2         | -0.02em        |
+| `--text-card-title-*` | 卡片标题                  | 16px | 600    | 1.3         | -0.01em        |
+| `--text-subtitle-*`   | 小标题                    | 14px | 500    | 1.4         | —              |
+| `--text-body-*`       | UI 正文                   | 13px | 400    | 1.5         | —              |
+| `--text-editor-*`     | 编辑器正文                | 16px | 400    | 1.8         | —              |
+| `--text-nav-*`        | 导航元素                  | 13px | 500    | 1.4         | 0              |
+| `--text-caption-*`    | 辅助信息                  | 12px | 400    | 1.4         | —              |
+| `--text-metadata-*`   | 元数据（时间戳、字数等）  | 12px | 400    | 1.4         | 0.02em         |
+| `--text-label-*`      | 大写标签                  | 10px | 500    | 1.2         | 0.1em          |
+| `--text-tree-*`       | 侧栏树节点                | 13px | 400    | 1.3         | —              |
+| `--text-status-*`     | 状态栏                    | 11px | 400    | 1.2         | —              |
+| `--text-mono-*`       | 代码/等宽                 | 13px | 400    | 1.5         | —              |
+
+**别名关系**：
+
+- `--text-heading-*` 与 `--text-page-title-*` **同值**，`heading` 为语义别名，用于区块级标题上下文。两者值必须保持同步，未来若需分化则先更新本 spec。
+- `--text-nav-*` 与 `--text-tree-*` **不同**：nav 的 weight 为 500（强调），tree 为 400（正文级）。
+- `--text-metadata-*` 与 `--text-caption-*` **不同**：metadata 有 0.02em letter-spacing（数据感），caption 无。
+
+---
+
+### Requirement: Tailwind v4 桥接层命名规范
+
+`@theme` 块中的变量名**必须**遵循 Tailwind v4 的 namespace 约定（参见 `node_modules/tailwindcss/theme.css`），否则不会生成对应 utility class。
+
+#### 字体尺寸（text-\*）
+
+```
+--text-<name>: <size>;
+--text-<name>--line-height: <value>;
+--text-<name>--letter-spacing: <value>;
+--text-<name>--font-weight: <value>;
+```
+
+通过 `@theme inline` 引用内部 Token：
+
+```css
+@theme inline {
+  --text-display: var(--text-display-size);
+  --text-display--line-height: var(--text-display-line-height);
+  --text-display--letter-spacing: var(--text-display-letter-spacing);
+  --text-display--font-weight: var(--text-display-weight);
+}
+```
+
+生成 utility class：`text-display` → 自动应用 font-size + line-height + letter-spacing + font-weight。
+
+#### 字重（font-weight-\*）
+
+```
+--font-weight-<name>: <value>;
+```
+
+通过 `@theme inline` 引用内部 Token：
+
+```css
+@theme inline {
+  --font-weight-light: var(--weight-light);
+}
+```
+
+生成 utility class：`font-light` → font-weight: 300。
+
+#### 字间距（tracking-\*）
+
+```
+--tracking-<name>: <value>;
+```
+
+通过 `@theme inline` 引用内部 Token：
+
+```css
+@theme inline {
+  --tracking-tight: var(--tracking-tight);
+}
+```
+
+生成 utility class：`tracking-tight` → letter-spacing: -0.03em。
+
+#### 行高（leading-\*）
+
+```
+--leading-<name>: <value>;
+```
+
+通过 `@theme inline` 引用内部 Token：
+
+```css
+@theme inline {
+  --leading-tight: var(--leading-tight);
+}
+```
+
+生成 utility class：`leading-tight` → line-height: 1.1。
+
+#### 何时用 `@theme` vs `@theme inline`
+
+- `@theme`（不带 inline）：硬编码值，Tailwind 会在编译时静态替换。适用于不依赖运行时 CSS 变量的值（如圆角、间距常量）。
+- `@theme inline`：值保留为 `var(--xxx)` 引用，在运行时解析。**适用于需要引用 tokens.css 中已定义的 CSS 变量的场景**——本项目的 typography / weight / tracking / leading token 均需走此路径。
+
+---
+
+### Requirement: 语义间距 Token
+
+语义间距**必须**通过引用基础间距 Token 定义（不得硬编码值）：
+
+| Token                   | 值               | 用途         |
+| ----------------------- | ---------------- | ------------ |
+| `--space-panel-padding` | `var(--space-4)` | 面板内边距   |
+| `--space-section-gap`   | `var(--space-6)` | 区块间距     |
+| `--space-item-gap`      | `var(--space-2)` | 列表项间距   |
+| `--space-inline-gap`    | `var(--space-1)` | 行内元素间距 |
+
+---
+
+### Requirement: Token 同步契约
+
+`renderer/src/styles/tokens.css` 与 `design/system/01-tokens.css` 中的 Token 变量名和值**必须**保持一致。新增、修改、删除 Token 时，两个文件必须同步更新。
+
+Guard 测试**必须**自动验证同步一致性。
+
+---
+
+## Scenarios
+
+#### Scenario: Tailwind utility class 消费 typography token
+
+- **假设** `@theme inline` 中定义了 `--text-display: var(--text-display-size)`
+- **当** 开发者在 JSX 中使用 `className="text-display"`
+- **则** Tailwind 生成的 CSS 包含 `font-size: var(--text-display-size)`
+- **并且** 同时应用 `line-height: var(--text-display-line-height)`
+- **并且** 同时应用 `letter-spacing: var(--text-display-letter-spacing)`
+- **并且** 同时应用 `font-weight: var(--text-display-weight)`
+
+#### Scenario: 新增 Token 时的同步流程
+
+- **假设** 需要新增一个 `--text-footnote-*` Token 族
+- **当** 在 `design/system/01-tokens.css` 中定义
+- **则** 必须同步到 `renderer/src/styles/tokens.css`
+- **并且** 必须在 `main.css` 的 `@theme inline` 中添加 Tailwind 桥接
+- **并且** guard 测试必须覆盖新 Token
+
+#### Scenario: 运行时主题切换时 Token 生效
+
+- **假设** `@theme inline` 使用 `var()` 引用 Token
+- **当** 用户切换 dark/light 主题
+- **则** CSS 变量值随主题切换，Tailwind utility class 自动生效新值


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

V1 视觉重塑 Wave 0 第一步：补全 Design Token 体系中缺失的 Typography Scale、语义间距别名、以及 `@theme` / `@theme inline` 桥接层中未导出的 animation duration 与 Tailwind v4 namespace 映射。

「地基不补完，上层每个 change 都要自行硬编码。」——粮仓满而灶台空，本 PR 为灶台引火。

## 关联 Issue

- Closes #1157

## 用户影响

- **无直接用户可见变化**（Wave 0 地基增强）
- 后续 v1-02 至 v1-16 的 child changes 将基于本 PR 新增 token 与 Tailwind v4 bridge 实施视觉对齐
- 新增 `openspec/specs/design-system/spec.md` 后，后续 token 扩展有了明确的命名与桥接契约

## 本次补齐内容

- 补全 `display / heading / nav / metadata` 四组 typography token
- 补全独立 `weight / tracking / leading` token
- 补全语义间距别名：`panel-padding / section-gap / item-gap / inline-gap`
- 在 `main.css` 中补全 `duration-instant / duration-slower`
- 使用 **`@theme inline` + Tailwind v4 正确 namespace** 建立 typography / font-weight / tracking / leading bridge
- 新增 `openspec/specs/design-system/spec.md`，明确 token 三层架构、命名规范、别名关系与 Tailwind 映射契约
- 新增 guard 测试，验证 token 完整性、同步一致性与 Tailwind v4 namespace 正确性

## 不修最坏后果

- Features 层 `text-[Npx]` arbitrary 值持续绕过 token 体系
- 后续 Wave 1-4 每个 change 都要自行硬编码 typography 值，一致性无法保障
- 浅色主题切换时 typography 无法统一调整
- token 命名边界与 Tailwind bridge 规则缺乏 canonical spec，后续变更容易再次漂移

## 验证证据

- [x] `pnpm typecheck` — ✅ 通过
- [x] `pnpm lint` — ✅ 通过
- [x] `pnpm -C apps/desktop vitest run` — ✅ 285 files / 2010 tests 全通过
- [x] `pnpm -C apps/desktop storybook:build` — ✅ 构建成功
- [x] `pnpm -C apps/desktop exec vitest run --config tests/unit/main/vitest.node.config.ts tests/lint/design-token-completeness.test.ts --reporter=verbose` — ✅ 17 tests 全通过
- [x] Tailwind v4 compile 验证 — ✅ `text-display / text-heading / text-nav / text-metadata / font-light / font-semibold / tracking-tight / tracking-wider / leading-tight / leading-relaxed` 均可生成 utility

## 回滚点

- 回滚 commit：`git revert <merge-commit>`
- 回滚后需要恢复的数据或配置：无——本 PR 只新增 CSS 变量、spec 与测试文件，不修改现有业务逻辑

## 非自动化检查（Tier 3）

- [x] **字体渲染**：N/A — 本 PR 仅新增 token、spec 与桥接规则，无实际页面排版改动
- [x] **品牌调性**：新增 token 全部使用 `--text-*`、`--weight-*`、`--tracking-*`、`--leading-*`、`--space-*` 语义化命名
- [x] **无障碍**：N/A — 无新增交互组件
- [x] **CJK 场景**：N/A — 无新增文本渲染组件

## 变更范围

| 文件 | 变更类型 |
|---|---|
| `design/system/01-tokens.css` | 追加 typography / weight / tracking / leading / 语义间距 token |
| `apps/desktop/renderer/src/styles/tokens.css` | 同步追加所有新增 token |
| `apps/desktop/renderer/src/styles/main.css` | 补全 `@theme` duration，并新增 `@theme inline` Tailwind v4 bridge |
| `apps/desktop/tests/lint/design-token-completeness.test.ts` | 新增 17 个 guard 测试 |
| `openspec/specs/design-system/spec.md` | 新增 canonical spec，明确 token 架构与桥接契约 |
