### PR TITLE
refactor(v1-18): Arbitrary Value Cleanup 与变体推广

### DIFF
--- a/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
@@ -4,8 +4,8 @@
  * Scans all production .tsx files under features/ and components/ for
  * styling violations that bypass the Design Token system:
  *
- *   1. Tailwind built-in shadows (shadow-lg, shadow-xl, shadow-2xl)
- *      → must use a token-wrapped shadow utility
+ *   1. Tailwind shadow-2xl (not registered in @theme inline)
+ *      → must use a token-wrapped shadow utility or register in @theme
  *   2. Tailwind raw color utilities (bg-red-600, text-green-500, etc.)
  *      → must use semantic Token via var(--)
  *   3. Hardcoded hex (#xxx, #xxxxxx) or rgba() values in className / style
@@ -58,11 +58,13 @@ const HEX_RGBA_ALLOWLISTED_FILES = [/SettingsAppearancePage\.tsx$/];
 
 /**
  * Tailwind built-in shadow classes that bypass the Token shadow system.
- * Matches: shadow-lg, shadow-xl, shadow-2xl (and hover/focus variants)
+ * Matches: shadow-2xl (and hover/focus variants)
+ * Does NOT match: shadow-sm/md/lg/xl — these are registered via @theme inline
+ *                 and resolve to design-token values (--shadow-sm … --shadow-xl).
  * Does NOT match: shadow-[var(--shadow-lg)] (token-wrapped)
  */
 const BARE_SHADOW_REGEX =
-  /(?<!\[var\(--shadow-)(?:^|[\s"'`])(?:!?(?:hover:|focus:|active:|group-hover:)*)(!?shadow-(?:lg|xl|2xl))\b(?!\])/;
+  /(?<!\[var\(--shadow-)(?:^|[\s"'`])(?:!?(?:hover:|focus:|active:|group-hover:)*)(!?shadow-2xl)\b(?!\])/;
 
 /**
  * Tailwind raw color utilities (not wrapped in var(--)).
@@ -274,7 +276,7 @@ describe("Token global compliance: no style bypass in production files", () => {
     }
   }
 
-  it("no production files should use bare Tailwind shadow classes (shadow-lg/xl/2xl)", () => {
+  it("no production files should use bare Tailwind shadow classes not registered in @theme (shadow-2xl)", () => {
     const shadowViolations = allViolations
       .map((f) => ({
         file: f.file,
@@ -291,7 +293,7 @@ describe("Token global compliance: no style bypass in production files", () => {
         .join("");
       expect.fail(
         `Found ${shadowViolations.reduce((n, v) => n + v.violations.length, 0)} bare shadow violation(s) in ${shadowViolations.length} file(s).\n` +
-          `Use shadow-[var(--shadow-lg)] instead of shadow-lg.\n${report}`,
+          `Use shadow-[var(--shadow-2xl)] or register --shadow-2xl in @theme inline.\n${report}`,
       );
     }
   });

--- a/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
+++ b/apps/desktop/renderer/src/__tests__/token-global-compliance.test.ts
@@ -293,7 +293,7 @@ describe("Token global compliance: no style bypass in production files", () => {
         .join("");
       expect.fail(
         `Found ${shadowViolations.reduce((n, v) => n + v.violations.length, 0)} bare shadow violation(s) in ${shadowViolations.length} file(s).\n` +
-          `Use shadow-[var(--shadow-2xl)] or register --shadow-2xl in @theme inline.\n${report}`,
+          `Use a token-backed shadow utility or register the shadow token in @theme inline.\n${report}`,
       );
     }
   });

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffContent.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffContent.tsx
@@ -97,45 +97,45 @@ const afterPanelStyles = [diffPanelStyles, "bg-[var(--color-bg-surface)]"].join(
   " ",
 );
 const labelStyles = [
-  "uppercase text-[10px] font-bold tracking-wider",
+  "uppercase text-label font-bold tracking-wider",
   "mb-4",
 ].join(" ");
 const beforeLabelStyles = [
   labelStyles,
-  "text-[var(--color-error)] opacity-70",
+  "text-(--color-error) opacity-70",
 ].join(" ");
 const afterLabelStyles = [
   labelStyles,
-  "text-[var(--color-success)] opacity-70",
+  "text-(--color-success) opacity-70",
 ].join(" ");
 const textStyles = ["text-sm", "leading-relaxed", "font-mono"].join(" ");
-const beforeTextStyles = [textStyles, "text-[var(--color-fg-muted)]"].join(" ");
-const afterTextStyles = [textStyles, "text-[var(--color-fg-default)]"].join(
+const beforeTextStyles = [textStyles, "text-(--color-fg-muted)"].join(" ");
+const afterTextStyles = [textStyles, "text-(--color-fg-default)"].join(
   " ",
 );
 const removedStyles = [
-  "bg-[var(--color-error-subtle)] text-[var(--color-error)] line-through px-0.5",
+  "bg-[var(--color-error-subtle)] text-(--color-error) line-through px-0.5",
   "rounded-sm",
 ].join(" ");
 const addedStyles = [
-  "bg-[var(--color-success-subtle)] text-[var(--color-success)] px-0.5 rounded-sm",
+  "bg-[var(--color-success-subtle)] text-(--color-success) px-0.5 rounded-sm",
 ].join(" ");
 const stateIndicatorStyles = [
   "absolute top-2 right-2 flex",
-  "items-center gap-1 text-[10px] font-medium",
+  "items-center gap-1 text-label font-medium",
   "px-2 py-0.5 rounded-full",
 ].join(" ");
 const pendingIndicatorStyles = [
   stateIndicatorStyles,
-  "bg-[var(--color-info-subtle)] text-[var(--color-info)]",
+  "bg-[var(--color-info-subtle)] text-(--color-info)",
 ].join(" ");
 const acceptedIndicatorStyles = [
   stateIndicatorStyles,
-  "bg-[var(--color-success-subtle)] text-[var(--color-success)]",
+  "bg-[var(--color-success-subtle)] text-(--color-success)",
 ].join(" ");
 const rejectedIndicatorStyles = [
   stateIndicatorStyles,
-  "bg-[var(--color-error-subtle)] text-[var(--color-error)]",
+  "bg-[var(--color-error-subtle)] text-(--color-error)",
 ].join(" ");
 
 interface AiDiffContentProps {

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffContent.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffContent.tsx
@@ -100,19 +100,16 @@ const labelStyles = [
   "uppercase text-label font-bold tracking-wider",
   "mb-4",
 ].join(" ");
-const beforeLabelStyles = [
-  labelStyles,
-  "text-(--color-error) opacity-70",
-].join(" ");
+const beforeLabelStyles = [labelStyles, "text-(--color-error) opacity-70"].join(
+  " ",
+);
 const afterLabelStyles = [
   labelStyles,
   "text-(--color-success) opacity-70",
 ].join(" ");
 const textStyles = ["text-sm", "leading-relaxed", "font-mono"].join(" ");
 const beforeTextStyles = [textStyles, "text-(--color-fg-muted)"].join(" ");
-const afterTextStyles = [textStyles, "text-(--color-fg-default)"].join(
-  " ",
-);
+const afterTextStyles = [textStyles, "text-(--color-fg-default)"].join(" ");
 const removedStyles = [
   "bg-[var(--color-error-subtle)] text-(--color-error) line-through px-0.5",
   "rounded-sm",

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffModal.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffModal.tsx
@@ -70,9 +70,9 @@ const overlayStyles = [
 const contentStyles = [
   "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2",
   "z-[var(--z-modal)] bg-[var(--color-bg-surface)] border border-[var(--color-border-default)]",
-  "rounded-[var(--radius-lg)] shadow-[var(--shadow-xl)] w-full max-w-4xl",
+  "rounded-lg shadow-xl w-full max-w-4xl",
   // eslint-disable-next-line creonow/no-hardcoded-dimension -- dialog content height per design spec
-  "h-[500px] overflow-hidden flex flex-col",
+  "h-125 overflow-hidden flex flex-col",
   "transition-[opacity,transform] duration-[var(--duration-normal)] ease-[var(--ease-default)]",
   "data-[state=open]:opacity-100 data-[state=open]:scale-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-95",
   "focus:outline-none",
@@ -84,34 +84,34 @@ const headerStyles = [
 ].join(" ");
 const navContainerStyles = [
   "flex items-center gap-3 bg-[var(--color-bg-base)]",
-  "rounded-[var(--radius-sm)] px-2 py-1 border",
+  "rounded-sm px-2 py-1 border",
   "border-[var(--color-separator)]",
 ].join(" ");
 const navButtonStyles = [
-  "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors duration-[var(--duration-fast)]",
+  "text-(--color-fg-muted) hover:text-(--color-fg-default) transition-colors duration-[var(--duration-fast)]",
   "p-0.5 focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)]",
   "focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
 ].join(" ");
-const navTextStyles = ["text-xs font-mono text-[var(--color-fg-muted)]"].join(
+const navTextStyles = ["text-xs font-mono text-(--color-fg-muted)"].join(
   " ",
 );
 const closeButtonStyles = [
-  "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] p-1 transition-colors",
+  "text-(--color-fg-muted) hover:text-(--color-fg-default) p-1 transition-colors",
   "duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)]",
   "focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 const changeActionButtonStyles = [
   "h-6 w-6 flex items-center",
-  "justify-center rounded-[var(--radius-sm)] transition-colors duration-[var(--duration-fast)]",
+  "justify-center rounded-sm transition-colors duration-[var(--duration-fast)]",
   "focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 const acceptChangeButtonStyles = [
   changeActionButtonStyles,
-  "text-[var(--color-fg-muted)] hover:bg-[var(--color-success-subtle)] hover:text-[var(--color-success)]",
+  "text-(--color-fg-muted) hover:bg-[var(--color-success-subtle)] hover:text-(--color-success)",
 ].join(" ");
 const rejectChangeButtonStyles = [
   changeActionButtonStyles,
-  "text-[var(--color-fg-muted)] hover:bg-[var(--color-error-subtle)] hover:text-[var(--color-error)]",
+  "text-(--color-fg-muted) hover:bg-[var(--color-error-subtle)] hover:text-(--color-error)",
 ].join(" ");
 interface AiDiffModalBodyProps extends Omit<AiDiffModalProps, "open"> {
   currentIndex: number;
@@ -164,10 +164,10 @@ function AiDiffModalBody({
       {/* Header */}
       <div className={headerStyles}>
         <div className="flex items-center gap-4">
-          <DialogPrimitive.Title className="font-medium text-sm text-[var(--color-fg-default)]">
+          <DialogPrimitive.Title className="font-medium text-sm text-(--color-fg-default)">
             {t("ai.diff.reviewChanges")}
           </DialogPrimitive.Title>
-          <span className="text-xs text-[var(--color-fg-muted)]">
+          <span className="text-xs text-(--color-fg-muted)">
             {t("ai.diff.modifyCount", { count: totalChanges })}
           </span>
         </div>

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffModal.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffModal.tsx
@@ -92,9 +92,7 @@ const navButtonStyles = [
   "p-0.5 focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)]",
   "focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
 ].join(" ");
-const navTextStyles = ["text-xs font-mono text-(--color-fg-muted)"].join(
-  " ",
-);
+const navTextStyles = ["text-xs font-mono text-(--color-fg-muted)"].join(" ");
 const closeButtonStyles = [
   "text-(--color-fg-muted) hover:text-(--color-fg-default) p-1 transition-colors",
   "duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)]",

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffSummary.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffSummary.tsx
@@ -32,34 +32,34 @@ const footerStyles = [
 ].join(" ");
 const statsStyles = [
   "flex items-center gap-4 text-xs",
-  "text-[var(--color-fg-muted)]",
+  "text-(--color-fg-muted)",
 ].join(" ");
-const addedStatsStyles = ["text-[var(--color-success)]"].join(" ");
-const removedStatsStyles = ["text-[var(--color-error)]"].join(" ");
+const addedStatsStyles = ["text-(--color-success)"].join(" ");
+const removedStatsStyles = ["text-(--color-error)"].join(" ");
 const textButtonStyles = [
-  "px-3 py-1.5 rounded-[var(--radius-sm)] text-xs",
+  "px-3 py-1.5 rounded-sm text-xs",
   "font-medium transition-colors duration-[var(--duration-fast)] focus-visible:outline",
   "focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50",
   "disabled:cursor-not-allowed",
 ].join(" ");
 const rejectAllStyles = [
   textButtonStyles,
-  "text-[var(--color-error)] hover:bg-[var(--color-error-subtle)]",
+  "text-(--color-error) hover:bg-[var(--color-error-subtle)]",
 ].join(" ");
 const acceptAllStyles = [
   textButtonStyles,
-  "text-[var(--color-success)] hover:bg-[var(--color-success-subtle)]",
+  "text-(--color-success) hover:bg-[var(--color-success-subtle)]",
 ].join(" ");
 const editManuallyStyles = [
-  "px-4 py-2 rounded-[var(--radius-sm)] text-xs",
-  "font-medium text-[var(--color-fg-default)] border border-[var(--color-separator)]",
+  "px-4 py-2 rounded-sm text-xs",
+  "font-medium text-(--color-fg-default) border border-[var(--color-separator)]",
   "hover:bg-[var(--color-bg-hover)] transition-colors duration-[var(--duration-fast)] focus-visible:outline",
   "focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50",
   "disabled:cursor-not-allowed",
 ].join(" ");
 const applyChangesStyles = [
-  "px-4 py-2 rounded-[var(--radius-sm)] text-xs",
-  "font-medium bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)]",
+  "px-4 py-2 rounded-sm text-xs",
+  "font-medium bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)]",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
   "flex items-center gap-2",
@@ -124,11 +124,11 @@ export function AiDiffSummary({
           </span>
           {(acceptedCount > 0 || rejectedCount > 0) && (
             <>
-              <span className="text-[var(--color-separator)]">|</span>
-              <span className="text-[var(--color-success)]">
+              <span className="text-(--color-separator)">|</span>
+              <span className="text-(--color-success)">
                 {t("ai.diff.statsAccepted", { count: acceptedCount })}
               </span>
-              <span className="text-[var(--color-error)]">
+              <span className="text-(--color-error)">
                 {t("ai.diff.statsRejected", { count: rejectedCount })}
               </span>
             </>

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffSummary.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiDiffSummary.tsx
@@ -96,6 +96,7 @@ export function AiDiffSummary({
         <div className="flex gap-2">
           <Button
             type="button"
+            variant="pill"
             data-testid="ai-reject-all"
             className={rejectAllStyles}
             onClick={onRejectAll}
@@ -105,6 +106,7 @@ export function AiDiffSummary({
           </Button>
           <Button
             type="button"
+            variant="pill"
             data-testid="ai-accept-all"
             className={acceptAllStyles}
             onClick={onAcceptAll}
@@ -140,6 +142,7 @@ export function AiDiffSummary({
         {onEditManually && (
           <Button
             type="button"
+            variant="pill"
             className={editManuallyStyles}
             onClick={onEditManually}
             disabled={isApplying}

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
@@ -76,15 +76,11 @@ function RetryButtonContent(props: {
   }
   if (props.retryState === "success") {
     return (
-      <span className="text-(--color-success)">
-        {t("ai.error.success")}
-      </span>
+      <span className="text-(--color-success)">{t("ai.error.success")}</span>
     );
   }
   if (props.retryState === "error") {
-    return (
-      <span className="text-(--color-error)">{t("ai.error.failed")}</span>
-    );
+    return <span className="text-(--color-error)">{t("ai.error.failed")}</span>;
   }
   return (
     <span>

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
@@ -112,6 +112,7 @@ export function AiErrorCardActions(props: {
           {props.onUpgradePlan && (
             <Button
               type="button"
+              variant="pill"
               className={upgradeButtonStyles}
               onClick={props.onUpgradePlan}
             >
@@ -135,6 +136,7 @@ export function AiErrorCardActions(props: {
           {props.onRetry && (
             <Button
               type="button"
+              variant="pill"
               className={retryButtonStyles}
               onClick={props.handleRetry}
               disabled={props.retryState === "loading"}
@@ -164,6 +166,7 @@ export function AiErrorCardActions(props: {
         props.onRetry && (
           <Button
             type="button"
+            variant="pill"
             className={retryButtonStyles}
             onClick={props.handleRetry}
             disabled={props.isRetryDisabled}

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorActions.tsx
@@ -41,20 +41,20 @@ const Spinner = ({ className = "" }: { className?: string }) => (
 );
 const buttonContainerStyles = ["flex", "items-center", "gap-2"].join(" ");
 const retryButtonStyles = [
-  "text-xs font-medium text-[var(--color-fg-default)] bg-[var(--color-bg-hover)]",
-  "hover:bg-[var(--color-bg-active)] px-3 py-1.5 rounded-[var(--radius-sm)]",
+  "text-xs font-medium text-(--color-fg-default) bg-[var(--color-bg-hover)]",
+  "hover:bg-[var(--color-bg-active)] px-3 py-1.5 rounded-sm",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
   "flex items-center gap-1.5",
 ].join(" ");
 const upgradeButtonStyles = [
-  "text-xs font-medium text-[var(--color-bg-base)] bg-[var(--color-warning)]",
-  "hover:bg-[var(--color-warning)]/80 px-3 py-1.5 rounded-[var(--radius-sm)]",
+  "text-xs font-medium text-(--color-bg-base) bg-[var(--color-warning)]",
+  "hover:bg-[var(--color-warning)]/80 px-3 py-1.5 rounded-sm",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 const linkButtonStyles = [
-  "text-xs font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]",
+  "text-xs font-medium text-(--color-fg-muted) hover:text-(--color-fg-default)",
   "px-2 flex items-center gap-1",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
@@ -76,14 +76,14 @@ function RetryButtonContent(props: {
   }
   if (props.retryState === "success") {
     return (
-      <span className="text-[var(--color-success)]">
+      <span className="text-(--color-success)">
         {t("ai.error.success")}
       </span>
     );
   }
   if (props.retryState === "error") {
     return (
-      <span className="text-[var(--color-error)]">{t("ai.error.failed")}</span>
+      <span className="text-(--color-error)">{t("ai.error.failed")}</span>
     );
   }
   return (

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -73,8 +73,8 @@ const cardStyles = [
   "transition-all duration-[var(--duration-normal)] ease-[var(--ease-default)]",
 ].join(" ");
 const dismissButtonStyles = [
-  "absolute top-2 right-2 p-1",
-  "rounded-sm text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)]",
+  "absolute top-2 right-2",
+  "text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)]",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
@@ -195,6 +195,7 @@ export function AiErrorCard({
       {showDismiss && (
         <Button
           type="button"
+          size="icon"
           className={dismissButtonStyles}
           onClick={handleDismiss}
           title={t("ai.error.dismiss")}

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorCard.tsx
@@ -69,12 +69,12 @@ const CloseIcon = () => (
   </svg>
 );
 const cardStyles = [
-  "rounded-[var(--radius-lg)] p-3 border relative",
+  "rounded-lg p-3 border relative",
   "transition-all duration-[var(--duration-normal)] ease-[var(--ease-default)]",
 ].join(" ");
 const dismissButtonStyles = [
   "absolute top-2 right-2 p-1",
-  "rounded-[var(--radius-sm)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]",
+  "rounded-sm text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)]",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorDetails.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorDetails.tsx
@@ -122,18 +122,16 @@ export function getBgColorByType(type: AiErrorType): string {
 }
 
 const contentStyles = ["flex", "items-start", "gap-3"].join(" ");
-const iconContainerStyles = [
-  "p-1.5 rounded-sm shrink-0 mt-0.5",
-].join(" ");
+const iconContainerStyles = ["p-1.5 rounded-sm shrink-0 mt-0.5"].join(" ");
 const titleStyles = [
   "text-sm font-medium text-(--color-fg-default) mb-0.5",
 ].join(" ");
 const descriptionStyles = [
   "text-xs text-(--color-fg-muted) leading-snug mb-2",
 ].join(" ");
-const errorCodeStyles = [
-  "text-label font-mono text-(--color-error) mb-2",
-].join(" ");
+const errorCodeStyles = ["text-label font-mono text-(--color-error) mb-2"].join(
+  " ",
+);
 const countdownStyles = [
   "text-label font-mono text-(--color-warning) bg-[var(--color-warning-subtle)]",
   "inline-block px-1.5 py-0.5 rounded-sm",

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorDetails.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiErrorDetails.tsx
@@ -84,22 +84,22 @@ function getIconColorsByType(type: AiErrorType): { bg: string; text: string } {
     case "rate_limit":
       return {
         bg: "bg-[var(--color-warning-subtle)]",
-        text: "text-[var(--color-warning)]",
+        text: "text-(--color-warning)",
       };
     case "usage_limit":
       return {
         bg: "bg-[var(--color-warning-subtle)]",
-        text: "text-[var(--color-warning)]",
+        text: "text-(--color-warning)",
       };
     case "service_error":
       return {
         bg: "bg-[var(--color-error-subtle)]",
-        text: "text-[var(--color-error)]",
+        text: "text-(--color-error)",
       };
     default:
       return {
         bg: "bg-[var(--color-warning-subtle)]",
-        text: "text-[var(--color-warning)]",
+        text: "text-(--color-warning)",
       };
   }
 }
@@ -123,25 +123,25 @@ export function getBgColorByType(type: AiErrorType): string {
 
 const contentStyles = ["flex", "items-start", "gap-3"].join(" ");
 const iconContainerStyles = [
-  "p-1.5 rounded-[var(--radius-sm)] shrink-0 mt-0.5",
+  "p-1.5 rounded-sm shrink-0 mt-0.5",
 ].join(" ");
 const titleStyles = [
-  "text-sm font-medium text-[var(--color-fg-default)] mb-0.5",
+  "text-sm font-medium text-(--color-fg-default) mb-0.5",
 ].join(" ");
 const descriptionStyles = [
-  "text-xs text-[var(--color-fg-muted)] leading-snug mb-2",
+  "text-xs text-(--color-fg-muted) leading-snug mb-2",
 ].join(" ");
 const errorCodeStyles = [
-  "text-[10px] font-mono text-[var(--color-error)] mb-2",
+  "text-label font-mono text-(--color-error) mb-2",
 ].join(" ");
 const countdownStyles = [
-  "text-[10px] font-mono text-[var(--color-warning)] bg-[var(--color-warning-subtle)]",
-  "inline-block px-1.5 py-0.5 rounded-[var(--radius-sm)]",
+  "text-label font-mono text-(--color-warning) bg-[var(--color-warning-subtle)]",
+  "inline-block px-1.5 py-0.5 rounded-sm",
   "border border-[var(--color-warning)]/10 mb-2",
 ].join(" ");
 const readyToRetryStyles = [
-  "text-[10px] font-mono text-[var(--color-success)] bg-[var(--color-success-subtle)]",
-  "inline-block px-1.5 py-0.5 rounded-[var(--radius-sm)]",
+  "text-label font-mono text-(--color-success) bg-[var(--color-success-subtle)]",
+  "inline-block px-1.5 py-0.5 rounded-sm",
   "border border-[var(--color-success)]/10 mb-2 animate-pulse",
 ].join(" ");
 

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiInlineConfirm.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiInlineConfirm.tsx
@@ -69,33 +69,33 @@ const containerStyles = ["relative", "group"].join(" ");
 const toolbarStyles = [
   "absolute -top-12 right-0 flex",
   "items-center gap-1 bg-[var(--color-bg-raised)] border",
-  "border-[var(--color-separator)] rounded-[var(--radius-lg)] shadow-[var(--shadow-xl)] p-1",
+  "border-[var(--color-separator)] rounded-lg shadow-xl p-1",
   "z-[var(--z-popover)] transition-opacity duration-[var(--duration-normal)]",
 ].join(" ");
 const actionButtonBaseStyles = [
   "h-7 px-2 flex items-center",
-  "gap-1.5 rounded-[var(--radius-sm)] text-[var(--color-fg-muted)] transition-colors",
+  "gap-1.5 rounded-sm text-(--color-fg-muted) transition-colors",
   "duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)]",
   "focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
 ].join(" ");
 const acceptButtonStyles = [
   actionButtonBaseStyles,
-  "hover:bg-[var(--color-success-subtle)] hover:text-[var(--color-success)]",
+  "hover:bg-[var(--color-success-subtle)] hover:text-(--color-success)",
 ].join(" ");
 const rejectButtonStyles = [
   actionButtonBaseStyles,
-  "hover:bg-[var(--color-error-subtle)] hover:text-[var(--color-error)]",
+  "hover:bg-[var(--color-error-subtle)] hover:text-(--color-error)",
 ].join(" ");
 const diffButtonStyles = [
   "h-7 w-7 flex items-center",
-  "justify-center rounded-[var(--radius-sm)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)]",
-  "hover:text-[var(--color-fg-default)] transition-colors duration-[var(--duration-fast)] focus-visible:outline",
+  "justify-center rounded-sm text-(--color-fg-muted) hover:bg-[var(--color-bg-hover)]",
+  "hover:text-(--color-fg-default) transition-colors duration-[var(--duration-fast)] focus-visible:outline",
   "focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)]",
 ].join(" ");
 const separatorStyles = ["w-px h-4 bg-[var(--color-separator)] mx-0.5"].join(
   " ",
 );
-const labelStyles = ["text-[11px]", "font-medium"].join(" ");
+const labelStyles = ["text-status", "font-medium"].join(" ");
 
 /** AiInlineConfirm - Inline confirmation component for AI suggestions Displays an AI-suggested text modification with Accept/Reject actions. Features: - Shows original text (strikethrough) and suggested text (highlighted) - Internal state machine: pending → applying → accepted/rejected - Smooth animations for all state transitions - Loading spinner during applying state
  * @example

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiInlinePreview.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiInlinePreview.tsx
@@ -106,9 +106,7 @@ export function AiInlinePreview({
             <span className={`${originalTextStyles} mr-2`}>{originalText}</span>
           )}
           <span className={pendingHighlightStyles}>
-            <span className="text-(--color-fg-default)">
-              {suggestedText}
-            </span>
+            <span className="text-(--color-fg-default)">{suggestedText}</span>
           </span>
         </>
       )}

--- a/apps/desktop/renderer/src/components/features/AiDialogs/AiInlinePreview.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/AiInlinePreview.tsx
@@ -13,7 +13,7 @@ const contentWrapperStyles = [
  * Styles for the original text (strikethrough)
  */
 const originalTextStyles = [
-  "text-[var(--color-fg-muted)]",
+  "text-(--color-fg-muted)",
   "line-through",
   "decoration-[var(--color-error)]/50",
   "bg-[var(--color-error-subtle)]",
@@ -60,7 +60,7 @@ const pendingHighlightStyles = [
  * Styles for accepted final state (no highlight)
  */
 const acceptedTextStyles = [
-  "text-[var(--color-fg-default)]",
+  "text-(--color-fg-default)",
   "transition-all",
   "duration-[var(--duration-normal)]",
 ].join(" ");
@@ -69,7 +69,7 @@ const acceptedTextStyles = [
  * Styles for rejected final state (original text restored)
  */
 const rejectedTextStyles = [
-  "text-[var(--color-fg-default)]",
+  "text-(--color-fg-default)",
   "transition-all",
   "duration-[var(--duration-normal)]",
 ].join(" ");
@@ -106,7 +106,7 @@ export function AiInlinePreview({
             <span className={`${originalTextStyles} mr-2`}>{originalText}</span>
           )}
           <span className={pendingHighlightStyles}>
-            <span className="text-[var(--color-fg-default)]">
+            <span className="text-(--color-fg-default)">
               {suggestedText}
             </span>
           </span>
@@ -116,7 +116,7 @@ export function AiInlinePreview({
       {/* Applying state: show suggested with loading indicator */}
       {isApplying && (
         <span className={suggestedTextStyles}>
-          <span className="text-[var(--color-fg-default)] opacity-70">
+          <span className="text-(--color-fg-default) opacity-70">
             {suggestedText}
           </span>
         </span>

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialog.tsx
@@ -31,7 +31,7 @@ const overlayStyles = [
 const contentStyles = [
   "fixed left-1/2 top-1/2 -translate-x-1/2",
   "-translate-y-1/2 z-[var(--z-modal)] bg-[var(--color-bg-surface)] border",
-  "border-[var(--color-border-default)] rounded-[var(--radius-xl)] shadow-[var(--shadow-xl)] w-full",
+  "border-[var(--color-border-default)] rounded-xl shadow-xl w-full",
   "max-w-sm p-6 flex flex-col",
   "items-center text-center transition-[opacity,transform] duration-[var(--duration-normal)]",
   "ease-[var(--ease-default)] data-[state=open]:opacity-100 data-[state=open]:scale-100 data-[state=closed]:opacity-0",

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialogContent.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialogContent.tsx
@@ -114,25 +114,25 @@ export function getIconColorsByType(type: SystemDialogType): {
     case "delete":
       return {
         bg: "bg-[var(--color-error-subtle)]",
-        text: "text-[var(--color-error)]",
+        text: "text-(--color-error)",
         border: "border-[var(--color-error)]/20",
       };
     case "unsaved_changes":
       return {
         bg: "bg-[var(--color-warning-subtle)]",
-        text: "text-[var(--color-warning)]",
+        text: "text-(--color-warning)",
         border: "border-[var(--color-warning)]/20",
       };
     case "export_complete":
       return {
         bg: "bg-[var(--color-success-subtle)]",
-        text: "text-[var(--color-success)]",
+        text: "text-(--color-success)",
         border: "border-[var(--color-success)]/20",
       };
     default:
       return {
         bg: "bg-[var(--color-warning-subtle)]",
-        text: "text-[var(--color-warning)]",
+        text: "text-(--color-warning)",
         border: "border-[var(--color-warning)]/20",
       };
   }
@@ -143,19 +143,19 @@ export const iconContainerStyles = [
   "items-center justify-center mb-4 border",
 ].join(" ");
 export const titleStyles = [
-  "text-lg font-semibold text-[var(--color-fg-default)] mb-2",
+  "text-lg font-semibold text-(--color-fg-default) mb-2",
 ].join(" ");
 export const descriptionStyles = [
-  "text-sm text-[var(--color-fg-muted)] mb-6 leading-relaxed",
+  "text-sm text-(--color-fg-muted) mb-6 leading-relaxed",
 ].join(" ");
 export const keyboardHintStyles = [
-  "text-[10px] text-[var(--color-fg-muted)] mt-3 flex",
+  "text-label text-(--color-fg-muted) mt-3 flex",
   "items-center gap-3",
 ].join(" ");
 export const kbdStyles = [
   "px-1.5 py-0.5 rounded bg-[var(--color-bg-hover)]",
   "border border-[var(--color-separator)] text-[9px] font-mono",
-  "text-[var(--color-fg-muted)]",
+  "text-(--color-fg-muted)",
 ].join(" ");
 export const buttonContainerStyles = [
   "flex",
@@ -164,7 +164,7 @@ export const buttonContainerStyles = [
   "w-full",
 ].join(" ");
 export const buttonBaseStyles = [
-  "h-9 rounded-[var(--radius-lg)] text-sm font-medium",
+  "h-9 rounded-lg text-sm font-medium",
   "transition-colors duration-[var(--duration-fast)] focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
   "focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed",
   "flex items-center justify-center gap-2",
@@ -172,29 +172,29 @@ export const buttonBaseStyles = [
 export const cancelButtonStyles = [
   buttonBaseStyles,
   "flex-1 border border-[var(--color-separator)] bg-transparent",
-  "hover:bg-[var(--color-bg-hover)] text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)] text-(--color-fg-default)",
 ].join(" ");
 export const deleteButtonStyles = [
   buttonBaseStyles,
-  "flex-1 bg-[var(--color-btn-danger-bg)] hover:bg-[var(--color-btn-danger-hover)] text-[var(--color-fg-on-accent)]",
-  "shadow-[var(--shadow-lg)]",
+  "flex-1 bg-[var(--color-btn-danger-bg)] hover:bg-[var(--color-btn-danger-hover)] text-(--color-fg-on-accent)",
+  "shadow-lg",
 ].join(" ");
 export const discardButtonStyles = [
   buttonBaseStyles,
   "px-4 border border-[var(--color-error)]/20 hover:bg-[var(--color-error-subtle)]",
-  "text-[var(--color-error)]",
+  "text-(--color-error)",
 ].join(" ");
 export const saveButtonStyles = [
   buttonBaseStyles,
-  "px-4 bg-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] text-[var(--color-fg-inverse)]",
+  "px-4 bg-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] text-(--color-fg-inverse)",
 ].join(" ");
 export const doneButtonStyles = [
   buttonBaseStyles,
   "flex-1 border border-[var(--color-separator)] bg-transparent",
-  "hover:bg-[var(--color-bg-hover)] text-[var(--color-fg-default)]",
+  "hover:bg-[var(--color-bg-hover)] text-(--color-fg-default)",
 ].join(" ");
 export const openFileButtonStyles = [
   buttonBaseStyles,
-  "flex-1 bg-[var(--color-btn-success-bg)] hover:bg-[var(--color-btn-success-hover)] text-[var(--color-fg-on-accent)]",
-  "shadow-[var(--shadow-lg)]",
+  "flex-1 bg-[var(--color-btn-success-bg)] hover:bg-[var(--color-btn-success-hover)] text-(--color-fg-on-accent)",
+  "shadow-lg",
 ].join(" ");

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphLegend.tsx
@@ -119,7 +119,7 @@ export function GraphLegend({ className = "" }: GraphLegendProps): JSX.Element {
   return (
     <div className={`${legendStyles} ${className}`}>
       {/* Title */}
-      <div className="text-[10px] uppercase tracking-wider text-[var(--color-fg-subtle)] font-medium mb-1">
+      <div className="text-label uppercase tracking-wider text-(--color-fg-subtle) font-medium mb-1">
         {t("kg.legend.title")}
       </div>
 
@@ -127,7 +127,7 @@ export function GraphLegend({ className = "" }: GraphLegendProps): JSX.Element {
       {legendItems.map((item) => (
         <div key={item.type} className="flex items-center gap-2">
           <ShapeIndicator shape={item.shape} colorVar={item.colorVar} />
-          <span className="text-[11px] text-[var(--color-fg-muted)]">
+          <span className="text-status text-(--color-fg-muted)">
             {item.label}
           </span>
         </div>

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -118,13 +118,13 @@ const labelBaseStyles = [
   "top-14",
   "left-1/2",
   "-translate-x-1/2",
-  "text-[11px]",
+  "text-status",
   "whitespace-nowrap",
   "px-1.5",
   "py-0.5",
   "rounded",
   "pointer-events-none",
-  "text-[var(--color-fg-default)]",
+  "text-(--color-fg-default)",
   "opacity-90",
   "transition-opacity",
   "duration-[var(--duration-fast)]",
@@ -173,7 +173,7 @@ export function GraphNode({
     (selected || dragging) && labelHoverStyles,
     // Event nodes need counter-rotation for label
     isEventType && "-rotate-45",
-    isEventType && "top-[60px]",
+    isEventType && "top-15",
   ]
     .filter(Boolean)
     .join(" ");
@@ -233,7 +233,7 @@ export function GraphNode({
       {/* Dragging indicator */}
       {dragging && (
         <span
-          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--color-fg-on-accent)] rounded"
+          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-(--color-fg-on-accent) rounded"
           style={{ backgroundColor: color }}
         >
           {t("kg.graph.dragging")}

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
@@ -122,6 +122,7 @@ export function GraphToolbar({
           <>
             <Button
               onClick={onBack}
+              size="icon"
               className="text-(--color-fg-muted) hover:text-(--color-fg-default) transition-colors"
               aria-label={t("kg.toolbar.goBack")}
             >
@@ -149,6 +150,7 @@ export function GraphToolbar({
         {filterButtons.map(({ filter, label, colorClass }) => (
           <Button
             key={filter}
+            variant="pill"
             onClick={() => onFilterChange(filter)}
             className={`${filterButtonBase} ${
               activeFilter === filter
@@ -170,7 +172,8 @@ export function GraphToolbar({
         <div className="flex items-center bg-[var(--color-bg-raised)] rounded border border-[var(--color-border-default)]">
           <Button
             onClick={onZoomOut}
-            className="p-1.5 text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
+            size="icon"
+            className="text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             aria-label={t("kg.toolbar.zoomOut")}
           >
             <svg
@@ -189,7 +192,8 @@ export function GraphToolbar({
           </span>
           <Button
             onClick={onZoomIn}
-            className="p-1.5 text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
+            size="icon"
+            className="text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             aria-label={t("kg.toolbar.zoomIn")}
           >
             <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphToolbar.tsx
@@ -64,15 +64,15 @@ const filterButtonBase = [
 ].join(" ");
 
 const filterButtonInactive = [
-  "text-[var(--color-fg-muted)]",
+  "text-(--color-fg-muted)",
   "border-transparent",
-  "hover:text-[var(--color-fg-default)]",
+  "hover:text-(--color-fg-default)",
   "hover:border-[var(--color-border-hover)]",
 ].join(" ");
 
 const filterButtonActive = [
   "bg-[var(--color-bg-raised)]",
-  "text-[var(--color-fg-default)]",
+  "text-(--color-fg-default)",
   "border-[var(--color-border-hover)]",
 ].join(" ");
 
@@ -122,7 +122,7 @@ export function GraphToolbar({
           <>
             <Button
               onClick={onBack}
-              className="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+              className="text-(--color-fg-muted) hover:text-(--color-fg-default) transition-colors"
               aria-label={t("kg.toolbar.goBack")}
             >
               <svg
@@ -139,7 +139,7 @@ export function GraphToolbar({
             <div className="h-4 w-px bg-[var(--color-border-hover)]" />
           </>
         )}
-        <h1 className="text-sm font-medium tracking-wide text-[var(--color-fg-default)]">
+        <h1 className="text-sm font-medium tracking-wide text-(--color-fg-default)">
           {t("kg.toolbar.title")}
         </h1>
       </div>
@@ -170,7 +170,7 @@ export function GraphToolbar({
         <div className="flex items-center bg-[var(--color-bg-raised)] rounded border border-[var(--color-border-default)]">
           <Button
             onClick={onZoomOut}
-            className="p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            className="p-1.5 text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             aria-label={t("kg.toolbar.zoomOut")}
           >
             <svg
@@ -184,12 +184,12 @@ export function GraphToolbar({
               <line x1="5" y1="12" x2="19" y2="12" />
             </svg>
           </Button>
-          <span className="text-[10px] w-8 text-center text-[var(--color-fg-subtle)]">
+          <span className="text-label w-8 text-center text-(--color-fg-subtle)">
             {Math.round(zoom * 100)}%
           </span>
           <Button
             onClick={onZoomIn}
-            className="p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            className="p-1.5 text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             aria-label={t("kg.toolbar.zoomIn")}
           >
             <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -50,7 +50,7 @@ function KgEmptyIllustration(): JSX.Element {
         fill="none"
         stroke="currentColor"
         strokeWidth="1.5"
-        className="text-[var(--color-fg-subtle)]"
+        className="text-(--color-fg-subtle)"
       >
         <circle cx="12" cy="5" r="3" />
         <circle cx="5" cy="19" r="3" />
@@ -387,7 +387,7 @@ export function KnowledgeGraph({
             <div className="absolute bottom-6 left-6 z-30">
               <Button
                 onClick={handleAddNode}
-                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
+                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
                 aria-label={t("kg.graph.addNode")}
               >
                 <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/KnowledgeGraph.tsx
@@ -387,7 +387,8 @@ export function KnowledgeGraph({
             <div className="absolute bottom-6 left-6 z-30">
               <Button
                 onClick={handleAddNode}
-                className="w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
+                size="icon"
+                className="rounded-full bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
                 aria-label={t("kg.graph.addNode")}
               >
                 <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -118,7 +118,8 @@ export function NodeDetailCard({
           {onDelete && (
             <Button
               onClick={onDelete}
-              className="p-1 text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
+              size="icon"
+              className="text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
               aria-label={t("kg.nodeDetail.deleteNode")}
               title={t("kg.nodeDetail.deleteNode")}
             >
@@ -140,7 +141,8 @@ export function NodeDetailCard({
           {/* Close button */}
           <Button
             onClick={onClose}
-            className="p-1 text-(--color-fg-subtle) hover:text-(--color-fg-default) transition-colors"
+            size="icon"
+            className="text-(--color-fg-subtle) hover:text-(--color-fg-default) transition-colors"
             aria-label={t("kg.nodeDetail.close")}
           >
             <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeDetailCard.tsx
@@ -50,7 +50,7 @@ const cardStyles = [
   "border",
   "border-[var(--color-border-hover)]",
   "rounded-lg",
-  "shadow-[var(--shadow-xl)]",
+  "shadow-xl",
   "p-4",
   "flex",
   "flex-col",
@@ -94,7 +94,7 @@ export function NodeDetailCard({
           {/* Name and role */}
           <div>
             <div className="flex items-center gap-2">
-              <div className="text-sm font-semibold text-[var(--color-fg-default)]">
+              <div className="text-sm font-semibold text-(--color-fg-default)">
                 {label}
               </div>
               <Badge variant={typeToVariant[type]} size="sm">
@@ -103,7 +103,7 @@ export function NodeDetailCard({
             </div>
             {role && (
               <div
-                className="text-[10px] uppercase tracking-wider font-medium"
+                className="text-label uppercase tracking-wider font-medium"
                 style={{ color: typeColor }}
               >
                 {role}
@@ -118,7 +118,7 @@ export function NodeDetailCard({
           {onDelete && (
             <Button
               onClick={onDelete}
-              className="p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
+              className="p-1 text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
               aria-label={t("kg.nodeDetail.deleteNode")}
               title={t("kg.nodeDetail.deleteNode")}
             >
@@ -140,7 +140,7 @@ export function NodeDetailCard({
           {/* Close button */}
           <Button
             onClick={onClose}
-            className="p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-fg-default)] transition-colors"
+            className="p-1 text-(--color-fg-subtle) hover:text-(--color-fg-default) transition-colors"
             aria-label={t("kg.nodeDetail.close")}
           >
             <svg
@@ -164,7 +164,7 @@ export function NodeDetailCard({
           {attributes.map((attr, index) => (
             <span
               key={`${attr.key}-${index}`}
-              className="px-2 py-0.5 rounded bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] text-[10px] text-[var(--color-fg-muted)]"
+              className="px-2 py-0.5 rounded bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] text-label text-(--color-fg-muted)"
             >
               {attr.key}: {attr.value}
             </span>
@@ -174,7 +174,7 @@ export function NodeDetailCard({
 
       {/* Description */}
       {description && (
-        <p className="text-xs text-[var(--color-fg-muted)] leading-relaxed line-clamp-3">
+        <p className="text-xs text-(--color-fg-muted) leading-relaxed line-clamp-3">
           {description}
         </p>
       )}

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -22,8 +22,7 @@ const nodeTypeColorVars: Record<NodeType, string> = {
 /**
  * Label styles
  */
-const labelStyles =
-  "block text-xs font-medium text-(--color-fg-muted) mb-1.5";
+const labelStyles = "block text-xs font-medium text-(--color-fg-muted) mb-1.5";
 
 /**
  * Generate a unique ID for new nodes

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -282,8 +282,9 @@ export function NodeEditDialog({
                   />
                   <Button
                     type="button"
+                    size="icon"
                     onClick={() => handleRemoveAttribute(index)}
-                    className="w-8 h-8 flex items-center justify-center text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
+                    className="flex items-center justify-center text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
                     aria-label={t("kg.nodeEdit.deleteProperty")}
                   >
                     <svg

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/NodeEditDialog.tsx
@@ -23,7 +23,7 @@ const nodeTypeColorVars: Record<NodeType, string> = {
  * Label styles
  */
 const labelStyles =
-  "block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5";
+  "block text-xs font-medium text-(--color-fg-muted) mb-1.5";
 
 /**
  * Generate a unique ID for new nodes
@@ -249,14 +249,14 @@ export function NodeEditDialog({
             <Button
               type="button"
               onClick={handleAddAttribute}
-              className="text-[11px] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
+              className="text-status text-(--color-fg-muted) hover:text-(--color-fg-default) transition-colors"
             >
               {t("kg.nodeEdit.addProperty")}
             </Button>
           </div>
 
           {attributes.length === 0 ? (
-            <p className="text-xs text-[var(--color-fg-subtle)] italic">
+            <p className="text-xs text-(--color-fg-subtle) italic">
               {t("kg.nodeEdit.noProperties")}
             </p>
           ) : (
@@ -271,7 +271,7 @@ export function NodeEditDialog({
                     placeholder={t("kg.nodeEdit.propertyNamePlaceholder")}
                     className="flex-1"
                   />
-                  <span className="text-[var(--color-fg-subtle)]">:</span>
+                  <span className="text-(--color-fg-subtle)">:</span>
                   <Input
                     value={attr.value}
                     onChange={(e) =>
@@ -283,7 +283,7 @@ export function NodeEditDialog({
                   <Button
                     type="button"
                     onClick={() => handleRemoveAttribute(index)}
-                    className="w-8 h-8 flex items-center justify-center text-[var(--color-fg-subtle)] hover:text-[var(--color-error)] transition-colors"
+                    className="w-8 h-8 flex items-center justify-center text-(--color-fg-subtle) hover:text-(--color-error) transition-colors"
                     aria-label={t("kg.nodeEdit.deleteProperty")}
                   >
                     <svg

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -263,7 +263,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-4 w-60"
       >
         <h1
-          class="text-sm font-medium tracking-wide text-[var(--color-fg-default)]"
+          class="text-sm font-medium tracking-wide text-(--color-fg-default)"
         >
           Knowledge Graph
         </h1>
@@ -272,7 +272,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-2"
       >
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-[var(--color-fg-default)] border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-(--color-fg-default) border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -282,7 +282,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -295,7 +295,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -308,7 +308,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -321,7 +321,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -334,7 +334,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -355,7 +355,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         >
           <button
             aria-label="Zoom out"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -379,14 +379,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
             </span>
           </button>
           <span
-            class="text-[10px] w-8 text-center text-[var(--color-fg-subtle)]"
+            class="text-label w-8 text-center text-(--color-fg-subtle)"
           >
             100
             %
           </span>
           <button
             aria-label="Zoom in"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -459,7 +459,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           class="mb-4 flex h-16 w-16 items-center justify-center rounded-full border-2 border-dashed border-[var(--color-border-default)]"
         >
           <svg
-            class="text-[var(--color-fg-subtle)]"
+            class="text-(--color-fg-subtle)"
             fill="none"
             height="32"
             stroke="currentColor"
@@ -540,7 +540,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-4 w-60"
       >
         <h1
-          class="text-sm font-medium tracking-wide text-[var(--color-fg-default)]"
+          class="text-sm font-medium tracking-wide text-(--color-fg-default)"
         >
           Knowledge Graph
         </h1>
@@ -549,7 +549,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-2"
       >
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-[var(--color-fg-default)] border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-(--color-fg-default) border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -559,7 +559,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -572,7 +572,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -585,7 +585,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -598,7 +598,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -611,7 +611,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -632,7 +632,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         >
           <button
             aria-label="Zoom out"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -656,14 +656,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
             </span>
           </button>
           <span
-            class="text-[10px] w-8 text-center text-[var(--color-fg-subtle)]"
+            class="text-label w-8 text-center text-(--color-fg-subtle)"
           >
             100
             %
           </span>
           <button
             aria-label="Zoom in"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -789,7 +789,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               </span>
             </div>
             <div
-              class="absolute top-14 left-1/2 -translate-x-1/2 text-[11px] whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-[var(--color-fg-default)] opacity-90 transition-opacity duration-[var(--duration-fast)]"
+              class="absolute top-14 left-1/2 -translate-x-1/2 text-status whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-(--color-fg-default) opacity-90 transition-opacity duration-[var(--duration-fast)]"
               style="background-color: color-mix(in srgb, var(--color-bg-base) 80%, transparent);"
             >
               林小雨
@@ -804,7 +804,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           class="bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded p-3 flex flex-col gap-2 "
         >
           <div
-            class="text-[10px] uppercase tracking-wider text-[var(--color-fg-subtle)] font-medium mb-1"
+            class="text-label uppercase tracking-wider text-(--color-fg-subtle) font-medium mb-1"
           >
             Graph Legend
           </div>
@@ -816,7 +816,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-character); background-color: color-mix(in srgb, var(--color-node-character) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Character
             </span>
@@ -829,7 +829,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-location); background-color: color-mix(in srgb, var(--color-node-location) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Location
             </span>
@@ -842,7 +842,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-event); background-color: color-mix(in srgb, var(--color-node-event) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Event
             </span>
@@ -855,7 +855,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-item); background-color: color-mix(in srgb, var(--color-node-item) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Item
             </span>
@@ -868,7 +868,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-other); background-color: color-mix(in srgb, var(--color-node-other) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Faction
             </span>
@@ -880,7 +880,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
       >
         <button
           aria-label="Add Node"
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] rounded-full bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
           type="button"
         >
           <span
@@ -929,7 +929,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-4 w-60"
       >
         <h1
-          class="text-sm font-medium tracking-wide text-[var(--color-fg-default)]"
+          class="text-sm font-medium tracking-wide text-(--color-fg-default)"
         >
           Knowledge Graph
         </h1>
@@ -938,7 +938,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         class="flex items-center gap-2"
       >
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-[var(--color-fg-default)] border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer bg-[var(--color-bg-raised)] text-(--color-fg-default) border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -948,7 +948,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -961,7 +961,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -974,7 +974,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -987,7 +987,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -1000,7 +1000,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </span>
         </button>
         <button
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-[var(--color-fg-muted)] border-transparent hover:text-[var(--color-fg-default)] hover:border-[var(--color-border-hover)]"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-full)] px-3 py-1 rounded-full text-xs font-medium border transition-all duration-[var(--duration-fast)] flex items-center gap-2 cursor-pointer text-(--color-fg-muted) border-transparent hover:text-(--color-fg-default) hover:border-[var(--color-border-hover)]"
           type="button"
         >
           <span
@@ -1021,7 +1021,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         >
           <button
             aria-label="Zoom out"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -1045,14 +1045,14 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
             </span>
           </button>
           <span
-            class="text-[10px] w-8 text-center text-[var(--color-fg-subtle)]"
+            class="text-label w-8 text-center text-(--color-fg-subtle)"
           >
             100
             %
           </span>
           <button
             aria-label="Zoom in"
-            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] p-1.5 text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] text-(--color-fg-muted) hover:text-(--color-fg-default) hover:bg-[var(--color-bg-hover)] transition-colors"
             type="button"
           >
             <span
@@ -1254,7 +1254,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               </span>
             </div>
             <div
-              class="absolute top-14 left-1/2 -translate-x-1/2 text-[11px] whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-[var(--color-fg-default)] opacity-90 transition-opacity duration-[var(--duration-fast)]"
+              class="absolute top-14 left-1/2 -translate-x-1/2 text-status whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-(--color-fg-default) opacity-90 transition-opacity duration-[var(--duration-fast)]"
               style="background-color: color-mix(in srgb, var(--color-bg-base) 80%, transparent);"
             >
               林远
@@ -1287,7 +1287,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               </svg>
             </div>
             <div
-              class="absolute top-14 left-1/2 -translate-x-1/2 text-[11px] whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-[var(--color-fg-default)] opacity-90 transition-opacity duration-[var(--duration-fast)]"
+              class="absolute top-14 left-1/2 -translate-x-1/2 text-status whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-(--color-fg-default) opacity-90 transition-opacity duration-[var(--duration-fast)]"
               style="background-color: color-mix(in srgb, var(--color-bg-base) 80%, transparent);"
             >
               旧港
@@ -1329,7 +1329,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               </svg>
             </div>
             <div
-              class="absolute top-14 left-1/2 -translate-x-1/2 text-[11px] whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-[var(--color-fg-default)] opacity-90 transition-opacity duration-[var(--duration-fast)] -rotate-45 top-[60px]"
+              class="absolute top-14 left-1/2 -translate-x-1/2 text-status whitespace-nowrap px-1.5 py-0.5 rounded pointer-events-none text-(--color-fg-default) opacity-90 transition-opacity duration-[var(--duration-fast)] -rotate-45 top-15"
               style="background-color: color-mix(in srgb, var(--color-bg-base) 80%, transparent);"
             >
               废弃仓库事件
@@ -1344,7 +1344,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           class="bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] rounded p-3 flex flex-col gap-2 "
         >
           <div
-            class="text-[10px] uppercase tracking-wider text-[var(--color-fg-subtle)] font-medium mb-1"
+            class="text-label uppercase tracking-wider text-(--color-fg-subtle) font-medium mb-1"
           >
             Graph Legend
           </div>
@@ -1356,7 +1356,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-character); background-color: color-mix(in srgb, var(--color-node-character) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Character
             </span>
@@ -1369,7 +1369,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-location); background-color: color-mix(in srgb, var(--color-node-location) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Location
             </span>
@@ -1382,7 +1382,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-event); background-color: color-mix(in srgb, var(--color-node-event) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Event
             </span>
@@ -1395,7 +1395,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-item); background-color: color-mix(in srgb, var(--color-node-item) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Item
             </span>
@@ -1408,7 +1408,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
               style="border-color: var(--color-node-other); background-color: color-mix(in srgb, var(--color-node-other) 10%, transparent);"
             />
             <span
-              class="text-[11px] text-[var(--color-fg-muted)]"
+              class="text-status text-(--color-fg-muted)"
             >
               Faction
             </span>
@@ -1420,7 +1420,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
       >
         <button
           aria-label="Add Node"
-          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-9 px-[var(--space-4)] text-[var(--text-body-size)] rounded-[var(--radius-md)] w-10 h-10 rounded-full bg-[var(--color-fg-default)] text-[var(--color-fg-inverse)] hover:bg-[var(--color-fg-muted)] shadow-[var(--shadow-lg)] flex items-center justify-center transition-transform hover:scale-105"
+          class="inline-flex items-center justify-center gap-2 font-medium cursor-pointer select-none transition-colors duration-[var(--duration-fast)] ease-[var(--ease-default)] overflow-hidden max-w-full focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)] focus-visible:outline-offset-[var(--ring-focus-offset)] focus-visible:outline-[var(--color-ring-focus)] disabled:opacity-50 disabled:cursor-not-allowed bg-transparent text-[var(--color-fg-default)] border border-[var(--color-border-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] active:bg-[var(--color-bg-active)] h-10 w-10 p-0 text-[var(--text-body-size)] rounded-[var(--radius-md)] rounded-full bg-[var(--color-fg-default)] text-(--color-fg-inverse) hover:bg-[var(--color-fg-muted)] shadow-lg flex items-center justify-center transition-transform hover:scale-105"
           type="button"
         >
           <span

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -154,6 +154,12 @@
   --leading-tight: var(--leading-tight);
   --leading-normal: var(--leading-normal);
   --leading-relaxed: var(--leading-relaxed);
+
+  /* 阴影 → utility: shadow-sm / shadow-md / shadow-lg / shadow-xl */
+  --shadow-sm: 0 1px 2px var(--color-shadow);
+  --shadow-md: 0 4px 8px var(--color-shadow);
+  --shadow-lg: 0 8px 16px var(--color-shadow);
+  --shadow-xl: 0 16px 32px var(--color-shadow);
 }
 
 /* === 全局基础样式 === */

--- a/apps/desktop/tests/lint/arbitrary-value-cleanup-v1-18.test.ts
+++ b/apps/desktop/tests/lint/arbitrary-value-cleanup-v1-18.test.ts
@@ -1,0 +1,67 @@
+/**
+ * v1-18 Arbitrary Value Cleanup Guards
+ *
+ * 守卫测试：确保 features/ 层的 arbitrary CSS 值已被 Design Token 替代。
+ * 口径：apps/desktop/renderer/src/components/features/，排除 .stories. 和 .test. 文件。
+ */
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const FEATURES_DIR = path.join(
+  REPO_ROOT,
+  "apps/desktop/renderer/src/components/features",
+);
+
+function countArbitrary(pattern: string): number {
+  try {
+    const result = execSync(
+      `grep -rn '${pattern}' "${FEATURES_DIR}" --include='*.tsx' | grep -v '.stories.' | grep -v '.test.' | wc -l`,
+      { encoding: "utf8" },
+    );
+    return parseInt(result.trim(), 10);
+  } catch {
+    return 0;
+  }
+}
+
+function countVariants(): number {
+  try {
+    const result = execSync(
+      `grep -rnE 'variant="(pill|bento|compact|underline|category)"|size="icon"' "${FEATURES_DIR}" --include='*.tsx' | wc -l`,
+      { encoding: "utf8" },
+    );
+    return parseInt(result.trim(), 10);
+  } catch {
+    return 0;
+  }
+}
+
+describe("v1-18 Arbitrary Value Cleanup Guards", () => {
+  it("text-[ arbitrary values in features/ prod ≤ 10", () => {
+    expect(countArbitrary("text-\\[")).toBeLessThanOrEqual(10);
+  });
+
+  it("rounded-[ arbitrary values in features/ prod ≤ 5", () => {
+    expect(countArbitrary("rounded-\\[")).toBeLessThanOrEqual(5);
+  });
+
+  it("p-[]/m-[]/gap-[] arbitrary values in features/ prod = 0", () => {
+    const p = countArbitrary("p-\\[");
+    const m = countArbitrary("m-\\[");
+    const gap = countArbitrary("gap-\\[");
+    expect(p + m + gap).toBe(0);
+  });
+
+  it("shadow-[ arbitrary values in features/ prod ≤ 3", () => {
+    expect(countArbitrary("shadow-\\[")).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("v1-18 Variant Adoption Guards", () => {
+  it("v1-02 variant usage in features/ ≥ 15", () => {
+    expect(countVariants()).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens-shadow.test.cjs
+++ b/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens-shadow.test.cjs
@@ -1,5 +1,6 @@
 // @ts-nocheck — ESLint RuleTester is JS-only
-// Additional tests for shadow class matching in no-raw-tailwind-tokens
+// Shadow classes (shadow-xs/sm/md/lg/xl/2xl) are exported via @theme
+// and map to our design tokens. They are no longer flagged.
 const { RuleTester } = require("eslint");
 const rule = require("../no-raw-tailwind-tokens.cjs");
 
@@ -11,50 +12,34 @@ const tester = new RuleTester({
   },
 });
 
-tester.run("creonow/no-raw-tailwind-tokens (shadow extension)", rule, {
-  valid: [
-    // CSS variable reference — should not trigger
-    { code: `const x = "shadow-[var(--shadow-card)]";` },
-    // Custom shadow with arbitrary value — should not trigger
-    { code: `const x = "shadow-[0_4px_6px_rgba(0,0,0,0.1)]";` },
-    // Design token usage — should not trigger
-    { code: `const x = "shadow-surface";` },
-    // Drop shadow variant — should not trigger
-    { code: `const x = "drop-shadow-md";` },
-    // CSS variable name — should not trigger
-    { code: `const x = "--shadow-md";` },
-    // shadow-2xl is registered in @theme as design token — should not trigger
-    { code: `const cls = "shadow-2xl";` },
-    // shadow-xs is registered in @theme as design token — should not trigger
-    { code: `const cls = "shadow-xs";` },
-  ],
-  invalid: [
-    // Built-in shadow-lg — should trigger
-    {
-      code: `const cls = "shadow-lg";`,
-      errors: [{ messageId: "rawShadow" }],
-    },
-    // Built-in shadow-xl — should trigger
-    {
-      code: `const cls = "shadow-xl";`,
-      errors: [{ messageId: "rawShadow" }],
-    },
-    // Built-in shadow-sm — should trigger
-    {
-      code: `const cls = "shadow-sm";`,
-      errors: [{ messageId: "rawShadow" }],
-    },
-    // Multiple shadows in one string — should trigger twice
-    {
-      code: `const cls = "shadow-xl shadow-lg";`,
-      errors: [{ messageId: "rawShadow" }, { messageId: "rawShadow" }],
-    },
-    // With modifier prefix — should trigger
-    {
-      code: `const cls = "hover:shadow-lg";`,
-      errors: [{ messageId: "rawShadow" }],
-    },
-  ],
-});
+tester.run(
+  "creonow/no-raw-tailwind-tokens (shadow — now allowed via @theme)",
+  rule,
+  {
+    valid: [
+      // CSS variable reference — should not trigger
+      { code: `const x = "shadow-[var(--shadow-card)]";` },
+      // Custom shadow with arbitrary value — should not trigger
+      { code: `const x = "shadow-[0_4px_6px_rgba(0,0,0,0.1)]";` },
+      // Design token usage — should not trigger
+      { code: `const x = "shadow-surface";` },
+      // Drop shadow variant — should not trigger
+      { code: `const x = "drop-shadow-md";` },
+      // CSS variable name — should not trigger
+      { code: `const x = "--shadow-md";` },
+      // @theme-exported shadow utilities — should not trigger
+      { code: `const cls = "shadow-xs";` },
+      { code: `const cls = "shadow-sm";` },
+      { code: `const cls = "shadow-lg";` },
+      { code: `const cls = "shadow-xl";` },
+      { code: `const cls = "shadow-2xl";` },
+      { code: `const cls = "hover:shadow-lg";` },
+      { code: `const cls = "shadow-xl shadow-2xl";` },
+    ],
+    invalid: [],
+  },
+);
 
-console.log("✅ no-raw-tailwind-tokens (shadow extension): all tests passed");
+console.log(
+  "✅ no-raw-tailwind-tokens (shadow — @theme allowed): all tests passed",
+);

--- a/scripts/eslint-rules/no-raw-tailwind-tokens.cjs
+++ b/scripts/eslint-rules/no-raw-tailwind-tokens.cjs
@@ -2,13 +2,15 @@
  * Custom ESLint rule: no-raw-tailwind-tokens
  *
  * Forbids raw Tailwind color values (e.g., bg-red-600, text-gray-300)
- * and built-in shadow classes (shadow-lg, shadow-xl, shadow-2xl)
  * in ANY string literal or template literal. This covers all usage patterns:
  *   - className="bg-red-600"           (direct JSX attribute)
  *   - className={`shadow-lg ${x}`}     (template literal)
  *   - ["shadow-2xl", ...].join(" ")    (array → join)
  *   - cn("hover:bg-red-600", ...)      (clsx/cn helper)
  *   - { color: "text-blue-400" }       (object property value)
+ *
+ * Note: shadow-xs/sm/md/lg/xl/2xl are exported via @theme and map to
+ * our design tokens. They are no longer flagged.
  *
  * The regex patterns are specific enough (e.g., bg-red-600) that false
  * positives on non-Tailwind strings are essentially impossible.
@@ -22,13 +24,11 @@ const rule = {
     type: "suggestion",
     docs: {
       description:
-        "Disallow raw Tailwind color values and built-in shadow classes in any string literal. Use semantic Design Tokens instead.",
+        "Disallow raw Tailwind color values in any string literal. Use semantic Design Tokens instead.",
     },
     messages: {
       rawColor:
         "Avoid raw Tailwind color '{{value}}'. Use a semantic Design Token instead. See docs/references/design-ui-architecture.md.",
-      rawShadow:
-        "Avoid Tailwind built-in shadow class '{{value}}'. Use --shadow-* Design Token instead.",
     },
     schema: [],
   },
@@ -39,14 +39,6 @@ const rule = {
     // Also matches opacity suffixes: shadow-red-500/20, bg-red-600/50
     const RAW_COLOR_RE =
       /\b(?:[\w-]*:)?(?:bg|text|border|ring|shadow|outline|fill|stroke|from|via|to|divide|placeholder|accent|caret|decoration)-(?:red|blue|green|yellow|purple|pink|indigo|violet|cyan|teal|emerald|lime|amber|orange|fuchsia|rose|sky|slate|gray|zinc|neutral|stone|warm)-\d{1,3}(?:\/\d{1,3})?\b/g;
-
-    // Matches: shadow-sm, shadow-md, shadow-lg, shadow-xl (but not shadow-[custom] or shadow-surface etc.)
-    // Note: shadow-xs and shadow-2xl are registered in @theme as design tokens,
-    // so they are NOT blocked — using them via Tailwind utilities IS using the design token.
-    // Also with modifier prefixes: hover:shadow-lg, data-[state=active]:shadow-sm
-    // Negative lookbehind (?<!-) prevents matching inside CSS var names (--shadow-md)
-    // and Tailwind drop-shadow utilities (drop-shadow-md).
-    const RAW_SHADOW_RE = /(?<!-)\b(?:[\w[\]=-]*:)?shadow-(?:sm|md|lg|xl)\b/g;
 
     /**
      * Check a string value for raw Tailwind tokens.
@@ -60,14 +52,6 @@ const rule = {
         context.report({
           node,
           messageId: "rawColor",
-          data: { value: match[0] },
-        });
-      }
-      RAW_SHADOW_RE.lastIndex = 0;
-      while ((match = RAW_SHADOW_RE.exec(value)) !== null) {
-        context.report({
-          node,
-          messageId: "rawShadow",
           data: { value: match[0] },
         });
       }


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 概述

v1-18: features/ 层 arbitrary value 全面清理 + v1-02 变体推广。

Closes #1221

## 变更内容

### 1. Arbitrary Value 清理

| 度量 | 基线 | 目标 | 最终 |
|------|------|------|------|
| text-[ | 95 | ≤10 | **2** |
| rounded-[ | 18 | ≤5 | **0** |
| p-[]/m-[]/gap-[] | 1 | 0 | **0** |
| shadow-[ | 7 | ≤3 | **0** |
| w-[]/h-[] | 8 | 0 | **0** |

残留 2 处 `text-[9px]`：无对应 token（最小 token text-label=10px）。

### 2. 替换策略
- `text-[Npx]` → `text-label`(10px) / `text-status`(11px) / `text-body`(13px) / `text-subtitle`(14px) 等
- `text-[var(--color-*)]` → `text-(--color-*)`（Tailwind v4 shorthand）
- `rounded-[var(--radius-*)]` → `rounded-sm/lg/xl`
- `shadow-[var(--shadow-*)]` → `shadow-lg/xl`（新增 @theme inline shadow 导出）
- `h-[500px]` → `h-125`、`top-[60px]` → `top-15`

### 3. v1-02 变体推广（0 → 15）
- 8× `size="icon"`（KnowledgeGraph icon buttons）
- 7× `variant="pill"`（KnowledgeGraph entity tags）

### 4. 基础设施
- `main.css @theme inline` 新增 shadow-sm/md/lg/xl 导出
- ESLint `no-raw-tailwind-tokens` 规则移除 rawShadow 检测（shadow 已注册为 @theme utility）

## 验证证据

- 守卫测试 5/5 ✅（arbitrary 上限 + variant 下限）
- 全量 renderer 测试 ✅
- TypeCheck ✅
- ESLint 0 errors ✅
- Storybook build ✅

## 回滚点

6 个 commit 可逐步还原。每个 commit scope 独立（AiDialogs / KnowledgeGraph / infra）。

## 审计门禁

内部审计 ACCEPT（Tier S）— 0 BLOCKER, 2 SIGNIFICANT（text-label 附加属性、shorthand 混用，均不阻塞）。
等待独立审计 Agent FINAL-VERDICT。

## 非自动化检查（Tier 3）

> 涉及 UI 改动时必填。

- [x] **字体渲染**：N/A — 本 PR 不修改字体资源或 @font-face 声明，仅清理 className 中的 arbitrary value。Visual regression CI 已通过，确认样式替换未引起字体渲染异常。
- [x] **品牌调性**：新增样式全部使用 Design Token，未引入 Tailwind 原始色值或硬编码值
  - `text-[Npx]` 全部替换为语义化 token：`text-label`(10px) / `text-status`(11px) / `text-caption`(11px) / `text-body`(13px) / `text-subtitle`(14px) / `text-card-title`(16px) / `text-heading`(24px) / `text-display`(48px)
  - `text-[var(--color-*)]` 替换为 Tailwind v4 shorthand `text-(--color-*)`，仍引用 Design Token
  - `rounded-[var(--radius-*)]` 替换为标准 Tailwind utility `rounded-sm/lg/xl`
  - `shadow-[var(--shadow-*)]` 替换为 `shadow-lg/xl`（通过 `@theme inline` 注册为合法 utility）
  - 尺寸 arbitrary `h-[500px]/top-[60px]` 替换为 Tailwind 标准值 `h-125/top-15`
  - ESLint `no-raw-tailwind-tokens` 规则确保无原始色值回归
  - v1-02 变体推广：`size="icon"` × 8 + `variant="pill"` × 7 = 15 处，全部复用组件库定义的标准变体
- [x] **无障碍**：N/A — 本 PR 仅做 className 替换（arbitrary → token/utility），不改变 DOM 结构、ARIA 属性或交互行为。AiDiffModal.test.tsx 21/21 通过，确认键盘和交互路径未受影响。
- [x] **CJK 场景**：N/A — 本 PR 的 `text-[Npx]` → `text-*` 替换保持相同的 `font-size` 计算值，不影响 CJK 字符渲染。残留 2 处 `text-[9px]` 因无对应 token（最小 token text-label=10px）保留，CJK 文本不使用 9px 字号。
