### PR TITLE
refactor(quality,search): replace hardcoded font sizes with Design Tokens

### DIFF
--- a/apps/desktop/renderer/src/features/quality-gates/QualityCheckItems.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityCheckItems.tsx
@@ -136,10 +136,10 @@ export function IssueCard({
   if (issue.ignored) {
     return (
       <div className="p-3 bg-[var(--color-bg-raised)] rounded-lg border border-[var(--color-separator)] opacity-50">
-        <p className="text-[12px] text-[var(--color-fg-muted)] line-through">
+        <p className="text-(--text-caption) text-[var(--color-fg-muted)] line-through">
           {issue.description}
         </p>
-        <span className="text-[10px] text-[var(--color-fg-placeholder)] mt-1 inline-block">
+        <span className="text-(--text-label) text-[var(--color-fg-placeholder)] mt-1 inline-block">
           {t("qualityGates.ignored")}
         </span>
       </div>
@@ -154,11 +154,11 @@ export function IssueCard({
       }`}
       data-testid={`issue-card-${issue.id}`}
     >
-      <p className="text-[12px] text-[var(--color-fg-default)] leading-relaxed">
+      <p className="text-(--text-caption) text-[var(--color-fg-default)] leading-relaxed">
         {issue.description}
       </p>
       {issue.location && (
-        <div className="flex items-center gap-1 mt-2 text-[10px] text-[var(--color-fg-muted)]">
+        <div className="flex items-center gap-1 mt-2 text-(--text-label) text-[var(--color-fg-muted)]">
           <LocationIcon />
           <Button
             type="button"
@@ -175,7 +175,7 @@ export function IssueCard({
           size="sm"
           onClick={() => onFix?.(checkId, issue.id)}
           loading={isFixing}
-          className="!h-6 !text-[10px] !px-2"
+          className="!h-6 !text-(--text-label) !px-2"
         >
           {t("qualityGates.fixIssue")}
         </Button>
@@ -183,7 +183,7 @@ export function IssueCard({
           variant="ghost"
           size="sm"
           onClick={() => onIgnore?.(checkId, issue.id)}
-          className="!h-6 !text-[10px] !px-2"
+          className="!h-6 !text-(--text-label) !px-2"
         >
           {t("qualityGates.ignore")}
         </Button>
@@ -191,7 +191,7 @@ export function IssueCard({
           variant="ghost"
           size="sm"
           onClick={() => onViewInEditor?.(checkId, issue.id)}
-          className="!h-6 !text-[10px] !px-2"
+          className="!h-6 !text-(--text-label) !px-2"
         >
           {t("qualityGates.viewInEditor")}
         </Button>
@@ -242,12 +242,12 @@ export function CheckItemRow({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-[13px] font-medium text-[var(--color-fg-default)]">
+            <span className="text-(--text-body) font-medium text-[var(--color-fg-default)]">
               {check.name}
             </span>
             {issueCount > 0 && (
               <span
-                className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${
+                className={`text-(--text-label) font-medium px-1.5 py-0.5 rounded-full ${
                   check.status === "error"
                     ? "bg-[var(--color-error-subtle)] text-[var(--color-error)]"
                     : "bg-[var(--color-warning-subtle)] text-[var(--color-warning)]"
@@ -257,16 +257,16 @@ export function CheckItemRow({
               </span>
             )}
             {check.ignoredCount && check.ignoredCount > 0 && (
-              <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
                 {t("qualityGates.ignoredCount", { count: check.ignoredCount })}
               </span>
             )}
           </div>
-          <p className="text-[11px] text-[var(--color-fg-muted)] mt-0.5 leading-relaxed">
+          <p className="text-(--text-status) text-[var(--color-fg-muted)] mt-0.5 leading-relaxed">
             {check.description}
           </p>
           {check.resultValue && check.status === "passed" && (
-            <span className="text-[11px] text-[var(--color-success)] mt-1 inline-block">
+            <span className="text-(--text-status) text-[var(--color-success)] mt-1 inline-block">
               {check.resultValue}
             </span>
           )}

--- a/apps/desktop/renderer/src/features/quality-gates/QualityGatesPanel.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityGatesPanel.tsx
@@ -67,7 +67,7 @@ export function QualityGatesPanelContent({
     >
       <div className={headerStyles}>
         <div>
-          <h2 className="text-[15px] font-semibold text-[var(--color-fg-default)] tracking-tight">
+          <h2 className="text-(--text-subtitle) font-semibold text-[var(--color-fg-default)] tracking-tight">
             {t("qualityGates.title")}
           </h2>
           <div className="mt-2">
@@ -106,7 +106,7 @@ export function QualityGatesPanelContent({
         {panelStatus === "all-passed" && (
           <div className="p-4 bg-[var(--color-success-subtle)] border border-[var(--color-success)]/20 rounded-[var(--radius-lg)] text-center">
             <CheckCircleIcon />
-            <p className="text-[13px] text-[var(--color-success)] mt-2">
+            <p className="text-(--text-body) text-[var(--color-success)] mt-2">
               {t("qualityGates.allPassedMessage")}
             </p>
           </div>

--- a/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
@@ -55,10 +55,10 @@ export function CheckGroupAccordion({
     >
       <div className="px-4 py-3 bg-[var(--color-bg-raised)] border-b border-[var(--color-separator)]">
         <div className="flex items-center justify-between">
-          <span className="text-[13px] font-medium text-[var(--color-fg-default)]">
+          <span className="text-(--text-body) font-medium text-[var(--color-fg-default)]">
             {group.name}
           </span>
-          <span className="text-[11px] text-[var(--color-fg-muted)]">
+          <span className="text-(--text-status) text-[var(--color-fg-muted)]">
             {t("qualityGates.checksCount", {
               passed: passedCount,
               total: checkCount,
@@ -101,7 +101,7 @@ function SettingsToggle({
     <div className="flex items-center justify-between">
       <Label
         htmlFor={id}
-        className={`text-[13px] text-[var(--color-fg-default)] select-none cursor-pointer ${disabled ? "opacity-50" : ""}`}
+        className={`text-(--text-body) text-[var(--color-fg-default)] select-none cursor-pointer ${disabled ? "opacity-50" : ""}`}
       >
         {label}
       </Label>
@@ -118,6 +118,7 @@ function SettingsToggle({
             : "bg-[var(--color-bg-hover)] border-[var(--color-border-default)]"
         } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
       >
+        {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：toggle knob 非标尺寸 left-[3px] w-[18px] h-[18px]，无对应 Design Token */}
         <span
           className={`absolute left-[3px] w-[18px] h-[18px] rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
             checked
@@ -157,7 +158,7 @@ export function SettingsSection({
       >
         <div className="flex items-center gap-2">
           <SettingsIcon />
-          <span className="text-[13px] font-medium text-[var(--color-fg-default)]">
+          <span className="text-(--text-body) font-medium text-[var(--color-fg-default)]">
             {t("qualityGates.settings")}
           </span>
         </div>
@@ -185,7 +186,7 @@ export function SettingsSection({
             <div className="flex items-center justify-between">
               <Label
                 htmlFor="check-frequency"
-                className="text-[13px] text-[var(--color-fg-default)]"
+                className="text-(--text-body) text-[var(--color-fg-default)]"
               >
                 {t("qualityGates.checkFrequency")}
               </Label>
@@ -199,7 +200,7 @@ export function SettingsSection({
                   })
                 }
                 options={frequencyOptions}
-                className="text-[12px]"
+                className="text-(--text-caption)"
               />
             </div>
           </div>

--- a/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
@@ -118,9 +118,10 @@ function SettingsToggle({
             : "bg-[var(--color-bg-hover)] border-[var(--color-border-default)]"
         } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
       >
-        {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：toggle knob 非标尺寸 left-[3px] w-[18px] h-[18px]，无对应 Design Token */}
+        {/* 审计：v1-18d #1243 KEEP — left-[3px] 无标准 token，指示器偏移为设计规范固定值 */}
+        {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：toggle knob 非标尺寸 left-[3px]，无对应 Design Token */}
         <span
-          className={`absolute left-[3px] w-[18px] h-[18px] rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
+          className={`absolute left-[3px] w-4.5 h-4.5 rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
             checked
               ? "translate-x-[20px] bg-[var(--color-fg-inverse)]"
               : "translate-x-0 bg-[var(--color-fg-subtle)]"

--- a/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
@@ -121,7 +121,7 @@ function SettingsToggle({
         <span
           className={`absolute left-(--dimension-rule-indicator-offset) w-4.5 h-4.5 rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
             checked
-              ? "translate-x-[20px] bg-[var(--color-fg-inverse)]"
+              ? "translate-x-5 bg-[var(--color-fg-inverse)]"
               : "translate-x-0 bg-[var(--color-fg-subtle)]"
           }`}
         />

--- a/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
+++ b/apps/desktop/renderer/src/features/quality-gates/QualityRuleList.tsx
@@ -118,10 +118,8 @@ function SettingsToggle({
             : "bg-[var(--color-bg-hover)] border-[var(--color-border-default)]"
         } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
       >
-        {/* 审计：v1-18d #1243 KEEP — left-[3px] 无标准 token，指示器偏移为设计规范固定值 */}
-        {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：toggle knob 非标尺寸 left-[3px]，无对应 Design Token */}
         <span
-          className={`absolute left-[3px] w-4.5 h-4.5 rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
+          className={`absolute left-(--dimension-rule-indicator-offset) w-4.5 h-4.5 rounded-full transition-transform duration-[var(--duration-slow)] pointer-events-none ${
             checked
               ? "translate-x-[20px] bg-[var(--color-fg-inverse)]"
               : "translate-x-0 bg-[var(--color-fg-subtle)]"

--- a/apps/desktop/renderer/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanel.tsx
@@ -194,7 +194,8 @@ export function SearchPanel(props: {
         onClick={onClose}
       />
       {/* 审计：v1-13 #007 KEEP */}
-      {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：search modal width per design spec (w-[640px]) */}
+      {/* 审计：v1-18d #1243 KEEP — max-h-[80vh] 无标准 token，搜索面板最大高度为视口相对值 */}
+      {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：search modal width per design spec (w-[640px]), max-h-[80vh] 无标准 Tailwind utility */}
       <div className="relative w-[640px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden z-[var(--z-modal)] bg-[var(--color-bg-surface)] border border-[var(--color-separator)] shadow-[0_24px_48px_-12px_var(--color-shadow)] motion-safe:animate-[slideDown_0.3s_ease-out]">
         {/* Header */}
         <div className="flex flex-col border-b border-[var(--color-separator)] bg-[var(--color-bg-surface)]">

--- a/apps/desktop/renderer/src/features/search/SearchPanelParts.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanelParts.tsx
@@ -45,10 +45,10 @@ export function ResultGroup(props: {
       className={`py-2 ${props.hasBorderTop ? "border-t border-[var(--color-separator)]" : ""}`}
     >
       <div className="px-4 py-1.5 flex items-center justify-between">
-        <span className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-widest">
+        <span className="text-(--text-label) font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-widest">
           {props.title}
         </span>
-        <span className="text-[10px] font-mono text-[var(--color-fg-placeholder)]">
+        <span className="text-(--text-label) font-mono text-[var(--color-fg-placeholder)]">
           {t("search.results.match", { count: props.count })}
         </span>
       </div>
@@ -67,10 +67,10 @@ export function KeyHint(props: {
 }): JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="flex items-center justify-center min-w-[20px] h-5 px-1 rounded bg-[var(--color-bg-overlay)] border border-[var(--color-separator)] text-[10px] text-[var(--color-fg-muted)] font-mono">
+      <span className="flex items-center justify-center min-w-5 h-5 px-1 rounded bg-[var(--color-bg-overlay)] border border-[var(--color-separator)] text-(--text-label) text-[var(--color-fg-muted)] font-mono">
         {props.icon || props.text}
       </span>
-      <span className="text-[10px] text-[var(--color-fg-placeholder)] ml-1">
+      <span className="text-(--text-label) text-[var(--color-fg-placeholder)] ml-1">
         {props.label}
       </span>
     </div>
@@ -111,7 +111,7 @@ export function SearchFilterBar(props: {
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-[10px] text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
+        <span className="text-(--text-label) text-[var(--color-fg-placeholder)] uppercase tracking-wider font-medium">
           {t("search.filters.scope")}
         </span>
         <Button

--- a/apps/desktop/renderer/src/features/search/SearchResultItems.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchResultItems.tsx
@@ -103,7 +103,7 @@ export const DocumentResultItem = React.memo(
               <HighlightText text={item.title} query={query} />
             </h4>
             {item.matchScore && (
-              <span className="text-[10px] font-mono text-[var(--color-info)] bg-[var(--color-info-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-info-subtle)] shrink-0">
+              <span className="text-(--text-label) font-mono text-[var(--color-info)] bg-[var(--color-info-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-info-subtle)] shrink-0">
                 {t("search.matchScore", { score: item.matchScore })}
               </span>
             )}
@@ -124,17 +124,17 @@ export const DocumentResultItem = React.memo(
                 size={16}
                 strokeWidth={1.5}
               />
-              <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
                 {item.path}
               </span>
               {item.editedTime && (
                 <>
-                  <span className="text-[10px] text-[var(--color-fg-placeholder)] mx-1">
+                  <span className="text-(--text-label) text-[var(--color-fg-placeholder)] mx-1">
                     {/* 审计：v1-13 #006 KEEP */}
                     {/* eslint-disable-next-line i18next/no-literal-string -- 技术原因：decorative separator dot, not user-facing translatable text */}
                     •
                   </span>
-                  <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+                  <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
                     {item.editedTime}
                   </span>
                 </>
@@ -183,7 +183,7 @@ export const MemoryResultItem = React.memo(function MemoryResultItem(props: {
             <HighlightText text={item.title} query={query} />
           </h4>
           <div className="flex items-center gap-2 shrink-0">
-            <span className="text-[10px] font-mono text-[var(--color-success)] bg-[var(--color-success-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-success-subtle)] opacity-0 group-hover:opacity-100 transition-opacity">
+            <span className="text-(--text-label) font-mono text-[var(--color-success)] bg-[var(--color-success-subtle)] px-1.5 py-0.5 rounded border border-[var(--color-success-subtle)] opacity-0 group-hover:opacity-100 transition-opacity">
               {t("search.resultTypes.highRelevance")}
             </span>
           </div>
@@ -198,7 +198,7 @@ export const MemoryResultItem = React.memo(function MemoryResultItem(props: {
               size={16}
               strokeWidth={1.5}
             />
-            <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+            <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
               {item.meta}
             </span>
           </div>
@@ -235,11 +235,11 @@ export const KnowledgeResultItem = React.memo(
             <HighlightText text={item.title} query={query} />
           </h4>
           <div className="flex items-center gap-2">
-            <span className="text-[10px] text-[var(--color-fg-placeholder)] border border-[var(--color-separator)] px-1.5 py-0.5 rounded">
+            <span className="text-(--text-label) text-[var(--color-fg-placeholder)] border border-[var(--color-separator)] px-1.5 py-0.5 rounded">
               {t("search.resultTypes.entity")}
             </span>
             {item.meta ? (
-              <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+              <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
                 {item.meta}
               </span>
             ) : null}

--- a/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
@@ -168,7 +168,7 @@ export function SearchResultsArea(props: {
           })}
         />
         <div className="mt-6 p-4 bg-[var(--color-separator)] rounded-lg border border-[var(--color-separator)]">
-          <p className="text-[10px] text-[var(--color-fg-placeholder)] font-medium uppercase tracking-wider mb-2">
+          <p className="text-(--text-label) text-[var(--color-fg-placeholder)] font-medium uppercase tracking-wider mb-2">
             {t("search.suggestionsTitle")}
           </p>
           <p className="text-xs text-[var(--color-fg-muted)]">
@@ -213,10 +213,10 @@ export function SearchResultsArea(props: {
                     className={`py-2 ${row.hasBorderTop ? "border-t border-[var(--color-separator)]" : ""}`}
                   >
                     <div className="px-4 py-1.5 flex items-center justify-between">
-                      <span className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-widest">
+                      <span className="text-(--text-label) font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-widest">
                         {row.category}
                       </span>
-                      <span className="text-[10px] font-mono text-[var(--color-fg-placeholder)]">
+                      <span className="text-(--text-label) font-mono text-[var(--color-fg-placeholder)]">
                         {t("search.results.match", { count: row.count })}
                       </span>
                     </div>

--- a/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
@@ -190,6 +190,8 @@ export function SearchResultsArea(props: {
   const useVirtual = virtualItems.length > 0;
 
   if (useVirtual) {
+    // 审计：v1-18d #1243 KEEP — max-h-[60vh] 无标准 token，搜索结果区域最大高度为视口相对值
+    // eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：max-h-[60vh] 无标准 Tailwind utility
     return (
       <div ref={scrollRef} className="overflow-y-auto max-h-[60vh]">
         <div

--- a/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchResultsArea.tsx
@@ -190,10 +190,11 @@ export function SearchResultsArea(props: {
   const useVirtual = virtualItems.length > 0;
 
   if (useVirtual) {
-    // 审计：v1-18d #1243 KEEP — max-h-[60vh] 无标准 token，搜索结果区域最大高度为视口相对值
-    // eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：max-h-[60vh] 无标准 Tailwind utility
     return (
-      <div ref={scrollRef} className="overflow-y-auto max-h-[60vh]">
+      <div
+        ref={scrollRef}
+        className="overflow-y-auto max-h-(--dimension-search-results-max-h)"
+      >
         <div
           className="relative"
           style={{ height: `${virtualizer.getTotalSize()}px` }}

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -160,6 +160,10 @@
   --shadow-md: 0 4px 8px var(--color-shadow);
   --shadow-lg: 0 8px 16px var(--color-shadow);
   --shadow-xl: 0 16px 32px var(--color-shadow);
+
+  /* Dimension tokens — component-specific fixed values (v1-18d) */
+  --dimension-rule-indicator-offset: 3px;
+  --dimension-search-results-max-h: 60vh;
 }
 
 /* === 全局基础样式 === */


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

v1-18d: features/quality+search/ 字号 → token 替换 + 非文字 arbitrary 清理

## 关联 Issue

Closes #1243

## 用户影响

- 无用户可见变化。字号映射到语义 Design Token，视觉输出不变。

## 不修最坏后果

- features/quality-gates/ 和 features/search/ 中约 36 处硬编码字号值继续留在生产代码，后续主题切换/设计系统迭代无法统一控制。

## 验证证据

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm -C apps/desktop storybook:build`
- 补充验证：`grep -rn 'text-\[[0-9]' apps/desktop/renderer/src/features/quality-gates/ apps/desktop/renderer/src/features/search/ --include='*.tsx' | grep -v test | grep -v stories | wc -l` → 0

## 回滚点

- 回滚 commit/分支：revert merge commit on main
- 回滚后需要恢复的数据或配置：无

## 非自动化检查（Tier 3）

- [x] **字体渲染**：本次改动仅替换 CSS class 名称（text-[Npx] → text-(--text-token)），不改变实际渲染像素值。N/A — 无视觉变更
- [x] **品牌调性**：所有新增样式均使用 Design Token（--text-label, --text-status, --text-caption, --text-body, --text-subtitle），新增 dimension token（--dimension-rule-indicator-offset, --dimension-search-results-max-h）均在 @theme inline 注册。无 Tailwind 原始色值或硬编码值
- [x] **无障碍**：本次改动不涉及动态内容区域或交互行为变更。N/A
- [x] **CJK 场景**：本次改动不涉及文本显示逻辑变更，仅替换 CSS token。N/A