### PR TITLE
refactor(character): replace hardcoded font sizes with Design Tokens

### DIFF
--- a/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
+++ b/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
@@ -214,7 +214,9 @@ export function AddRelationshipPopover({
                       <div className="text-sm text-[var(--color-fg-default)] truncate">
                         {character.name}
                       </div>
-                      <div className={`text-(--text-label) ${roleConfig.color}`}>
+                      <div
+                        className={`text-(--text-label) ${roleConfig.color}`}
+                      >
                         {roleConfig.label}
                       </div>
                     </div>

--- a/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
+++ b/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
@@ -157,7 +157,7 @@ export function AddRelationshipPopover({
         trigger ?? (
           <Button
             type="button"
-            className="text-[10px] text-[var(--color-info)] hover:text-[var(--color-info)]/80 flex items-center gap-1 font-medium transition-colors"
+            className="text-(--text-label) text-[var(--color-info)] hover:text-[var(--color-info)]/80 flex items-center gap-1 font-medium transition-colors"
           >
             <PlusIcon />
             {t("character.addRelation.triggerLabel")}
@@ -177,7 +177,7 @@ export function AddRelationshipPopover({
 
         {/* Character Selection */}
         <div className="px-4 py-3 border-b border-[var(--color-border-default)]">
-          <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
+          <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
             {t("character.addRelation.selectCharacter")}
           </div>
           {selectableCharacters.length > 0 ? (
@@ -214,7 +214,7 @@ export function AddRelationshipPopover({
                       <div className="text-sm text-[var(--color-fg-default)] truncate">
                         {character.name}
                       </div>
-                      <div className={`text-[10px] ${roleConfig.color}`}>
+                      <div className={`text-(--text-label) ${roleConfig.color}`}>
                         {roleConfig.label}
                       </div>
                     </div>
@@ -234,7 +234,7 @@ export function AddRelationshipPopover({
 
         {/* Relationship Type Selection */}
         <div className="px-4 py-3 border-b border-[var(--color-border-default)]">
-          <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
+          <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
             {t("character.addRelation.relationshipType")}
           </div>
           <div className="flex flex-wrap gap-2">
@@ -249,7 +249,7 @@ export function AddRelationshipPopover({
                   className={[
                     "px-2.5",
                     "py-1",
-                    "text-[11px]",
+                    "text-(--text-status)",
                     "font-medium",
                     "rounded",
                     "border",

--- a/apps/desktop/renderer/src/features/character/CharacterAppearances.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterAppearances.tsx
@@ -54,7 +54,7 @@ export function CharacterAppearances(
         <Label className={labelStyles}>
           {t("character.detail.appearances")}
         </Label>
-        <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+        <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
           {props.appearances.length} {t("character.detail.chapters")}
         </span>
       </div>
@@ -82,7 +82,7 @@ export function CharacterAppearances(
           <div className="text-xs text-[var(--color-fg-placeholder)] py-4 text-center border border-dashed border-[var(--color-border-default)] rounded-lg">
             {t("character.detail.noAppearances")}
           </div>
-          <p className="text-[11px] text-[var(--color-fg-placeholder)]">
+          <p className="text-(--text-status) text-[var(--color-fg-placeholder)]">
             {t("character.detail.noAppearancesFallbackHint")}
           </p>
         </>

--- a/apps/desktop/renderer/src/features/character/CharacterBasicInfo.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterBasicInfo.tsx
@@ -70,7 +70,7 @@ export function CharacterBasicInfo(
               ? t("character.detail.collapseProfile")
               : t("character.detail.expandProfile")
           }
-          className="!px-1.5 !py-0.5 !h-auto text-[10px] text-[var(--color-fg-placeholder)] hover:text-[var(--color-fg-muted)] inline-flex items-center gap-1 font-medium"
+          className="!px-1.5 !py-0.5 !h-auto text-(--text-label) text-[var(--color-fg-placeholder)] hover:text-[var(--color-fg-muted)] inline-flex items-center gap-1 font-medium"
         >
           <span aria-hidden="true">
             {props.isExpanded

--- a/apps/desktop/renderer/src/features/character/CharacterCard.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCard.tsx
@@ -74,6 +74,7 @@ export function CharacterCard({
       {/* Selected indicator (blue left border) */}
       {selected && (
         <div
+          // 审计：v1-18b #1240 KEEP — w-[3px] 无标准 token，角色卡片装饰线宽度为设计规范固定值
           // eslint-disable-next-line creonow/no-hardcoded-dimension -- 3px has no standard Tailwind utility
           className="absolute left-[-1px] top-1 bottom-1 w-[3px] bg-[var(--color-info)] rounded-r-sm"
           data-testid="character-card-selected-indicator"

--- a/apps/desktop/renderer/src/features/character/CharacterCard.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCard.tsx
@@ -74,9 +74,7 @@ export function CharacterCard({
       {/* Selected indicator (blue left border) */}
       {selected && (
         <div
-          // 审计：v1-18b #1240 KEEP — w-[3px] 无标准 token，角色卡片装饰线宽度为设计规范固定值
-          // eslint-disable-next-line creonow/no-hardcoded-dimension -- 3px has no standard Tailwind utility
-          className="absolute left-[-1px] top-1 bottom-1 w-[3px] bg-[var(--color-info)] rounded-r-sm"
+          className="absolute left-[-1px] top-1 bottom-1 w-(--dimension-character-accent) bg-[var(--color-info)] rounded-r-sm"
           data-testid="character-card-selected-indicator"
         />
       )}

--- a/apps/desktop/renderer/src/features/character/CharacterCard.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCard.tsx
@@ -74,6 +74,7 @@ export function CharacterCard({
       {/* Selected indicator (blue left border) */}
       {selected && (
         <div
+          // eslint-disable-next-line creonow/no-hardcoded-dimension -- 3px has no standard Tailwind utility
           className="absolute left-[-1px] top-1 bottom-1 w-[3px] bg-[var(--color-info)] rounded-r-sm"
           data-testid="character-card-selected-indicator"
         />
@@ -147,7 +148,7 @@ export function CharacterCard({
           </span>
           <span
             className={[
-              "text-[11px]",
+              "text-(--text-status)",
               "mt-1.5",
               "truncate",
               "transition-colors",

--- a/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterCardList.tsx
@@ -88,7 +88,7 @@ export function CharacterCardList({
                 <p className="text-sm font-medium text-[var(--color-fg-default)] truncate">
                   {card.name}
                 </p>
-                <span className="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]">
+                <span className="text-(--text-label) px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]">
                   {card.typeLabel}
                 </span>
               </div>

--- a/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterDetailDialog.tsx
@@ -176,12 +176,12 @@ export function CharacterDetailDialog({
       <DialogPrimitive.Portal container={container}>
         <DialogPrimitive.Overlay className={getOverlayStyles(hasContainer)} />
         <DialogPrimitive.Content className={getContentStyles(hasContainer)}>
-          <div className="absolute top-0 left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent opacity-50" />
+          <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--color-border-hover)] to-transparent opacity-50" />
 
           {/* Header: Avatar + Name + Role */}
           <div className="p-6 pb-0 flex items-start gap-6 shrink-0">
             <div className="relative group cursor-pointer shrink-0">
-              <div className="w-16 h-16 rounded-full p-[1px] bg-gradient-to-b from-[var(--color-border-hover)] to-[var(--color-bg-surface)]">
+              <div className="w-16 h-16 rounded-full p-px bg-gradient-to-b from-[var(--color-border-hover)] to-[var(--color-bg-surface)]">
                 <Avatar
                   src={editedCharacter.avatarUrl}
                   fallback={editedCharacter.name}
@@ -219,7 +219,7 @@ export function CharacterDetailDialog({
                   onChange={(role) => handleFieldChange("role", role)}
                   layer="modal"
                 />
-                <div className="h-3 w-[1px] bg-[var(--color-border-hover)]" />
+                <div className="h-3 w-px bg-[var(--color-border-hover)]" />
                 <GroupSelector
                   value={editedCharacter.group}
                   onChange={(group) => handleFieldChange("group", group)}

--- a/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
@@ -83,7 +83,7 @@ function EmptyGroupState({ onClick }: { onClick?: () => void }) {
         "hover:!bg-[var(--color-bg-surface)]",
       ].join(" ")}
     >
-      <span className="text-[11px]">{t("character.panel.noCharacters")}</span>
+      <span className="text-(--text-status)">{t("character.panel.noCharacters")}</span>
     </Button>
   );
 }
@@ -115,10 +115,10 @@ export function CharacterGroupSection({
     <div>
       {/* Group header */}
       <div className="px-2 mb-3 flex items-center justify-between group">
-        <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
+        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
           {config.label}
         </div>
-        <span className="text-[10px] text-[var(--color-fg-placeholder)] group-hover:text-[var(--color-fg-muted)] transition-colors">
+        <span className="text-(--text-label) text-[var(--color-fg-placeholder)] group-hover:text-[var(--color-fg-muted)] transition-colors">
           {characters.length}
         </span>
       </div>

--- a/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
@@ -83,7 +83,9 @@ function EmptyGroupState({ onClick }: { onClick?: () => void }) {
         "hover:!bg-[var(--color-bg-surface)]",
       ].join(" ")}
     >
-      <span className="text-(--text-status)">{t("character.panel.noCharacters")}</span>
+      <span className="text-(--text-status)">
+        {t("character.panel.noCharacters")}
+      </span>
     </Button>
   );
 }

--- a/apps/desktop/renderer/src/features/character/CharacterRelationships.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterRelationships.tsx
@@ -26,7 +26,7 @@ function RelationshipItem({
             size="sm"
             className="grayscale opacity-60 border border-[var(--color-border-default)]"
           />
-          <div className="absolute -bottom-1 -right-1 bg-[var(--color-bg-hover)] rounded-full p-[2px] border border-[var(--color-border-default)]">
+          <div className="absolute -bottom-1 -right-1 bg-[var(--color-bg-hover)] rounded-full p-0.5 border border-[var(--color-border-default)]">
             <div className={`w-2 h-2 rounded-full ${typeConfig.color}`} />
           </div>
         </div>
@@ -34,7 +34,7 @@ function RelationshipItem({
           <span className="text-xs font-medium text-[var(--color-fg-muted)]">
             {relationship.characterName}
           </span>
-          <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+          <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
             {relationship.characterRole
               ? ROLE_DISPLAY[relationship.characterRole]?.label
               : ""}
@@ -42,7 +42,7 @@ function RelationshipItem({
         </div>
       </div>
       <div className="flex items-center gap-3">
-        <span className="text-[10px] font-medium text-[var(--color-fg-muted)] bg-[var(--color-bg-hover)] px-2 py-1 rounded border border-[var(--color-border-default)]">
+        <span className="text-(--text-label) font-medium text-[var(--color-fg-muted)] bg-[var(--color-bg-hover)] px-2 py-1 rounded border border-[var(--color-border-default)]">
           {typeConfig.label}
         </span>
         {onRemove && (
@@ -101,7 +101,7 @@ export function CharacterRelationships(
             layer="modal"
           />
         ) : (
-          <span className="text-[10px] text-[var(--color-fg-placeholder)]">
+          <span className="text-(--text-label) text-[var(--color-fg-placeholder)]">
             {t("character.detail.noOtherCharacters")}
           </span>
         )}

--- a/apps/desktop/renderer/src/features/character/GroupSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/GroupSelector.tsx
@@ -84,7 +84,7 @@ export function GroupSelector({
       sideOffset={4}
     >
       <div className="min-w-35 py-1 -mx-2 -my-2">
-        <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
+        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
           {t("character.groupSelector.selectGroup")}
         </div>
         {GROUP_OPTIONS.map((group) => {

--- a/apps/desktop/renderer/src/features/character/RoleSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/RoleSelector.tsx
@@ -82,7 +82,7 @@ export function RoleSelector({
             "px-2",
             "py-0.5",
             "rounded",
-            "text-[11px]",
+            "text-(--text-status)",
             "font-medium",
             "uppercase",
             "tracking-wide",
@@ -98,7 +98,7 @@ export function RoleSelector({
       sideOffset={4}
     >
       <div className="min-w-40 py-1 -mx-2 -my-2">
-        <div className="text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
+        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
           {t("character.roleSelector.selectRole")}
         </div>
         {ROLE_OPTIONS.map((role) => {

--- a/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
+++ b/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
@@ -38,6 +38,7 @@ export function getContentStyles(hasContainer: boolean): string {
     // 审计：v1-13 #001 KEEP
     // eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：dialog content width per design spec (w-[560px])
     "w-[560px]",
+    // eslint-disable-next-line creonow/no-hardcoded-dimension -- no standard token for viewport-relative max-height
     hasContainer ? "max-h-[calc(100%-3.5rem)]" : "max-h-[92vh]",
     "bg-[var(--color-bg-surface)]",
     "border",
@@ -92,7 +93,7 @@ export function getZodiacFromBirthDate(
 }
 
 export const labelStyles = [
-  "text-[10px]",
+  "text-(--text-label)",
   "uppercase",
   "tracking-[0.1em]",
   "text-[var(--color-fg-placeholder)]",
@@ -119,7 +120,7 @@ export function ProfileTableRow({
 }) {
   return (
     <div className="grid grid-cols-[160px_1fr]">
-      <div className="px-4 py-3 bg-[var(--color-bg-base)] border-r border-[var(--color-border-default)] text-[10px] uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
+      <div className="px-4 py-3 bg-[var(--color-bg-base)] border-r border-[var(--color-border-default)] text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
         {label}
       </div>
       <div className="px-4 py-3 min-w-0">{children}</div>
@@ -136,7 +137,7 @@ export function ProfileSummaryItem({
   value: string;
 }): JSX.Element {
   return (
-    <div className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-[11px]">
+    <div className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-(--text-status)">
       <span className="text-[var(--color-fg-placeholder)]">{label}</span>
       <span className="text-[var(--color-fg-default)]">{value}</span>
     </div>

--- a/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
+++ b/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
@@ -38,6 +38,7 @@ export function getContentStyles(hasContainer: boolean): string {
     // 审计：v1-13 #001 KEEP
     // eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：dialog content width per design spec (w-[560px])
     "w-[560px]",
+    // 审计：v1-18b #1240 KEEP — max-h-[92vh] 无标准 token，对话框最大高度为视口相对值
     // eslint-disable-next-line creonow/no-hardcoded-dimension -- no standard token for viewport-relative max-height
     hasContainer ? "max-h-[calc(100%-3.5rem)]" : "max-h-[92vh]",
     "bg-[var(--color-bg-surface)]",

--- a/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
+++ b/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
@@ -38,9 +38,10 @@ export function getContentStyles(hasContainer: boolean): string {
     // 审计：v1-13 #001 KEEP
     // eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：dialog content width per design spec (w-[560px])
     "w-[560px]",
-    // 审计：v1-18b #1240 KEEP — max-h-[92vh] 无标准 token，对话框最大高度为视口相对值
-    // eslint-disable-next-line creonow/no-hardcoded-dimension -- no standard token for viewport-relative max-height
-    hasContainer ? "max-h-[calc(100%-3.5rem)]" : "max-h-[92vh]",
+    // eslint-disable-next-line creonow/no-hardcoded-dimension -- calc expression, no standard token
+    hasContainer
+      ? "max-h-[calc(100%-3.5rem)]"
+      : "max-h-(--dimension-character-dialog-max-h)",
     "bg-[var(--color-bg-surface)]",
     "border",
     "border-[var(--color-border-default)]",

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -36,7 +36,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
                 林远
               </p>
               <span
-                class="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
+                class="text-(--text-label) px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
               >
                 角色
               </span>
@@ -97,7 +97,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
                 张薇
               </p>
               <span
-                class="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
+                class="text-(--text-label) px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
               >
                 角色
               </span>
@@ -240,7 +240,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
                 神秘老人
               </p>
               <span
-                class="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
+                class="text-(--text-label) px-2 py-0.5 rounded-full bg-[var(--color-bg-hover)] text-[var(--color-fg-subtle)] border border-[var(--color-border-default)]"
               >
                 角色
               </span>

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -161,9 +161,11 @@
   --shadow-lg: 0 8px 16px var(--color-shadow);
   --shadow-xl: 0 16px 32px var(--color-shadow);
 
-  /* Dimension tokens — component-specific fixed values (v1-18d) */
+  /* Dimension tokens — component-specific fixed values */
   --dimension-rule-indicator-offset: 3px;
   --dimension-search-results-max-h: 60vh;
+  --dimension-character-accent: 3px;
+  --dimension-character-dialog-max-h: 92vh;
 }
 
 /* === 全局基础样式 === */


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

v1-18b: features/character/ 字号 → token 替换 + 非文字 arbitrary 清理

## 关联 Issue

Closes #1240

## 用户影响

- 无用户可见变化。字号映射到语义 Design Token，视觉输出不变。

## 不修最坏后果

- features/character/ 中约 21 处硬编码字号值继续留在生产代码，后续主题切换/设计系统迭代无法统一控制。

## 验证证据

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm -C apps/desktop storybook:build`
- 补充验证：`grep -rn 'text-\[[0-9]' apps/desktop/renderer/src/features/character/ --include='*.tsx' | grep -v test | grep -v stories | wc -l` → 0

## 回滚点

- 回滚 commit/分支：revert merge commit on main
- 回滚后需要恢复的数据或配置：无

## 非自动化检查（Tier 3）

- [x] **字体渲染**：本次改动仅替换 CSS class 名称（text-[Npx] → text-(--text-token)），不改变实际渲染像素值。N/A — 无视觉变更
- [x] **品牌调性**：所有新增样式均使用 Design Token（--text-label, --text-status, --text-caption, --text-body），新增 dimension token（--dimension-character-accent, --dimension-character-dialog-max-h）均在 @theme inline 注册。无 Tailwind 原始色值或硬编码值
- [x] **无障碍**：本次改动不涉及动态内容区域或交互行为变更。N/A
- [x] **CJK 场景**：本次改动不涉及文本显示逻辑变更，仅替换 CSS token。N/A