### PR TITLE
refactor(components): replace hardcoded font sizes with Design Tokens (#1238)

### DIFF
--- a/apps/desktop/renderer/src/components/composites/CommandItem.tsx
+++ b/apps/desktop/renderer/src/components/composites/CommandItem.tsx
@@ -113,14 +113,14 @@ export function CommandItem({
       )}
 
       {/* Label */}
-      <span className="flex-1 text-[13px] truncate">
+      <span className="flex-1 text-(--text-body) truncate">
         {labelContent ?? label}
       </span>
 
       {/* Shortcut hint */}
       {hint && (
         <div
-          className={`ml-2 px-1.5 py-0.5 text-[11px] rounded bg-[color:var(--color-bg-selected)] border border-[color:var(--color-separator)] ${
+          className={`ml-2 px-1.5 py-0.5 text-(--text-status) rounded bg-[color:var(--color-bg-selected)] border border-[color:var(--color-separator)] ${
             active
               ? "text-[color:var(--color-fg-default)] border-[color:var(--color-border-default)]"
               : "text-[color:var(--color-fg-muted)]"

--- a/apps/desktop/renderer/src/components/composites/EmptyState.tsx
+++ b/apps/desktop/renderer/src/components/composites/EmptyState.tsx
@@ -51,7 +51,7 @@ const descriptionStyles = [
   "text-xs",
   "text-[color:var(--color-fg-muted)]",
   // eslint-disable-next-line creonow/no-hardcoded-dimension -- Composite: max-width for text readability
-  "max-w-[240px]",
+  "max-w-60",
   "leading-relaxed",
 ].join(" ");
 

--- a/apps/desktop/renderer/src/components/composites/FormField.tsx
+++ b/apps/desktop/renderer/src/components/composites/FormField.tsx
@@ -27,9 +27,10 @@ export interface FormFieldProps {
 
 const containerStyles = ["flex", "flex-col", "gap-2"].join(" ");
 
-const labelStyles = ["text-(--text-body)", "text-[color:var(--color-fg-muted)]"].join(
-  " ",
-);
+const labelStyles = [
+  "text-(--text-body)",
+  "text-[color:var(--color-fg-muted)]",
+].join(" ");
 
 const labelErrorStyles = [
   "text-(--text-body)",

--- a/apps/desktop/renderer/src/components/composites/FormField.tsx
+++ b/apps/desktop/renderer/src/components/composites/FormField.tsx
@@ -27,12 +27,12 @@ export interface FormFieldProps {
 
 const containerStyles = ["flex", "flex-col", "gap-2"].join(" ");
 
-const labelStyles = ["text-[13px]", "text-[color:var(--color-fg-muted)]"].join(
+const labelStyles = ["text-(--text-body)", "text-[color:var(--color-fg-muted)]"].join(
   " ",
 );
 
 const labelErrorStyles = [
-  "text-[13px]",
+  "text-(--text-body)",
   "text-[color:var(--color-error)]",
 ].join(" ");
 

--- a/apps/desktop/renderer/src/components/composites/PanelContainer.tsx
+++ b/apps/desktop/renderer/src/components/composites/PanelContainer.tsx
@@ -44,7 +44,7 @@ const titleGroupStyles = [
   "flex",
   "items-center",
   "gap-2",
-  "text-[13px]",
+  "text-(--text-body)",
   "text-[color:var(--color-fg-muted)]",
   "font-medium",
 ].join(" ");

--- a/apps/desktop/renderer/src/components/composites/SearchInput.tsx
+++ b/apps/desktop/renderer/src/components/composites/SearchInput.tsx
@@ -69,7 +69,7 @@ const shortcutHintStyles = [
   "right-2",
   "top-1/2",
   "-translate-y-1/2",
-  "text-[10px]",
+  "text-(--text-label)",
   "text-[color:var(--color-fg-placeholder)]",
   "pointer-events-none",
 ].join(" ");

--- a/apps/desktop/renderer/src/components/composites/SidebarItem.tsx
+++ b/apps/desktop/renderer/src/components/composites/SidebarItem.tsx
@@ -32,7 +32,7 @@ const baseStyles = [
   "px-3",
   "h-8",
   "rounded-[var(--radius-sm)]",
-  "text-[13px]",
+  "text-(--text-body)",
   "text-[color:var(--color-fg-default)]",
   "cursor-pointer",
   "select-none",

--- a/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialogContent.tsx
+++ b/apps/desktop/renderer/src/components/features/AiDialogs/SystemDialogContent.tsx
@@ -154,7 +154,7 @@ export const keyboardHintStyles = [
 ].join(" ");
 export const kbdStyles = [
   "px-1.5 py-0.5 rounded bg-[var(--color-bg-hover)]",
-  "border border-[var(--color-separator)] text-[9px] font-mono",
+  "border border-[var(--color-separator)] text-(--text-label) font-mono",
   "text-(--color-fg-muted)",
 ].join(" ");
 export const buttonContainerStyles = [

--- a/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
+++ b/apps/desktop/renderer/src/components/features/KnowledgeGraph/GraphNode.tsx
@@ -233,7 +233,7 @@ export function GraphNode({
       {/* Dragging indicator */}
       {dragging && (
         <span
-          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-(--color-fg-on-accent) rounded"
+          className="absolute -right-2 -top-2 px-1.5 py-0.5 text-(--text-label) uppercase tracking-wider text-(--color-fg-on-accent) rounded"
           style={{ backgroundColor: color }}
         >
           {t("kg.graph.dragging")}

--- a/apps/desktop/renderer/src/components/layout/AppShellMainArea.tsx
+++ b/apps/desktop/renderer/src/components/layout/AppShellMainArea.tsx
@@ -131,7 +131,7 @@ export function AppShellMainArea(props: AppShellMainAreaProps): JSX.Element {
   return (
     <main
       id="main-content"
-      className={`relative flex flex-1 bg-[var(--color-bg-base)] text-[var(--color-fg-muted)] text-[13px] ${
+      className={`relative flex flex-1 bg-[var(--color-bg-base)] text-[var(--color-fg-muted)] text-(--text-body) ${
         props.currentProject
           ? "items-stretch justify-stretch"
           : props.projectItems.length > 0

--- a/apps/desktop/renderer/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/renderer/src/components/layout/StatusBar.tsx
@@ -81,7 +81,7 @@ export function StatusBar(): JSX.Element {
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      className="shrink-0 flex items-center justify-between gap-3 px-3 text-[11px] font-[var(--font-family-ui)] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator-bold)]"
+      className="shrink-0 flex items-center justify-between gap-3 px-3 text-(--text-status) font-[var(--font-family-ui)] text-[var(--color-fg-muted)] bg-[var(--color-bg-surface)] border-t border-[var(--color-separator-bold)]"
       style={{ height: LAYOUT_DEFAULTS.statusBarHeight }}
     >
       <div className="min-w-0 flex items-center gap-2">

--- a/apps/desktop/renderer/src/components/layout/__snapshots__/workbench.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/components/layout/__snapshots__/workbench.stories.snapshot.test.ts.snap
@@ -2072,7 +2072,7 @@ exports[`workbench stories snapshots > [WB-TEST-01] should cover icon bar + righ
             class="flex items-center justify-between p-3 border-b border-[color:var(--color-separator)]"
           >
             <div
-              class="flex items-center gap-2 text-[13px] text-[color:var(--color-fg-muted)] font-medium"
+              class="flex items-center gap-2 text-(--text-body) text-[color:var(--color-fg-muted)] font-medium"
             >
               <span>
                 AI

--- a/apps/desktop/renderer/src/components/layout/appShellCommands.tsx
+++ b/apps/desktop/renderer/src/components/layout/appShellCommands.tsx
@@ -169,7 +169,7 @@ export function buildFileEntries(args: {
       icon: (
         <span
           aria-hidden="true"
-          className="inline-flex h-4 w-4 items-center justify-center text-[9px] font-semibold text-[var(--color-fg-muted)]"
+          className="inline-flex h-4 w-4 items-center justify-center text-(--text-label) font-semibold text-[var(--color-fg-muted)]"
         >
           {item.type[0]?.toUpperCase() ?? "D"}
         </span>

--- a/apps/desktop/renderer/src/components/patterns/ErrorState.tsx
+++ b/apps/desktop/renderer/src/components/patterns/ErrorState.tsx
@@ -282,7 +282,7 @@ function BannerError({
             type="button"
             onClick={onAction}
             className={[
-              "mt-2 text-[12px] font-medium underline",
+              "mt-2 text-(--text-caption) font-medium underline",
               colors.text,
               "hover:opacity-80",
               "focus-visible:outline focus-visible:outline-[length:var(--ring-focus-width)]",
@@ -407,7 +407,7 @@ function FullPageError({
     <div
       className={[
         "flex flex-col items-center justify-center",
-        "min-h-[24rem] p-8",
+        "min-h-96 p-8",
         "text-center",
         className,
       ]

--- a/apps/desktop/renderer/src/components/patterns/LoadingState.tsx
+++ b/apps/desktop/renderer/src/components/patterns/LoadingState.tsx
@@ -350,7 +350,7 @@ export function LoadingState({
             <span className={`brand-spinner-letter ${bs.letter}`}>C</span>
           </div>
           {text && (
-            <span className="text-[13px] text-[var(--color-fg-muted)]">
+            <span className="text-(--text-body) text-[var(--color-fg-muted)]">
               {text}
             </span>
           )}
@@ -374,7 +374,7 @@ export function LoadingState({
         >
           <Spinner size={size} />
           {text && (
-            <span className="text-[13px] text-[var(--color-fg-muted)]">
+            <span className="text-(--text-body) text-[var(--color-fg-muted)]">
               {text}
             </span>
           )}


### PR DESCRIPTION
## Summary
Replace 15 hardcoded `text-[Npx]` + 2 non-text arbitrary values across 13 files in components/ layer with semantic Design Tokens and standard Tailwind utilities.

Closes #1238

## Verification
```bash
grep -rn 'text-\[[0-9]' apps/desktop/renderer/src/components/{composites,patterns,layout,features}/ --include='*.tsx' | grep -v test | grep -v stories | grep -v __tests__ | wc -l
# → 0
pnpm typecheck  # → 0 errors
pnpm lint       # → 0 errors
```

## Rollback
`git revert <commit>` — pure class name changes, no logic.