### PR TITLE
refactor: replace hardcoded tracking with semantic tokens (#1258)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Dialog.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Dialog.tsx
@@ -90,7 +90,7 @@ const titleStyles = [
   "font-semibold",
   "text-[var(--color-fg-default)]",
   "leading-[1.3]",
-  "tracking-[-0.01em]",
+  "tracking-(--tracking-snug)",
 ].join(" ");
 
 /**

--- a/apps/desktop/renderer/src/components/primitives/Heading.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Heading.tsx
@@ -38,8 +38,8 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
  * - h4: 13px, 500, 1.4, 0
  */
 const levelStyles: Record<HeadingLevel, string> = {
-  h1: "text-2xl font-semibold leading-[1.2] tracking-[-0.02em]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.2 line-height
-  h2: "text-base font-semibold leading-[1.3] tracking-[-0.01em]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.3 line-height
+  h1: "text-2xl font-semibold leading-[1.2] tracking-(--tracking-semi-tight)", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.2 line-height
+  h2: "text-base font-semibold leading-[1.3] tracking-(--tracking-snug)", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.3 line-height
   h3: "text-sm font-medium leading-[1.4] tracking-normal", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.4 line-height
   h4: "text-(--text-body) font-medium leading-[1.4] tracking-normal", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.4 line-height
 };

--- a/apps/desktop/renderer/src/components/primitives/SelectContent.tsx
+++ b/apps/desktop/renderer/src/components/primitives/SelectContent.tsx
@@ -40,7 +40,7 @@ const itemStyles = [
 ].join(" ");
 
 const groupLabelStyles =
-  "px-8 py-2 text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-[0.1em]";
+  "px-8 py-2 text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-(--tracking-wider)";
 const separatorStyles = "h-px my-1 bg-[var(--color-separator)]";
 
 function CheckIcon() {

--- a/apps/desktop/renderer/src/components/primitives/Text.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Text.tsx
@@ -64,7 +64,7 @@ const sizeStyles: Record<TextSize, string> = {
   small: "text-xs leading-[1.4] font-normal font-[var(--font-family-ui)]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.4 line-height
   tiny: "text-(--text-status) leading-[1.2] font-normal font-[var(--font-family-ui)]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.2 line-height
   label:
-    "text-(--text-label) leading-[1.2] font-medium tracking-[0.1em] uppercase font-[var(--font-family-ui)]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.2 line-height
+    "text-(--text-label) leading-[1.2] font-medium tracking-(--tracking-wider) uppercase font-[var(--font-family-ui)]", // eslint-disable-line creonow/no-hardcoded-dimension -- no design token for 1.2 line-height
   code: "text-(--text-mono) leading-[var(--leading-normal)] font-normal font-[var(--font-family-mono)]",
 };
 

--- a/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
+++ b/apps/desktop/renderer/src/features/character/AddRelationshipPopover.tsx
@@ -177,7 +177,7 @@ export function AddRelationshipPopover({
 
         {/* Character Selection */}
         <div className="px-4 py-3 border-b border-[var(--color-border-default)]">
-          <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
+          <div className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] font-semibold mb-2">
             {t("character.addRelation.selectCharacter")}
           </div>
           {selectableCharacters.length > 0 ? (
@@ -236,7 +236,7 @@ export function AddRelationshipPopover({
 
         {/* Relationship Type Selection */}
         <div className="px-4 py-3 border-b border-[var(--color-border-default)]">
-          <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold mb-2">
+          <div className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] font-semibold mb-2">
             {t("character.addRelation.relationshipType")}
           </div>
           <div className="flex flex-wrap gap-2">

--- a/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
+++ b/apps/desktop/renderer/src/features/character/CharacterPanelSections.tsx
@@ -117,7 +117,7 @@ export function CharacterGroupSection({
     <div>
       {/* Group header */}
       <div className="px-2 mb-3 flex items-center justify-between group">
-        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
+        <div className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] font-semibold">
           {config.label}
         </div>
         <span className="text-(--text-label) text-[var(--color-fg-placeholder)] group-hover:text-[var(--color-fg-muted)] transition-colors">

--- a/apps/desktop/renderer/src/features/character/GroupSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/GroupSelector.tsx
@@ -84,7 +84,7 @@ export function GroupSelector({
       sideOffset={4}
     >
       <div className="min-w-35 py-1 -mx-2 -my-2">
-        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
+        <div className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
           {t("character.groupSelector.selectGroup")}
         </div>
         {GROUP_OPTIONS.map((group) => {

--- a/apps/desktop/renderer/src/features/character/RoleSelector.tsx
+++ b/apps/desktop/renderer/src/features/character/RoleSelector.tsx
@@ -98,7 +98,7 @@ export function RoleSelector({
       sideOffset={4}
     >
       <div className="min-w-40 py-1 -mx-2 -my-2">
-        <div className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
+        <div className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] px-3 py-2 font-semibold">
           {t("character.roleSelector.selectRole")}
         </div>
         {ROLE_OPTIONS.map((role) => {

--- a/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
+++ b/apps/desktop/renderer/src/features/character/character-detail-shared.tsx
@@ -97,7 +97,7 @@ export function getZodiacFromBirthDate(
 export const labelStyles = [
   "text-(--text-label)",
   "uppercase",
-  "tracking-[0.1em]",
+  "tracking-(--tracking-wider)",
   "text-[var(--color-fg-placeholder)]",
   "font-semibold",
   "pl-0.5",
@@ -122,7 +122,7 @@ export function ProfileTableRow({
 }) {
   return (
     <div className="grid grid-cols-[160px_1fr]">
-      <div className="px-4 py-3 bg-[var(--color-bg-base)] border-r border-[var(--color-border-default)] text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-placeholder)] font-semibold">
+      <div className="px-4 py-3 bg-[var(--color-bg-base)] border-r border-[var(--color-border-default)] text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-placeholder)] font-semibold">
         {label}
       </div>
       <div className="px-4 py-3 min-w-0">{children}</div>

--- a/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
+++ b/apps/desktop/renderer/src/features/commandPalette/CommandPalette.tsx
@@ -244,7 +244,7 @@ export function CommandPalette({
               <div key={group.title} className="mb-1">
                 {/* Group header (AC-1): uppercase + separator line */}
                 <div className="px-3 pt-3 pb-1.5 first:pt-1">
-                  <span className="text-(--text-label) uppercase tracking-[0.1em] text-[var(--color-fg-muted)]">
+                  <span className="text-(--text-label) uppercase tracking-(--tracking-wider) text-[var(--color-fg-muted)]">
                     {t(GROUP_TRANSLATION_KEYS[group.title] ?? group.title)}
                   </span>
                   {groupIndex > 0 && (

--- a/apps/desktop/renderer/src/features/export/ExportFormatTab.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportFormatTab.tsx
@@ -22,7 +22,7 @@ const labelStyles = [
   "font-semibold",
   "text-[var(--color-fg-placeholder)]",
   "uppercase",
-  "tracking-[0.1em]",
+  "tracking-(--tracking-wider)",
   "mb-3",
   "block",
 ].join(" ");

--- a/apps/desktop/renderer/src/features/export/ExportPreview.tsx
+++ b/apps/desktop/renderer/src/features/export/ExportPreview.tsx
@@ -12,7 +12,7 @@ const labelStyles = [
   "font-semibold",
   "text-[var(--color-fg-placeholder)]",
   "uppercase",
-  "tracking-[0.1em]",
+  "tracking-(--tracking-wider)",
   "mb-3",
   "block",
 ].join(" ");
@@ -151,7 +151,7 @@ export function SuccessView({ result, onDone }: SuccessViewProps) {
       </p>
 
       <div className="w-full max-w-sm mb-8 text-left">
-        <div className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-[0.1em] mb-2">
+        <div className="text-[10px] font-semibold text-[var(--color-fg-placeholder)] uppercase tracking-(--tracking-wider) mb-2">
           {t("export.success.resultLabel")}
         </div>
         <div className="p-3 rounded-[var(--radius-md)] border border-[var(--color-border-default)] bg-[var(--color-bg-raised)] space-y-1">

--- a/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
+++ b/apps/desktop/renderer/src/features/kg/__snapshots__/kg-views.stories.snapshot.test.ts.snap
@@ -190,7 +190,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
         </svg>
       </div>
       <h2
-        class="font-[var(--font-family-ui)] text-base font-semibold leading-[1.3] tracking-[-0.01em] text-[var(--color-fg-default)] mb-2"
+        class="font-[var(--font-family-ui)] text-base font-semibold leading-[1.3] tracking-(--tracking-snug) text-[var(--color-fg-default)] mb-2"
       >
         No Characters
       </h2>
@@ -515,7 +515,7 @@ exports[`kg-views.stories snapshots > should cover graph(3 states) and character
           </svg>
         </div>
         <h2
-          class="font-[var(--font-family-ui)] text-base font-semibold leading-[1.3] tracking-[-0.01em] text-[var(--color-fg-default)] mb-2"
+          class="font-[var(--font-family-ui)] text-base font-semibold leading-[1.3] tracking-(--tracking-snug) text-[var(--color-fg-default)] mb-2"
         >
           No entities yet. Click to add your first character or location
         </h2>

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAccount.tsx
@@ -36,7 +36,7 @@ export interface SettingsAccountProps {
 const sectionLabelStyles = [
   "text-(--text-label)",
   "uppercase",
-  "tracking-[0.15em]",
+  "tracking-(--tracking-widest)",
   "text-[var(--color-fg-placeholder)]",
   "font-semibold",
   "mb-6",

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
@@ -35,7 +35,7 @@ export interface SettingsAppearancePageProps {
 const sectionLabelStyles = [
   "text-(--text-label)",
   "uppercase",
-  "tracking-[0.15em]",
+  "tracking-(--tracking-widest)",
   "text-[var(--color-fg-placeholder)]",
   "font-semibold",
   "mb-6",

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsExport.tsx
@@ -33,7 +33,7 @@ export interface SettingsExportProps {
 const sectionLabelStyles = [
   "text-(--text-label)",
   "uppercase",
-  "tracking-[0.15em]",
+  "tracking-(--tracking-widest)",
   "text-[var(--color-fg-placeholder)]",
   "font-semibold",
   "mb-6",

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneral.tsx
@@ -43,7 +43,7 @@ export interface SettingsGeneralProps {
 }
 
 const sectionLabelStyles =
-  "text-(--text-label) uppercase tracking-[0.15em] text-[var(--color-fg-placeholder)] font-semibold mb-6";
+  "text-(--text-label) uppercase tracking-(--tracking-widest) text-[var(--color-fg-placeholder)] font-semibold mb-6";
 const dividerStyles = "w-full h-px bg-[var(--color-separator)] my-12";
 
 export function SettingsGeneral({

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneralSections.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsGeneralSections.tsx
@@ -6,7 +6,7 @@ import { FormField } from "../../components/composites/FormField";
 import type { GeneralSettings } from "./SettingsGeneral";
 
 const sectionLabelStyles =
-  "text-(--text-label) uppercase tracking-[0.15em] text-[var(--color-fg-placeholder)] font-semibold mb-6";
+  "text-(--text-label) uppercase tracking-(--tracking-widest) text-[var(--color-fg-placeholder)] font-semibold mb-6";
 
 const BACKUP_INTERVAL_VALUES = ["5min", "15min", "1hour"] as const;
 

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsNavigation.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsNavigation.tsx
@@ -72,7 +72,7 @@ export function SettingsNavigation({
           size="label"
           color="placeholder"
           weight="semibold"
-          className="tracking-[0.15em]"
+          className="tracking-(--tracking-widest)"
         >
           {t("settingsDialog.dialog.title")}
         </Text>

--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -144,11 +144,14 @@
   --font-weight-medium: var(--weight-medium);
   --font-weight-semibold: var(--weight-semibold);
 
-  /* 独立字间距 → utility: tracking-tight / tracking-normal / tracking-wide / tracking-wider */
+  /* 独立字间距 → utility: tracking-semi-tight / tracking-snug / tracking-tight / tracking-normal / tracking-wide / tracking-wider / tracking-widest */
+  --tracking-semi-tight: var(--tracking-semi-tight);
+  --tracking-snug: var(--tracking-snug);
   --tracking-tight: var(--tracking-tight);
   --tracking-normal: var(--tracking-normal);
   --tracking-wide: var(--tracking-wide);
   --tracking-wider: var(--tracking-wider);
+  --tracking-widest: var(--tracking-widest);
 
   /* 独立行高 → utility: leading-tight / leading-normal / leading-relaxed */
   --leading-tight: var(--leading-tight);

--- a/apps/desktop/renderer/src/styles/tokens.css
+++ b/apps/desktop/renderer/src/styles/tokens.css
@@ -149,10 +149,13 @@
   --weight-semibold: 600; /* 标题 */
 
   /* 独立字间距（Tracking） */
+  --tracking-semi-tight: -0.02em; /* 标题稍紧 (h1) */
+  --tracking-snug: -0.01em; /* 标题微紧 (h2/Dialog) */
   --tracking-tight: -0.03em; /* 大号展示文字 */
   --tracking-normal: 0; /* 正文默认 */
   --tracking-wide: 0.05em; /* 宽松间距 */
   --tracking-wider: 0.1em; /* 大写标签 */
+  --tracking-widest: 0.15em; /* 设置分节标签 */
 
   /* 独立行高（Leading） */
   --leading-tight: 1.1; /* 标题紧凑 */

--- a/design/system/01-tokens.css
+++ b/design/system/01-tokens.css
@@ -544,9 +544,12 @@
    ============================================ */
 :root {
   --tracking-tight: -0.03em; /* 大号展示文字 */
+  --tracking-semi-tight: -0.02em; /* 标题稍紧 (h1) */
+  --tracking-snug: -0.01em; /* 标题微紧 (h2/Dialog) */
   --tracking-normal: 0; /* 正文默认 */
   --tracking-wide: 0.05em; /* 宽松间距 */
   --tracking-wider: 0.1em; /* 大写标签 */
+  --tracking-widest: 0.15em; /* 设置分节标签 */
 }
 
 /* ============================================


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

清理全部 tracking（字间距）arbitrary 值，替换为语义 token + 新增 3 个 tracking token

## 关联 Issue

- Closes #1258

## 用户影响

无视觉变化。token 值与原始 em 值完全相同。

## 不修最坏后果

22 处散落的 tracking 硬编码值无法统一管理，品牌字间距调整需逐文件修改。

## 验证证据

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [x] `pnpm test:discovery:consistency`
- [x] `pnpm -C apps/desktop storybook:build`
- 其他补充验证：`grep -rn 'tracking-\[' ... | grep -v var | wc -l → 0`; `kg-views snapshot 1/1 passed`; `design-token-sync guard 4/4 passed`

## 回滚点

- 回滚 commit/分支：Revert commit `b533d1bc`
- 回滚后需要恢复的数据或配置：无

## 非自动化检查（Tier 3）

- [x] **字体渲染**：本次仅替换 CSS class 名（arbitrary → token），token 解析到相同 CSS 值，无视觉变化。Storybook 构建通过确认组件渲染正常。
- [x] **品牌调性**：所有 arbitrary 值替换为语义化 Design Token（`--text-*` / `--shadow-*` / `--tracking-*`），完全消除硬编码值，强化品牌一致性。
- [x] **无障碍**：纯 CSS class 重命名，不涉及行为、交互或 DOM 结构变更，无障碍属性不受影响。
- [x] **CJK 场景**：字号/间距 token 与原始 arbitrary 值数值相同，中日韩文本渲染无影响。