### PR TITLE
feat: v1-17 字体本地打包与视觉回归 — @theme inline shadow 去重

### DIFF
--- a/apps/desktop/renderer/src/styles/main.css
+++ b/apps/desktop/renderer/src/styles/main.css
@@ -155,11 +155,7 @@
   --leading-normal: var(--leading-normal);
   --leading-relaxed: var(--leading-relaxed);
 
-  /* 阴影 → utility: shadow-sm / shadow-md / shadow-lg / shadow-xl */
-  --shadow-sm: 0 1px 2px var(--color-shadow);
-  --shadow-md: 0 4px 8px var(--color-shadow);
-  --shadow-lg: 0 8px 16px var(--color-shadow);
-  --shadow-xl: 0 16px 32px var(--color-shadow);
+  /* 阴影 → 已统一到上方 @theme 静态块（shadow-xs ~ shadow-2xl） */
 
   /* Dimension tokens — component-specific fixed values */
   --dimension-rule-indicator-offset: 3px;


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## 主题

v1-17 将 shadow-xs/2xl 添加到了静态 `@theme` 块（6 个 shadow token 完整导出），但 `@theme inline` 块仍保留了旧的 4 条 shadow 声明（sm/md/lg/xl），造成声明不对称。本 PR 移除 `@theme inline` 中的冗余 shadow 条目，使所有 6 个 shadow utility 统一由单一 `@theme` 源提供。

## 关联 Issue

- Closes #1263

## 用户影响

- 消除 @theme / @theme inline 双重声明可能导致的优先级混淆
- shadow utility 行为无变化（值完全一致）

## 不修最坏后果

- 后续维护者可能误以为 `@theme inline` 才是 shadow 的主源，漏改 xs/2xl

## 验证证据

- [x] `pnpm typecheck` — 通过
- [x] `pnpm lint` — 0 errors, 401 warnings（均为预存）
- [x] v1-17 guard tests（28/28 pass）
- [x] `pnpm -C apps/desktop storybook:build` — 成功
- woff2 count: 14（≥12 ✅）
- @font-face count: 14（≥12 ✅）
- shadow-[var(--shadow-2xl)] residual: 0 ✅

## 回滚点

- 回滚 commit: `git revert <commit-sha>`
- 无数据/配置依赖

## 非自动化检查（Tier 3）

- [x] **品牌调性**：仅移除冗余声明，未引入新值
- N/A 字体渲染/无障碍/CJK — 本 PR 不涉及视觉变更