### PR TITLE
refactor: Wave 2 arbitrary value residual cleanup (#1270)

### DIFF
--- a/apps/desktop/renderer/src/components/primitives/Badge.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.test.tsx
@@ -173,7 +173,7 @@ describe("Badge", () => {
       render(<Badge variant="pill">Tag</Badge>);
 
       const badge = screen.getByText("Tag");
-      expect(badge.className).toContain("tracking-[var(--tracking-wide)]");
+      expect(badge.className).toContain("tracking-(--tracking-wide)");
     });
 
     it("pill 应该有 weight-semibold", () => {

--- a/apps/desktop/renderer/src/components/primitives/Badge.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.tsx
@@ -72,7 +72,7 @@ const variantStyles: Record<BadgeVariant, string> = {
     "bg-[var(--color-bg-hover)]",
     "text-[var(--color-fg-muted)]",
     "uppercase",
-    "tracking-[var(--tracking-wide)]",
+    "tracking-(--tracking-wide)",
     "font-[var(--weight-semibold)]",
     "rounded-[var(--radius-full)]",
   ].join(" "),

--- a/apps/desktop/renderer/src/components/primitives/Badge.v1-02-behavior.test.tsx
+++ b/apps/desktop/renderer/src/components/primitives/Badge.v1-02-behavior.test.tsx
@@ -27,7 +27,7 @@ describe("Badge v1-02 行为测试", () => {
     it("使用 tracking-wide 字间距", () => {
       render(<Badge variant="pill">Tag</Badge>);
       const badge = screen.getByText("Tag");
-      expect(badge.className).toContain("tracking-[var(--tracking-wide)]");
+      expect(badge.className).toContain("tracking-(--tracking-wide)");
     });
 
     it("使用 weight-semibold 字重", () => {

--- a/apps/desktop/renderer/src/components/primitives/useRadioGroup.ts
+++ b/apps/desktop/renderer/src/components/primitives/useRadioGroup.ts
@@ -33,7 +33,7 @@ export const sizeStyles = {
   sm: {
     radio: "w-4 h-4",
     label: "text-xs",
-    description: "text-[10px]",
+    description: "text-(--text-label)",
     gap: "gap-2",
   },
   md: {

--- a/apps/desktop/renderer/src/features/dashboard/DashboardHero.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardHero.tsx
@@ -33,7 +33,7 @@ export function HeroCard(props: {
     >
       <div className="flex-1 min-w-0 p-[var(--space-10)] flex flex-col justify-center">
         <div
-          className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-faint)] mb-[var(--space-3)] font-[var(--text-label-weight)]"
+          className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-faint) mb-(--space-3) font-(--text-label-weight)"
           style={{
             fontSize: "var(--text-label-size)",
             lineHeight: "var(--text-label-line-height)",
@@ -58,7 +58,7 @@ export function HeroCard(props: {
         </p>
         <div className="flex items-center gap-[var(--space-3)]">
           <span
-            className="uppercase text-[var(--color-fg-faint)] border border-[var(--color-separator)] px-[var(--space-3)] py-[var(--space-1)] rounded-full"
+            className="uppercase text-(--color-fg-faint) border border-[var(--color-separator)] px-[var(--space-3)] py-[var(--space-1)] rounded-full"
             style={{
               fontSize: "var(--text-status-size)",
               letterSpacing: "var(--tracking-wide)",
@@ -67,7 +67,7 @@ export function HeroCard(props: {
             {formatStageTag(project.stage, t)}
           </span>
           <ArrowRight
-            className="w-[var(--space-4)] h-[var(--space-4)] text-[var(--color-fg-faint)] transition-transform duration-[var(--duration-normal)] ease-[var(--ease-default)] group-hover:rotate-[-45deg]"
+            className="w-[var(--space-4)] h-[var(--space-4)] text-(--color-fg-faint) transition-transform duration-[var(--duration-normal)] ease-[var(--ease-default)] group-hover:rotate-[-45deg]"
             strokeWidth={1.5}
           />
         </div>
@@ -76,7 +76,7 @@ export function HeroCard(props: {
       {/* 审计：v1-13 #028 KEEP */}
       {/* eslint-disable-next-line creonow/no-hardcoded-dimension -- 技术原因：百分比布局无标准 Tailwind 工具类可替代 */}
       <div className="w-[35%] max-w-70 hidden lg:block bg-[var(--color-bg-surface)] border-l border-[var(--color-separator)] relative overflow-hidden">
-        <div className="absolute inset-0 flex items-center justify-center text-[var(--color-fg-faint)]">
+        <div className="absolute inset-0 flex items-center justify-center text-(--color-fg-faint)">
           <PenTool
             className="w-[var(--space-16)] h-[var(--space-16)] opacity-20"
             strokeWidth={1.5}

--- a/apps/desktop/renderer/src/features/dashboard/DashboardProjectGrid.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardProjectGrid.tsx
@@ -129,9 +129,9 @@ export function ProjectCard(props: {
       tabIndex={0}
       className="border border-transparent p-[var(--space-6)] h-50 flex flex-col cursor-pointer transition-[border-color,background-color,box-shadow] duration-[var(--duration-slow)] ease-[var(--ease-default)] hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-hover)] hover:shadow-sm"
     >
-      <div className="flex justify-between items-start mb-[var(--space-4)]">
+      <div className="flex justify-between items-start mb-(--space-4)">
         <div
-          className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] font-[var(--text-label-weight)]"
+          className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) font-(--text-label-weight)"
           style={{ fontSize: "var(--text-label-size)" }}
         >
           {dateStr}
@@ -163,7 +163,7 @@ export function ProjectCard(props: {
       </h3>
 
       <p
-        className="text-[var(--color-fg-muted)] leading-relaxed line-clamp-3 flex-1"
+        className="text-(--color-fg-muted) leading-relaxed line-clamp-3 flex-1"
         style={{ fontSize: "var(--text-body-size)" }}
       >
         {t("dashboard.openProjectHint")}
@@ -222,7 +222,7 @@ export function NewDraftCard(props: { onClick: () => void }): JSX.Element {
         strokeWidth={1.5}
       />
       <div
-        className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] relative font-[var(--text-label-weight)]"
+        className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) relative font-(--text-label-weight)"
         style={{ fontSize: "var(--text-label-size)" }}
       >
         {t("dashboard.newDraft")}

--- a/apps/desktop/renderer/src/features/dashboard/DashboardSidebar.tsx
+++ b/apps/desktop/renderer/src/features/dashboard/DashboardSidebar.tsx
@@ -24,7 +24,7 @@ function StatItem(props: { label: string; value: string }): JSX.Element {
   return (
     <div className="flex flex-col gap-[var(--space-1)]">
       <span
-        className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] font-[var(--text-label-weight)]"
+        className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) font-(--text-label-weight)"
         style={{ fontSize: "var(--text-label-size)" }}
       >
         {props.label}
@@ -71,7 +71,7 @@ export function DashboardSidebar(props: DashboardSidebarProps): JSX.Element {
       {/* Recent Documents */}
       <div>
         <div
-          className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] mb-[var(--space-4)] font-[var(--text-label-weight)]"
+          className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) mb-(--space-4) font-(--text-label-weight)"
           style={{ fontSize: "var(--text-label-size)" }}
         >
           {t("dashboard.sidebar.recentDocs")}
@@ -99,7 +99,7 @@ export function DashboardSidebar(props: DashboardSidebarProps): JSX.Element {
       {/* Quick Actions */}
       <div>
         <div
-          className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] mb-[var(--space-4)] font-[var(--text-label-weight)]"
+          className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) mb-(--space-4) font-(--text-label-weight)"
           style={{ fontSize: "var(--text-label-size)" }}
         >
           {t("dashboard.sidebar.quickActions")}
@@ -136,7 +136,7 @@ export function DashboardSidebar(props: DashboardSidebarProps): JSX.Element {
       {/* Statistics (AC-5: stat display + monospace meta) */}
       <div>
         <div
-          className="uppercase tracking-[var(--text-label-letter-spacing)] text-[var(--color-fg-muted)] mb-[var(--space-4)] font-[var(--text-label-weight)]"
+          className="uppercase tracking-(--text-label-letter-spacing) text-(--color-fg-muted) mb-(--space-4) font-(--text-label-weight)"
           style={{ fontSize: "var(--text-label-size)" }}
         >
           {t("dashboard.sidebar.statistics")}

--- a/apps/desktop/renderer/src/features/quality-gates/qualityGatesTypes.ts
+++ b/apps/desktop/renderer/src/features/quality-gates/qualityGatesTypes.ts
@@ -81,7 +81,7 @@ export const panelContainerStyles = [
   "bg-[var(--color-bg-surface)]",
   "border-l border-[var(--color-separator)]",
   "flex flex-col h-full",
-  "shadow-[var(--shadow-xl)] shrink-0",
+  "shadow-xl shrink-0",
 ].join(" ");
 
 export const headerStyles = [

--- a/apps/desktop/renderer/src/features/settings-dialog/settingsDialogStyles.ts
+++ b/apps/desktop/renderer/src/features/settings-dialog/settingsDialogStyles.ts
@@ -36,7 +36,7 @@ export const contentStyles = [
   "border",
   "border-[var(--color-border-default)]",
   "rounded-[var(--radius-lg)]",
-  "shadow-[var(--shadow-xl)]",
+  "shadow-xl",
   "flex",
   "overflow-hidden",
   // Animation


### PR DESCRIPTION
## 变更内容

Wave 2 三个已合并 PR 的漏网修复（11 处 arbitrary value）：

### v1-18g 遗漏 (PR #1264)
- `useRadioGroup.ts:36`：`text-[10px]` → `text-(--text-label)`

### v1-18i 遗漏 (PR #1261)
- `settingsDialogStyles.ts:39`：`shadow-[var(--shadow-xl)]` → `shadow-xl`
- `qualityGatesTypes.ts:84`：`shadow-[var(--shadow-xl)]` → `shadow-xl`

### v1-18j 遗漏 (PR #1265)
- `DashboardSidebar.tsx` ×4：`tracking-[var(...)]` → `tracking-(...)`
- `DashboardProjectGrid.tsx` ×2：同上
- `DashboardHero.tsx` ×1：同上
- `Badge.tsx` ×1：`tracking-[var(--tracking-wide)]` → `tracking-(--tracking-wide)`

同一行内的 `text-[var(--color-*)]`、`font-[var(--*)]`、`mb-[var(--*)]` 也一并转换为 Tailwind v4 shorthand。

## 验证证据

- `pnpm typecheck` → 0 errors ✅
- `pnpm lint` → 0 errors (401 pre-existing warnings) ✅
- `grep 'shadow-\[var(--shadow' src/` → 0 ✅
- `grep 'tracking-\[var(' src/` → 0 ✅
- `grep 'text-\[10px\]' primitives/` → 0 ✅

## 回滚点

单 commit，`git revert` 即可。

## 审计门禁

- [ ] 审计 Agent 已发布 FINAL-VERDICT

Closes #1270