### PR TITLE
style(files): migrate rotate animation to Tailwind classes

### DIFF
--- a/apps/desktop/renderer/src/features/files/FileTreeNodeRow.tsx
+++ b/apps/desktop/renderer/src/features/files/FileTreeNodeRow.tsx
@@ -176,12 +176,7 @@ export const FileTreeNodeRow = React.memo(
                     e.stopPropagation();
                     props.toggleFolderExpanded(item.documentId);
                   }}
-                  className="shrink-0 w-4 text-(--text-label) text-[var(--color-fg-muted)] transition-transform duration-[var(--duration-fast)]"
-                  style={{
-                    transform: props.expandedFolderIds.has(item.documentId)
-                      ? "rotate(90deg)"
-                      : "rotate(0deg)",
-                  }}
+                  className={`shrink-0 w-4 text-(--text-label) text-[var(--color-fg-muted)] transition-transform duration-[var(--duration-fast)] ${props.expandedFolderIds.has(item.documentId) ? "rotate-90" : "rotate-0"}`}
                   aria-label={
                     props.expandedFolderIds.has(item.documentId)
                       ? t("files.tree.collapse")


### PR DESCRIPTION
## Summary

Closes #1276

Replace inline `style={{ transform: rotate(...) }}` with Tailwind `rotate-90` / `rotate-0` classes in `FileTreeNodeRow.tsx`.

## Changes

- Removed inline `style` prop for arrow rotation
- Added conditional `rotate-90` / `rotate-0` Tailwind classes to className
- Existing `transition-transform duration-[var(--duration-fast)]` already handles animation

## Verification

- `grep -c 'rotate(90deg)' FileTreeNodeRow.tsx` → **0**
- `pnpm typecheck` → ✅
- `pnpm lint` → ✅
- `pnpm -C apps/desktop exec vitest run FileTree` → 9 files, 80 tests passed
- `pnpm -C apps/desktop storybook:build` → ✅
- Prettier check → ✅

## Rollback

Revert this single commit.

## Audit Gate

Awaiting independent audit before merge.