### PR TITLE
style(ai): complete hover/focus/transition coverage (#1274)

### DIFF
--- a/apps/desktop/renderer/src/features/ai/AiInputArea.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiInputArea.tsx
@@ -167,7 +167,7 @@ export const AiInputArea = React.forwardRef<
                 <Button
                   type="button"
                   data-testid="ai-selection-reference-close"
-                  className="focus-ring h-5 w-5 shrink-0 rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)]"
+                  className="focus-ring h-5 w-5 shrink-0 rounded text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
                   onClick={() => props.setSelectionSnapshot(null)}
                 >
                   ×

--- a/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
+++ b/apps/desktop/renderer/src/features/ai/SkillPicker.tsx
@@ -156,7 +156,7 @@ export function SkillPicker(props: {
                         <Button
                           type="button"
                           data-testid={`ai-skill-toggle-${item.id}`}
-                          className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
+                          className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                           onClick={() =>
                             props.onToggleSkill?.(item.id, !item.enabled)
                           }
@@ -185,7 +185,7 @@ export function SkillPicker(props: {
                 </Text>
                 <Button
                   type="button"
-                  className="mt-2 px-2 py-1 text-(--text-status) rounded border border-[var(--color-border-default)] text-[var(--color-fg-default)]"
+                  className="mt-2 px-2 py-1 text-(--text-status) rounded border border-[var(--color-border-default)] text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-colors"
                   onClick={() => {
                     if (props.onCreateSkill) {
                       props.onCreateSkill();
@@ -230,7 +230,7 @@ export function SkillPicker(props: {
                                   <Button
                                     type="button"
                                     data-testid={`ai-skill-demote-${item.id}`}
-                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
+                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                                     onClick={() =>
                                       props.onUpdateScope?.(item.id, "project")
                                     }
@@ -242,7 +242,7 @@ export function SkillPicker(props: {
                                   <Button
                                     type="button"
                                     data-testid={`ai-skill-toggle-${item.id}`}
-                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
+                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                                     onClick={() =>
                                       props.onToggleSkill?.(
                                         item.id,
@@ -297,7 +297,7 @@ export function SkillPicker(props: {
                                   <Button
                                     type="button"
                                     data-testid={`ai-skill-promote-${item.id}`}
-                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
+                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                                     onClick={() =>
                                       props.onUpdateScope?.(item.id, "global")
                                     }
@@ -309,7 +309,7 @@ export function SkillPicker(props: {
                                   <Button
                                     type="button"
                                     data-testid={`ai-skill-toggle-${item.id}`}
-                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)]"
+                                    className="px-2 py-1 text-(--text-label) rounded border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] transition-colors"
                                     onClick={() =>
                                       props.onToggleSkill?.(
                                         item.id,


### PR DESCRIPTION
## 主题
Added explicit transition-colors to 6 SkillPicker action buttons and 1 AiInputArea dismiss button. Added hover state to create-skill button.

## 关联 Issue
Closes #1274

## 用户影响
Smoother hover/focus transitions on AI panel interactive elements

## 不修最坏后果
No functional risk; CSS-only changes

## 验证证据
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → 0 errors
- [x] `pnpm -C apps/desktop exec vitest run ai` → 48 files, 259 tests passed
- [x] `pnpm -C apps/desktop storybook:build` → success
- [x] `grep -c transition SkillPicker.tsx` → 8 (≥7)

## 回滚点
Revert commit f344c27c

## Audit Gate
Pending independent audit.