### PR TITLE
style(settings): complete interaction polish (#1277)

### DIFF
--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsAppearancePage.tsx
@@ -38,7 +38,10 @@ const sectionLabelStyles = [
   "tracking-(--tracking-widest)",
   "text-[var(--color-fg-placeholder)]",
   "font-semibold",
+  "pb-3",
   "mb-6",
+  "border-b",
+  "border-[var(--color-separator)]",
 ].join(" ");
 
 /**

--- a/apps/desktop/renderer/src/features/settings-dialog/SettingsNavigation.tsx
+++ b/apps/desktop/renderer/src/features/settings-dialog/SettingsNavigation.tsx
@@ -89,7 +89,7 @@ export function SettingsNavigation({
               variant="ghost"
               className={`${navButtonBaseStyles} ${
                 isActive
-                  ? "text-[var(--color-fg-default)] bg-[var(--color-bg-selected)]"
+                  ? "text-[var(--color-fg-default)] bg-[var(--color-bg-selected)] font-medium"
                   : "text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-surface)] border-transparent"
               }`}
             >


### PR DESCRIPTION
Closes #1277

## 变更摘要
补齐 Settings 面板交互动效：
- SettingsAppearancePage: 添加 section header divider (pb-3 border-b)
- SettingsNavigation: 添加 active state font-medium
- 其余 AC (slider labels, toggle timing, color swatch) 已满足

## 验证证据
- `pnpm typecheck` → 0 errors
- `vitest run settings` → 14 files, 91 tests passed
- `pnpm lint` → 0 errors
- `storybook:build` → success

## 回滚点
Revert commit `3fe0d773`

## 审计门禁
内审通过 ✅ — 无 BLOCKER