### PR TITLE
refactor(ai): split AiMessageList into sub-components (#1279)

### DIFF
--- a/apps/desktop/renderer/src/features/ai/AiCandidateCards.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiCandidateCards.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from "react-i18next";
+import type { AiCandidate } from "../../stores/aiStore";
+import { Text } from "../../components/primitives";
+import { Button } from "../../components/primitives/Button";
+
+// ---------------------------------------------------------------------------
+// AiCandidateCards — candidate selection grid + regenerate action
+// ---------------------------------------------------------------------------
+
+export function AiCandidateCards(props: {
+  candidates: AiCandidate[];
+  selectedCandidate: AiCandidate | null;
+  working: boolean;
+  onSelectCandidate: (id: string) => void;
+  onRegenerateAll: () => void;
+}): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {props.candidates.length > 0 ? (
+        <div
+          data-testid="ai-candidate-list"
+          className="w-full grid grid-cols-1 gap-2"
+        >
+          {props.candidates.map((candidate, index) => {
+            const isSelected = props.selectedCandidate?.id === candidate.id;
+            return (
+              <Button
+                key={candidate.id}
+                data-testid={`ai-candidate-card-${index + 1}`}
+                type="button"
+                onClick={() => props.onSelectCandidate(candidate.id)}
+                className={`focus-ring w-full text-left rounded-[var(--radius-md)] border px-3 py-2 transition-colors ${
+                  isSelected
+                    ? "border-[var(--color-accent)] bg-[var(--color-bg-selected)]"
+                    : "border-[var(--color-border-default)] bg-[var(--color-bg-base)] hover:bg-[var(--color-bg-hover)]"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-(--text-caption) font-semibold text-[var(--color-fg-default)]">
+                    {t("ai.candidate", { index: index + 1 })}
+                  </span>
+                  {isSelected ? (
+                    <span className="text-(--text-status) text-[var(--color-fg-accent)]">
+                      {t("ai.candidateSelected")}
+                    </span>
+                  ) : null}
+                </div>
+                <Text
+                  size="small"
+                  color="muted"
+                  className="mt-1 whitespace-pre-wrap"
+                >
+                  {candidate.summary}
+                </Text>
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {props.candidates.length > 1 ? (
+        <div className="w-full flex justify-end">
+          <Button
+            data-testid="ai-candidate-regenerate"
+            variant="ghost"
+            size="sm"
+            onClick={() => void props.onRegenerateAll()}
+            disabled={props.working}
+          >
+            {t("ai.regenerateAll")}
+          </Button>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/desktop/renderer/src/features/ai/AiJudgeResult.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiJudgeResult.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import type { JudgeResultEvent } from "@shared/types/judge";
+import { Text } from "../../components/primitives";
+import { judgeSeverityClass } from "./aiPanelFormatting";
+
+// ---------------------------------------------------------------------------
+// AiJudgeResult — judge verdict display
+// ---------------------------------------------------------------------------
+
+export function AiJudgeResult(props: {
+  result: JudgeResultEvent;
+}): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      data-testid="ai-judge-result"
+      className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2 space-y-1"
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <span
+          data-testid="ai-judge-severity"
+          className={`text-(--text-status) font-semibold uppercase tracking-wide ${judgeSeverityClass(props.result.severity)}`}
+        >
+          {props.result.severity}
+        </span>
+        {props.result.labels.length === 0 ? (
+          <span
+            data-testid="ai-judge-pass"
+            className="text-(--text-caption) text-[var(--color-fg-default)]"
+          >
+            {t("ai.judgePass")}
+          </span>
+        ) : (
+          props.result.labels.map((label) => (
+            <span
+              key={label}
+              className="text-(--text-caption) text-[var(--color-fg-default)]"
+            >
+              {label}
+            </span>
+          ))
+        )}
+      </div>
+      <Text data-testid="ai-judge-summary" size="small" color="muted">
+        {props.result.summary}
+      </Text>
+      {props.result.partialChecksSkipped ? (
+        <Text data-testid="ai-judge-partial" size="small" color="muted">
+          {t("ai.judgePartialSkipped")}
+        </Text>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/renderer/src/features/ai/AiMessageList.tsx
+++ b/apps/desktop/renderer/src/features/ai/AiMessageList.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { SettingsTab } from "../settings-dialog/SettingsDialog";
 
-import { AiErrorCard } from "../../components/features/AiDialogs";
-
 import { Spinner, Text } from "../../components/primitives";
-import { Button } from "../../components/primitives/Button";
 
 import {
   type AiApplyStatus,
@@ -18,178 +15,14 @@ import {
 
 import { useTranslation } from "react-i18next";
 import type { JudgeResultEvent } from "@shared/types/judge";
-import { judgeSeverityClass } from "./aiPanelFormatting";
 
 import { AiEmptyState } from "./AiEmptyState";
 import { AiUsageStats } from "./AiUsageStats";
 import { AiProposalView } from "./AiProposalView";
 import type { AiErrorConfigs } from "./aiPanelHelpers";
-
-// ---------------------------------------------------------------------------
-// ErrorGuideCard — extracted inline component
-// ---------------------------------------------------------------------------
-
-export function ErrorGuideCard(props: {
-  testId: string;
-  title: string;
-  description: string;
-  steps: string[];
-  errorCode: string;
-  severity?: "error" | "warning" | "info";
-  command?: string;
-  actionLabel?: string;
-  actionTestId?: string;
-  onAction?: () => void;
-}): JSX.Element {
-  const [copied, setCopied] = React.useState(false);
-  const sev = props.severity ?? "error";
-
-  const borderColorMap = {
-    error: "bg-[var(--color-error)]",
-    warning: "bg-[var(--color-warning)]",
-    info: "bg-[var(--color-info)]",
-  };
-
-  const bgColorMap = {
-    error: "bg-[var(--color-error-subtle)]",
-    warning: "bg-[var(--color-warning-subtle)]",
-    info: "bg-[var(--color-info-subtle)]",
-  };
-
-  async function handleCopyCommand(): Promise<void> {
-    if (!props.command || !navigator.clipboard?.writeText) {
-      return;
-    }
-    await navigator.clipboard.writeText(props.command);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1200);
-  }
-
-  const { t } = useTranslation();
-
-  return (
-    <section
-      data-testid={props.testId}
-      className={`w-full rounded-[var(--radius-md)] ${bgColorMap[sev]}`}
-    >
-      <div className="flex">
-        <div
-          className={`w-1.5 rounded-l-[var(--radius-md)] ${borderColorMap[sev]}`}
-        />
-        <div className="flex-1 px-3 py-2.5">
-          <h4 className="text-(--text-body) font-semibold text-[var(--color-fg-default)]">
-            {props.title}
-          </h4>
-          <p className="mt-1 text-(--text-caption) leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap">
-            {props.description}
-          </p>
-          <ol className="mt-2 list-decimal pl-4 space-y-1 text-(--text-caption) leading-snug text-[var(--color-fg-default)]">
-            {props.steps.map((step, index) => (
-              <li key={`${props.testId}-step-${index}`}>{step}</li>
-            ))}
-          </ol>
-          {props.command ? (
-            <div className="mt-2 flex items-center gap-2">
-              <code className="rounded-[var(--radius-sm)] bg-[var(--color-bg-base)] px-2 py-1 text-(--text-status) text-[var(--color-fg-default)]">
-                {props.command}
-              </code>
-              <Button
-                type="button"
-                data-testid={`${props.testId}-copy-command`}
-                className="focus-ring text-(--text-status) px-2 py-1 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-default"
-                onClick={() => void handleCopyCommand()}
-              >
-                {copied ? t("ai.panel.copied") : t("ai.panel.copy")}
-              </Button>
-            </div>
-          ) : null}
-          <div className="mt-2 flex items-center gap-2">
-            {props.onAction && props.actionLabel ? (
-              <Button
-                type="button"
-                data-testid={props.actionTestId}
-                className="focus-ring text-(--text-status) px-2 py-1 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-default"
-                onClick={props.onAction}
-              >
-                {props.actionLabel}
-              </Button>
-            ) : null}
-            <span className="text-(--text-label) font-mono text-[var(--color-error)]">
-              {/* 审计：v1-13 #013 KEEP */}
-              {/* eslint-disable-next-line creonow/no-raw-error-code-in-ui -- 技术原因：diagnostic code reference for AI error display; user-friendly description shown above */}
-              {props.errorCode}
-            </span>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// AiPanelErrorDisplay
-// ---------------------------------------------------------------------------
-
-function AiPanelErrorDisplay(props: {
-  errorConfigs: AiErrorConfigs;
-  clearError: () => void;
-  openSettings: (section?: SettingsTab) => void;
-}): JSX.Element | null {
-  const { t } = useTranslation();
-  const ec = props.errorConfigs;
-
-  if (ec.showDbGuide) {
-    return (
-      <ErrorGuideCard
-        testId="ai-error-guide-db"
-        title={t("ai.panel.dbErrorTitle")}
-        description={ec.dbGuideError?.message ?? t("ai.panel.dbErrorFallback")}
-        steps={[t("ai.panel.dbStep1"), t("ai.panel.dbStep2")]}
-        command={ec.dbGuideCommand}
-        errorCode="DB_ERROR"
-        severity="error"
-      />
-    );
-  }
-
-  if (ec.showProviderGuide) {
-    return (
-      <ErrorGuideCard
-        testId="ai-error-guide-provider"
-        title={t("ai.panel.providerTitle")}
-        description={t("ai.panel.providerDescription")}
-        steps={[
-          t("ai.panel.providerStep1"),
-          t("ai.panel.providerStep2"),
-          t("ai.panel.providerStep3"),
-        ]}
-        errorCode={ec.providerGuideCode ?? "AI_NOT_CONFIGURED"}
-        severity="warning"
-        actionLabel={t("ai.panel.openSettingsAi")}
-        actionTestId="ai-error-guide-open-settings"
-        onAction={() => props.openSettings("ai")}
-      />
-    );
-  }
-
-  return (
-    <>
-      {ec.skillsErrorConfig ? (
-        <AiErrorCard error={ec.skillsErrorConfig} showDismiss={false} />
-      ) : null}
-      {ec.modelsErrorConfig ? (
-        <AiErrorCard error={ec.modelsErrorConfig} showDismiss={false} />
-      ) : null}
-      {ec.runtimeErrorConfig ? (
-        <AiErrorCard
-          error={ec.runtimeErrorConfig}
-          errorCodeTestId="ai-error-code"
-          onDismiss={props.clearError}
-        />
-      ) : null}
-    </>
-  );
-}
+import { AiPanelErrorDisplay } from "./ErrorGuideCard";
+import { AiCandidateCards } from "./AiCandidateCards";
+import { AiJudgeResult } from "./AiJudgeResult";
 
 // ---------------------------------------------------------------------------
 // AiMessageList — message stream rendering (chat area content)
@@ -337,61 +170,13 @@ export function AiMessageList(props: AiMessageListProps): JSX.Element {
         openSettings={props.openSettings}
       />
 
-      {props.lastCandidates.length > 0 ? (
-        <div
-          data-testid="ai-candidate-list"
-          className="w-full grid grid-cols-1 gap-2"
-        >
-          {props.lastCandidates.map((candidate, index) => {
-            const isSelected = props.selectedCandidate?.id === candidate.id;
-            return (
-              <Button
-                key={candidate.id}
-                data-testid={`ai-candidate-card-${index + 1}`}
-                type="button"
-                onClick={() => props.onSelectCandidate(candidate.id)}
-                className={`focus-ring w-full text-left rounded-[var(--radius-md)] border px-3 py-2 transition-colors ${
-                  isSelected
-                    ? "border-[var(--color-accent)] bg-[var(--color-bg-selected)]"
-                    : "border-[var(--color-border-default)] bg-[var(--color-bg-base)] hover:bg-[var(--color-bg-hover)]"
-                }`}
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-(--text-caption) font-semibold text-[var(--color-fg-default)]">
-                    {t("ai.candidate", { index: index + 1 })}
-                  </span>
-                  {isSelected ? (
-                    <span className="text-(--text-status) text-[var(--color-fg-accent)]">
-                      {t("ai.candidateSelected")}
-                    </span>
-                  ) : null}
-                </div>
-                <Text
-                  size="small"
-                  color="muted"
-                  className="mt-1 whitespace-pre-wrap"
-                >
-                  {candidate.summary}
-                </Text>
-              </Button>
-            );
-          })}
-        </div>
-      ) : null}
-
-      {props.lastCandidates.length > 1 ? (
-        <div className="w-full flex justify-end">
-          <Button
-            data-testid="ai-candidate-regenerate"
-            variant="ghost"
-            size="sm"
-            onClick={() => void props.onRegenerateAll()}
-            disabled={props.working}
-          >
-            {t("ai.regenerateAll")}
-          </Button>
-        </div>
-      ) : null}
+      <AiCandidateCards
+        candidates={props.lastCandidates}
+        selectedCandidate={props.selectedCandidate}
+        working={props.working}
+        onSelectCandidate={props.onSelectCandidate}
+        onRegenerateAll={props.onRegenerateAll}
+      />
 
       {!hasHistoryReplay && props.activeOutputText ? (
         <div
@@ -414,46 +199,7 @@ export function AiMessageList(props: AiMessageListProps): JSX.Element {
         )
       ) : null}
 
-      {props.judgeResult ? (
-        <div
-          data-testid="ai-judge-result"
-          className="w-full rounded-[var(--radius-md)] bg-[var(--color-bg-base)] px-3 py-2 space-y-1"
-        >
-          <div className="flex items-center gap-2 flex-wrap">
-            <span
-              data-testid="ai-judge-severity"
-              className={`text-(--text-status) font-semibold uppercase tracking-wide ${judgeSeverityClass(props.judgeResult.severity)}`}
-            >
-              {props.judgeResult.severity}
-            </span>
-            {props.judgeResult.labels.length === 0 ? (
-              <span
-                data-testid="ai-judge-pass"
-                className="text-(--text-caption) text-[var(--color-fg-default)]"
-              >
-                {t("ai.judgePass")}
-              </span>
-            ) : (
-              props.judgeResult.labels.map((label) => (
-                <span
-                  key={label}
-                  className="text-(--text-caption) text-[var(--color-fg-default)]"
-                >
-                  {label}
-                </span>
-              ))
-            )}
-          </div>
-          <Text data-testid="ai-judge-summary" size="small" color="muted">
-            {props.judgeResult.summary}
-          </Text>
-          {props.judgeResult.partialChecksSkipped ? (
-            <Text data-testid="ai-judge-partial" size="small" color="muted">
-              {t("ai.judgePartialSkipped")}
-            </Text>
-          ) : null}
-        </div>
-      ) : null}
+      {props.judgeResult ? <AiJudgeResult result={props.judgeResult} /> : null}
 
       {props.usageStats ? (
         <AiUsageStats

--- a/apps/desktop/renderer/src/features/ai/ErrorGuideCard.tsx
+++ b/apps/desktop/renderer/src/features/ai/ErrorGuideCard.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import type { SettingsTab } from "../settings-dialog/SettingsDialog";
+
+import { AiErrorCard } from "../../components/features/AiDialogs";
+import { Button } from "../../components/primitives/Button";
+
+import { useTranslation } from "react-i18next";
+import type { AiErrorConfigs } from "./aiPanelHelpers";
+
+// ---------------------------------------------------------------------------
+// ErrorGuideCard — extracted inline component
+// ---------------------------------------------------------------------------
+
+export function ErrorGuideCard(props: {
+  testId: string;
+  title: string;
+  description: string;
+  steps: string[];
+  errorCode: string;
+  severity?: "error" | "warning" | "info";
+  command?: string;
+  actionLabel?: string;
+  actionTestId?: string;
+  onAction?: () => void;
+}): JSX.Element {
+  const [copied, setCopied] = React.useState(false);
+  const sev = props.severity ?? "error";
+
+  const borderColorMap = {
+    error: "bg-[var(--color-error)]",
+    warning: "bg-[var(--color-warning)]",
+    info: "bg-[var(--color-info)]",
+  };
+
+  const bgColorMap = {
+    error: "bg-[var(--color-error-subtle)]",
+    warning: "bg-[var(--color-warning-subtle)]",
+    info: "bg-[var(--color-info-subtle)]",
+  };
+
+  async function handleCopyCommand(): Promise<void> {
+    if (!props.command || !navigator.clipboard?.writeText) {
+      return;
+    }
+    await navigator.clipboard.writeText(props.command);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  }
+
+  const { t } = useTranslation();
+
+  return (
+    <section
+      data-testid={props.testId}
+      className={`w-full rounded-[var(--radius-md)] ${bgColorMap[sev]}`}
+    >
+      <div className="flex">
+        <div
+          className={`w-1.5 rounded-l-[var(--radius-md)] ${borderColorMap[sev]}`}
+        />
+        <div className="flex-1 px-3 py-2.5">
+          <h4 className="text-(--text-body) font-semibold text-[var(--color-fg-default)]">
+            {props.title}
+          </h4>
+          <p className="mt-1 text-(--text-caption) leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap">
+            {props.description}
+          </p>
+          <ol className="mt-2 list-decimal pl-4 space-y-1 text-(--text-caption) leading-snug text-[var(--color-fg-default)]">
+            {props.steps.map((step, index) => (
+              <li key={`${props.testId}-step-${index}`}>{step}</li>
+            ))}
+          </ol>
+          {props.command ? (
+            <div className="mt-2 flex items-center gap-2">
+              <code className="rounded-[var(--radius-sm)] bg-[var(--color-bg-base)] px-2 py-1 text-(--text-status) text-[var(--color-fg-default)]">
+                {props.command}
+              </code>
+              <Button
+                type="button"
+                data-testid={`${props.testId}-copy-command`}
+                className="focus-ring text-(--text-status) px-2 py-1 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-default"
+                onClick={() => void handleCopyCommand()}
+              >
+                {copied ? t("ai.panel.copied") : t("ai.panel.copy")}
+              </Button>
+            </div>
+          ) : null}
+          <div className="mt-2 flex items-center gap-2">
+            {props.onAction && props.actionLabel ? (
+              <Button
+                type="button"
+                data-testid={props.actionTestId}
+                className="focus-ring text-(--text-status) px-2 py-1 rounded-[var(--radius-sm)] border border-[var(--color-border-default)] text-[var(--color-fg-default)] hover:bg-[var(--color-bg-hover)] transition-default"
+                onClick={props.onAction}
+              >
+                {props.actionLabel}
+              </Button>
+            ) : null}
+            <span className="text-(--text-label) font-mono text-[var(--color-error)]">
+              {/* 审计：v1-13 #013 KEEP */}
+              {/* eslint-disable-next-line creonow/no-raw-error-code-in-ui -- 技术原因：diagnostic code reference for AI error display; user-friendly description shown above */}
+              {props.errorCode}
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AiPanelErrorDisplay
+// ---------------------------------------------------------------------------
+
+export function AiPanelErrorDisplay(props: {
+  errorConfigs: AiErrorConfigs;
+  clearError: () => void;
+  openSettings: (section?: SettingsTab) => void;
+}): JSX.Element | null {
+  const { t } = useTranslation();
+  const ec = props.errorConfigs;
+
+  if (ec.showDbGuide) {
+    return (
+      <ErrorGuideCard
+        testId="ai-error-guide-db"
+        title={t("ai.panel.dbErrorTitle")}
+        description={ec.dbGuideError?.message ?? t("ai.panel.dbErrorFallback")}
+        steps={[t("ai.panel.dbStep1"), t("ai.panel.dbStep2")]}
+        command={ec.dbGuideCommand}
+        errorCode="DB_ERROR"
+        severity="error"
+      />
+    );
+  }
+
+  if (ec.showProviderGuide) {
+    return (
+      <ErrorGuideCard
+        testId="ai-error-guide-provider"
+        title={t("ai.panel.providerTitle")}
+        description={t("ai.panel.providerDescription")}
+        steps={[
+          t("ai.panel.providerStep1"),
+          t("ai.panel.providerStep2"),
+          t("ai.panel.providerStep3"),
+        ]}
+        errorCode={ec.providerGuideCode ?? "AI_NOT_CONFIGURED"}
+        severity="warning"
+        actionLabel={t("ai.panel.openSettingsAi")}
+        actionTestId="ai-error-guide-open-settings"
+        onAction={() => props.openSettings("ai")}
+      />
+    );
+  }
+
+  return (
+    <>
+      {ec.skillsErrorConfig ? (
+        <AiErrorCard error={ec.skillsErrorConfig} showDismiss={false} />
+      ) : null}
+      {ec.modelsErrorConfig ? (
+        <AiErrorCard error={ec.modelsErrorConfig} showDismiss={false} />
+      ) : null}
+      {ec.runtimeErrorConfig ? (
+        <AiErrorCard
+          error={ec.runtimeErrorConfig}
+          errorCodeTestId="ai-error-code"
+          onDismiss={props.clearError}
+        />
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #1279

## 变更摘要
将 AiMessageList.tsx (488行) 拆分为 4 个独立文件：
- `AiMessageList.tsx` → 234 行 (≤250 ✅)
- `ErrorGuideCard.tsx` → 174 行 (≤250 ✅)
- `AiCandidateCards.tsx` → 78 行
- `AiJudgeResult.tsx` → 55 行

## 验证证据
- `pnpm typecheck` → 0 errors
- `vitest run ai` → 258/259 pass (1 pre-existing flaky)
- `pnpm lint` → 0 errors
- `storybook:build` → success

## 回滚点
Revert commit `00b59de6`

## 审计门禁
内审通过 ✅ — 无 BLOCKER