### PR TITLE
style(search): fix filter pill shadow to sm (#1273)

### DIFF
--- a/apps/desktop/renderer/src/features/search/SearchPanelParts.tsx
+++ b/apps/desktop/renderer/src/features/search/SearchPanelParts.tsx
@@ -21,7 +21,7 @@ export function CategoryButton(props: {
       onClick={props.onClick}
       className={`!px-3 !py-1 !h-auto !text-xs !font-medium !rounded-full whitespace-nowrap ${
         props.active
-          ? "!bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] shadow-lg shadow-[var(--color-info-subtle)]"
+          ? "!bg-[var(--color-info)] !text-[var(--color-fg-on-accent)] shadow-sm shadow-[var(--color-info-subtle)]"
           : "!bg-[var(--color-separator)] !text-[var(--color-fg-muted)] !border !border-transparent hover:!border-[var(--color-bg-overlay)] hover:!text-[var(--color-fg-default)] hover:!bg-[var(--color-bg-overlay)]"
       }`}
     >


### PR DESCRIPTION
Closes #1273

## 变更摘要
修正搜索面板 filter pill 激活态 shadow：`shadow-lg` → `shadow-sm`，与设计规范 AC-6 对齐。

单文件单行变更。

## 验证证据
- `grep -c shadow-lg SearchPanelParts.tsx` → 0
- `grep -c shadow-sm SearchPanelParts.tsx` → 1
- `pnpm typecheck` → 0 errors
- `vitest run SearchPanel` → 30 tests passed

## 回滚点
Revert commit `a7cc603f`

## 审计门禁
内审通过 ✅ — 无 BLOCKER